### PR TITLE
Add attribute type AdaptiveCard when sending ms teams events

### DIFF
--- a/gateway/transport/plugins/webhooks/microsoftteams.review.create.json
+++ b/gateway/transport/plugins/webhooks/microsoftteams.review.create.json
@@ -19,7 +19,9 @@
       "type": "message",
       "attachments": [
         {
+          "contentType": "application/vnd.microsoft.card.adaptive",
           "content": {
+            "type": "AdaptiveCard",
             "body": [
               {
                 "separator": true,
@@ -73,8 +75,7 @@
             "msteams": {
               "width": "full"
             }
-          },
-          "contentType": "application/vnd.microsoft.card.adaptive"
+          }
         }
       ]
     }


### PR DESCRIPTION
- [gateway] Add attribute attachments[].content.type to AdaptiveCard when sending ms teams events
- [gateway] Add review simple structure to differentiate sessions with reviews when creating session.open events