### PR TITLE
assigning status active to new users of a custom IDP

### DIFF
--- a/gateway/security/idp/authenticator.go
+++ b/gateway/security/idp/authenticator.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	defaultProviderIssuer   = "https://hoophq.us.auth0.com/"
+	DefaultProviderIssuer   = "https://hoophq.us.auth0.com/"
 	defaultProviderClientID = "DatIOCxntNv8AZrQLVnLb3tr1Y3oVwGW"
-	defaultProviderAudience = defaultProviderIssuer + "api/v2/"
+	defaultProviderAudience = DefaultProviderIssuer + "api/v2/"
 )
 
 var invalidAuthErr = errors.New("invalid auth")
@@ -101,7 +101,7 @@ func NewProvider(profile string) *Provider {
 	}
 
 	if provider.Issuer == "" {
-		provider.Issuer = defaultProviderIssuer
+		provider.Issuer = DefaultProviderIssuer
 	}
 
 	if provider.ClientID == "" {

--- a/gateway/security/service.go
+++ b/gateway/security/service.go
@@ -187,6 +187,9 @@ func (s *Service) signup(context *user.Context, sub string, idTokenClaims map[st
 			groups = mapGroupsToString(groupsClaim)
 		}
 		status := user.StatusReviewing
+		if s.Provider.Issuer != idp.DefaultProviderIssuer {
+			status = user.StatusActive
+		}
 
 		var org string
 		if context.Org != nil {


### PR DESCRIPTION
Custom IDP users are getting a "reviewing" status after signup.

If the IDP provider is not our default hoop saas, then the status will be "active" right away