### PR TITLE
fix decoding null data properly for Postgres with DLP

### DIFF
--- a/agent/dlp/pg.go
+++ b/agent/dlp/pg.go
@@ -148,6 +148,11 @@ func redactDataRow(dlpclient Client, conf *deidentifyConfig, dataRows *bytes.Buf
 			if err != nil {
 				return &Chunk{data: dataRows}, fmt.Errorf("failed reading column (idx=%v,len=%v), err=%v", i, columnLength, err)
 			}
+			// allows decoding this value to the proper type when the data
+			// is returning from the dlp service
+			if columnLength == pgtypes.ServerDataRowNull {
+				columnData = []byte(pg.DLPColumnNullType)
+			}
 			// must append it only once
 			if len(tableInput.Headers) < int(columnNumbers) {
 				tableInput.Headers = append(tableInput.Headers, &dlppb.FieldId{Name: fmt.Sprintf("%v", i)})

--- a/agent/dlp/types.go
+++ b/agent/dlp/types.go
@@ -2,9 +2,10 @@ package dlp
 
 import (
 	"bytes"
+	"context"
+
 	dlp "cloud.google.com/go/dlp/apiv2"
 	"cloud.google.com/go/dlp/apiv2/dlppb"
-	"context"
 	pbdlp "github.com/runopsio/hoop/common/dlp"
 	pb "github.com/runopsio/hoop/common/proto"
 )

--- a/agent/pg/dlp.go
+++ b/agent/pg/dlp.go
@@ -1,0 +1,5 @@
+package pg
+
+const (
+	DLPColumnNullType = "__hooptypes:NULL"
+)

--- a/agent/pg/packet.go
+++ b/agent/pg/packet.go
@@ -195,6 +195,11 @@ func NewDataRowPacket(fieldCount uint16, dataRowValues ...string) *Packet {
 	p.frame = append(p.frame, fieldCountBytes[:]...)
 	for _, val := range dataRowValues {
 		var columnLen [4]byte
+		if val == DLPColumnNullType {
+			binary.BigEndian.PutUint32(columnLen[:], pg.ServerDataRowNull)
+			p.frame = append(p.frame, columnLen[:]...)
+			continue
+		}
 		binary.BigEndian.PutUint32(columnLen[:], uint32(len(val)))
 		p.frame = append(p.frame, columnLen[:]...)
 		p.frame = append(p.frame, []byte(val)...)

--- a/client/cmd/config/config.go
+++ b/client/cmd/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/runopsio/hoop/client/cmd/styles"
 	clientconfig "github.com/runopsio/hoop/client/config"
@@ -30,8 +29,8 @@ func init() {
 
 var MainCmd = &cobra.Command{
 	Use:          "config",
-	Short:        "It manages the hoop configuration file",
-	Hidden:       true,
+	Short:        "Manage the hoop configuration file",
+	Hidden:       false,
 	SilenceUsage: false,
 }
 
@@ -40,10 +39,6 @@ var createCmd = &cobra.Command{
 	Short:        "Creates or override a client hoop configuration file",
 	SilenceUsage: false,
 	Run: func(cmd *cobra.Command, args []string) {
-		accessToken := os.Getenv("HOOP_TOKEN")
-		if accessToken == "" {
-			styles.PrintErrorAndExit("missing HOOP_TOKEN environment variable")
-		}
 		if _, err := grpc.ParseServerAddress(grpcURLFlag); err != nil {
 			styles.PrintErrorAndExit("--grpc-url value is not a gRPC address")
 		}
@@ -52,11 +47,7 @@ var createCmd = &cobra.Command{
 			styles.PrintErrorAndExit("--api-url value is not an http address")
 		}
 
-		if len(strings.Split(accessToken, ".")) != 3 {
-			styles.PrintErrorAndExit("access token is not a jwt token")
-		}
-
-		filepath, err := clientconfig.NewConfigFile(apiURLFlag, grpcURLFlag, accessToken)
+		filepath, err := clientconfig.NewConfigFile(apiURLFlag, grpcURLFlag, os.Getenv("HOOP_TOKEN"))
 		if err != nil {
 			styles.PrintErrorAndExit("failed creating configuration file, err=%v", err)
 		}
@@ -66,7 +57,7 @@ var createCmd = &cobra.Command{
 
 var viewCmd = &cobra.Command{
 	Use:          "view",
-	Short:        "Show the client hoop configuration file",
+	Short:        "Show the current configuration",
 	SilenceUsage: false,
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clientconfig.GetClientConfigOrDie()

--- a/gateway/api/plugins/plugin.go
+++ b/gateway/api/plugins/plugin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/runopsio/hoop/common/log"
+	"github.com/runopsio/hoop/common/proto"
 	"github.com/runopsio/hoop/gateway/storagev2"
 	connectionstorage "github.com/runopsio/hoop/gateway/storagev2/connection"
 	pluginstorage "github.com/runopsio/hoop/gateway/storagev2/plugin"
@@ -253,6 +254,10 @@ func parsePluginConnections(c *gin.Context, req PluginRequest) ([]*types.PluginC
 			c.JSON(http.StatusUnprocessableEntity, gin.H{"message": msg})
 			return nil, nil, io.EOF
 		}
+		connConfig := reqconn.Config
+		if req.Name == plugintypes.PluginDLPName && len(connConfig) == 0 {
+			connConfig = proto.DefaultInfoTypes
+		}
 		// create deterministic uuid to allow plugin connection entities
 		// to be updated instead of generating new ones
 		docUUID := uuid.NewSHA1(uuid.NameSpaceURL, bytes.NewBufferString(fmt.Sprintf("%s:%s", req.Name, conn.Id)).Bytes())
@@ -260,7 +265,7 @@ func parsePluginConnections(c *gin.Context, req PluginRequest) ([]*types.PluginC
 			ID:           docUUID.String(),
 			ConnectionID: conn.Id,
 			Name:         conn.Name,
-			Config:       reqconn.Config,
+			Config:       connConfig,
 		})
 		connectionIDs = append(connectionIDs, docUUID.String())
 	}

--- a/gateway/connection/api.go
+++ b/gateway/connection/api.go
@@ -224,6 +224,7 @@ func (h *Handler) RunExec(c *gin.Context) {
 	err = sessionStorage.Write(storageCtx, newSession)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"message": "The session couldn't be created"})
+		return
 	}
 
 	sessionapi.RunExec(c, newSession, body.ClientArgs)

--- a/gateway/connection/service.go
+++ b/gateway/connection/service.go
@@ -113,6 +113,9 @@ func (s *Service) Evict(ctx *user.Context, connectionName string) error {
 }
 
 func (s *Service) FindOne(context *user.Context, name string) (*Connection, error) {
+	if name == "" {
+		return nil, nil
+	}
 	result, err := s.Storage.FindOne(context, name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- return proper error when a connection does not exists
- allow configuring configuration file without strictly requiring access token
- add default info types when reconfiguring dlp plugin