### PR TITLE
[bugtfix] Remove azp claim check when validating access tokens.

### DIFF
--- a/gateway/security/idp/authenticator.go
+++ b/gateway/security/idp/authenticator.go
@@ -86,13 +86,6 @@ func (p *Provider) VerifyAccessToken(accessToken string) (string, error) {
 		if !ok || subject == "" {
 			return "", fmt.Errorf("'sub' not found or has an empty value")
 		}
-		// https://openid.net/specs/openid-connect-core-1_0.html
-		// If an azp (authorized party) Claim is present, the Client SHOULD verify that its client_id is the Claim Value.
-		if authorizedParty, ok := claims["azp"].(string); ok {
-			if authorizedParty != p.ClientID {
-				return "", fmt.Errorf("it's not an authorized party")
-			}
-		}
 		return subject, nil
 	}
 	return "", fmt.Errorf("failed type casting token.Claims (%T) to jwt.MapClaims", token.Claims)


### PR DESCRIPTION
 The server already validates if the authorized party is stored in the system