### PR TITLE
fixed NPE during login after gateway restart (xtdb not ready yet)

### DIFF
--- a/gateway/security/service.go
+++ b/gateway/security/service.go
@@ -72,8 +72,9 @@ func (s *Service) Callback(state, code string) string {
 	if err != nil {
 		if login != nil {
 			s.loginOutcome(login, outcomeError)
+			return login.Redirect + "?error=unexpected_error"
 		}
-		return login.Redirect + "?error=unexpected_error"
+		return "https://app.hoop.dev/callback?error=unexpected_error"
 	}
 
 	token, idToken, err := s.exchangeCodeByToken(code)


### PR DESCRIPTION
During gateway restart, if a user tries to login, xtdb won't be ready yet. This is cause the query to fail, and thus, generating a nil login struct. The code was using the nil struct to perform something, resulting in NPE.

This was fixed addressing a default callback value when login is null.