### PR TITLE
Fix race condition problem when approving concurrent jit access

### DIFF
--- a/gateway/pgrest/review/review.go
+++ b/gateway/pgrest/review/review.go
@@ -133,12 +133,13 @@ func (r *review) FetchOneBySid(ctx pgrest.OrgContext, sid string) (*types.Review
 	return parseReview(rev), nil
 }
 
-func (r *review) FetchJit(ctx pgrest.OrgContext, connectionID string) (*types.Review, error) {
+func (r *review) FetchJit(ctx pgrest.OrgContext, ownerUserID, connectionID string) (*types.Review, error) {
 	var rev Review
-	err := pgrest.New("/reviews?org_id=eq.%s&connection_id=eq.%s&type=eq.jit&status=eq.APPROVED&revoked_at=gt.now&select=*,review_groups(*)",
-		ctx.GetOrgID(), url.QueryEscape(connectionID)).
-		FetchOne().
-		DecodeInto(&rev)
+	err := pgrest.New("/reviews?org_id=eq.%s&type=eq.jit&status=eq.APPROVED&owner_id=eq.%s&connection_id=eq.%s&select=*,review_groups(*)&order=created_at.desc&limit=1",
+		ctx.GetOrgID(),
+		url.QueryEscape(ownerUserID),
+		url.QueryEscape(connectionID),
+	).FetchOne().DecodeInto(&rev)
 	if err != nil {
 		if err == pgrest.ErrNotFound {
 			return nil, nil

--- a/gateway/review/service.go
+++ b/gateway/review/service.go
@@ -82,11 +82,6 @@ func (s *Service) Persist(ctx pgrest.OrgContext, review *types.Review) error {
 	return nil
 }
 
-// FindApprovedJitReviews returns jit reviews that are active based on the access duration
-func (s *Service) FindApprovedJitReviews(ctx pgrest.OrgContext, connID string) (*types.Review, error) {
-	return pgreview.New().FetchJit(ctx, connID)
-}
-
 func (s *Service) Revoke(ctx pgrest.OrgContext, reviewID string) (*types.Review, error) {
 	rev, err := s.FindOne(ctx, reviewID)
 	if err != nil {

--- a/gateway/transport/plugins/review/review_test.go
+++ b/gateway/transport/plugins/review/review_test.go
@@ -1,0 +1,65 @@
+package review
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/gateway/storagev2/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTime(hour, minute int) *time.Time {
+	t := time.Date(2024, time.September, 9, hour, minute, 0, 0, time.UTC)
+	return &t
+}
+
+func TestValidateJit(t *testing.T) {
+	for _, tt := range []struct {
+		msg string
+		jit *types.Review
+		now *time.Time
+		err error
+	}{
+		{
+			msg: "it should validate without any error when jit is not expired",
+			now: newTime(10, 19),
+			jit: &types.Review{
+				RevokeAt: newTime(10, 20),
+			},
+		},
+		{
+			msg: "it should validate with error if jit is expired",
+			now: newTime(10, 21),
+			jit: &types.Review{
+				RevokeAt: newTime(10, 20),
+			},
+			err: errJitExpired,
+		},
+		{
+			msg: "it should validate with error if revoked at is nil",
+			now: newTime(10, 21),
+			jit: &types.Review{
+				RevokeAt: nil,
+			},
+			err: fmt.Errorf("internal error, found inconsistent jit record"),
+		},
+		{
+			msg: "it should validate with error if revoked at is zero",
+			now: newTime(10, 21),
+			jit: &types.Review{
+				RevokeAt: func() *time.Time { t := time.Time{}; return &t }(),
+			},
+			err: fmt.Errorf("internal error, found inconsistent jit record"),
+		},
+	} {
+		t.Run(tt.msg, func(t *testing.T) {
+			err := validateJit(tt.jit, *tt.now)
+			if tt.err != nil {
+				assert.EqualError(t, err, tt.err.Error())
+				return
+			}
+			assert.Nil(t, err)
+		})
+	}
+}


### PR DESCRIPTION
- Move logic of validating jit expiration to GO to facilitate diagnosing time expiration issues