### PR TITLE
Make output tab in editor persistent based on user selection

### DIFF
--- a/webapp/src/webapp/subs.cljs
+++ b/webapp/src/webapp/subs.cljs
@@ -358,3 +358,8 @@
  :reports->session
  (fn [db _]
    (:reports->session db)))
+
+(rf/reg-sub
+ ::selected-tab
+ (fn [db]
+   (get db :output->selected-output-tab "Terminal")))


### PR DESCRIPTION
These changes do the following:

1. added a new re-frame subscription ::selected-tab to store the currently selected tab.

2. added a new re-frame event ::set-selected-tab to update the selected tab when the user changes it.

3. In the main function, replaced the local selected-tab atom with a subscription to ::selected-tab.

4. updated the tabs component to dispatch the ::set-selected-tab event when a tab is clicked.

5. replaced @selected-tab with @selected-tab in the case statement that renders the appropriate component based on the selected tab.

These changes will make the output tab (Terminal or Tabular) persistent. The selected tab will be stored in the re-frame app-db, and it will persist across code runs until the user explicitly changes it.