### PR TITLE
add proxy capabilities to new node api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ plugins/.idea/*
 common/.idea/*
 .idea/*
 .fleet/*
+.clj-kondo/*
+.lsp/*
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -67,6 +67,7 @@ func (api *Api) StartAPI(sentryInit bool) {
 	api.logger = zaplogger
 	// https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies
 	route.SetTrustedProxies(nil)
+	route.Use(proxyNodeAPIMiddleware())
 	// UI
 	staticUiPath := os.Getenv("STATIC_UI_PATH")
 	if staticUiPath == "" {


### PR DESCRIPTION
This will proxy the requests to the new node api if a client sends a request in the request path `/api/` and with the header `x-backend-api: express`.