### PR TITLE
agent trying to connect to remote SAAS when first local attempt fail

### DIFF
--- a/common/grpc/client.go
+++ b/common/grpc/client.go
@@ -119,7 +119,6 @@ func (c *mutexClient) StartKeepAlive() {
 			proto := &pb.Packet{Type: pb.PacketKeepAliveType.String()}
 			if err := c.Send(proto); err != nil {
 				if err != nil {
-					fmt.Errorf("Error sending keep alive")
 					break
 				}
 			}


### PR DESCRIPTION
- Agent try to connect to 127.0.0.1 first time.
- If the "Dial" fails, then it tries the secondaryServerAddress (app.hoop.dev:8443).

Task description: https://3.basecamp.com/5385186/buckets/28171754/todos/5583501196