### PR TITLE
Improvement on webapp execution endpoints

### DIFF
--- a/common/grpc/streamrecv.go
+++ b/common/grpc/streamrecv.go
@@ -1,0 +1,38 @@
+package grpc
+
+import (
+	pb "github.com/runopsio/hoop/common/proto"
+)
+
+type DataStream struct {
+	pkt *pb.Packet
+	err error
+}
+
+func (s *DataStream) Recv() (*pb.Packet, error) { return s.pkt, s.err }
+
+// NewStreamRecv starts the stream.Recv() in background.
+// and send the messages through the dataStream channel
+//
+// It blocks until it receives a message into m or the stream is
+// done. It returns io.EOF when the client has performed a CloseSend. On
+// any non-EOF error, the stream is aborted and the error contains the
+// RPC status.
+//
+// It is safe to have a goroutine calling SendMsg and another goroutine
+// calling RecvMsg on the same stream at the same time, but it is not
+// safe to call RecvMsg on the same stream in different goroutines.
+func NewStreamRecv(stream pb.ClientReceiver) chan *DataStream {
+	ch := make(chan *DataStream)
+	go func() {
+		defer close(ch)
+		for {
+			pkt, err := stream.Recv()
+			ch <- &DataStream{pkt, err}
+			if err != nil {
+				break
+			}
+		}
+	}()
+	return ch
+}

--- a/common/monitoring/monitoring.go
+++ b/common/monitoring/monitoring.go
@@ -86,7 +86,10 @@ func SentryPreRun(cmd *cobra.Command, args []string) {
 
 type ShutdownFn func()
 
-func NewOpenTracing(apiKey string) (ShutdownFn, error) {
+func NewOpenTracing(apiURL, apiKey string) (ShutdownFn, error) {
+	if isLocalEnvironment(apiURL) {
+		return func() {}, nil
+	}
 	// Enable multi-span attributes
 	bsp := honeycomb.NewBaggageSpanProcessor()
 

--- a/common/proto/types.go
+++ b/common/proto/types.go
@@ -13,9 +13,12 @@ import (
 )
 
 type (
-	ClientTransport interface {
-		Send(*Packet) error
+	ClientReceiver interface {
 		Recv() (*Packet, error)
+	}
+	ClientTransport interface {
+		ClientReceiver
+		Send(*Packet) error
 		StreamContext() context.Context
 		StartKeepAlive()
 		Close() (error, error)

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -169,7 +169,7 @@ func (api *Api) buildRoutes(route *gin.RouterGroup) {
 	route.POST("/connections/:name/exec",
 		api.Authenticate,
 		api.TrackRequest(analytics.EventApiExecConnection),
-		apiconnections.RunExec)
+		sessionapi.Post)
 	route.GET("/connections",
 		api.Authenticate,
 		apiconnections.List)

--- a/gateway/pgrest/connections/connections.go
+++ b/gateway/pgrest/connections/connections.go
@@ -11,28 +11,6 @@ import (
 type connections struct{}
 
 func New() *connections { return &connections{} }
-func (c *connections) FetchOneForExec(ctx pgrest.OrgContext, name string) (*types.Connection, error) {
-	var conn pgrest.Connection
-	err := pgrest.New("/connections?select=*,orgs(id,name)&org_id=eq.%v&name=eq.%v",
-		ctx.GetOrgID(), name).
-		FetchOne().
-		DecodeInto(&conn)
-	if err != nil {
-		if err == pgrest.ErrNotFound {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return &types.Connection{
-		Id:      conn.ID,
-		OrgId:   conn.OrgID,
-		Name:    conn.Name,
-		Command: conn.Command,
-		Type:    conn.Type,
-		SubType: conn.SubType,
-		AgentId: conn.AgentID,
-	}, nil
-}
 
 func (c *connections) FetchByNames(ctx pgrest.OrgContext, connectionNames []string) (map[string]types.Connection, error) {
 	var connList []pgrest.Connection

--- a/gateway/transport/interceptors/tracing/tracing.go
+++ b/gateway/transport/interceptors/tracing/tracing.go
@@ -40,7 +40,7 @@ type interceptor struct {
 
 func New(apiURL string) grpc.StreamServerInterceptor {
 	// TODO: call this func when the gateway shutdowns
-	shutdownFn, err := monitoring.NewOpenTracing("f26akXhvu7OG1PKqTVoUZB")
+	shutdownFn, err := monitoring.NewOpenTracing(apiURL, "f26akXhvu7OG1PKqTVoUZB")
 	if err != nil {
 		log.Errorf("failed initializing open tracing client, err=%v", err)
 	}

--- a/gateway/transport/stream.go
+++ b/gateway/transport/stream.go
@@ -33,6 +33,8 @@ type dataStream struct {
 	err error
 }
 
+func (s *dataStream) Recv() (*pb.Packet, error) { return s.pkt, s.err }
+
 // newDataStreamCh starts the stream.Recv() in background.
 // In case it fails to deliver data, it will cancel the given context
 //

--- a/gateway/transport/streamclient/proxy.go
+++ b/gateway/transport/streamclient/proxy.go
@@ -183,7 +183,6 @@ func (s *ProxyStream) IsAgentOnline() bool { return IsAgentOnline(s.StreamAgentI
 // based on the agent id and the id of the connection, otherwise it returns the
 // agent_id of the connection
 func (s *ProxyStream) StreamAgentID() streamtypes.ID {
-	s.Context().Done()
 	if s.pluginCtx.AgentMode == pb.AgentModeMultiConnectionType {
 		return streamtypes.NewStreamID(s.pluginCtx.AgentID, s.pluginCtx.ConnectionName)
 	}


### PR DESCRIPTION
- [gateway/api] Removed time.After to avoid leak of channels on clientexec calls
- [gateway/api] Exec routes now return a new attribute output_status=failed|success|running
- [gateway/api] Exec routes will always return exit_code=-2 in case the exit code is not set
- [gateway/api] Receiving packets via stream.Recv is performed in a go routine
- [gateway/api] /api/connections/:name/exec /api/sessions endpoints uses the same exec handler
- [gateway/transport] Receiving packets via stream.Recv is performed in a go routine
- [gateway/transport] Skip enabling tracing for local environments