### PR TITLE
Feat/connections access modes

### DIFF
--- a/client/cmd/proxymanager.go
+++ b/client/cmd/proxymanager.go
@@ -60,7 +60,7 @@ var (
 						log.Infof("connection not found")
 						return nil
 					case codes.FailedPrecondition:
-						log.Info(pb.ErrAgentOffline)
+						log.Info(err)
 						return nil
 					}
 				}

--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -23,19 +23,23 @@ type Review struct {
 }
 
 type Connection struct {
-	ID            string         `json:"id"`
-	Name          string         `json:"name"`
-	Command       []string       `json:"command"`
-	Type          string         `json:"type"`
-	SubType       string         `json:"subtype"`
-	Secrets       map[string]any `json:"secret"`
-	AgentId       string         `json:"agent_id"`
-	Status        string         `json:"status"` // read only field
-	Reviewers     []string       `json:"reviewers"`
-	RedactEnabled bool           `json:"redact_enabled"`
-	RedactTypes   []string       `json:"redact_types"`
-	ManagedBy     *string        `json:"managed_by"`
-	Tags          []string       `json:"tags"`
+	ID                 string         `json:"id"`
+	Name               string         `json:"name"`
+	Command            []string       `json:"command"`
+	Type               string         `json:"type"`
+	SubType            string         `json:"subtype"`
+	Secrets            map[string]any `json:"secret"`
+	AgentId            string         `json:"agent_id"`
+	Status             string         `json:"status"` // read only field
+	Reviewers          []string       `json:"reviewers"`
+	RedactEnabled      bool           `json:"redact_enabled"`
+	RedactTypes        []string       `json:"redact_types"`
+	ManagedBy          *string        `json:"managed_by"`
+	Tags               []string       `json:"tags"`
+	AccessModeRunbooks string         `json:"access_mode_runbooks"`
+	AccessModeExec     string         `json:"access_mode_exec"`
+	AccessModeConnect  string         `json:"access_mode_connect"`
+	AccessSchema       string         `json:"access_schema"`
 }
 
 func Post(c *gin.Context) {
@@ -68,18 +72,23 @@ func Post(c *gin.Context) {
 	if streamclient.IsAgentOnline(streamtypes.NewStreamID(req.AgentId, "")) {
 		req.Status = pgrest.ConnectionStatusOnline
 	}
+
 	err = pgconnections.New().Upsert(ctx, pgrest.Connection{
-		ID:        req.ID,
-		OrgID:     ctx.OrgID,
-		AgentID:   req.AgentId,
-		Name:      req.Name,
-		Command:   req.Command,
-		Type:      string(req.Type),
-		SubType:   req.SubType,
-		Envs:      coerceToMapString(req.Secrets),
-		Status:    req.Status,
-		ManagedBy: nil,
-		Tags:      req.Tags,
+		ID:                 req.ID,
+		OrgID:              ctx.OrgID,
+		AgentID:            req.AgentId,
+		Name:               req.Name,
+		Command:            req.Command,
+		Type:               string(req.Type),
+		SubType:            req.SubType,
+		Envs:               coerceToMapString(req.Secrets),
+		Status:             req.Status,
+		ManagedBy:          nil,
+		Tags:               req.Tags,
+		AccessModeRunbooks: string(req.AccessModeRunbooks),
+		AccessModeExec:     string(req.AccessModeExec),
+		AccessModeConnect:  string(req.AccessModeConnect),
+		AccessSchema:       string(req.AccessSchema),
 	})
 	if err != nil {
 		log.Errorf("failed creating connection, err=%v", err)
@@ -145,17 +154,21 @@ func Put(c *gin.Context) {
 	req.Name = conn.Name
 	req.Status = conn.Status
 	err = pgconnections.New().Upsert(ctx, pgrest.Connection{
-		ID:        conn.ID,
-		OrgID:     conn.OrgID,
-		AgentID:   req.AgentId,
-		Name:      conn.Name,
-		Command:   req.Command,
-		Type:      req.Type,
-		SubType:   req.SubType,
-		Envs:      coerceToMapString(req.Secrets),
-		Status:    conn.Status,
-		ManagedBy: nil,
-		Tags:      req.Tags,
+		ID:                 conn.ID,
+		OrgID:              conn.OrgID,
+		AgentID:            req.AgentId,
+		Name:               conn.Name,
+		Command:            req.Command,
+		Type:               req.Type,
+		SubType:            req.SubType,
+		Envs:               coerceToMapString(req.Secrets),
+		Status:             conn.Status,
+		ManagedBy:          nil,
+		Tags:               req.Tags,
+		AccessModeRunbooks: req.AccessModeRunbooks,
+		AccessModeExec:     req.AccessModeExec,
+		AccessModeConnect:  req.AccessModeConnect,
+		AccessSchema:       req.AccessSchema,
 	})
 	if err != nil {
 		log.Errorf("failed updating connection, err=%v", err)
@@ -243,19 +256,23 @@ func List(c *gin.Context) {
 				}
 			}
 			responseConnList = append(responseConnList, Connection{
-				ID:            conn.ID,
-				Name:          conn.Name,
-				Command:       conn.Command,
-				Type:          conn.Type,
-				SubType:       conn.SubType,
-				Secrets:       coerceToAnyMap(conn.Envs),
-				AgentId:       conn.AgentID,
-				Status:        conn.Status,
-				Reviewers:     reviewers,
-				RedactEnabled: len(redactTypes) > 0,
-				RedactTypes:   redactTypes,
-				ManagedBy:     conn.ManagedBy,
-				Tags:          conn.Tags,
+				ID:                 conn.ID,
+				Name:               conn.Name,
+				Command:            conn.Command,
+				Type:               conn.Type,
+				SubType:            conn.SubType,
+				Secrets:            coerceToAnyMap(conn.Envs),
+				AgentId:            conn.AgentID,
+				Status:             conn.Status,
+				Reviewers:          reviewers,
+				RedactEnabled:      len(redactTypes) > 0,
+				RedactTypes:        redactTypes,
+				ManagedBy:          conn.ManagedBy,
+				Tags:               conn.Tags,
+				AccessModeRunbooks: conn.AccessModeRunbooks,
+				AccessModeExec:     conn.AccessModeExec,
+				AccessModeConnect:  conn.AccessModeConnect,
+				AccessSchema:       conn.AccessSchema,
 			})
 		}
 
@@ -294,19 +311,23 @@ func Get(c *gin.Context) {
 		}
 	}
 	c.JSON(http.StatusOK, Connection{
-		ID:            conn.ID,
-		Name:          conn.Name,
-		Command:       conn.Command,
-		Type:          conn.Type,
-		SubType:       conn.SubType,
-		Secrets:       coerceToAnyMap(conn.Envs),
-		AgentId:       conn.AgentID,
-		Status:        conn.Status,
-		Reviewers:     reviewers,
-		RedactEnabled: len(redactTypes) > 0,
-		RedactTypes:   redactTypes,
-		ManagedBy:     conn.ManagedBy,
-		Tags:          conn.Tags,
+		ID:                 conn.ID,
+		Name:               conn.Name,
+		Command:            conn.Command,
+		Type:               conn.Type,
+		SubType:            conn.SubType,
+		Secrets:            coerceToAnyMap(conn.Envs),
+		AgentId:            conn.AgentID,
+		Status:             conn.Status,
+		Reviewers:          reviewers,
+		RedactEnabled:      len(redactTypes) > 0,
+		RedactTypes:        redactTypes,
+		ManagedBy:          conn.ManagedBy,
+		Tags:               conn.Tags,
+		AccessModeRunbooks: conn.AccessModeRunbooks,
+		AccessModeExec:     conn.AccessModeExec,
+		AccessModeConnect:  conn.AccessModeConnect,
+		AccessSchema:       conn.AccessSchema,
 	})
 }
 

--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -85,10 +85,10 @@ func Post(c *gin.Context) {
 		Status:             req.Status,
 		ManagedBy:          nil,
 		Tags:               req.Tags,
-		AccessModeRunbooks: string(req.AccessModeRunbooks),
-		AccessModeExec:     string(req.AccessModeExec),
-		AccessModeConnect:  string(req.AccessModeConnect),
-		AccessSchema:       string(req.AccessSchema),
+		AccessModeRunbooks: req.AccessModeRunbooks,
+		AccessModeExec:     req.AccessModeExec,
+		AccessModeConnect:  req.AccessModeConnect,
+		AccessSchema:       req.AccessSchema,
 	})
 	if err != nil {
 		log.Errorf("failed creating connection, err=%v", err)

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -314,22 +314,23 @@ func GetUserInfo(c *gin.Context) {
 		roleName = RoleAdminType
 	}
 	userInfoData := map[string]any{
-		"id":             ctx.UserID,
-		"name":           ctx.UserName,
-		"email":          ctx.UserEmail,
-		"picture":        ctx.UserPicture,
-		"status":         ctx.UserStatus,
-		"verified":       true, // DEPRECATED in flavor of role (guest)
-		"slack_id":       ctx.SlackID,
-		"groups":         groupList,
-		"is_admin":       ctx.IsAdminUser(), // DEPRECATED in flavor of role (admin)
-		"is_multitenant": isOrgMultiTenant,  // DEPRECATED is flavor of tenancy_type
-		"tenancy_type":   tenancyType,
-		"role":           roleName,
-		"org_id":         ctx.OrgID,
-		"org_name":       ctx.OrgName,
-		"org_license":    ctx.OrgLicense,
-		"feature_ask_ai": askAIFeatureStatus,
+		"id":                      ctx.UserID,
+		"name":                    ctx.UserName,
+		"email":                   ctx.UserEmail,
+		"picture":                 ctx.UserPicture,
+		"status":                  ctx.UserStatus,
+		"verified":                true, // DEPRECATED in flavor of role (guest)
+		"slack_id":                ctx.SlackID,
+		"groups":                  groupList,
+		"is_admin":                ctx.IsAdminUser(), // DEPRECATED in flavor of role (admin)
+		"is_multitenant":          isOrgMultiTenant,  // DEPRECATED is flavor of tenancy_type
+		"tenancy_type":            tenancyType,
+		"role":                    roleName,
+		"org_id":                  ctx.OrgID,
+		"org_name":                ctx.OrgName,
+		"org_license":             ctx.OrgLicense,
+		"feature_ask_ai":          askAIFeatureStatus,
+		"webapp_users_management": appconfig.Get().WebappUsersManagement(),
 	}
 	if ctx.IsAnonymous() {
 		userInfoData["verified"] = false

--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -35,6 +35,7 @@ type Config struct {
 	apiURL                string
 	apiHostname           string
 	apiScheme             string
+	webappUsersManagement string
 
 	isLoaded bool
 }
@@ -82,6 +83,10 @@ func Load() error {
 	if err != nil {
 		return err
 	}
+	webappUsersManagement := os.Getenv("WEBAPP_USERS_MANAGEMENT")
+	if webappUsersManagement == "" {
+		webappUsersManagement = "on"
+	}
 	runtimeConfig = Config{
 		apiURL:                fmt.Sprintf("%s://%s", apiRawURL.Scheme, apiRawURL.Host),
 		apiHostname:           apiRawURL.Hostname(),
@@ -93,6 +98,7 @@ func Load() error {
 		licenseSignerOrgID:    allowedOrgID,
 		gcpDLPJsonCredentials: gcpJsonCred,
 		webhookAppKey:         os.Getenv("WEBHOOK_APPKEY"),
+		webappUsersManagement: webappUsersManagement,
 		isLoaded:              true,
 	}
 	return nil
@@ -185,7 +191,8 @@ func (c Config) PostgRESTRole() string         { return c.pgCred.postgrestRole }
 
 func (c Config) MigrationPathFiles() string { return c.migrationPathFiles }
 
-func (c Config) IsAskAIAvailable() bool { return c.askAICredentials != nil }
+func (c Config) WebappUsersManagement() string { return c.webappUsersManagement }
+func (c Config) IsAskAIAvailable() bool        { return c.askAICredentials != nil }
 func (c Config) AskAIApiURL() (u string) {
 	if c.IsAskAIAvailable() {
 		return fmt.Sprintf("%s://%s", c.askAICredentials.Scheme, c.askAICredentials.Host)

--- a/gateway/pgrest/connections/connections.go
+++ b/gateway/pgrest/connections/connections.go
@@ -28,13 +28,17 @@ func (c *connections) FetchByIDs(ctx pgrest.OrgContext, connectionIDs []string) 
 		for _, connID := range connectionIDs {
 			if conn.ID == connID {
 				itemMap[connID] = types.Connection{
-					Id:      conn.ID,
-					OrgId:   conn.OrgID,
-					Name:    conn.Name,
-					Command: conn.Command,
-					Type:    conn.Type,
-					SubType: conn.SubType,
-					AgentId: conn.AgentID,
+					Id:                 conn.ID,
+					OrgId:              conn.OrgID,
+					Name:               conn.Name,
+					Command:            conn.Command,
+					Type:               conn.Type,
+					SubType:            conn.SubType,
+					AgentId:            conn.AgentID,
+					AccessModeRunbooks: conn.AccessModeRunbooks,
+					AccessModeExec:     conn.AccessModeExec,
+					AccessModeConnect:  conn.AccessModeConnect,
+					AccessSchema:       conn.AccessSchema,
 				}
 				break
 			}
@@ -91,18 +95,31 @@ func (c *connections) Upsert(ctx pgrest.OrgContext, conn pgrest.Connection) erro
 	if conn.Status == "" {
 		conn.Status = pgrest.ConnectionStatusOffline
 	}
+
+	if conn.AccessSchema == "" {
+		if conn.Type == "database" {
+			conn.AccessSchema = "enabled"
+		} else {
+			conn.AccessSchema = "disabled"
+		}
+	}
+
 	return pgrest.New("/rpc/update_connection").RpcCreate(map[string]any{
-		"id":         conn.ID,
-		"org_id":     ctx.GetOrgID(),
-		"name":       conn.Name,
-		"agent_id":   toAgentID(conn.AgentID),
-		"type":       conn.Type,
-		"subtype":    subType,
-		"command":    conn.Command,
-		"envs":       conn.Envs,
-		"status":     conn.Status,
-		"managed_by": conn.ManagedBy,
-		"tags":       conn.Tags,
+		"id":                   conn.ID,
+		"org_id":               ctx.GetOrgID(),
+		"name":                 conn.Name,
+		"agent_id":             toAgentID(conn.AgentID),
+		"type":                 conn.Type,
+		"subtype":              subType,
+		"command":              conn.Command,
+		"envs":                 conn.Envs,
+		"status":               conn.Status,
+		"managed_by":           conn.ManagedBy,
+		"tags":                 conn.Tags,
+		"access_mode_runbooks": conn.AccessModeRunbooks,
+		"access_mode_exec":     conn.AccessModeExec,
+		"access_mode_connect":  conn.AccessModeConnect,
+		"access_schema":        conn.AccessSchema,
 	}).Error()
 }
 

--- a/gateway/pgrest/connections/connections.go
+++ b/gateway/pgrest/connections/connections.go
@@ -97,10 +97,9 @@ func (c *connections) Upsert(ctx pgrest.OrgContext, conn pgrest.Connection) erro
 	}
 
 	if conn.AccessSchema == "" {
+		conn.AccessSchema = "disabled"
 		if conn.Type == "database" {
 			conn.AccessSchema = "enabled"
-		} else {
-			conn.AccessSchema = "disabled"
 		}
 	}
 

--- a/gateway/pgrest/current_state.template.sql
+++ b/gateway/pgrest/current_state.template.sql
@@ -134,7 +134,8 @@ CREATE VIEW env_vars AS SELECT id, org_id, envs FROM private.env_vars;
 CREATE VIEW connections AS
     SELECT id, org_id, agent_id, name, command, type, subtype,
         (SELECT envs FROM env_vars WHERE id = c.id) AS envs,
-        status, managed_by, _tags AS tags, created_at, updated_at
+        status, managed_by, _tags AS tags, access_mode_connect, access_mode_exec, 
+        access_mode_runbooks, access_schema, created_at, updated_at
     FROM private.connections c;
 
 CREATE FUNCTION agents(connections) RETURNS SETOF agents ROWS 1 AS $$
@@ -160,10 +161,14 @@ CREATE FUNCTION update_connection(params json) RETURNS SETOF connections ROWS 1 
             (
                 SELECT array_agg(v)::TEXT[]
                 FROM jsonb_array_elements_text((params->>'tags')::JSONB) AS v
-            ) AS tags
+            ) AS tags,
+            (params->>'access_mode_connect')::private.enum_access_status AS access_mode_connect,
+            (params->>'access_mode_exec')::private.enum_access_status AS access_mode_exec,
+            (params->>'access_mode_runbooks')::private.enum_access_status AS access_mode_runbooks,
+            (params->>'access_schema')::private.enum_access_status AS access_schema
     ), conn AS (
-        INSERT INTO connections (id, org_id, agent_id, name, command, type, subtype, status, managed_by, tags)
-            (SELECT id, org_id, agent_id, name, command, type, subtype, status, managed_by, tags FROM user_input)
+        INSERT INTO connections (id, org_id, agent_id, name, command, type, subtype, status, managed_by, tags, access_mode_runbooks, access_mode_connect, access_mode_exec, access_schema)
+            (SELECT id, org_id, agent_id, name, command, type, subtype, status, managed_by, tags, access_mode_runbooks, access_mode_connect, access_mode_exec, access_schema FROM user_input)
         ON CONFLICT (org_id, name)
             DO UPDATE SET
                 agent_id = (SELECT agent_id FROM user_input),
@@ -173,6 +178,10 @@ CREATE FUNCTION update_connection(params json) RETURNS SETOF connections ROWS 1 
                 status = (SELECT status FROM user_input),
                 managed_by = (SELECT managed_by FROM user_input),
                 tags = (SELECT tags FROM user_input),
+                access_mode_connect = (SELECT access_mode_connect FROM user_input),
+                access_mode_exec = (SELECT access_mode_exec FROM user_input),
+                access_mode_runbooks = (SELECT access_mode_runbooks FROM user_input),
+                access_schema = (SELECT access_schema FROM user_input),
                 updated_at = NOW()
         RETURNING *
     ), envs AS (
@@ -182,7 +191,7 @@ CREATE FUNCTION update_connection(params json) RETURNS SETOF connections ROWS 1 
                 DO UPDATE SET envs = (SELECT envs FROM user_input)
             RETURNING *
     )
-    SELECT c.id, c.org_id, c.agent_id, c.name, c.command, c.type, c.subtype, e.envs, c.status, c.managed_by, c.tags, c.created_at, c.updated_at
+    SELECT c.id, c.org_id, c.agent_id, c.name, c.command, c.type, c.subtype, e.envs, c.status, c.managed_by, c.tags, c.access_mode_runbooks, c.access_mode_connect, c.access_mode_exec, c.access_schema, c.created_at, c.updated_at
     FROM conn c
     INNER JOIN envs e
         ON e.id = c.id;

--- a/gateway/pgrest/types.go
+++ b/gateway/pgrest/types.go
@@ -88,17 +88,21 @@ const (
 )
 
 type Connection struct {
-	ID        string            `json:"id"`
-	OrgID     string            `json:"org_id"`
-	AgentID   string            `json:"agent_id"`
-	Name      string            `json:"name"`
-	Command   []string          `json:"command"`
-	Type      string            `json:"type"`
-	SubType   string            `json:"subtype"`
-	Envs      map[string]string `json:"envs"`
-	Status    string            `json:"status"` // read only field
-	ManagedBy *string           `json:"managed_by"`
-	Tags      []string          `json:"tags"`
+	ID                 string            `json:"id"`
+	OrgID              string            `json:"org_id"`
+	AgentID            string            `json:"agent_id"`
+	Name               string            `json:"name"`
+	Command            []string          `json:"command"`
+	Type               string            `json:"type"`
+	SubType            string            `json:"subtype"`
+	Envs               map[string]string `json:"envs"`
+	Status             string            `json:"status"` // read only field
+	ManagedBy          *string           `json:"managed_by"`
+	Tags               []string          `json:"tags"`
+	AccessModeRunbooks string            `json:"access_mode_runbooks"`
+	AccessModeExec     string            `json:"access_mode_exec"`
+	AccessModeConnect  string            `json:"access_mode_connect"`
+	AccessSchema       string            `json:"access_schema"`
 
 	// read only attributes
 	Org              Org                `json:"orgs"`

--- a/gateway/storagev2/types/types.go
+++ b/gateway/storagev2/types/types.go
@@ -77,27 +77,35 @@ type Client struct {
 }
 
 type Connection struct {
-	Id       string         `json:"id"`
-	OrgId    string         `json:"-"`
-	Name     string         `json:"name"`
-	IconName string         `json:"icon_name"`
-	Command  []string       `json:"command"`
-	Type     string         `json:"type"`
-	SubType  string         `json:"subtype"`
-	Secret   map[string]any `json:"secret"`
-	AgentId  string         `json:"agent_id"`
+	Id                 string         `json:"id"`
+	OrgId              string         `json:"-"`
+	Name               string         `json:"name"`
+	IconName           string         `json:"icon_name"`
+	Command            []string       `json:"command"`
+	Type               string         `json:"type"`
+	SubType            string         `json:"subtype"`
+	Secret             map[string]any `json:"secret"`
+	AgentId            string         `json:"agent_id"`
+	AccessModeRunbooks string         `json:"access_mode_runbooks"`
+	AccessModeExec     string         `json:"access_mode_exec"`
+	AccessModeConnect  string         `json:"access_mode_connect"`
+	AccessSchema       string         `json:"access_schema"`
 }
 
 type ConnectionInfo struct {
-	ID            string
-	Name          string
-	Type          string
-	SubType       string
-	CmdEntrypoint []string
-	Secrets       map[string]any
-	AgentID       string
-	AgentName     string
-	AgentMode     string
+	ID                 string
+	Name               string
+	Type               string
+	SubType            string
+	CmdEntrypoint      []string
+	Secrets            map[string]any
+	AgentID            string
+	AgentName          string
+	AgentMode          string
+	AccessModeRunbooks string
+	AccessModeExec     string
+	AccessModeConnect  string
+	AccessSchema       string
 }
 
 type ReviewOwner struct {

--- a/gateway/transport/interceptors/auth/auth.go
+++ b/gateway/transport/interceptors/auth/auth.go
@@ -177,10 +177,10 @@ func (i *interceptor) getConnection(name string, userCtx *pguserauth.Context) (*
 		AgentID:            conn.AgentID,
 		AgentMode:          conn.Agent.Mode,
 		AgentName:          conn.Agent.Name,
-		AccessModeRunbooks: string(conn.AccessModeRunbooks),
-		AccessModeExec:     string(conn.AccessModeExec),
-		AccessModeConnect:  string(conn.AccessModeConnect),
-		AccessSchema:       string(conn.AccessSchema),
+		AccessModeRunbooks: conn.AccessModeRunbooks,
+		AccessModeExec:     conn.AccessModeExec,
+		AccessModeConnect:  conn.AccessModeConnect,
+		AccessSchema:       conn.AccessSchema,
 	}, nil
 }
 

--- a/gateway/transport/interceptors/auth/auth.go
+++ b/gateway/transport/interceptors/auth/auth.go
@@ -168,15 +168,19 @@ func (i *interceptor) getConnection(name string, userCtx *pguserauth.Context) (*
 		return nil, nil
 	}
 	return &types.ConnectionInfo{
-		ID:            conn.ID,
-		Name:          conn.Name,
-		Type:          string(conn.Type),
-		SubType:       conn.SubType,
-		CmdEntrypoint: conn.Command,
-		Secrets:       conn.AsSecrets(),
-		AgentID:       conn.AgentID,
-		AgentMode:     conn.Agent.Mode,
-		AgentName:     conn.Agent.Name,
+		ID:                 conn.ID,
+		Name:               conn.Name,
+		Type:               string(conn.Type),
+		SubType:            conn.SubType,
+		CmdEntrypoint:      conn.Command,
+		Secrets:            conn.AsSecrets(),
+		AgentID:            conn.AgentID,
+		AgentMode:          conn.Agent.Mode,
+		AgentName:          conn.Agent.Name,
+		AccessModeRunbooks: string(conn.AccessModeRunbooks),
+		AccessModeExec:     string(conn.AccessModeExec),
+		AccessModeConnect:  string(conn.AccessModeConnect),
+		AccessSchema:       string(conn.AccessSchema),
 	}, nil
 }
 

--- a/gateway/transport/proxymanager.go
+++ b/gateway/transport/proxymanager.go
@@ -165,6 +165,14 @@ func (s *Server) proccessConnectOKAck(stream *streamclient.ProxyStream) error {
 			disp.sendResponse(nil, ErrUnsupportedType)
 			return fmt.Errorf("connection type %s/%s not supported", conn.Type, conn.SubType)
 		}
+
+		if conn.AccessModeConnect == "disabled" {
+			errorMessage := fmt.Sprintf("the %v connection has the access mode connect (Native) feature disabled", conn.Name)
+
+			disp.sendResponse(nil, status.Error(codes.FailedPrecondition, errorMessage))
+			return status.Error(codes.FailedPrecondition, errorMessage)
+		}
+
 		clientOrigin := pb.ConnectionOriginClientProxyManager
 		stream.SetPluginContext(func(pluginCtx *plugintypes.Context) {
 			pluginCtx.ConnectionID = conn.ID

--- a/gateway/transport/server.go
+++ b/gateway/transport/server.go
@@ -108,13 +108,13 @@ func (s *Server) PreConnect(ctx context.Context, req *pb.PreConnectRequest) (*pb
 
 func GetAccessModesFromConnect(clientVerb string, clientOrigin string) string {
 	switch {
-	case clientVerb == "exec" && clientOrigin == "client":
+	case clientVerb == pb.ClientVerbExec && clientOrigin == pb.ConnectionOriginClient:
 		return "exec"
-	case clientVerb == "exec" && clientOrigin == "client-api":
+	case clientVerb == pb.ClientVerbExec && clientOrigin == pb.ConnectionOriginClientAPI:
 		return "exec"
-	case clientVerb == "connect":
+	case clientVerb == pb.ClientVerbConnect:
 		return "connect"
-	case clientVerb == "exec" && clientOrigin == "client-api-runbooks":
+	case clientVerb == pb.ClientVerbExec && clientOrigin == pb.ConnectionOriginClientAPIRunbooks:
 		return "runbooks"
 	default:
 		return ""
@@ -187,19 +187,14 @@ func (s *Server) Connect(stream pb.Transport_ConnectServer) (err error) {
 	// Verifying if the feature is enabled
 	currentAccessMode := GetAccessModesFromConnect(clientVerb[0], clientOrigin[0])
 
-	println("-------------------> currentAccessMode: ", currentAccessMode)
-	println("-------------------> clientVerb: ", clientVerb[0])
-	println("-------------------> clientOrigin: ", clientOrigin[0])
-
 	AccessModes := map[string]string{
 		"exec":     gwctx.Connection.AccessModeExec,
 		"connect":  gwctx.Connection.AccessModeConnect,
 		"runbooks": gwctx.Connection.AccessModeRunbooks}
 
-	switch {
-	case AccessModes[currentAccessMode] == "disabled":
+	if AccessModes[currentAccessMode] == "disabled" {
 		return status.Error(codes.FailedPrecondition,
-			fmt.Sprintf("the %v connection has the %v feature disabled", gwctx.Connection.Name, currentAccessMode))
+			fmt.Sprintf("the %v access mode connection has the %v feature disabled", gwctx.Connection.Name, currentAccessMode))
 	}
 	// End of verification of the feature enabled
 

--- a/rootfs/app/migrations/000020_conn_add_access_modes.down.sql
+++ b/rootfs/app/migrations/000020_conn_add_access_modes.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+SET search_path TO private;
+
+ALTER TABLE connections 
+DROP COLUMN access_mode_runbooks,
+DROP COLUMN access_mode_exec,
+DROP COLUMN access_mode_connect,
+DROP COLUMN access_schema;
+
+DROP TYPE IF EXISTS enum_access_status;
+
+COMMIT;

--- a/rootfs/app/migrations/000020_conn_add_access_modes.up.sql
+++ b/rootfs/app/migrations/000020_conn_add_access_modes.up.sql
@@ -4,14 +4,16 @@ SET search_path TO private;
 
 CREATE TYPE enum_access_status AS ENUM ('enabled', 'disabled');
 
-ALTER TABLE connections ADD COLUMN access_mode_runbooks enum_access_status NOT NULL;
-ALTER TABLE connections ADD COLUMN access_mode_exec enum_access_status NOT NULL;
-ALTER TABLE connections ADD COLUMN access_mode_connect enum_access_status NOT NULL;
-ALTER TABLE connections ADD COLUMN access_schema enum_access_status NOT NULL;
+ALTER TABLE connections ADD COLUMN access_mode_runbooks enum_access_status;
+ALTER TABLE connections ADD COLUMN access_mode_exec enum_access_status;
+ALTER TABLE connections ADD COLUMN access_mode_connect enum_access_status;
+ALTER TABLE connections ADD COLUMN access_schema enum_access_status;
 
-UPDATE connections SET access_mode_runbooks = 'enabled' WHERE access_mode_runbooks IS NULL;
-UPDATE connections SET access_mode_exec = 'enabled' WHERE access_mode_exec IS NULL;
-UPDATE connections SET access_mode_connect = 'enabled' WHERE access_mode_connect IS NULL;
-UPDATE connections SET access_schema = 'enabled' WHERE access_schema IS NULL;
+-- enable old connections with defaults (enabled)
+UPDATE connections
+    SET access_mode_runbooks = 'enabled',
+        access_mode_exec = 'enabled',
+        access_mode_connect = 'enabled',
+        access_schema = 'enabled';
 
 COMMIT;

--- a/rootfs/app/migrations/000020_conn_add_access_modes.up.sql
+++ b/rootfs/app/migrations/000020_conn_add_access_modes.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+SET search_path TO private;
+
+CREATE TYPE enum_access_status AS ENUM ('enabled', 'disabled');
+
+ALTER TABLE connections ADD COLUMN access_mode_runbooks enum_access_status NOT NULL;
+ALTER TABLE connections ADD COLUMN access_mode_exec enum_access_status NOT NULL;
+ALTER TABLE connections ADD COLUMN access_mode_connect enum_access_status NOT NULL;
+ALTER TABLE connections ADD COLUMN access_schema enum_access_status NOT NULL;
+
+UPDATE connections SET access_mode_runbooks = 'enabled' WHERE access_mode_runbooks IS NULL;
+UPDATE connections SET access_mode_exec = 'enabled' WHERE access_mode_exec IS NULL;
+UPDATE connections SET access_mode_connect = 'enabled' WHERE access_mode_connect IS NULL;
+UPDATE connections SET access_schema = 'enabled' WHERE access_schema IS NULL;
+
+COMMIT;

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp",
-  "version": "1.22.0",
+  "version": "1.22.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp",
-      "version": "1.22.0",
+      "version": "1.22.2",
       "dependencies": {
         "@codemirror/commands": "^6.3.2",
         "@codemirror/lang-javascript": "^6.2.1",

--- a/webapp/src/webapp/components/checkboxes.cljs
+++ b/webapp/src/webapp/components/checkboxes.cljs
@@ -1,0 +1,45 @@
+(ns webapp.components.checkboxes
+  (:require [clojure.string :as cs]))
+
+
+;; Description: Renders a single checkbox input along with its label and optionally a description.
+;; Parameters:
+;; - A map with the following keys:
+;;   - :name (String): The `name` attribute for the checkbox input element. Used as a unique identifier.
+;;   - :label (String): The text displayed next to the checkbox. This text is capitalized and displayed as the content of the label.
+;;   - :description (String, optional): Additional description for the checkbox. If provided, displayed below the label in smaller text.
+;;   - :checked? (Atom, Boolean): An atom that indicates whether the checkbox is checked (`true`) or not (`false`).
+(defn item [{:keys [name label description checked?]}]
+  [:div {:class "relative flex items-center"}
+   [:div {:class "flex h-6 items-center"}
+    [:input {:id name
+             :name name
+             :type "checkbox"
+             :aria-describedby (str name "-description")
+             :checked @checked?
+             :on-change #(swap! checked? not)
+             :class "h-4 w-4 rounded border-gray-300 text-blue-500 focus:ring-blue-500"}]]
+   [:div {:class "ml-3 text-sm leading-6"}
+    [:label {:for name
+             :class (str (if @checked? "text-gray-900 " "text-gray-500 ")
+                         "font-semibold font-medium")}
+     (str (cs/capitalize label))]
+    (when description
+      [:p {:id (str name "-description")
+           :class (str (if @checked? "text-gray-900 " "text-gray-500 ")
+                       "text-xs")}
+       description])]])
+
+
+;; Description: Renders a group of checkboxes as a fieldset.
+;; Parameters:
+;; - checkboxes: A collection of maps, each representing a checkbox. Each map must contain keys for the `checkbox` function, such as `:name`, `:label`, `:description`, and `:checked?`.
+(defn group [checkboxes]
+  (println checkboxes)
+  [:fieldset
+   [:legend {:class "sr-only"}
+    "Notifications"]
+   [:div {:class "space-y-5"}
+    (for [checkbox checkboxes]
+      ^{:key (:name checkbox)}
+      [item checkbox])]])

--- a/webapp/src/webapp/connections/constants.cljs
+++ b/webapp/src/webapp/connections/constants.cljs
@@ -88,6 +88,10 @@
   {:name "postgres-demo"
    :type "database"
    :subtype "postgres"
+   :access_mode_runbooks "enabled"
+   :access_mode_exec "enabled"
+   :access_mode_connect "enabled"
+   :access_schema "enabled"
    :agent_id ""
    :reviewers []
    :redact_enabled true

--- a/webapp/src/webapp/connections/views/form/application.cljs
+++ b/webapp/src/webapp/connections/views/form/application.cljs
@@ -3,13 +3,14 @@
             ["unique-names-generator" :as ung]
             [re-frame.core :as rf]
             [reagent.core :as r]
+            [webapp.components.checkboxes :as checkboxes]
             [webapp.components.headings :as h]
+            [webapp.components.multiselect :as multi-select]
             [webapp.connections.constants :as constants]
             [webapp.connections.views.form.hoop-run-instructions :as instructions]
             [webapp.connections.views.form.toggle-data-masking :as toggle-data-masking]
             [webapp.connections.views.form.toggle-review :as toggle-review]
-            [webapp.shared-ui.sidebar.connection-overlay :as connection-overlay]
-            [webapp.components.multiselect :as multi-select]))
+            [webapp.shared-ui.sidebar.connection-overlay :as connection-overlay]))
 
 (defn random-connection-name []
   (let [numberDictionary (.generate ung/NumberDictionary #js{:length 4})
@@ -35,7 +36,10 @@
                  review-toggle-enabled?
                  approval-groups-value
                  data-masking-toggle-enabled?
-                 data-masking-groups-value]}]
+                 data-masking-groups-value
+                 access-mode-runbooks
+                 access-mode-connect
+                 access-mode-exec]}]
       [:<>
        [:section {:class "mb-large"}
         [:div {:class "mb-small"}
@@ -90,7 +94,7 @@
                                                                  "text-gray-700"))}
                    (:label application)]]]))])]]]
 
