### PR TITLE
added default random token to agents without env var set

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	pb "github.com/runopsio/hoop/common/proto"
 	"log"
 	"os"
@@ -15,6 +16,9 @@ func Run() {
 
 	svrAddr := os.Getenv("SERVER_ADDRESS")
 	token := os.Getenv("TOKEN")
+	if token == "" {
+		token = "x-agt-" + uuid.NewString()
+	}
 
 	client, err := grpc.Connect(svrAddr, token, grpc.WithOption("origin", pb.ConnectionOriginAgent))
 	if err != nil {


### PR DESCRIPTION
- generates random token inside app, in case TOKEN variable is not set.
- if variable TOKEN is set, then agent will use it instead of generating new

**NOTE: the token that is generated inside the API is a memory one only, and should not be used in production.**