### PR TITLE
[agent] Send kill to process group to avoid stale process when a session is closed

### DIFF
--- a/agent/const.go
+++ b/agent/const.go
@@ -1,6 +1,7 @@
 package agent
 
 const (
+	execStoreKey          string = "exec:%s"
 	cmdStoreKey           string = "cmd:%s"
 	dlpClientKey          string = "dlp_client"
 	connEnvKey            string = "connenv"


### PR DESCRIPTION
- [agent] configure setpgid when issuing exec
- [agent] add cmd to agent session store to allow ending process correctly