### PR TITLE
propagate stdout and stderr streams properly to hoop exec cmd

### DIFF
--- a/agent/terminal/server-exec.go
+++ b/agent/terminal/server-exec.go
@@ -76,7 +76,7 @@ func (c *Command) OnPostExec() error {
 	return nil
 }
 
-func (c *Command) Run(streamWriter io.WriteCloser, stdinInput []byte, onExecErr OnExecErrFn, clientArgs ...string) error {
+func (c *Command) Run(stdoutw, stderrw io.WriteCloser, stdinInput []byte, onExecErr OnExecErrFn, clientArgs ...string) error {
 	pipeStdout, err := c.cmd.StdoutPipe()
 	if err != nil {
 		onExecErr(term.InternalErrorExitCode, "internal error, failed returning stdout pipe")
@@ -106,8 +106,8 @@ func (c *Command) Run(streamWriter io.WriteCloser, stdinInput []byte, onExecErr 
 		onExecErr(term.InternalErrorExitCode, "internal error, failed writing input")
 		return err
 	}
-	stdoutCh := copyBuffer(streamWriter, pipeStdout, 1024, "stdout")
-	stderrCh := copyBuffer(streamWriter, pipeStderr, 1024, "stderr")
+	stdoutCh := copyBuffer(stdoutw, pipeStdout, 1024, "stdout")
+	stderrCh := copyBuffer(stderrw, pipeStderr, 1024, "stderr")
 
 	go func() {
 		exitCode = 0

--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -79,11 +79,10 @@ func parseExecInput(c *connect) []byte {
 
 func runExec(args []string) {
 	config := getClientConfig()
-
-	loader := spinner.New(spinner.CharSets[78], 70*time.Millisecond)
+	loader := spinner.New(spinner.CharSets[78], 70*time.Millisecond, spinner.WithWriter(os.Stderr))
 	loader.Color("green")
+	loader.Suffix = " running ..."
 	loader.Start()
-	loader.Suffix = " executing input ..."
 
 	c := newClientConnect(config, loader, args, pb.ClientVerbExec)
 	pkt := &pb.Packet{
@@ -98,8 +97,6 @@ func runExec(args []string) {
 		_, _ = c.client.Close()
 		c.printErrorAndExit("failed executing command, err=%v", err)
 	}
-
-	loader.Stop()
 
 	for {
 		pkt, err := c.client.Recv()

--- a/client/go.mod
+++ b/client/go.mod
@@ -3,7 +3,9 @@ module github.com/runopsio/hoop/client
 go 1.19
 
 require (
-	github.com/briandowns/spinner v1.19.0
+	// latest version breaks when using the loader to stderr
+	// update to latest version after this https://github.com/briandowns/spinner/pull/136
+	github.com/briandowns/spinner v1.18.0
 	github.com/creack/pty v1.1.18
 	github.com/runopsio/hoop/common v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.5.0

--- a/common/proto/const.go
+++ b/common/proto/const.go
@@ -50,6 +50,7 @@ const (
 	SpecClientConnectionID        string = "client.connection_id"
 	SpecClientExecExitCodeKey     string = "terminal.exit_code"
 	SpecClientExecArgsKey         string = "terminal.args"
+	SpecServerExecStdStreamKey    string = "terminal.std_stream"
 	SpecAgentConnectionParamsKey  string = "agent.connection_params"
 	SpecAgentGCPRawCredentialsKey string = "agent.gcp_credentials"
 	SpecTCPServerConnectKey       string = "tcp.server_connect"
@@ -71,6 +72,9 @@ const (
 
 	ConnectionOriginAgent  = "agent"
 	ConnectionOriginClient = "client"
+
+	StdOut = "stdout"
+	StdErr = "stderr"
 
 	ClientLoginCallbackAddress string = "127.0.0.1:3587"
 

--- a/common/proto/types.go
+++ b/common/proto/types.go
@@ -80,6 +80,20 @@ func NewStreamWriter(client ClientTransport, pktType PacketType, spec map[string
 	return &streamWriter{client: client, packetType: pktType, packetSpec: spec}
 }
 
+func NewStdoutStreamWriter(client ClientTransport, pktType PacketType, spec map[string][]byte) io.WriteCloser {
+	if spec != nil {
+		spec[SpecServerExecStdStreamKey] = []byte(StdOut)
+	}
+	return &streamWriter{client: client, packetType: pktType, packetSpec: spec}
+}
+
+func NewStderrStreamWriter(client ClientTransport, pktType PacketType, spec map[string][]byte) io.WriteCloser {
+	if spec != nil {
+		spec[SpecServerExecStdStreamKey] = []byte(StdErr)
+	}
+	return &streamWriter{client: client, packetType: pktType, packetSpec: spec}
+}
+
 func NewHookStreamWriter(
 	client ClientTransport,
 	pktType PacketType,


### PR DESCRIPTION
Before:
```sh
# contains stdout + stderr
hoop exec ... > /tmp/out
```
Some commands write info messages to stderr, like heroku cli:
<img width="392" alt="image" src="https://user-images.githubusercontent.com/586235/210468855-b5c448cc-847e-4a43-99c5-4de819a9c84b.png">

Polluting the standard output, which make every saved output contain these messages

After merging:
```sh
# will only contains stdout output
hoop exec ... > /tmp/out
```

> I'm trying to make heroku work with hoop to present this to groove, which found errors running with the old agent
