### PR TITLE
feat: Add API key authentication middleware

### DIFF
--- a/gateway/security/apikey/apikey.go
+++ b/gateway/security/apikey/apikey.go
@@ -1,0 +1,13 @@
+package apikey
+
+import (
+	"os"
+)
+
+func ValidateOrgApiKey(orgID string, apiKey string) (bool, error) {
+	// Load the API key from an environment variable
+	envApiKey := os.Getenv("ORG_API_KEY")
+
+	// Compare the provided API key with the one from the environment variable
+	return apiKey == envApiKey, nil
+}

--- a/gateway/security/apikey/apikey.go
+++ b/gateway/security/apikey/apikey.go
@@ -1,12 +1,20 @@
 package apikey
 
 import (
+	"errors"
 	"os"
 )
+
+var ErrAPIKeyNotConfigured = errors.New("API key authentication is not configured. Please check the documentation to learn how to enable it.")
 
 func ValidateOrgApiKey(orgID string, apiKey string) (bool, error) {
 	// Load the API key from an environment variable
 	envApiKey := os.Getenv("ORG_API_KEY")
+
+	// Check if the API key is configured
+	if envApiKey == "" {
+		return false, ErrAPIKeyNotConfigured
+	}
 
 	// Compare the provided API key with the one from the environment variable
 	return apiKey == envApiKey, nil


### PR DESCRIPTION
# Add API Key Authentication for Connection Management

## Summary
This PR introduces API key authentication for creating and deleting connections. This feature allows for automated connection management while maintaining security.

## Changes
- Added an `ApiKeyAuthMiddleware` to validate API keys for specific routes
- Implemented API key validation using an environment variable (`ORG_API_KEY`)
- Applied the new middleware to POST and DELETE connection routes

## Security Considerations
While not the most secure method, this implementation offers a balance between functionality and security:

1. **Optional Feature**: Customers can choose not to enable this feature by simply not setting the `ORG_API_KEY` environment variable.

2. **Limited Scope**: The API key authentication only works for creating or deleting connections. It cannot be used to read any information, sensitive or otherwise, making it relatively harmless from a data security standpoint.

3. **Potential for Service Disruption**: The main risk is the potential deletion of connections, which could disrupt service. However, this risk is mitigated by:
   - The requirement of both admin authentication and the API key
   - The ability to easily restore connections using database backups

4. **No Data Exposure**: This feature does not expose any sensitive data, as it's limited to connection management operations.

## Usage
To enable this feature, set the `ORG_API_KEY` environment variable with a secure, randomly generated key. Use this key in the `X-API-Key` header when making POST or DELETE requests to the connections endpoints.

## Testing
- [ ] Verify that connection creation works with a valid API key
- [ ] Verify that connection deletion works with a valid API key
- [ ] Confirm that these operations fail without a valid API key
- [ ] Ensure that other endpoints are not affected by this change
