### PR TITLE
Add tenancy_type and role attributes enum and deprecated boolean types

### DIFF
--- a/gateway/analytics/events.go
+++ b/gateway/analytics/events.go
@@ -30,10 +30,6 @@ const (
 	EventFetchReviews           = "hoop-fetch-reviews"
 	EventApiExecReview          = "hoop-api-exec-review"
 	EventSearch                 = "hoop-search"
-	EventCreateClientKey        = "hoop-create-clientkey"
-	EventFetchClientKey         = "hoop-fetch-clientkey"
-	EventUpdateClientKey        = "hoop-update-clientkey"
-	EventDeleteClientKey        = "hoop-delete-clientkey"
 	EventOpenWebhooksDashboard  = "hoop-open-webhooks-dashboard"
 
 	EventGrpcExec                = "hoop-grpc-exec"

--- a/gateway/api/apiroles.go
+++ b/gateway/api/apiroles.go
@@ -27,8 +27,8 @@ func FullAccessRole(c *gin.Context) {
 	c.Next()
 }
 
-// DefaultAccessRole grants access to admin and regular users
-func DefaultAccessRole(c *gin.Context) {
+// StandardAccessRole grants access to admin and regular users
+func StandardAccessRole(c *gin.Context) {
 	c.Set(roleContextKey, RoleDefaultAccess)
 	c.Next()
 }

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -92,8 +92,8 @@ func (api *Api) StartAPI(sentryInit bool) {
 }
 
 func (api *Api) buildRoutes(route *gin.RouterGroup) {
-	// set default role to all routes
-	route.Use(DefaultAccessRole)
+	// set standard role to all routes
+	route.Use(StandardAccessRole)
 
 	loginHandler := loginapi.New(api.IDProvider)
 	route.GET("/login", loginHandler.Login)


### PR DESCRIPTION
This PR add user attributes as enum instead of using boolean types.

It introduces the attribute `role` with the following types:

- `admin` - admin user, permit accessing admin api routes
- `standard` - standard role, access all routes except the admin
- `unregistered` - grants access to userinfo and signup (multitenant) endpoint.
- `guest` - an user invited by an administrator

The `tenancy_type` could be `multitenant` or `selfhosted`.