### PR TITLE
add more standard returns when interacting with templates

### DIFF
--- a/gateway/runbooks/api.go
+++ b/gateway/runbooks/api.go
@@ -162,10 +162,6 @@ func (h *Handler) RunExec(c *gin.Context) {
 				ExitCode:  &resp.exitCode})
 		}
 	case <-time.After(time.Second * 50):
-		statusCode := http.StatusAccepted
-		if req.Redirect {
-			statusCode = http.StatusFound
-		}
 		// closing the client will force the goroutine to end
 		// and the result will return async
 		client.Close()


### PR DESCRIPTION
Always returns the following structure on success requests:

```json
{
    "exit_code": 0,
    "session_id": "ac50a57a-77ca-46f3-97d2-4b508cb5f612"
}
```

Always returns the following structure on errors:
```json
{
    "exit_code": 1,
    "session_id": "ac50a57a-77ca-46f3-97d2-4b508cb5f612",
    "message": "error-msg"
}
```