### PR TITLE
Add runbook env vars primitives

### DIFF
--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -523,8 +523,6 @@ type Review struct {
 	Session string `json:"session" format:"uuid" readonly:"true" example:"35DB0A2F-E5CE-4AD8-A308-55C3108956E5"`
 	// The input that was issued when the resource was created
 	Input string `json:"input" readonly:"true" example:"SELECT NOW()"`
-	// The environment variables when the resource was created
-	InputEnvVars map[string]string `json:"input_envvars" readonly:"true"`
 	// The client arguments when the resource was created
 	InputClientArgs []string `json:"input_clientargs" readonly:"true" example:"-x"`
 	// The amount of time (nanoseconds) to allow access to the connection. It's valid only for `jit` type reviews`

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -282,6 +282,10 @@ type RunbookRequest struct {
 	RefHash string `json:"ref_hash" example:"20320ebbf9fc612256b67dc9e899bbd6e4745c77"`
 	// The parameters of the runbook. It must match with the declared attributes
 	Parameters map[string]string `json:"parameters" example:"amount:10,wallet_id:6736"`
+	// Environment Variables that will be included in the runtime
+	// * { envvar:[env-key]: [base64-val] } - Expose the value as environment variable
+	// * { filesystem:[env-key]: [base64-val] } - Expose the value as a temporary file path creating the value in the filesystem
+	EnvVars map[string]string `json:"env_vars" example:"envvar:PASSWORD:MTIz,filesystem:SECRET_FILE:bXlzZWNyZXQ="`
 	// Additional arguments to pass down to the connection
 	ClientArgs []string `json:"client_args" example:"--verbose"`
 	// Metadata attributes to add in the session

--- a/gateway/api/runbooks/runbooks.go
+++ b/gateway/api/runbooks/runbooks.go
@@ -171,6 +171,14 @@ func RunExec(c *gin.Context) {
 		return
 	}
 
+	for key, val := range req.EnvVars {
+		// don't replace environment variables from runbook
+		if _, ok := runbook.EnvVars[key]; ok {
+			continue
+		}
+		runbook.EnvVars[key] = val
+	}
+
 	runbookParamsJson, _ := json.Marshal(req.Parameters)
 	sessionLabels := types.SessionLabels{
 		"runbookFile":       req.FileName,

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -294,13 +294,14 @@ func Get(c *gin.Context) {
 	// TODO: refactor to use the postgrest direct function
 	if review != nil {
 		session.Review = &types.ReviewJSON{
-			Id:               review.Id,
-			OrgId:            review.OrgId,
-			CreatedAt:        review.CreatedAt,
-			Type:             review.Type,
-			Session:          review.Session,
-			Input:            review.Input,
-			InputEnvVars:     review.InputEnvVars,
+			Id:        review.Id,
+			OrgId:     review.OrgId,
+			CreatedAt: review.CreatedAt,
+			Type:      review.Type,
+			Session:   review.Session,
+			Input:     review.Input,
+			// Redacted for now
+			// InputEnvVars:     review.InputEnvVars,
 			InputClientArgs:  review.InputClientArgs,
 			AccessDuration:   review.AccessDuration,
 			Status:           review.Status,

--- a/gateway/pgrest/review/review.go
+++ b/gateway/pgrest/review/review.go
@@ -151,13 +151,14 @@ func (r *review) FetchJit(ctx pgrest.OrgContext, ownerUserID, connectionID strin
 
 func ToJson(rev types.Review) *types.ReviewJSON {
 	return &types.ReviewJSON{
-		Id:               rev.Id,
-		OrgId:            rev.OrgId,
-		CreatedAt:        rev.CreatedAt,
-		Type:             rev.Type,
-		Session:          rev.Session,
-		Input:            rev.Input,
-		InputEnvVars:     rev.InputEnvVars,
+		Id:        rev.Id,
+		OrgId:     rev.OrgId,
+		CreatedAt: rev.CreatedAt,
+		Type:      rev.Type,
+		Session:   rev.Session,
+		Input:     rev.Input,
+		// Redacted for now
+		// InputEnvVars:     rev.InputEnvVars,
 		InputClientArgs:  rev.InputClientArgs,
 		AccessDuration:   rev.AccessDuration,
 		Status:           rev.Status,

--- a/gateway/review/api.go
+++ b/gateway/review/api.go
@@ -112,13 +112,14 @@ func sanitizeReview(review *types.Review) types.ReviewJSON {
 	}
 
 	return types.ReviewJSON{
-		Id:              review.Id,
-		OrgId:           review.OrgId,
-		CreatedAt:       review.CreatedAt,
-		Type:            review.Type,
-		Session:         review.Session,
-		Input:           review.Input,
-		InputEnvVars:    review.InputEnvVars,
+		Id:        review.Id,
+		OrgId:     review.OrgId,
+		CreatedAt: review.CreatedAt,
+		Type:      review.Type,
+		Session:   review.Session,
+		Input:     review.Input,
+		// Redacted for now
+		// InputEnvVars:    review.InputEnvVars,
 		InputClientArgs: review.InputClientArgs,
 		AccessDuration:  review.AccessDuration,
 		Status:          review.Status,

--- a/gateway/storagev2/types/types.go
+++ b/gateway/storagev2/types/types.go
@@ -149,20 +149,21 @@ type Review struct {
 }
 
 type ReviewJSON struct {
-	Id               string            `json:"id"`
-	OrgId            string            `json:"org"`
-	CreatedAt        time.Time         `json:"created_at"`
-	Type             string            `json:"type"`
-	Session          string            `json:"session"`
-	Input            string            `json:"input"`
-	InputEnvVars     map[string]string `json:"input_envvars"`
-	InputClientArgs  []string          `json:"input_clientargs"`
-	AccessDuration   time.Duration     `json:"access_duration"`
-	Status           ReviewStatus      `json:"status"`
-	RevokeAt         *time.Time        `json:"revoke_at"`
-	ReviewOwner      ReviewOwner       `json:"review_owner"`
-	Connection       ReviewConnection  `json:"review_connection"`
-	ReviewGroupsData []ReviewGroup     `json:"review_groups_data"`
+	Id        string    `json:"id"`
+	OrgId     string    `json:"org"`
+	CreatedAt time.Time `json:"created_at"`
+	Type      string    `json:"type"`
+	Session   string    `json:"session"`
+	Input     string    `json:"input"`
+	// Redacted for now
+	// InputEnvVars     map[string]string `json:"input_envvars"`
+	InputClientArgs  []string         `json:"input_clientargs"`
+	AccessDuration   time.Duration    `json:"access_duration"`
+	Status           ReviewStatus     `json:"status"`
+	RevokeAt         *time.Time       `json:"revoke_at"`
+	ReviewOwner      ReviewOwner      `json:"review_owner"`
+	Connection       ReviewConnection `json:"review_connection"`
+	ReviewGroupsData []ReviewGroup    `json:"review_groups_data"`
 }
 
 type SessionEventStream []any


### PR DESCRIPTION
This change will allow adding environment variables to the runtime of an execution.
- Remove the attribute `input_envvars` from displaying in the public api