### PR TITLE
added groups handling from IDP

### DIFF
--- a/common/proto/types.go
+++ b/common/proto/types.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	reflect "reflect"
-	"strings"
 
 	"github.com/hoophq/pluginhooks"
 )
@@ -175,15 +174,6 @@ func BufferedPayload(payload []byte) *bufio.Reader {
 func IsInList(item string, items []string) bool {
 	for _, i := range items {
 		if i == item {
-			return true
-		}
-	}
-	return false
-}
-
-func StartsWithInList(item string, items []string) bool {
-	for _, i := range items {
-		if strings.Contains(i, item) {
 			return true
 		}
 	}

--- a/gateway/security/service.go
+++ b/gateway/security/service.go
@@ -114,10 +114,7 @@ func (s *Service) Callback(state, code string) string {
 
 	groupsClaim, _ := idTokenClaims[pb.CustomClaimGroups].([]any)
 	if len(groupsClaim) > 0 {
-		groups := make([]string, 0)
-		for _, g := range groupsClaim {
-			groups = append(groups, g.(string))
-		}
+		groups := mapGroupsToString(groupsClaim)
 
 		context.User.Groups = groups
 		if err := s.UserService.Persist(context.User); err != nil {
@@ -187,9 +184,7 @@ func (s *Service) signup(context *user.Context, sub string, idTokenClaims map[st
 		groups := make([]string, 0)
 		groupsClaim, _ := idTokenClaims[pb.CustomClaimGroups].([]any)
 		if len(groupsClaim) > 0 {
-			for _, g := range groupsClaim {
-				groups = append(groups, g.(string))
-			}
+			groups = mapGroupsToString(groupsClaim)
 		}
 		status := user.StatusReviewing
 
@@ -243,4 +238,16 @@ func (s *Service) signup(context *user.Context, sub string, idTokenClaims map[st
 func (s *Service) loginOutcome(login *login, outcome outcomeType) {
 	login.Outcome = outcome
 	s.Storage.PersistLogin(login)
+}
+
+func mapGroupsToString(groupsClaim []any) []string {
+	groups := make([]string, 0)
+	for _, g := range groupsClaim {
+		groupName, _ := g.(string)
+		if groupName == "" {
+			continue
+		}
+		groups = append(groups, groupName)
+	}
+	return groups
 }

--- a/gateway/user/service.go
+++ b/gateway/user/service.go
@@ -162,7 +162,7 @@ func isPublicDomain(domain string) bool {
 }
 
 func (user *User) IsAdmin() bool {
-	return pb.IsInList(GroupAdmin, user.Groups) || pb.StartsWithInList(GroupAdmin, user.Groups)
+	return pb.IsInList(GroupAdmin, user.Groups)
 }
 
 func isInStatus(status StatusType) bool {


### PR DESCRIPTION
**Fixes on authentication/authorization flow:**

- Now we fetch the sub from the access token during signup. This will prevent issues regarding different subs for access and id tokens. No more specific if/else per IDP is necessary
- ID tokens may or may not receive the custom claim "https://app.hoop.dev/org". If the claim is present, then it will take precedence over the email-parsing logic
- ID tokens may or may not receive the custom claim "https://app.hoop.dev/groups". If it is present, than hoop will consider this as source of truth. If not present, than hoop will continue the way it is
- groups that **contains** _"admin"_ in its name will be considered as "admin". This is because some clients will use custom groups with hoop, and "admin" is a generic word that could conflict with other groups. So some customers will use the pattern **_{org}\_admin_** to represent a group at their provider that belongs to hoop and is an admin