### PR TITLE
General Enhancements for Client Proxies

### DIFF
--- a/client/proxy/closer.go
+++ b/client/proxy/closer.go
@@ -1,0 +1,8 @@
+package proxy
+
+import "io"
+
+type Closer interface {
+	io.Closer
+	CloseTCPConnection(connectionID string)
+}

--- a/client/proxy/mysql.go
+++ b/client/proxy/mysql.go
@@ -94,12 +94,13 @@ func (s *MySQLServer) PacketWriteClient(connectionID string, pkt *pb.Packet) (in
 	return conn.Write(pkt.Payload)
 }
 
-func (s *MySQLServer) PacketCloseConnection(connectionID string) {
+func (s *MySQLServer) CloseTCPConnection(connectionID string) {
 	if conn, err := s.getConnection(connectionID); err == nil {
 		_ = conn.Close()
 	}
-	_ = s.listener.Close()
 }
+
+func (s *MySQLServer) Close() error { return s.listener.Close() }
 
 func (s *MySQLServer) getConnection(connectionID string) (io.WriteCloser, error) {
 	connWrapperObj := s.connectionStore.Get(connectionID)

--- a/client/proxy/pg.go
+++ b/client/proxy/pg.go
@@ -92,12 +92,13 @@ func (p *PGServer) PacketWriteClient(connectionID string, pkt *pb.Packet) (int, 
 	return conn.Write(pkt.Payload)
 }
 
-func (p *PGServer) PacketCloseConnection(connectionID string) {
+func (p *PGServer) CloseTCPConnection(connectionID string) {
 	if conn, err := p.getConnection(connectionID); err == nil {
 		_ = conn.Close()
 	}
-	_ = p.listener.Close()
 }
+
+func (p *PGServer) Close() error { return p.listener.Close() }
 
 func (p *PGServer) getConnection(connectionID string) (io.WriteCloser, error) {
 	connWrapperObj := p.connectionStore.Get(connectionID)

--- a/client/proxy/tcp.go
+++ b/client/proxy/tcp.go
@@ -99,12 +99,13 @@ func (p *TCPServer) PacketWriteClient(connectionID string, pkt *pb.Packet) (int,
 	return conn.Write(pkt.Payload)
 }
 
-func (p *TCPServer) PacketCloseConnection(connectionID string) {
+func (p *TCPServer) CloseTCPConnection(connectionID string) {
 	if conn, err := p.getConnection(connectionID); err == nil {
 		_ = conn.Close()
 	}
-	_ = p.listener.Close()
 }
+
+func (p *TCPServer) Close() error { return p.listener.Close() }
 
 func (p *TCPServer) getConnection(connectionID string) (io.WriteCloser, error) {
 	connWrapperObj := p.connectionStore.Get(connectionID)

--- a/client/proxy/terminal.go
+++ b/client/proxy/terminal.go
@@ -88,7 +88,9 @@ func (t *Terminal) restoreTerm() {
 	}
 }
 
-func (t *Terminal) Close() {
+func (t *Terminal) CloseTCPConnection(_ string) {}
+func (t *Terminal) Close() error {
 	t.restoreTerm()
 	_, _ = t.client.Close()
+	return nil
 }

--- a/gateway/storagev2/clientstate/clientstate.go
+++ b/gateway/storagev2/clientstate/clientstate.go
@@ -3,6 +3,7 @@ package clientstate
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/runopsio/hoop/gateway/storagev2"
@@ -44,8 +45,9 @@ func Update(ctx *storagev2.Context, status types.ClientStatusType, opts ...*opti
 	// status ready must reset attributes
 	if obj == nil || status == types.ClientStatusReady {
 		obj = &types.Client{
-			ID:    xtuid.String(),
-			OrgID: ctx.OrgID,
+			ID:          xtuid.String(),
+			OrgID:       ctx.OrgID,
+			ConnectedAt: time.Now().UTC(),
 		}
 	}
 

--- a/gateway/storagev2/types/types.go
+++ b/gateway/storagev2/types/types.go
@@ -28,4 +28,5 @@ type Client struct {
 	RequestPort           string            `edn:"client/request-port"`
 	RequestAccessDuration time.Duration     `edn:"client/access-duration"`
 	ClientMetadata        map[string]string `edn:"client/metadata"`
+	ConnectedAt           time.Time         `edn:"client/connected-at"`
 }


### PR DESCRIPTION
- fix client proxy closing after tcp disconnects
- fix wrong parsing of connection params for tcp type
- make distinction between closing tcp connections and sessions
- add connected-at attribute to proxymanager endpoint

Ref: https://3.basecamp.com/5385186/buckets/28171754/todos/6223622451
Ref: https://3.basecamp.com/5385186/buckets/28171754/todos/6229060431