### PR TITLE
Add TCP connection type

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,24 +32,22 @@ The Gateway manages connections and users that are allowed to access resources. 
 
 To facilitate the deployment, it's possible to configure most of options using environment variables
 
-| ENVIRONMENT          | DESCRIPTION                                | AGENT | CLIENT | GATEWAY        |
-| -------------------- | ------------------------------------------ | ----- | ------ | -------------- |
-| XTDB_ADDRESS         | Database server address                    | no    | no     | yes            |
-| STATIC_UI_PATH       | The path where the UI assets resides       | no    | no     | yes            |
-| PROFILE              | "dev" runs gateway without authentication  | no    | no     | yes            |
-| IDP_CLIENT_SECRET    | required if not in 'dev' mode              | no    | no     | yes (required) |
+| ENVIRONMENT                          | DESCRIPTION                                | AGENT | CLIENT | GATEWAY  |
+| ------------------------------------ | ------------------------------------------ | ----- | ------ | -------- |
+| XTDB_ADDRESS                         | Database server address                    | no    | no     | yes      |
+| STATIC_UI_PATH                       | The path where the UI assets resides       | no    | no     | yes      |
+| PROFILE                              | "dev" runs gateway without authentication  | no    | no     | yes      |
+| GOOGLE_APPLICATION_CREDENTIALS_JSON  | GCP DLP credentials                        | no    | no     | yes      |
 
 To customize the identity provider, the following variables can be set:
 
 | ENVIRONMENT             | DESCRIPTION                                 | AGENT | CLIENT | GATEWAY |
 | ----------------------- | ------------------------------------------- | ----- | ------ | ------- |
-| IDP_DOMAIN              | Domain of identity provider                 | no    | no     | yes     |
-| IDP_CLIENT_ID           | ClientID of identity provider               | no    | no     | yes     |
-| IDP_AUDIENCE            | Audience of identity provider               | no    | no     | yes     |
-| IDP_JWKS_URL            | Public keys endpoint of identity provider   | no    | no     | yes     |
-| IDP_AUTHORIZE_ENDPOINT  | Authorization endpoint of identity provider | no    | no     | yes     |
-| IDP_TOKEN_ENDPOINT      | Token endpoint of identity provider         | no    | no     | yes     |
-
+| API_URL                 | The public address of the API               | no    | no     | yes     |
+| IDP_ISSUER              | The issuer of the application               | no    | no     | yes     |
+| IDP_CLIENT_ID           | The oauth2 client  id                       | no    | no     | yes     |
+| IDP_CLIENT_SECRET       | The oauth2 client secret                    | no    | no     | yes     |
+| IDP_AUDIENCE            | The audience name                           | no    | no     | yes     |
 
 ## Development QuickStart
 

--- a/agent/const.go
+++ b/agent/const.go
@@ -4,4 +4,5 @@ const (
 	connectionStoreParamsKey string = "params:%s"
 	cmdStoreKey              string = "cmd:%s"
 	dlpClientKey             string = "dlp_client"
+	connEnvKey               string = "connenv"
 )

