### PR TITLE
Increase max receive size of gRPC clients: 4MB to 16MB

### DIFF
--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -182,6 +182,7 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 				fmt.Println("------------------------------------------------------")
 				fmt.Println("ready to accept connections!")
 			case pb.ConnectionTypeCommandLine:
+				// https://github.com/creack/pty/issues/95
 				if runtime.GOOS == "windows" {
 					fmt.Println("command line is not supported on Windows")
 					os.Exit(1)

--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -39,10 +38,6 @@ var execCmd = &cobra.Command{
 	Use:   "exec CONNECTION",
 	Short: "Execute a given input in a remote resource",
 	PreRun: func(cmd *cobra.Command, args []string) {
-		if runtime.GOOS == "windows" {
-			fmt.Println("exec is not supported on Windows")
-			os.Exit(1)
-		}
 		if len(args) < 1 {
 			cmd.Usage()
 			os.Exit(1)

--- a/client/proxy/pg.go
+++ b/client/proxy/pg.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -140,6 +141,11 @@ func copyBuffer(dst io.Writer, src io.Reader) (written int64, err error) {
 				if pktLen > frameSize {
 					fullBuffer = append(fullBuffer, buf[0:nr]...)
 					continue
+				}
+				if pktLen != frameSize {
+					log.With("type", "simple").Warnf("action=begin, unknown packet format (frame/header) %v/%v",
+						frameSize, pktLen)
+					fmt.Println(hex.Dump(buf[0:nr]))
 				}
 			case pg.ClientParse:
 				return 0, fmt.Errorf("extended query protocol is not supported")

--- a/common/grpc/client.go
+++ b/common/grpc/client.go
@@ -55,6 +55,8 @@ const (
 	OptionUserInfo       OptionKey = "user-info"
 	OptionConnectionInfo OptionKey = "connection-info"
 	LocalhostAddr                  = "127.0.0.1:8010"
+
+	MaxRecvMsgSize int = 1024 * 1024 * 16
 )
 
 func WithOption(optKey OptionKey, val string) *ClientOptions {
@@ -82,7 +84,11 @@ func Connect(clientConfig ClientConfig, opts ...*ClientOptions) (pb.ClientTransp
 		return connect(clientConfig.ServerAddress,
 			[]grpc.DialOption{
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithUserAgent(clientConfig.UserAgent)},
+				grpc.WithUserAgent(clientConfig.UserAgent),
+				grpc.WithDefaultCallOptions(
+					grpc.MaxCallRecvMsgSize(MaxRecvMsgSize),
+				),
+			},
 			opts...)
 	}
 	// TODO: it's deprecated, use oauth.TokenSource
@@ -93,6 +99,9 @@ func Connect(clientConfig ClientConfig, opts ...*ClientOptions) (pb.ClientTransp
 		grpc.WithPerRPCCredentials(rpcCred),
 		grpc.WithBlock(),
 		grpc.WithUserAgent(clientConfig.UserAgent),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(MaxRecvMsgSize),
+		),
 	}
 	return connect(clientConfig.ServerAddress, dialOptions, opts...)
 }

--- a/gateway/transport/server.go
+++ b/gateway/transport/server.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
+	commongrpc "github.com/runopsio/hoop/common/grpc"
 	"github.com/runopsio/hoop/common/log"
 	pb "github.com/runopsio/hoop/common/proto"
 	"github.com/runopsio/hoop/gateway/agent"
@@ -125,12 +126,16 @@ func (s *Server) StartRPCServer() {
 	var grpcServer *grpc.Server
 	if tlsConfig != nil {
 		grpcServer = grpc.NewServer(
+			grpc.MaxRecvMsgSize(commongrpc.MaxRecvMsgSize),
 			grpc.Creds(credentials.NewTLS(tlsConfig)),
 			grpc.StreamInterceptor(s.AuthGrpcInterceptor),
 		)
 	}
 	if grpcServer == nil {
-		grpcServer = grpc.NewServer(grpc.StreamInterceptor(s.AuthGrpcInterceptor))
+		grpcServer = grpc.NewServer(
+			grpc.MaxRecvMsgSize(commongrpc.MaxRecvMsgSize),
+			grpc.StreamInterceptor(s.AuthGrpcInterceptor),
+		)
 	}
 	pb.RegisterTransportServer(grpcServer, s)
 	s.handleGracefulShutdown()


### PR DESCRIPTION
- Dump postgres simple query packets when it has an unknown format (header size < frame)
- Allow exec to work on windows