### PR TITLE
Add condition to obtain connection from apiv2

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,6 +21,9 @@ IDP_CLIENT_SECRET=
 IDP_ISSUER=https://hoophq.us.auth0.com/
 IDP_AUDIENCE=https://hoophq.us.auth0.com/api/v2/
 
+# the address of the node api proxy (host:port)
+NODE_API_ADDR=127.0.0.1:4001
+
 # dlp gcp credentials
 GOOGLE_APPLICATION_CREDENTIALS_JSON=
 

--- a/client/cmd/admin/admin.go
+++ b/client/cmd/admin/admin.go
@@ -4,11 +4,17 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/runopsio/hoop/client/cmd/styles"
 	clientconfig "github.com/runopsio/hoop/client/config"
 	"github.com/runopsio/hoop/common/version"
 	"github.com/spf13/cobra"
+)
+
+var (
+	hoopVersionStr = version.Get().Version
+	expressApiFlag bool
 )
 
 func init() {
@@ -17,9 +23,13 @@ func init() {
 	MainCmd.AddCommand(createCmd)
 	MainCmd.AddCommand(gatewayInfoCmd)
 	MainCmd.AddCommand(targetToConnection)
-}
+	MainCmd.PersistentFlags().BoolVar(&expressApiFlag, "apiv2", false, "perform request in the new api")
+	_ = MainCmd.PersistentFlags().MarkHidden("apiv2")
 
-var hoopVersionStr = version.Get().Version
+	if os.Getenv("HOOP_APIV2") == "true" {
+		expressApiFlag = true
+	}
+}
 
 var MainCmd = &cobra.Command{
 	Use:   "admin",

--- a/client/cmd/admin/apiutils.go
+++ b/client/cmd/admin/apiutils.go
@@ -170,9 +170,9 @@ func parseResourceOrDie(args []string, method, outputFlag string) *apiResource {
 		apir.decodeTo = "raw"
 	}
 
-	log.Debugf("decode=%v, method=%v, create=%v, list=%v, get=%v, delete=%v, path=%v",
+	log.Debugf("decode=%v, method=%v, create=%v, list=%v, get=%v, delete=%v, apiv2=%v, path=%v",
 		apir.decodeTo, apir.method, apir.resourceCreate, apir.resourceList,
-		apir.resourceGet, apir.resourceDelete, apir.suffixEndpoint)
+		apir.resourceGet, apir.resourceDelete, expressApiFlag, apir.suffixEndpoint)
 	return apir
 }
 
@@ -197,6 +197,10 @@ func httpRequest(apir *apiResource) (any, http.Header, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed creating http request, err=%v", err)
 	}
+	if expressApiFlag {
+		req.Header.Set("x-backend-api", "express")
+	}
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", apir.conf.Token))
 	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", hoopVersionStr))
 	resp, err := http.DefaultClient.Do(req)
