### PR TITLE
fix signup invited user not reaching properly to intercom

### DIFF
--- a/gateway/analytics/events.go
+++ b/gateway/analytics/events.go
@@ -6,7 +6,7 @@ const (
 
 	EventFetchUsers             = "hoop-fetch-users"
 	EventUpdateUser             = "hoop-update-user"
-	EventCreateUser             = "hoop-create-user"
+	EventCreateInvitedUser      = "hoop-create-invited-user"
 	EventCreateConnection       = "hoop-create-connection"
 	EventCreateServiceAccount   = "hoop-create-serviceaccount"
 	EventUpdateServiceAccount   = "hoop-update-serviceaccount"

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -127,7 +127,6 @@ func (api *Api) buildRoutes(route *gin.RouterGroup) {
 		api.UserHandler.Put)
 	route.POST("/users",
 		api.Authenticate,
-		api.TrackRequest(analytics.EventCreateUser),
 		api.AdminOnly,
 		userapi.Create)
 

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -3,6 +3,7 @@ package userapi
 import (
 	"net/http"
 	"net/mail"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
@@ -58,11 +59,16 @@ func Create(c *gin.Context) {
 		UserGroups: newUser.Groups,
 	}
 	ctx.Analytics().Identify(trackInvitedUserContext)
-	ctx.Analytics().Track(trackInvitedUserContext, analytics.EventSignup,
-		map[string]any{"user-agent": c.GetHeader("user-agent")})
+	go func() {
+		// wait some time until the identify call get times to reach to intercom
+		time.Sleep(time.Second * 10)
+		ctx.Analytics().Track(trackInvitedUserContext, analytics.EventSignup,
+			map[string]any{"user-agent": c.GetHeader("user-agent")})
+		ctx.Analytics().Track(trackInvitedUserContext, analytics.EventCreateInvitedUser,
+			map[string]any{"user-agent": c.GetHeader("user-agent")})
+	}()
 
 	c.JSON(http.StatusCreated, newUser)
-
 }
 
 func GetUserByID(c *gin.Context) {


### PR DESCRIPTION
The invited user was identified and right after we sent another event. This was causing the intercom to receive a 404 message, not giving time to identify the user.