### PR TITLE
Propagate client origin to plugins to persist sessions properly

### DIFF
--- a/agent/postgres.go
+++ b/agent/postgres.go
@@ -126,6 +126,7 @@ func (a *Agent) processPGProtocol(pkt *pb.Packet) {
 		log.Printf("failed writing startup packet, err=%v", err)
 		writePGClientErr(swPgClient,
 			pg.NewFatalError("failed writing startup packet, contact the administrator").Encode())
+		return
 	}
 	log.Println("finish startup phase")
 	mid := middlewares.New(swPgClient, pgServer, connenv.user, connenv.pass)
@@ -138,6 +139,7 @@ func (a *Agent) processPGProtocol(pkt *pb.Packet) {
 		log.Printf("failed creating redact middleware, err=%v", err)
 		writePGClientErr(swPgClient,
 			pg.NewFatalError("failed initalizing postgres proxy, contact the administrator").Encode())
+		return
 	}
 	swHookPgClient := pb.NewHookStreamWriter(a.client, pbclient.PGConnectionWrite, pkt.Spec, pluginHooks)
 	pg.NewProxy(

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -185,7 +185,7 @@ func (s *Server) subscribeClient(stream pb.Transport_ConnectServer, token string
 		Hostname:       hostname,
 		MachineId:      machineId,
 		KernelVersion:  kernelVersion,
-		ParamsData:     make(map[string]any),
+		ParamsData:     map[string]any{"client": clientOrigin},
 	}
 
 	plugins, err := s.loadConnectPlugins(context, pConfig)

--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -23,7 +23,7 @@ import (
 const (
 	Name               string = "audit"
 	StorageWriterParam string = "audit_storage_writer"
-	defaultAuditPath   string = "/opt/hoop/auditdb"
+	defaultAuditPath   string = "/opt/hoop/sessions"
 )
 
 var pluginAuditPath string


### PR DESCRIPTION
Found bug related to this task: https://github.com/hoophq/helm-chart/pull/3

- Change default audit folder to `/opt/hoop/sessions`  instead of `/opt/hoop/auditdb`
- Add proper returns when found error processing postgres protocol