### PR TITLE
fix(session) execute session rule for session owner

### DIFF
--- a/gateway/session/api.go
+++ b/gateway/session/api.go
@@ -196,7 +196,13 @@ func (h *Handler) RunExec(c *gin.Context) {
 		c.JSON(http.StatusNotFound, &clientexec.ExecErrResponse{Message: "review not found"})
 		return
 	}
-	if review.CreatedBy.Email != ctx.User.Email {
+
+	session, err := h.Service.FindOne(ctx, sessionId)
+	if session == nil || err != nil {
+		c.JSON(http.StatusNotFound, &clientexec.ExecErrResponse{Message: "session not found"})
+	}
+
+	if session.UserEmail != ctx.User.Email {
 		c.JSON(http.StatusBadRequest, &clientexec.ExecErrResponse{Message: "only the creator can trigger this action"})
 		return
 	}


### PR DESCRIPTION
This PR changes the owner verification from the review to the session for two reasons:

1. somehow this verification would fail and still needs some investigation, somewhere it wrongly saves the user email in the review or there is some logic that the data is not buggy, but we're misusing it here
2. it makes more sense to compare the email with the session since we need the session owner to execute it.