### PR TITLE
feat(copilot): add default query to empty editor

### DIFF
--- a/webapp/src/webapp/webclient/codemirror/extensions.cljs
+++ b/webapp/src/webapp/webclient/codemirror/extensions.cljs
@@ -10,7 +10,9 @@
                     (str "When the language is a query language, use this schema to help you: "
                          database-schema)))}
    {:role "user"
-    :content (str prefix "<FILL_ME>" suffix)}])
+    :content (if (and (empty? prefix) (empty? suffix))
+               "select <FILL_ME>"
+               (str prefix "<FILL_ME>" suffix))}])
 
 (defn fetch-autocomplete [language prefix suffix database-schema]
   (let [token (.getItem js/localStorage "jwt-token")


### PR DESCRIPTION
check if both the prefix and suffix are empty. If they are, it sets the user content to "select <FILL_ME>". Otherwise, it uses the original prefix and suffix.