### PR TITLE
add review complementar inputs

### DIFF
--- a/gateway/api/review/review.go
+++ b/gateway/api/review/review.go
@@ -58,15 +58,17 @@ func GetById(c *gin.Context) {
 	}
 
 	c.PureJSON(http.StatusOK, types.ReviewJSON{
-		Id:             review.Id,
-		OrgId:          review.OrgId,
-		CreatedAt:      review.CreatedAt,
-		Type:           review.Type,
-		Session:        review.Session,
-		Input:          review.Input,
-		AccessDuration: review.AccessDuration,
-		Status:         review.Status,
-		RevokeAt:       review.RevokeAt,
+		Id:              review.Id,
+		OrgId:           review.OrgId,
+		CreatedAt:       review.CreatedAt,
+		Type:            review.Type,
+		Session:         review.Session,
+		Input:           review.Input,
+		InputEnvVars:    review.InputEnvVars,
+		InputClientArgs: review.InputClientArgs,
+		AccessDuration:  review.AccessDuration,
+		Status:          review.Status,
+		RevokeAt:        review.RevokeAt,
 		ReviewOwner: types.ReviewOwner{
 			Id:    reviewOwnerToStringFn("xt/id"),
 			Name:  reviewOwnerToStringFn("user/name"),

--- a/gateway/review/api.go
+++ b/gateway/review/api.go
@@ -116,15 +116,17 @@ func sanitizeReview(review *types.Review) types.ReviewJSON {
 	}
 
 	return types.ReviewJSON{
-		Id:             review.Id,
-		OrgId:          review.OrgId,
-		CreatedAt:      review.CreatedAt,
-		Type:           review.Type,
-		Session:        review.Session,
-		Input:          review.Input,
-		AccessDuration: review.AccessDuration,
-		Status:         review.Status,
-		RevokeAt:       review.RevokeAt,
+		Id:              review.Id,
+		OrgId:           review.OrgId,
+		CreatedAt:       review.CreatedAt,
+		Type:            review.Type,
+		Session:         review.Session,
+		Input:           review.Input,
+		InputEnvVars:    review.InputEnvVars,
+		InputClientArgs: review.InputClientArgs,
+		AccessDuration:  review.AccessDuration,
+		Status:          review.Status,
+		RevokeAt:        review.RevokeAt,
 		ReviewOwner: types.ReviewOwner{
 			Id:    reviewOwnerToStringFn("xt/id"),
 			Name:  reviewOwnerToStringFn("user/name"),

--- a/gateway/review/service.go
+++ b/gateway/review/service.go
@@ -83,6 +83,8 @@ func (s *Service) Persist(context *user.Context, review *types.Review) error {
 		CreatedBy:        review.ReviewOwner.Id,
 		ReviewOwner:      review.ReviewOwner,
 		Input:            review.Input,
+		InputEnvVars:     review.InputEnvVars,
+		InputClientArgs:  review.InputClientArgs,
 		AccessDuration:   review.AccessDuration,
 		RevokeAt:         review.RevokeAt,
 		Status:           review.Status,

--- a/gateway/review/storage.go
+++ b/gateway/review/storage.go
@@ -26,6 +26,8 @@ func (s *Storage) FindAll(context *user.Context) ([]types.Review, error) {
 						:review/access-duration
 						:review/approved-at
 						:review/input
+						:review/input-envvars
+						:review/input-clientargs
 						:review/session
 						:review/connection
 						:review/created-by
@@ -58,6 +60,8 @@ func (s *Storage) FindApprovedJitReviews(ctx *user.Context, connID string) (*typ
 						:review/access-duration
 						:review/revoke-at
 						:review/input
+						:review/input-envvars
+						:review/input-clientargs
 						:review/session
 						:review/connection
 						:review/created-by
@@ -261,6 +265,8 @@ func (s *Storage) Persist(ctx *user.Context, review *types.Review) (int64, error
 		CreatedBy:        review.CreatedBy,
 		ReviewOwner:      review.ReviewOwner,
 		Input:            review.Input,
+		InputEnvVars:     review.InputEnvVars,
+		InputClientArgs:  review.InputClientArgs,
 		AccessDuration:   review.AccessDuration,
 		RevokeAt:         review.RevokeAt,
 		Status:           review.Status,

--- a/gateway/session/api.go
+++ b/gateway/session/api.go
@@ -116,6 +116,8 @@ func (a *Handler) FindOne(c *gin.Context) {
 			Type:             review.Type,
 			Session:          review.Session,
 			Input:            review.Input,
+			InputEnvVars:     review.InputEnvVars,
+			InputClientArgs:  review.InputClientArgs,
 			AccessDuration:   review.AccessDuration,
 			Status:           review.Status,
 			RevokeAt:         review.RevokeAt,
@@ -307,7 +309,7 @@ func (h *Handler) RunReviewedExec(c *gin.Context) {
 		defer close(clientResp)
 		defer client.Close()
 		select {
-		case clientResp <- client.Run([]byte(review.Input), nil):
+		case clientResp <- client.Run([]byte(review.Input), review.InputEnvVars, review.InputClientArgs...):
 		default:
 		}
 	}()

--- a/gateway/storagev2/types/types.go
+++ b/gateway/storagev2/types/types.go
@@ -110,36 +110,40 @@ type ReviewGroup struct {
 }
 
 type Review struct {
-	Id               string           `edn:"xt/id"`
-	OrgId            string           `edn:"review/org"`
-	CreatedAt        time.Time        `edn:"review/created-at"`
-	Type             string           `edn:"review/type"`
-	Session          string           `edn:"review/session"`
-	Input            string           `edn:"review/input"`
-	AccessDuration   time.Duration    `edn:"review/access-duration"`
-	Status           ReviewStatus     `edn:"review/status"`
-	RevokeAt         *time.Time       `edn:"review/revoke-at"`
-	CreatedBy        any              `edn:"review/created-by"`
-	ReviewOwner      ReviewOwner      `edn:"review/review-owner"`
-	ConnectionId     any              `edn:"review/connection"`
-	Connection       ReviewConnection `edn:"review/review-connection"`
-	ReviewGroupsIds  []string         `edn:"review/review-groups"`
-	ReviewGroupsData []ReviewGroup    `edn:"review/review-groups-data"`
+	Id               string            `edn:"xt/id"`
+	OrgId            string            `edn:"review/org"`
+	CreatedAt        time.Time         `edn:"review/created-at"`
+	Type             string            `edn:"review/type"`
+	Session          string            `edn:"review/session"`
+	Input            string            `edn:"review/input"`
+	InputEnvVars     map[string]string `edn:"review/input-envvars"`
+	InputClientArgs  []string          `edn:"review/input-clientargs"`
+	AccessDuration   time.Duration     `edn:"review/access-duration"`
+	Status           ReviewStatus      `edn:"review/status"`
+	RevokeAt         *time.Time        `edn:"review/revoke-at"`
+	CreatedBy        any               `edn:"review/created-by"`
+	ReviewOwner      ReviewOwner       `edn:"review/review-owner"`
+	ConnectionId     any               `edn:"review/connection"`
+	Connection       ReviewConnection  `edn:"review/review-connection"`
+	ReviewGroupsIds  []string          `edn:"review/review-groups"`
+	ReviewGroupsData []ReviewGroup     `edn:"review/review-groups-data"`
 }
 
 type ReviewJSON struct {
-	Id               string           `json:"id"`
-	OrgId            string           `json:"org"`
-	CreatedAt        time.Time        `json:"created_at"`
-	Type             string           `json:"type"`
-	Session          string           `json:"session"`
-	Input            string           `json:"input"`
-	AccessDuration   time.Duration    `json:"access_duration"`
-	Status           ReviewStatus     `json:"status"`
-	RevokeAt         *time.Time       `json:"revoke_at"`
-	ReviewOwner      ReviewOwner      `json:"review_owner"`
-	Connection       ReviewConnection `json:"review_connection"`
-	ReviewGroupsData []ReviewGroup    `json:"review_groups_data"`
+	Id               string            `json:"id"`
+	OrgId            string            `json:"org"`
+	CreatedAt        time.Time         `json:"created_at"`
+	Type             string            `json:"type"`
+	Session          string            `json:"session"`
+	Input            string            `json:"input"`
+	InputEnvVars     map[string]string `json:"input_envvars"`
+	InputClientArgs  []string          `json:"input_clientargs"`
+	AccessDuration   time.Duration     `json:"access_duration"`
+	Status           ReviewStatus      `json:"status"`
+	RevokeAt         *time.Time        `json:"revoke_at"`
+	ReviewOwner      ReviewOwner       `json:"review_owner"`
+	Connection       ReviewConnection  `json:"review_connection"`
+	ReviewGroupsData []ReviewGroup     `json:"review_groups_data"`
 }
 
 type SessionEventStream []any


### PR DESCRIPTION
This Pull Request propagates client args and environment variables that come from client executions.

- When executing runbooks env vars could be parsed and sent to the agent execution engine. This information is propagated to reviews (onetime type only) to permit re-executing them.
- When executing any command that has additional arguments (onetime and jit reviews) this data is persisted to reviews allowing re-executing them with the same arguments.

```sh
# -r is a client arg
hoop connect bash -- -r
# -c 'ls -l' is a client arg
hoop exec bash -- -c 'ls -l'
# env is an input
hoop exec bash -i 'env'
```

> Client args should be used to show as complement to input data.

Fix: https://3.basecamp.com/5385186/buckets/28171754/todos/6317418492