### PR TITLE
remove grpc.WithBlock() option when connecting to grpc server gateway

### DIFF
--- a/common/grpc/client.go
+++ b/common/grpc/client.go
@@ -97,7 +97,6 @@ func Connect(clientConfig ClientConfig, opts ...*ClientOptions) (pb.ClientTransp
 	dialOptions := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithPerRPCCredentials(rpcCred),
-		grpc.WithBlock(),
 		grpc.WithUserAgent(clientConfig.UserAgent),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(MaxRecvMsgSize),


### PR DESCRIPTION
Ref: https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md