### PR TITLE
Change hoop run attributes to review and data-masking

### DIFF
--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -237,7 +237,7 @@ func parseClientEnvVars() (map[string]string, error) {
 			invalidEnvs = append(invalidEnvs, envvarStr)
 			continue
 		}
-		envKey := fmt.Sprintf("envvar:%s", strings.ToUpper(key))
+		envKey := fmt.Sprintf("envvar:%s", key)
 		envVar[envKey] = base64.StdEncoding.EncodeToString([]byte(val))
 	}
 	if len(invalidEnvs) > 0 {

--- a/client/cmd/run.go
+++ b/client/cmd/run.go
@@ -40,8 +40,8 @@ func init() {
 	runCmd.Flags().StringVar(&runFlags.ConnectionString, "mssql", "", "The database connection uri, e.g.: sqlserver://...")
 	runCmd.Flags().StringVar(&runFlags.ConnectionString, "mongodb", "", "The database connection uri, e.g.: mongodb://...")
 	runCmd.Flags().StringVar(&runFlags.ConnectionString, "database", "", "Generic option for providing a database connection, e.g.: (postgres://,mysql://,sqlserver://,mongodb://)")
-	runCmd.Flags().StringSliceVar(&runFlags.Reviewers, "reviewers", nil, "The approval groups for this connection, interactions are reviewed when enabled")
-	runCmd.Flags().StringSliceVar(&runFlags.RedactTypes, "redact-types", nil, "The redact types for this connection, content is redacted when enabled")
+	runCmd.Flags().StringSliceVar(&runFlags.Reviewers, "review", nil, "The approval groups for this connection, interactions are reviewed when enabled")
+	runCmd.Flags().StringSliceVar(&runFlags.RedactTypes, "data-masking", nil, "The data masking types for this connection, content is redacted when enabled")
 
 	_ = runCmd.Flags().MarkHidden("export")
 	rootCmd.AddCommand(runCmd)

--- a/scripts/deploy-by-app.sh
+++ b/scripts/deploy-by-app.sh
@@ -3,7 +3,7 @@ set -e
 
 gh auth status
 
-declare -a apps=("appdemo" "clari" "ebanx" "enjoei" "rdstation" "tryrunops" "unico" "multitenant")
+declare -a apps=("appdemo" "ebanx" "enjoei" "rdstation" "tryrunops" "unico" "multitenant")
 echo -e "=> Here are the available apps to deploy"
 for app in "${apps[@]}"; do
   echo $app


### PR DESCRIPTION
- Remove coercing env var to upper when running `hoop exec|connect`