--- a/agent/tcp.go
+++ b/agent/tcp.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"log"
+
+	pb "github.com/runopsio/hoop/common/proto"
+)
+
+func (a *Agent) processTCPWriteServer(pkt *pb.Packet) {
+	sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
+	clientConnectionID := string(pkt.Spec[pb.SpecClientConnectionID])
+	if clientConnectionID == "" {
+		log.Println("connection id not found in memory")
+		return
+	}
+	clientConnectionIDKey := fmt.Sprintf("%s:%s", sessionID, string(clientConnectionID))
+	if tcpServer, ok := a.connStore.Get(clientConnectionIDKey).(io.WriteCloser); ok {
+		if _, err := tcpServer.Write(pkt.Payload); err != nil {
+			log.Printf("session=%v - failed writing first packet, err=%v", sessionID, err)
+			_ = tcpServer.Close()
+		}
+		return
+	}
+	tcpClient := pb.NewStreamWriter(a.client, pb.PacketTCPWriteClientType, map[string][]byte{
+		pb.SpecGatewaySessionID:   []byte(sessionID),
+		pb.SpecClientConnectionID: []byte(clientConnectionID),
+	})
+	connParams, _ := a.connStore.Get(sessionID).(*pb.AgentConnectionParams)
+	if connParams == nil {
+		log.Printf("session=%s - connection params not found", sessionID)
+		return
+	}
+	connenv, _ := connParams.EnvVars[connEnvKey].(*connEnv)
+	if connenv == nil {
+		log.Printf("session=%s - missing connection credentials in memory", sessionID)
+		return
+	}
+	tcpServer, err := newTCPConn(connenv.host, connenv.port)
+	if err != nil {
+		log.Printf("session=%s - failed connecting to %v, err=%v", sessionID, connenv.host, err)
+		return
+	}
+	a.connStore.Set(clientConnectionIDKey, tcpServer)
+	go func() {
+		defer a.connStore.Del(clientConnectionIDKey)
+		// the connect key is a noop packet. It's useful when
+		// a client needs the response of the server first to initate
+		// the protocol negotiation. e.g.: mysql
+		if _, ok := pkt.Spec[pb.SpecTCPServerConnectKey]; !ok {
+			if _, err := tcpServer.Write(pkt.Payload); err != nil {
+				log.Printf("session=%v - failed writing first packet, err=%v", sessionID, err)
+				return
+			}
+		}
+		if _, err := io.Copy(tcpClient, tcpServer); err != nil {
+			if err != io.EOF {
+				log.Printf("session=%v, done copying tcp connection", sessionID)
+			}
+		}
+	}()
+}

