### PR TITLE
fix creating connection with backslashed tab

### DIFF
--- a/client/cmd/admin/create-conn.go
+++ b/client/cmd/admin/create-conn.go
@@ -64,7 +64,11 @@ var createConnectionCmd = &cobra.Command{
 		apir := parseResourceOrDie(resourceArgs, method, outputFlag)
 		cmdList := []string{}
 		if len(args) > 1 {
-			cmdList = append(cmdList, args[1:]...)
+			for _, cmdparam := range args[1:] {
+				// allows passing \t literal when executing the command
+				cmdparam := strings.ReplaceAll(cmdparam, "\\t", "\t")
+				cmdList = append(cmdList, cmdparam)
+			}
 		}
 		envVar, err := parseEnvPerType()
 		if err != nil {

--- a/gateway/connection/api.go
+++ b/gateway/connection/api.go
@@ -90,11 +90,13 @@ func (a *Handler) Post(c *gin.Context) {
 		return
 	}
 
-	switch string(connection.Type) {
-	case pb.ConnectionTypePostgres:
-		connection.Command = []string{"psql", "-A", "-F\t", "-P", "pager=off", "-h", "$HOST", "-U", "$USER", "--port=$PORT", "$DB"}
-	case pb.ConnectionTypeMySQL:
-		connection.Command = []string{"mysql", "-h$HOST", "-u$USER", "--port=$PORT", "-D$DB"}
+	if len(connection.Command) == 0 {
+		switch string(connection.Type) {
+		case pb.ConnectionTypePostgres:
+			connection.Command = []string{"psql", "-A", "-F\t", "-P", "pager=off", "-h", "$HOST", "-U", "$USER", "--port=$PORT", "$DB"}
+		case pb.ConnectionTypeMySQL:
+			connection.Command = []string{"mysql", "-h$HOST", "-u$USER", "--port=$PORT", "-D$DB"}
+		}
 	}
 
 	_, err = a.Service.Persist("POST", context, &connection)


### PR DESCRIPTION
- Don't use a default command attribute if the client is sending.