### PR TITLE
fix max findings error with pg native

### DIFF
--- a/agent/dlp/types.go
+++ b/agent/dlp/types.go
@@ -17,7 +17,7 @@ const (
 	// this values needs to be low to avoid the max limit of findings per chunk
 	// https://cloud.google.com/dlp/docs/deidentify-sensitive-data#findings-limit
 	defaultMaxChunkSize = 62500
-	maxFindings         = 3000
+	maxFindings         = 2900
 	maxInfoTypes        = 30
 )
 

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -19,7 +19,7 @@ echo "--> STARTING GATEWAY ..."
 
 #export GRPC_GO_LOG_SEVERITY_LEVEL=info
 #export GODEBUG=http2debug
-# export GOOGLE_APPLICATION_CREDENTIALS_JSON=$(cat ../misc/profiles/hoop/dlp-serviceaccount.json)
+#export GOOGLE_APPLICATION_CREDENTIALS_JSON=$(cat ../misc/profiles/dlp-serviceaccount.json)
 export PORT=8009
 export PROFILE=dev
 export XTDB_ADDRESS=http://127.0.0.1:3001


### PR DESCRIPTION
When querying only one row, the max of rows to process result in 3000 records which is the [maximum findings per request](https://cloud.google.com/dlp/docs/deidentify-sensitive-data#findings-limit). I've added a safe max findings value to avoid such problem.