### PR TITLE
make agent_id attribute to be required

### DIFF
--- a/gateway/connection/service.go
+++ b/gateway/connection/service.go
@@ -34,7 +34,7 @@ type (
 		Name           string         `json:"name"     edn:"connection/name"    binding:"required"`
 		Command        []string       `json:"command"  edn:"connection/command" binding:"required"`
 		Type           Type           `json:"type"     edn:"connection/type"    binding:"required"`
-		AgentId        string         `json:"agent_id" edn:"connection/agent"`
+		AgentId        string         `json:"agent_id" edn:"connection/agent"   binding:"required"`
 		SecretProvider SecretProvider `json:"-"        edn:"connection/secret-provider"`
 	}
 


### PR DESCRIPTION
So, I had some problems when creating connections without enforcing the `agent_id`:

- The webapp auto create connection will let creating connections without any agent
- Users testing the demo and following our documentation needs to perform an update in the connection to select the proper agent.

This will improve the user experience, later on the webapp could enforce the dropdown box to be required also.