### PR TITLE
Allow postgres and mysql types connections to be less strictly

### DIFF
--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -169,10 +169,10 @@ func (s *Server) subscribeClient(stream pb.Transport_ConnectServer, token string
 
 	switch string(conn.Type) {
 	case pb.ConnectionTypeCommandLine: // noop - this type can connect/exec
-	default: // tcp, mysql, postgres
+	case pb.ConnectionTypeTCP:
 		if clientVerb == pb.ClientVerbExec {
 			return status.Errorf(codes.InvalidArgument,
-				fmt.Sprintf("exec is only allowed to command-line type connections. Use 'hoop connect %s' instead", conn.Name))
+				fmt.Sprintf("exec is not allowed for tcp type connections. Use 'hoop connect %s' instead", conn.Name))
 		}
 	}
 


### PR DESCRIPTION
This PR allows creating a postgres or mysql type along with a command entrypoint, making the connection to work with both verbs:

Examples:

```sh
hoop admin create conn pg \
    --overwrite \
    -a default \
    --type postgres \
    -e HOST=192.168.15.48 -e PORT=5444 -e USER=bob -e PASS=1a2b3c4d -e PGPASSWORD=1a2b3c4d \
    -- psql -h '$HOST' -U '$USER' --port 5444

# connect via IDE
hoop connect pg
# use the psql utility
hoop exec pg -- dellstore -c "select now()"
```

```sh
hoop admin create conn mysql \
    --overwrite \
    -a default \
    --type mysql \
    -e HOST=192.168.15.48 -e PORT=3310 -e USER=admin -e PASS=1a2b3c4d -e MYSQL_PWD=1a2b3c4d \
    -- mysql -h '$HOST' -u '$USER' --port 3310

# connect via IDE
hoop connect mysql
# use the mysql utility
hoop exec mysql -- -D mydb -Bse "select now()"
```