### PR TITLE
removing default audience

### DIFF
--- a/gateway/security/idp/authenticator.go
+++ b/gateway/security/idp/authenticator.go
@@ -106,9 +106,6 @@ func NewProvider(profile string) *Provider {
 		provider.ClientID = defaultProviderClientID
 	}
 
-	if provider.Audience == "" {
-		provider.Audience = defaultProviderAudience
-	}
 	oidcProviderConfig, err := newProviderConfig(provider.Context, provider.Issuer)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
If a default audience is applied during gateway boot, azure provider will refuse the login with error of extra param