### PR TITLE
fix(session) reforce to only admins see everyones sessions

### DIFF
--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -242,7 +242,8 @@ func Get(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"message": "failed fetching session"})
 		return
 	}
-	if session == nil {
+
+	if (session == nil || session.UserID != ctx.UserID) && !ctx.IsAdminUser() {
 		c.JSON(http.StatusNotFound, gin.H{"message": "not found"})
 		return
 	}


### PR DESCRIPTION
- added a verification at the controller level to allow admins only to see everyone's sessions