@@ -245,6 +249,10 @@ func httpDeleteRequest(apir *apiResource) error {
 	if err != nil {
 		return fmt.Errorf("failed creating http request, err=%v", err)
 	}
+	if expressApiFlag {
+		req.Header.Set("x-backend-api", "express")
+	}
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", apir.conf.Token))
 	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", hoopVersionStr))
 	resp, err := http.DefaultClient.Do(req)
@@ -277,6 +285,10 @@ func httpBodyRequest(apir *apiResource, method string, bodyMap map[string]any) (
 		return nil, fmt.Errorf("failed creating http request, err=%v", err)
 	}
 
+	if expressApiFlag {
+		req.Header.Set("x-backend-api", "express")
+	}
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", apir.conf.Token))
 	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", hoopVersionStr))
 	resp, err := http.DefaultClient.Do(req)

--- a/client/cmd/admin/create-conn.go
+++ b/client/cmd/admin/create-conn.go
@@ -103,6 +103,9 @@ var createConnectionCmd = &cobra.Command{
 			"command":  cmdList,
 			"secret":   envVar,
 			"agent_id": agentID,
+			// apiv2
+			"agentId": agentID,
+			"secrets": envVar,
 		}
 
 		resp, err := httpBodyRequest(apir, method, connectionBody)

--- a/client/cmd/admin/get.go
+++ b/client/cmd/admin/get.go
@@ -65,12 +65,12 @@ var getCmd = &cobra.Command{
 			switch contents := obj.(type) {
 			case map[string]any:
 				m := contents
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t",
+				fmt.Fprintf(w, "%s\t%s\t%v\t%v\t%v\t%s\t",
 					m["id"], m["name"], m["version"], m["hostname"], m["platform"], normalizeStatus(m["status"]))
 				fmt.Fprintln(w)
 			case []map[string]any:
 				for _, m := range contents {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t",
+					fmt.Fprintf(w, "%s\t%s\t%v\t%v\t%v\t%s\t",
 						m["id"], m["name"], m["version"], m["hostname"], m["platform"], normalizeStatus(m["status"]))
 					fmt.Fprintln(w)
 				}
@@ -84,9 +84,16 @@ var getCmd = &cobra.Command{
 				m := contents
 				enabledPlugins := plugingHandlerFn(fmt.Sprintf("%v", m["name"]))
 				agentID := fmt.Sprintf("%v", m["agent_id"])
+				if agentID == "" {
+					// express api
+					agentID = fmt.Sprintf("%v", m["agentId"])
+				}
 				status := agentHandlerFn("status", agentID)
 				agentName := agentHandlerFn("name", agentID)
 				secrets, _ := m["secret"].(map[string]any)
+				if secrets == nil {
+					secrets, _ = m["secrets"].(map[string]any)
+				}
 				cmdList, _ := m["command"].([]any)
 				cmd := joinCmd(cmdList)
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%v\t%s\t",

--- a/client/cmd/proxymanager.go
+++ b/client/cmd/proxymanager.go
@@ -111,7 +111,8 @@ func runAutoConnect(client pb.ClientTransport) (err error) {
 			log.With("type", connnectionType).Infof("session opened")
 			switch connnectionType {
 			case pb.ConnectionTypePostgres:
-				srv := proxy.NewPGServer(proxyPort, client)
+				listenAddr := fmt.Sprintf("127.0.0.1:%s", proxyPort)
+				srv := proxy.NewPGServer(listenAddr, client)
 				if err := srv.Serve(sid); err != nil {
 					return err
 				}

--- a/gateway/api/middleware.go
+++ b/gateway/api/middleware.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -139,10 +140,14 @@ func proxyNodeAPIMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		backendAPI := c.Request.Header.Get("x-backend-api")
 		if backendAPI == "express" && strings.HasPrefix(c.Request.URL.Path, "/api/") {
+			nodeApiUrl := os.Getenv("NODE_API_ADDR")
+			if nodeApiUrl == "" {
+				nodeApiUrl = "127.0.0.1:4001"
+			}
 			director := func(req *http.Request) {
 				req.Header = c.Request.Header
 				req.URL.Scheme = "http"
-				req.URL.Host = "127.0.0.1:4001"
+				req.URL.Host = nodeApiUrl
 				req.URL.Path = c.Request.URL.Path
 			}
 			proxy := &httputil.ReverseProxy{Director: director}

--- a/gateway/apiclient/apiclient.go
+++ b/gateway/apiclient/apiclient.go
@@ -1,0 +1,70 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/runopsio/hoop/common/log"
+	"github.com/runopsio/hoop/common/version"
+	apitypes "github.com/runopsio/hoop/gateway/apiclient/types"
+)
+
+var (
+	ErrNotFound    = fmt.Errorf("resource not found")
+	hoopVersionStr = version.Get().Version
+)
+
+type Client struct {
+	apiURL      string
+	accessToken string
+}
+
+func New(apiURL, accessToken string) *Client {
+	return &Client{apiURL: apiURL, accessToken: accessToken}
+}
+
+func httpGetRequest(apiURL, accessToken string, into any) error {
+	log.Debugf("performing http request at GET %v", apiURL)
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed creating http request, err=%v", err)
+	}
+	req.Header.Set("x-backend-api", "express")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", accessToken))
+	req.Header.Set("User-Agent", fmt.Sprintf("apiclient/%s", hoopVersionStr))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	log.Infof("http response %v, content-length=%v", resp.StatusCode, resp.ContentLength)
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return json.NewDecoder(resp.Body).Decode(into)
+	case http.StatusNotFound:
+		return ErrNotFound
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("failed performing request, status=%v, body=%v",
+		resp.StatusCode, string(respBody))
+}
+
+func (c *Client) GetConnection(name string) (*apitypes.Connection, error) {
+	var conn apitypes.Connection
+	err := httpGetRequest(fmt.Sprintf("%s/api/connections/%s", c.apiURL, name), c.accessToken, &conn)
+	switch err {
+	case ErrNotFound:
+		return nil, err
+	case nil: // noop
+	default:
+		log.Warnf("failed obtaining connection %v, reason=%v", name, err)
+		return nil, err
+	}
+	if conn.Secrets == nil {
+		conn.Secrets = map[string]any{}
+	}
+	return &conn, nil
+}

--- a/gateway/apiclient/types/types.go
+++ b/gateway/apiclient/types/types.go
@@ -1,0 +1,12 @@
+package apitypes
+
+type Connection struct {
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Type      string         `json:"type"`
+	Command   []string       `json:"command"`
+	Secrets   map[string]any `json:"secrets"`
+	AgentId   string         `json:"agentId"`
+	CreatedAt string         `json:"createdAt"`
+	UpdatedAt string         `json:"updatedAt"`
+}


### PR DESCRIPTION
It fetches the connection in the node api for all actions in the gRPC gateway, in case the connection doesn't exists or return an error from the api, it will fallback fetching from the old api.

- [cli] Adapt command line to create connections in apiv2
- [cli] Adapt command line to update connections in apiv2
- [cli] Adapt command line to create agents in apiv2
- [cli] Adapt command line to fetch connections and agents in apiv2
- [cli] Add option to direct requests to new api
- Introduce `NODE_API_ADDR` env to inform the address to proxy requests to the new api (useful in development)

## Switching to ApiV2 via command line

```sh
# via env
HOOP_APIV2=true hoop admin get conn
# or via flag
hoop admin get conn --apiv2
```

## Supported Resources / Commands

**Connections**

```sh
export HOOP_APIV2=true
# POST
hoop admin create conn <name>
# PUT request
hoop admin create conn <name> --overwrite
# GET (list)
hoop admin get conn
# GET (by name)
hoop admin get conn myconn
```

**Agents**

```sh
export HOOP_APIV2=true
# POST
hoop admin create agent <name>
# GET (list)
hoop admin get agents
# GET (by name)
hoop admin get agents default
```