--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -83,7 +83,7 @@ func (c *connect) processPacket(pkt *pb.Packet) {
 		}
 		connnectionType := pkt.Spec[pb.SpecConnectionType]
 		switch string(connnectionType) {
-		case "postgres":
+		case pb.ConnectionTypePostgres:
 			// start postgres server
 			pgp := proxy.NewPGServer(c.proxyPort, c.client)
 			if err := pgp.Serve(string(sessionID)); err != nil {
@@ -98,7 +98,25 @@ func (c *connect) processPacket(pkt *pb.Packet) {
 			fmt.Printf("      host=127.0.0.1 port=%s user=noop password=noop\n", pgp.ListenPort())
 			fmt.Println("------------------------------------------------------------")
 			log.Println("ready to accept connections!")
-		case "command-line":
+		case pb.ConnectionTypeTCP:
+			proxyPort := "8999"
+			if c.proxyPort != "" {
+				proxyPort = c.proxyPort
+			}
+			tcp := proxy.NewTCPServer(proxyPort, c.client, pb.PacketTCPWriteServerType)
+			if err := tcp.Serve(string(sessionID)); err != nil {
+				c.processGracefulExit(err)
+			}
+			c.loader.Stop()
+			c.client.StartKeepAlive()
+			c.connStore.Set(string(sessionID), tcp)
+			c.printHeader(string(sessionID))
+			fmt.Println()
+			fmt.Println("--------------------tcp-connection--------------------")
+			fmt.Printf("               host=127.0.0.1 port=%s\n", tcp.ListenPort())
+			fmt.Println("------------------------------------------------------")
+			log.Println("ready to accept connections!")
+		case pb.ConnectionTypeCommandLine:
 			if runtime.GOOS == "windows" {
 				fmt.Println("command line is not supported on Windows")
 				os.Exit(1)
@@ -133,6 +151,15 @@ func (c *connect) processPacket(pkt *pb.Packet) {
 		_, err := pgp.PacketWriteClient(connectionID, pkt)
 		if err != nil {
 			c.processGracefulExit(fmt.Errorf("failed writing to client, err=%v", err))
+		}
+	case pb.PacketTCPWriteClientType:
+		sessionID := pkt.Spec[pb.SpecGatewaySessionID]
+		connectionID := string(pkt.Spec[pb.SpecClientConnectionID])
+		if tcp, ok := c.connStore.Get(string(sessionID)).(*proxy.TCPServer); ok {
+			_, err := tcp.PacketWriteClient(connectionID, pkt)
+			if err != nil {
+				c.processGracefulExit(fmt.Errorf("failed writing to client, err=%v", err))
+			}
 		}
 	case pb.PacketCloseTCPConnectionType:
 		sessionID := pkt.Spec[pb.SpecGatewaySessionID]
@@ -171,6 +198,13 @@ func (c *connect) processGracefulExit(err error) {
 			fmt.Printf("\n\n")
 			c.printErrorAndExit(err.Error())
 		case *proxy.PGServer:
+			v.PacketCloseConnection(sessionID)
+			time.Sleep(time.Millisecond * 500)
+			if err == io.EOF {
+				os.Exit(0)
+			}
+			c.printErrorAndExit(err.Error())
+		case *proxy.TCPServer:
 			v.PacketCloseConnection(sessionID)
 			time.Sleep(time.Millisecond * 500)
 			if err == io.EOF {

--- a/client/proxy/tcp.go
+++ b/client/proxy/tcp.go
@@ -1,0 +1,129 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strconv"
+
+	"github.com/runopsio/hoop/common/memory"
+	pb "github.com/runopsio/hoop/common/proto"
+)
+
+type TCPServer struct {
+	listenPort      string
+	client          pb.ClientTransport
+	connectionStore memory.Store
+	listener        net.Listener
+	packetType      pb.PacketType
+}
+
+func NewTCPServer(listenPort string, client pb.ClientTransport, packetType pb.PacketType) *TCPServer {
+	return &TCPServer{
+		listenPort:      listenPort,
+		client:          client,
+		connectionStore: memory.New(),
+		packetType:      packetType,
+	}
+}
+
+func (p *TCPServer) Serve(sessionID string) error {
+	listenAddr := fmt.Sprintf("127.0.0.1:%s", p.listenPort)
+	lis, err := net.Listen("tcp4", listenAddr)
+	if err != nil {
+		return fmt.Errorf("failed listening to address %v, err=%v", listenAddr, err)
+	}
+	p.listener = lis
+	go func() {
+		connectionID := 0
+		for {
+			connectionID++
+			tcpClient, err := lis.Accept()
+			if err != nil {
+				log.Printf("failed obtain listening connection, err=%v", err)
+				break
+			}
+			go p.serveConn(sessionID, strconv.Itoa(connectionID), tcpClient)
+		}
+	}()
+	return nil
+}
+
+func (p *TCPServer) serveConn(sessionID, connectionID string, tcpClient net.Conn) {
+	defer func() {
+		log.Printf("session=%v | conn=%s | remote=%s - closing tcp connection",
+			sessionID, connectionID, tcpClient.RemoteAddr())
+		p.connectionStore.Del(connectionID)
+		if err := tcpClient.Close(); err != nil {
+			// TODO: log warn
+			log.Printf("failed closing client connection, err=%v", err)
+		}
+		_ = p.client.Send(&pb.Packet{
+			Type: pb.PacketCloseTCPConnectionType.String(),
+			Spec: map[string][]byte{
+				pb.SpecClientConnectionID: []byte(connectionID),
+				pb.SpecGatewaySessionID:   []byte(sessionID),
+			}})
+	}()
+	connWrapper := pb.NewConnectionWrapper(tcpClient, make(chan struct{}))
+	p.connectionStore.Set(connectionID, connWrapper)
+
+	log.Printf("session=%v | conn=%s | client=%s - connected",
+		sessionID, connectionID, tcpClient.RemoteAddr())
+	spec := map[string][]byte{
+		string(pb.SpecGatewaySessionID):   []byte(sessionID),
+		string(pb.SpecClientConnectionID): []byte(connectionID),
+	}
+	tcpServerWriter := pb.NewStreamWriter(p.client, p.packetType, spec)
+	// first make a connection in the agent to start exchanging packets.
+	// this is required for mysql server, where the server sends the packet
+	// first.
+	if err := p.connectTCP(sessionID, connectionID); err != nil {
+		log.Printf("session=%v | conn=%s - failed initializing tcp connection, err=%v",
+			sessionID, connectionID, err)
+	}
+	if _, err := io.Copy(tcpServerWriter, tcpClient); err != nil {
+		log.Printf("failed copying buffer, err=%v", err)
+		connWrapper.Close()
+	}
+}
+
+func (p *TCPServer) PacketWriteClient(connectionID string, pkt *pb.Packet) (int, error) {
+	conn, err := p.getConnection(connectionID)
+	if err != nil {
+		return 0, err
+	}
+	return conn.Write(pkt.Payload)
+}
+
+func (p *TCPServer) PacketCloseConnection(connectionID string) {
+	if conn, err := p.getConnection(connectionID); err == nil {
+		_ = conn.Close()
+	}
+	_ = p.listener.Close()
+}
+
+func (p *TCPServer) getConnection(connectionID string) (io.WriteCloser, error) {
+	connWrapperObj := p.connectionStore.Get(connectionID)
+	conn, ok := connWrapperObj.(io.WriteCloser)
+	if !ok {
+		return nil, fmt.Errorf("local connection %q not found", connectionID)
+	}
+	return conn, nil
+}
+
+func (p *TCPServer) connectTCP(sessionID, connectionID string) error {
+	return p.client.Send(&pb.Packet{
+		Type: p.packetType.String(),
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:    []byte(sessionID),
+			pb.SpecClientConnectionID:  []byte(connectionID),
+			pb.SpecTCPServerConnectKey: nil,
+		},
+	})
+}
+
+func (p *TCPServer) ListenPort() string {
+	return p.listenPort
+}

--- a/common/proto/const.go
+++ b/common/proto/const.go
@@ -23,6 +23,10 @@ const (
 	PacketTerminalWriteAgentStdinType   PacketType = "Terminal::Agent::WriteStdin"
 	PacketTerminalCloseType             PacketType = "Terminal::Close"
 
+	// Raw TCP
+	PacketTCPWriteServerType PacketType = "TCP::WriteServer"
+	PacketTCPWriteClientType PacketType = "TCP::WriteClient"
+
 	// PG protocol messages
 	PacketPGWriteServerType PacketType = "PG::WriteServer"
 	PacketPGWriteClientType PacketType = "PG::WriteClient"
@@ -35,8 +39,13 @@ const (
 	SpecClientExecArgsKey         string = "terminal.args"
 	SpecAgentConnectionParamsKey  string = "agent.connection_params"
 	SpecAgentGCPRawCredentialsKey string = "agent.gcp_credentials"
+	SpecTCPServerConnectKey       string = "tcp.server_connect"
 
 	DefaultKeepAlive time.Duration = 10 * time.Second
+
+	ConnectionTypeCommandLine string = "command-line"
+	ConnectionTypePostgres    string = "postgres"
+	ConnectionTypeTCP         string = "tcp"
 
 	DevProfile = "dev"
 

--- a/gateway/plugin/plugin.go
+++ b/gateway/plugin/plugin.go
@@ -37,6 +37,15 @@ func (c Config) GetString(key string) string {
 	return val.(string)
 }
 
+func (c Config) Int64(key string) int64 {
+	val, ok := c.ParamsData[key]
+	if !ok {
+		return -1
+	}
+	v, _ := val.(int64)
+	return v
+}
+
 func (c Config) GetDuration(key string) time.Duration {
 	val, ok := c.ParamsData[key]
 	if !ok {

--- a/gateway/session/service.go
+++ b/gateway/session/service.go
@@ -34,6 +34,7 @@ type (
 		EventStream EventStream `json:"event_stream" edn:"session/event-stream"`
 		// Must NOT index streams (all top keys are indexed in xtdb)
 		NonIndexedStream NonIndexedEventStreamList `json:"-"          edn:"session/xtdb-stream"`
+		EventSize        int64                     `json:"event_size" edn:"session/event-size"`
 		StartSession     time.Time                 `json:"start_date" edn:"session/start-date"`
 		EndSession       *time.Time                `json:"end_date"   edn:"session/end-date"`
 	}

--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -110,7 +110,9 @@ func (p *auditPlugin) OnReceive(pluginConfig plugin.Config, config []string, pkt
 		return p.writeOnReceive(pluginConfig.SessionId, 'i', queryBytes)
 	case pb.PacketTerminalClientWriteStdoutType:
 		return p.writeOnReceive(pluginConfig.SessionId, 'o', pkt.GetPayload())
-	case pb.PacketTerminalWriteAgentStdinType, pb.PacketTerminalRunProcType:
+	case pb.PacketTerminalWriteAgentStdinType,
+		pb.PacketTerminalRunProcType,
+		pb.PacketTCPWriteServerType:
 		return p.writeOnReceive(pluginConfig.SessionId, 'i', pkt.GetPayload())
 	}
 	return nil


### PR DESCRIPTION
The TCP type will truncate audit inputs at > 5000 bytes and it will not execute DLP.

- Update README.md
- Add event size to sessions
- Tested with mysql/postgres/http protocols