-       [:section {:class "mb-large"}
+       [:section {:class "space-y-8 mb-16"}
         [toggle-review/main {:free-license? (:free-license? (:data @user))
                              :user-groups user-groups
                              :review-toggle-enabled? review-toggle-enabled?
@@ -99,6 +103,28 @@
         [toggle-data-masking/main {:free-license? (:free-license? (:data @user))
                                    :data-masking-toggle-enabled? data-masking-toggle-enabled?
                                    :data-masking-groups-value data-masking-groups-value}]
+
+        [:div {:class " flex flex-col gap-4"}
+         [:div {:class "mr-24"}
+          [:div {:class "flex items-center gap-2"}
+           [h/h4-md "Enable custom access modes"]]
+          [:label {:class "text-xs text-gray-500"}
+           "Choose what users can run in this connection"]]
+
+         [checkboxes/group
+          [{:name "runbooks"
+            :label "Runbooks"
+            :description "Create templates to automate tasks in your organization"
+            :checked? access-mode-runbooks}
+           {:name "connect"
+            :label "Native"
+            :description "Access from your client of preference using hoop.dev to channel connections using our Desktop App or our Command Line Interface"
+            :checked? access-mode-connect}
+           {:name "exec"
+            :label "Web & One-Offs"
+            :description "Use hoop.dev's developer portal or our CLI's One-Offs commands directly in your terminal "
+            :checked? access-mode-exec}]]]
+
         [multi-select/text-input {:value tags-value
                                   :input-value tags-input-value
                                   :disabled? false

--- a/webapp/src/webapp/connections/views/form/custom.cljs
+++ b/webapp/src/webapp/connections/views/form/custom.cljs
@@ -2,6 +2,7 @@
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
             [webapp.components.button :as button]
+            [webapp.components.checkboxes :as checkboxes]
             [webapp.components.forms :as forms]
             [webapp.components.headings :as h]
             [webapp.components.multiselect :as multi-select]
@@ -144,6 +145,9 @@
                                       approval-groups-value
                                       data-masking-toggle-enabled?
                                       data-masking-groups-value
+                                      access-mode-runbooks
+                                      access-mode-connect
+                                      access-mode-exec
                                       connection-command
                                       config-file-name
                                       config-file-value
@@ -153,7 +157,7 @@
                                       on-click->add-more-file
                                       form-type]}]
       [:<>
-       [:section {:class "mb-large"}
+       [:section {:class "space-y-8 mb-16"}
         [toggle-review/main {:free-license? (:free-license? (:data @user))
                              :user-groups user-groups
                              :review-toggle-enabled? review-toggle-enabled?
@@ -162,6 +166,28 @@
         [toggle-data-masking/main {:free-license? (:free-license? (:data @user))
                                    :data-masking-toggle-enabled? data-masking-toggle-enabled?
                                    :data-masking-groups-value data-masking-groups-value}]
+
+        [:div {:class " flex flex-col gap-4"}
+         [:div {:class "mr-24"}
+          [:div {:class "flex items-center gap-2"}
+           [h/h4-md "Enable custom access modes"]]
+          [:label {:class "text-xs text-gray-500"}
+           "Choose what users can run in this connection"]]
+
+         [checkboxes/group
+          [{:name "runbooks"
+            :label "Runbooks"
+            :description "Create templates to automate tasks in your organization"
+            :checked? access-mode-runbooks}
+           {:name "connect"
+            :label "Native"
+            :description "Access from your client of preference using hoop.dev to channel connections using our Desktop App or our Command Line Interface"
+            :checked? access-mode-connect}
+           {:name "exec"
+            :label "Web & One-Offs"
+            :description "Use hoop.dev's developer portal or our CLI's One-Offs commands directly in your terminal "
+            :checked? access-mode-exec}]]]
+
         [multi-select/text-input {:value tags-value
                                   :input-value tags-input-value
                                   :disabled? false
@@ -177,6 +203,8 @@
 
        (if (= form-type :create)
          [:section {:class "mb-large"}
+          [h/h4-md "Choose your setup method"
+           {:class "font-bold mb-4"}]
           [tabs/tabs {:on-change #(reset! selected-tab %)
                       :tabs ["Command line" "Manually with credentials"]}]
           (case @selected-tab

--- a/webapp/src/webapp/connections/views/form/database.cljs
+++ b/webapp/src/webapp/connections/views/form/database.cljs
@@ -3,9 +3,11 @@
             ["unique-names-generator" :as ung]
             [re-frame.core :as rf]
             [reagent.core :as r]
+            [webapp.components.checkboxes :as checkboxes]
             [webapp.components.headings :as h]
             [webapp.components.multiselect :as multi-select]
             [webapp.components.tabs :as tabs]
+            [webapp.components.toggle :as toggle]
             [webapp.connections.constants :as constants]
             [webapp.connections.utilities :as utils]
             [webapp.connections.views.configuration-inputs :as config-inputs]
@@ -95,6 +97,10 @@
                          approval-groups-value
                          data-masking-toggle-enabled?
                          data-masking-groups-value
+                         access-schema-toggle-enabled?
+                         access-mode-runbooks
+                         access-mode-connect
+                         access-mode-exec
                          api-key
                          form-type]}]
       [:<>
@@ -152,7 +158,7 @@
                                                                  "text-gray-700"))}
                    (:label database)]]]))])]]]
 
