### PR TITLE
added idp custom scopes as optional env var

### DIFF
--- a/gateway/security/idp/authenticator.go
+++ b/gateway/security/idp/authenticator.go
@@ -139,7 +139,9 @@ func NewProvider(profile string) *Provider {
 
 func addCustomScopes(scopes []string, customScope string) []string {
 	custom := strings.Split(customScope, ",")
-	scopes = append(scopes, custom...)
+	for _, c := range custom {
+		scopes = append(scopes, strings.Trim(c, " "))
+	}
 	return scopes
 }
 


### PR DESCRIPTION
- Added IDP_CUSTOM_SCOPES as optional scope to be passed to the scope list.
- IDP_CUSTOM_SCOPES is a comma separated string. Ex: IDP_CUSTOM_SCOPES="my_scope,another_scope"

Note:
The default scope list currently is [openid, email, profile]. If the variable is set, then the items wll be appended:
[openid,email,profile,my_scope,another_scope]