### PR TITLE
Make sessions to end gracefully

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -215,9 +215,9 @@ func (a *Agent) buildConnectionParams(pkt *pb.Packet) (*pb.AgentConnectionParams
 	}
 	if connType == pb.ConnectionTypePostgres || connType == pb.ConnectionTypeTCP || connType == pb.ConnectionTypeMySQL {
 		if err := isPortActive(connEnvVars.host, connEnvVars.port); err != nil {
-			msg := fmt.Sprintf("session=%s - failed connecting to host=%q, port=%q, err=%v",
-				sessionIDKey, connEnvVars.host, connEnvVars.port, err)
-			log.Println(msg)
+			msg := fmt.Sprintf("failed connecting to %s:%s, err=%v",
+				connEnvVars.host, connEnvVars.port, err)
+			log.Infof("session=%v - %v", sessionIDKey, msg)
 			return nil, nil, fmt.Errorf("%s", msg)
 		}
 	}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -106,9 +106,12 @@ func (c *Config) GrpcClientConfig() (grpc.ClientConfig, error) {
 
 func (c *Config) isEmpty() bool { return c.GrpcURL == "" && c.Token == "" }
 func (c *Config) IsInsecure() (insecure bool) {
+
 	switch {
 	case os.Getenv("TLS_SERVER_NAME") != "":
-	case c.Mode == clientconfig.ModeLocal, c.Mode == clientconfig.ModeAgentAutoRegister:
+	case c.Mode == clientconfig.ModeLocal,
+		c.Mode == clientconfig.ModeAgentAutoRegister,
+		c.GrpcURL == grpc.LocalhostAddr:
 		insecure = true
 	}
 	return

--- a/agent/terminal-exec.go
+++ b/agent/terminal-exec.go
@@ -42,7 +42,8 @@ func (a *Agent) doExec(pkt *pb.Packet) {
 		a.sendClientSessionClose(sessionID, errMsg)
 		return
 	}
-	log.Printf("session=%v, tty=false - executing command:%v", string(sessionID), cmd.String())
+	log.Printf("session=%v, tty=false, stdinsize=%v - executing command:%v",
+		string(sessionID), len(pkt.Payload), cmd.String())
 
 	spec := map[string][]byte{pb.SpecGatewaySessionID: []byte(sessionID)}
 	stdoutw := pb.NewHookStreamWriter(a.client, pbclient.WriteStdout, spec, pluginHooks)

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -89,7 +89,8 @@ func (c *Config) isEmpty() bool { return c.GrpcURL == "" && c.ApiURL == "" }
 func (c *Config) IsInsecure() (insecure bool) {
 	switch {
 	case os.Getenv("TLS_SERVER_NAME") != "":
-	case c.Mode == clientconfig.ModeLocal:
+	case c.Mode == clientconfig.ModeLocal,
+		c.GrpcURL == grpc.LocalhostAddr:
 		insecure = true
 	}
 	return

--- a/common/grpc/client.go
+++ b/common/grpc/client.go
@@ -143,8 +143,8 @@ func (c *mutexClient) Recv() (*pb.Packet, error) {
 func (c *mutexClient) Close() (error, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	streamCloseErr := c.stream.CloseSend()
 	connCloseErr := c.grpcClient.Close()
+	streamCloseErr := c.stream.CloseSend()
 	return streamCloseErr, connCloseErr
 }
 

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -25,7 +25,7 @@ var (
 // Get returns the overall codebase version. It's for detecting
 // what code a binary was built from.
 func Get() Info {
-	return Info{
+	i := Info{
 		Version:   version,
 		GitCommit: gitCommit,
 		BuildDate: buildDate,
@@ -33,6 +33,12 @@ func Get() Info {
 		Compiler:  runtime.Compiler,
 		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+	if i.Version == "" {
+		i.Version = "unknown"
+		i.BuildDate = ""
+		i.GitCommit = ""
+	}
+	return i
 }
 
 func Decode(obj interface{}) *Info {

--- a/gateway/session/storage.go
+++ b/gateway/session/storage.go
@@ -2,9 +2,10 @@ package session
 
 import (
 	"fmt"
-	"github.com/runopsio/hoop/common/log"
 	"strings"
 	"time"
+
+	"github.com/runopsio/hoop/common/log"
 
 	"github.com/runopsio/hoop/gateway/plugin"
 
@@ -75,20 +76,6 @@ func (s *Storage) Persist(context *user.Context, session *Session) (*st.TxRespon
 }
 
 func (s *Storage) PersistStatus(status *SessionStatus) (*st.TxResponse, error) {
-	var obj [][]SessionStatus
-	err := s.queryDecoder(`{:query {
-		:find [(pull ?s [*])]
-		:in [session-id]
-		:where [[?s :session-status/session-id session-id]]}
-	:in-args [%q]}`, &obj, status.SessionID)
-	if err != nil {
-		return nil, fmt.Errorf("failed fetching previous session status, err=%v", err)
-	}
-	if len(obj) > 0 {
-		status.ID = obj[0][0].ID
-		status.SessionID = obj[0][0].SessionID
-		return s.SubmitPutTx(status)
-	}
 	if status.ID == "" || status.SessionID == "" {
 		return nil, fmt.Errorf("session id and xt/id must not be empty")
 	}

--- a/gateway/transport/plugins/accesscontrol/accesscontrol.go
+++ b/gateway/transport/plugins/accesscontrol/accesscontrol.go
@@ -19,24 +19,11 @@ func New() *accessControlPlugin {
 	return &accessControlPlugin{name: Name}
 }
 
-func (r *accessControlPlugin) Name() string {
-	return r.name
-}
-
-func (r *accessControlPlugin) OnStartup(config plugin.Config) error {
-	return nil
-}
-
-func (r *accessControlPlugin) OnConnect(config plugin.Config) error {
-	return nil
-}
-
+func (r *accessControlPlugin) Name() string                         { return r.name }
+func (r *accessControlPlugin) OnStartup(config plugin.Config) error { return nil }
+func (r *accessControlPlugin) OnConnect(config plugin.Config) error { return nil }
 func (r *accessControlPlugin) OnReceive(pluginConfig plugin.Config, config []string, pkt *pb.Packet) error {
 	return nil
 }
-
-func (r *accessControlPlugin) OnDisconnect(config plugin.Config) error {
-	return nil
-}
-
-func (r *accessControlPlugin) OnShutdown() {}
+func (r *accessControlPlugin) OnDisconnect(config plugin.Config, errMsg error) error { return nil }
+func (r *accessControlPlugin) OnShutdown()                                           {}

--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -2,6 +2,12 @@ package audit
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/getsentry/sentry-go"
 	pbdlp "github.com/runopsio/hoop/common/dlp"
 	"github.com/runopsio/hoop/common/log"
@@ -11,10 +17,7 @@ import (
 	pbagent "github.com/runopsio/hoop/common/proto/agent"
 	pbclient "github.com/runopsio/hoop/common/proto/client"
 	"github.com/runopsio/hoop/gateway/plugin"
-	"os"
-	"strconv"
-	"sync"
-	"time"
+	"go.uber.org/zap"
 )
 
 const (
@@ -29,6 +32,7 @@ type (
 		walSessionStore memory.Store
 		started         bool
 		mu              sync.RWMutex
+		log             *zap.SugaredLogger
 	}
 
 	StorageWriter interface {
@@ -37,7 +41,11 @@ type (
 )
 
 func New() *auditPlugin {
-	return &auditPlugin{name: Name, walSessionStore: memory.New()}
+	return &auditPlugin{
+		name:            Name,
+		walSessionStore: memory.New(),
+		log:             log.With("plugin", "audit"),
+	}
 }
 
 func (p *auditPlugin) Name() string {
@@ -65,7 +73,7 @@ func (p *auditPlugin) OnStartup(config plugin.Config) error {
 }
 
 func (p *auditPlugin) OnConnect(config plugin.Config) error {
-	log.Printf("session=%v | audit | processing on-connect", config.SessionId)
+	p.log.With("session", config.SessionId).Infof("processing on-connect")
 	if config.Org == "" || config.SessionId == "" {
 		return fmt.Errorf("failed processing audit plugin, missing org_id and session_id params")
 	}
@@ -110,13 +118,56 @@ func (p *auditPlugin) OnReceive(pluginConfig plugin.Config, config []string, pkt
 	return nil
 }
 
-func (p *auditPlugin) OnDisconnect(config plugin.Config) error {
-	if config.Org == "" || config.SessionId == "" {
-		return fmt.Errorf("missing org_id and session_id")
-	}
+func (p *auditPlugin) OnDisconnect(config plugin.Config, errMsg error) error {
+	p.log.With("session", config.SessionId, "origin", config.GetString("client")).
+		Debugf("processing disconnect")
 	switch config.GetString("client") {
 	case pb.ConnectionOriginClient:
-		p.closeSession(config.SessionId)
+		defer p.closeSession(config.SessionId)
+		if errMsg != nil {
+			_ = p.writeOnReceive(config.SessionId, 'e', 0, []byte(errMsg.Error()))
+			return nil
+		}
+	case pb.ConnectionOriginClientAPI:
+		if errMsg != nil {
+			// on errors, close the session right away
+			_ = p.writeOnReceive(config.SessionId, 'e', 0, []byte(errMsg.Error()))
+			p.closeSession(config.SessionId)
+			return nil
+		}
+		// keep the connection open to let packets flow async
+	case pb.ConnectionOriginAgent:
+		agentID := config.GetString("disconnect-agent-id")
+		if agentID != "" {
+			p.log.Warnf("agent %v was shutdown, graceful closing sessions", agentID)
+			// always close all sessions of this agent when it disconnects
+			// there's no capability of recovering the state of execution
+			// when this condition is present.
+			for key := range config.ParamsData {
+				if !strings.HasPrefix(key, agentID) {
+					continue
+				}
+				_, sessionID, found := strings.Cut(key, ":")
+				if !found {
+					continue
+				}
+				p.log.With("session", sessionID).Infof("closing session, agent %v was shutdown", agentID)
+				if errMsg != nil {
+					_ = p.writeOnReceive(sessionID, 'e', 0, []byte(errMsg.Error()))
+					p.closeSession(sessionID)
+					continue
+				}
+				p.closeSession(sessionID)
+			}
+			return nil
+		}
+		// it close sessions that are being processed async
+		// e.g.: when it receives a session close packet
+		defer p.closeSession(config.SessionId)
+		if errMsg != nil {
+			_ = p.writeOnReceive(config.SessionId, 'e', 0, []byte(errMsg.Error()))
+			return nil
+		}
 	}
 	return nil
 }
@@ -124,7 +175,7 @@ func (p *auditPlugin) OnDisconnect(config plugin.Config) error {
 func (p *auditPlugin) closeSession(sessionID string) {
 	go func() {
 		if err := p.writeOnClose(sessionID); err != nil {
-			log.Printf("session=%v audit - failed closing session: %v", sessionID, err)
+			p.log.Warnf("session=%v - failed closing session: %v", sessionID, err)
 		}
 	}()
 }
@@ -138,7 +189,7 @@ func decodeDlpSummary(pkt *pb.Packet) int64 {
 	}
 	var ts []*pbdlp.TransformationSummary
 	if err := pb.GobDecodeInto(tsEnc, &ts); err != nil {
-		log.Printf("failed decoding dlp transformation summary, err=%v", err)
+		log.With("plugin", "audit").Errorf("failed decoding dlp transformation summary, err=%v", err)
 		sentry.CaptureException(err)
 		return 0
 	}

--- a/gateway/transport/plugins/dlp/dlp.go
+++ b/gateway/transport/plugins/dlp/dlp.go
@@ -18,24 +18,12 @@ func New() *dlpPlugin {
 	return &dlpPlugin{name: Name}
 }
 
-func (p *dlpPlugin) Name() string {
-	return p.name
-}
-
-func (p *dlpPlugin) OnStartup(config plugin.Config) error {
-	return nil
-}
-
-func (p *dlpPlugin) OnConnect(config plugin.Config) error {
-	return nil
-}
-
+func (p *dlpPlugin) Name() string                         { return p.name }
+func (p *dlpPlugin) OnStartup(config plugin.Config) error { return nil }
+func (p *dlpPlugin) OnConnect(config plugin.Config) error { return nil }
 func (p *dlpPlugin) OnReceive(pluginConfig plugin.Config, config []string, pkt *pb.Packet) error {
 	return nil
 }
 
-func (p *dlpPlugin) OnDisconnect(config plugin.Config) error {
-	return nil
-}
-
-func (p *dlpPlugin) OnShutdown() {}
+func (p *dlpPlugin) OnDisconnect(config plugin.Config, errMsg error) error { return nil }
+func (p *dlpPlugin) OnShutdown()                                           {}

--- a/gateway/transport/plugins/index/index.go
+++ b/gateway/transport/plugins/index/index.go
@@ -114,7 +114,7 @@ func (p *indexPlugin) OnReceive(c plugin.Config, config []string, pkt *pb.Packet
 	return nil
 }
 
-func (p *indexPlugin) OnDisconnect(config plugin.Config) error {
+func (p *indexPlugin) OnDisconnect(config plugin.Config, errMsg error) error {
 	if config.Org == "" || config.SessionId == "" {
 		return fmt.Errorf("missing org_id and session_id")
 	}

--- a/gateway/transport/plugins/jit/jit.go
+++ b/gateway/transport/plugins/jit/jit.go
@@ -46,9 +46,7 @@ func New(apiURL string) *jitPlugin {
 		apiURL: apiURL}
 }
 
-func (r *jitPlugin) Name() string {
-	return r.name
-}
+func (r *jitPlugin) Name() string { return r.name }
 
 func (r *jitPlugin) OnStartup(config plugin.Config) error {
 	log.Printf("session=%v | jit | processing on-startup", config.SessionId)
@@ -85,7 +83,9 @@ func (r *jitPlugin) OnConnect(config plugin.Config) error {
 	if config.Org == "" || config.SessionId == "" {
 		return fmt.Errorf("failed processing jit plugin, missing org_id and session_id params")
 	}
-
+	if config.Verb != pb.ClientVerbConnect {
+		return fmt.Errorf("connection subject to jit, use 'hoop connect %s' to interact", config.ConnectionName)
+	}
 	return nil
 }
 
@@ -164,11 +164,8 @@ func (r *jitPlugin) OnReceive(pluginConfig plugin.Config, config []string, pkt *
 	return nil
 }
 
-func (r *jitPlugin) OnDisconnect(config plugin.Config) error {
-	return nil
-}
-
-func (r *jitPlugin) OnShutdown() {}
+func (r *jitPlugin) OnDisconnect(config plugin.Config, errMsg error) error { return nil }
+func (r *jitPlugin) OnShutdown()                                           {}
 
 func (r *jitPlugin) buildReviewUrl(reviewID string) string {
 	url := fmt.Sprintf("%s/plugins/jits/%s", r.apiURL, reviewID)

--- a/gateway/transport/plugins/review/review.go
+++ b/gateway/transport/plugins/review/review.go
@@ -85,7 +85,12 @@ func (r *reviewPlugin) OnConnect(config plugin.Config) error {
 	if config.Org == "" || config.SessionId == "" {
 		return fmt.Errorf("failed processing review plugin, missing org_id and session_id params")
 	}
-
+	if config.Verb != pb.ClientVerbExec {
+		if config.ConnectionType != pb.ConnectionTypeCommandLine {
+			return fmt.Errorf("the review plugin can't be used for this connection type, contact the administrator")
+		}
+		return fmt.Errorf("connection subject to review, use 'hoop exec %s' to interact", config.ConnectionName)
+	}
 	return nil
 }
 
@@ -155,9 +160,7 @@ func (r *reviewPlugin) OnReceive(pluginConfig plugin.Config, config []string, pk
 	return nil
 }
 
-func (r *reviewPlugin) OnDisconnect(config plugin.Config) error {
-	return nil
-}
+func (r *reviewPlugin) OnDisconnect(config plugin.Config, errMsg error) error { return nil }
 
 func (r *reviewPlugin) OnShutdown() {}
 


### PR DESCRIPTION
- [agent] Connect non-tls when mode env is set and address is 127.0.0.1
- [gateway] Fix session status bug not generating unique id throughout a session state
- [gateway] Close all sessions when an agent disconnects
- [gateway] End sessions gracefully when gateway is shutting down
- Add strict check when trying to exec into a non command-line type connection