-       [:section {:class "mb-large"}
+       [:section {:class "space-y-8 mb-16"}
         [toggle-review/main {:free-license? (:free-license? (:data @user))
                              :user-groups user-groups
                              :review-toggle-enabled? review-toggle-enabled?
@@ -161,6 +167,39 @@
         [toggle-data-masking/main {:free-license? (:free-license? (:data @user))
                                    :data-masking-toggle-enabled? data-masking-toggle-enabled?
                                    :data-masking-groups-value data-masking-groups-value}]
+
+        [:div {:class "flex justify-between items-center"}
+         [:div {:class "mr-24"}
+          [:div {:class "flex items-center gap-2"}
+           [h/h4-md "Enable schema in the Editor"]]
+          [:label {:class "text-xs text-gray-500"}
+           "Show database schemas in the connection details"]]
+         [toggle/main {:enabled? @access-schema-toggle-enabled?
+                       :on-click (fn []
+                                   (reset! access-schema-toggle-enabled?
+                                           (not @access-schema-toggle-enabled?)))}]]
+
+        [:div {:class " flex flex-col gap-4"}
+         [:div {:class "mr-24"}
+          [:div {:class "flex items-center gap-2"}
+           [h/h4-md "Enable custom access modes"]]
+          [:label {:class "text-xs text-gray-500"}
+           "Choose what users can run in this connection"]]
+
+         [checkboxes/group
+          [{:name "runbooks"
+            :label "Runbooks"
+            :description "Create templates to automate tasks in your organization"
+            :checked? access-mode-runbooks}
+           {:name "connect"
+            :label "Native"
+            :description "Access from your client of preference using hoop.dev to channel connections using our Desktop App or our Command Line Interface"
+            :checked? access-mode-connect}
+           {:name "exec"
+            :label "Web & One-Offs"
+            :description "Use hoop.dev's developer portal or our CLI's One-Offs commands directly in your terminal "
+            :checked? access-mode-exec}]]]
+
         [multi-select/text-input {:value tags-value
                                   :input-value tags-input-value
                                   :disabled? false
@@ -186,6 +225,8 @@
               :form-type form-type}]]
 
            [:section {:class "mb-large"}
+            [h/h4-md "Choose your setup method"
+             {:class "font-bold mb-4"}]
             [tabs/tabs {:default-value @selected-tab
                         :on-change #(reset! selected-tab %)
                         :tabs ["Command line" "Manually with credentials"]}]

--- a/webapp/src/webapp/connections/views/form/toggle_data_masking.cljs
+++ b/webapp/src/webapp/connections/views/form/toggle_data_masking.cljs
@@ -13,7 +13,7 @@
 (defn main [{:keys [free-license?
                     data-masking-toggle-enabled?
                     data-masking-groups-value]}]
-  [:div {:class "mb-large"}
+  [:div {:class ""}
    [:div {:class "mb-regular flex justify-between items-center"}
     [:div {:class "mr-24"}
      [:div {:class "flex items-center gap-2"}

--- a/webapp/src/webapp/connections/views/form/toggle_review.cljs
+++ b/webapp/src/webapp/connections/views/form/toggle_review.cljs
@@ -11,7 +11,7 @@
                     user-groups
                     review-toggle-enabled?
                     approval-groups-value]}]
-  [:div {:class "mb-large"}
+  [:div {:class ""}
    [:div {:class "mb-regular flex justify-between items-center"}
     [:div {:class "mr-24"}
      [:div {:class "flex items-center gap-2"}

--- a/webapp/src/webapp/events/editor_plugin.cljs
+++ b/webapp/src/webapp/events/editor_plugin.cljs
@@ -24,11 +24,12 @@
  ::editor-plugin->set-run-connection-list
  (fn
    [{:keys [db]} [_ connections current-connection-name]]
-   (let [connections-parsed (mapv (fn [{:keys [name type subtype status]}]
+   (let [connections-parsed (mapv (fn [{:keys [name type subtype status access_schema]}]
                                     {:name name
                                      :type type
                                      :subtype subtype
                                      :status status
+                                     :access_schema access_schema
                                      :selected (if (= name current-connection-name)
                                                  true
                                                  false)})
@@ -39,11 +40,12 @@
  :editor-plugin->set-filtered-run-connection-list
  (fn
    [db [_ connections current-connection-name]]
-   (let [connections-parsed (mapv (fn [{:keys [name type subtype status selected]}]
+   (let [connections-parsed (mapv (fn [{:keys [name type subtype status selected access_schema]}]
                                     {:name name
                                      :type type
                                      :subtype subtype
                                      :status status
+                                     :access_schema access_schema
                                      :selected (if (= name current-connection-name)
                                                  true
                                                  selected)})

--- a/webapp/src/webapp/webclient/aside/connections_running_list.cljs
+++ b/webapp/src/webapp/webclient/aside/connections_running_list.cljs
@@ -33,7 +33,6 @@
                         (not (schema-disabled? connection))))
            [:> hero-solid-icon/EllipsisVerticalIcon {:class "text-white h-5 w-5 shrink-0"
                                                      :aria-hidden "true"}])]
-
         (when (or (not context-connection?)
                   (and (show-tree? connection)
                        (not (schema-disabled? connection))))

--- a/webapp/src/webapp/webclient/panel.cljs
+++ b/webapp/src/webapp/webclient/panel.cljs
@@ -172,8 +172,9 @@
                                          (first (filter #(= (:name connection) (:name %))
                                                         (:connections (get-plugin-by-name "editor")))))
             schema-disabled? (fn [connection]
-                               (= (first (:config (current-connection-details connection)))
-                                  "schema=disabled"))
+                               (or (= (first (:config (current-connection-details connection)))
+                                      "schema=disabled")
+                                   (= (:access_schema connection) "disabled")))
             run-connections-list-selected (filterv #(and (:selected %)
                                                          (not= (:name %) connection-name))
                                                    (:data @run-connections-list))


### PR DESCRIPTION
- [gateway] Add access modes policies to block the usage of certain verbs (connect, exec, runbooks)
- [gateway] Add option to toggle the introspection schema of a connection
- [gateway] Add option env to disable webapp users management, `env WEBAPP_USERS_MANAGEMENT=off`