### PR TITLE
fix disconnect issues with exec

### DIFF
--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -125,6 +125,7 @@ func runExec(args []string) {
 	}()
 
 	c := newClientConnect(config, loader, args, pb.ClientVerbExec)
+	c.client.StartKeepAlive()
 	execSpec := newClientArgsSpec(c.clientArgs)
 	execInputPayload := parseExecInput(c)
 	sendOpenSessionPktFn := func() {

--- a/common/grpc/client.go
+++ b/common/grpc/client.go
@@ -35,7 +35,7 @@ type (
 )
 
 const (
-	OptionConnectionName OptionKey = "connection_name"
+	OptionConnectionName OptionKey = "connection-name"
 	defaultAddress                 = "127.0.0.1:8010"
 )
 
@@ -68,12 +68,12 @@ func Connect(serverAddress, token string, opts ...*ClientOptions) (pb.ClientTran
 	ver := version.Get()
 	contextOptions = append(contextOptions,
 		"version", ver.Version,
-		"go_version", ver.GoVersion,
+		"go-version", ver.GoVersion,
 		"compiler", ver.Compiler,
 		"platform", ver.Platform,
 		"hostname", osmap["hostname"],
-		"machine_id", osmap["machine_id"],
-		"kernel_version", osmap["kernel_version"],
+		"machine-id", osmap["machine_id"],
+		"kernel-version", osmap["kernel_version"],
 	)
 	for _, opt := range opts {
 		contextOptions = append(contextOptions, []string{

--- a/gateway/runbooks/api.go
+++ b/gateway/runbooks/api.go
@@ -110,7 +110,7 @@ func (h *Handler) RunExec(c *gin.Context) {
 		grpc.WithOption(grpc.OptionConnectionName, connectionName),
 		grpc.WithOption("origin", pb.ConnectionOriginClientAPI),
 		grpc.WithOption("verb", pb.ClientVerbExec),
-		grpc.WithOption("session_id", sessionID))
+		grpc.WithOption("session-id", sessionID))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"session_id": nil, "message": err.Error()})
 		return

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -109,10 +109,10 @@ func getPlugins(id string) []pluginConfig {
 
 func setClientMetdata(into *client.Client, md metadata.MD) {
 	into.Hostname = extractData(md, "hostname")
-	into.MachineId = extractData(md, "machine_id")
-	into.KernelVersion = extractData(md, "kernel_version")
+	into.MachineId = extractData(md, "machine-id")
+	into.KernelVersion = extractData(md, "kernel-version")
 	into.Version = extractData(md, "version")
-	into.GoVersion = extractData(md, "go_version")
+	into.GoVersion = extractData(md, "go-version")
 	into.Compiler = extractData(md, "compiler")
 	into.Platform = extractData(md, "platform")
 	into.Verb = extractData(md, "verb")
@@ -123,9 +123,9 @@ func (s *Server) subscribeClient(stream pb.Transport_ConnectServer, token string
 	md, _ := metadata.FromIncomingContext(ctx)
 
 	hostname := extractData(md, "hostname")
-	machineId := extractData(md, "machine_id")
-	kernelVersion := extractData(md, "kernel_version")
-	connectionName := extractData(md, "connection_name")
+	machineId := extractData(md, "machine-id")
+	kernelVersion := extractData(md, "kernel-version")
+	connectionName := extractData(md, "connection-name")
 	clientVerb := extractData(md, "verb")
 	clientOrigin := extractData(md, "origin")
 
@@ -152,7 +152,7 @@ func (s *Server) subscribeClient(stream pb.Transport_ConnectServer, token string
 	// When a session id is coming from the client,
 	// it's not safe to rely on it. A validation is required
 	// to maintain the integrity of the database.
-	sessionID := extractData(md, "session_id")
+	sessionID := extractData(md, "session-id")
 	if sessionID != "" {
 		if err := s.validateSessionID(sessionID); err != nil {
 			return status.Errorf(codes.AlreadyExists, err.Error())

--- a/gateway/transport/server.go
+++ b/gateway/transport/server.go
@@ -202,8 +202,13 @@ func (s *Server) disconnectClient(sessionID string) {
 func extractData(md metadata.MD, metaName string) string {
 	data := md.Get(metaName)
 	if len(data) == 0 {
-		return ""
+		// keeps compatibility with old clients that
+		// pass headers with underline. HTTP headers are not
+		// accepted with underline for some servers, e.g.: nginx
+		data = md.Get(strings.ReplaceAll(metaName, "-", "_"))
+		if len(data) == 0 {
+			return ""
+		}
 	}
-
 	return data[0]
 }


### PR DESCRIPTION
It fixes hoop exec timeout errors:

```
rpc error: code = Internal desc = stream terminated by RST_STREAM with error code: PROTOCOL_ERROR
```

Change headers format to comply with http headers.

When running the gateway over nginx, the following error happens:


>.2023/02/27 12:21:27 [info] 83002#0: *3 client sent invalid header: "connection_name" while reading client request headers, client: 127.0.0.1, server: mylocaldomain.tld, host: "mylocaldomain.tld:8443"


