### PR TITLE
Allow customizing the svix client to send webhooks to a svix self hosted installation

### DIFF
--- a/gateway/api/webhooks/dashboard.go
+++ b/gateway/api/webhooks/dashboard.go
@@ -3,11 +3,11 @@ package webhooks
 import (
 	"context"
 	"net/http"
-	"os"
 
 	"github.com/gin-gonic/gin"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/storagev2"
 	svix "github.com/svix/svix-webhooks/go"
 )
@@ -23,9 +23,13 @@ import (
 //	@Router			/webhooks-dashboard [get]
 func Get(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
-	appKey := os.Getenv("WEBHOOK_APPKEY")
+	appKey := appconfig.Get().WebhookAppKey()
 	if appKey == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"message": "webhook app key is not configured"})
+		return
+	}
+	if webhookAppURL := appconfig.Get().WebhookAppURL(); webhookAppURL != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "dashboard is not available using self hosted Svix (webhook provider)"})
 		return
 	}
 	svixClient := svix.New(appKey, nil)

--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -35,6 +35,7 @@ type Config struct {
 	msPresidioAnalyzerURL   string
 	msPresidioAnonymizerURL string
 	webhookAppKey           string
+	webhookAppURL           *url.URL
 	licenseSigningKey       *rsa.PrivateKey
 	licenseSignerOrgID      string
 	migrationPathFiles      string
@@ -117,6 +118,13 @@ func Load() error {
 	if apiRawURL.Path == "/" {
 		apiRawURL.Path = ""
 	}
+	var webhookAppURL *url.URL
+	if svixAppURL := os.Getenv("WEBHOOK_APPURL"); svixAppURL != "" {
+		webhookAppURL, err = url.Parse(svixAppURL)
+		if err != nil {
+			return fmt.Errorf("failed parsing WEBHOOK_APPURL, reason=%v", err)
+		}
+	}
 	runtimeConfig = Config{
 		apiKey:                  os.Getenv("API_KEY"),
 		apiURL:                  fmt.Sprintf("%s://%s", apiRawURL.Scheme, apiRawURL.Host),
@@ -137,6 +145,7 @@ func Load() error {
 		msPresidioAnalyzerURL:   os.Getenv("MSPRESIDIO_ANALYZER_URL"),
 		msPresidioAnonymizerURL: os.Getenv("MSPRESIDIO_ANONYMIZER_URL"),
 		webhookAppKey:           os.Getenv("WEBHOOK_APPKEY"),
+		webhookAppURL:           webhookAppURL,
 		webappUsersManagement:   webappUsersManagement,
 		jwtSecretKey:            []byte(os.Getenv("JWT_SECRET_KEY")),
 		webappStaticUIPath:      webappStaticUiPath,
@@ -276,6 +285,7 @@ func (c Config) ApiURLPath() string         { return c.apiURLPath }
 func (c Config) ApiKey() string                  { return c.apiKey }
 func (c Config) AuthMethod() string              { return c.authMethod }
 func (c Config) WebhookAppKey() string           { return c.webhookAppKey }
+func (c Config) WebhookAppURL() *url.URL         { return c.webhookAppURL }
 func (c Config) GcpDLPJsonCredentials() string   { return c.gcpDLPJsonCredentials }
 func (c Config) DlpProvider() string             { return c.dlpProvider }
 func (c Config) MSPresidioAnalyzerURL() string   { return c.msPresidioAnalyzerURL }

--- a/gateway/transport/plugins/webhooks/webhooks.go
+++ b/gateway/transport/plugins/webhooks/webhooks.go
@@ -30,7 +30,8 @@ type plugin struct {
 func New() *plugin {
 	if webhookAppKey := appconfig.Get().WebhookAppKey(); webhookAppKey != "" {
 		log.Infof("loaded webhook app key with success")
-		return &plugin{svix.New(webhookAppKey, nil), memory.New()}
+		webhookAppUrl := appconfig.Get().WebhookAppURL()
+		return &plugin{svix.New(webhookAppKey, &svix.SvixOptions{ServerUrl: webhookAppUrl}), memory.New()}
 	}
 	return &plugin{}
 }
@@ -226,7 +227,7 @@ func (p *plugin) processSessionOpenEvent(ctx plugintypes.Context, pkt *pb.Packet
 		},
 	})
 	if err != nil {
-		log.With("appid", appID).Warnf("failed sending webhook event to remote sourcev, err=%v", err)
+		log.With("appid", appID).Warnf("failed sending webhook event to remote source, err=%v", err)
 		return
 	}
 	if out != nil {


### PR DESCRIPTION
- Introduce `WEBHOOK_APPURL` env configuration