### PR TITLE
Allow maintaining the session of identity providers

### DIFF
--- a/gateway/api/serverinfo/serverinfo.go
+++ b/gateway/api/serverinfo/serverinfo.go
@@ -25,7 +25,6 @@ var (
 		LogLevel:                os.Getenv("LOG_LEVEL"),
 		GoDebug:                 os.Getenv("GODEBUG"),
 		AdminUsername:           os.Getenv("ADMIN_USERNAME"),
-		AuthMethod:              appconfig.Get().AuthMethod(),
 		HasRedactCredentials:    isEnvSet("GOOGLE_APPLICATION_CREDENTIALS_JSON"),
 		HasWebhookAppKey:        isEnvSet("WEBHOOK_APPKEY"),
 		HasIDPAudience:          isEnvSet("IDP_AUDIENCE"),
@@ -71,6 +70,7 @@ func (h *handler) Get(c *gin.Context) {
 	if isOrgMultiTenant {
 		tenancyType = "multitenant"
 	}
+	serverInfoData.AuthMethod = appconfig.Get().AuthMethod()
 	serverInfoData.TenancyType = tenancyType
 	serverInfoData.GrpcURL = h.grpcURL
 	serverInfoData.ApiURL = appconfig.Get().ApiURL()

--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -273,6 +273,9 @@
     [layout :auth [local-auth-login/panel]]
     [layout :auth (rf/dispatch [:auth->get-auth-link])]))
 
+(defmethod routes/panels :idplogin-hoop-panel []
+  [layout :auth (rf/dispatch [:auth->get-auth-link {:prompt-login? true}])])
+
 (defmethod routes/panels :register-hoop-panel [_ gateway-info]
   (if (= (-> gateway-info :data :auth_method) "local")
     [layout :auth [local-auth-register/panel]]

--- a/webapp/src/webapp/events/auth.cljs
+++ b/webapp/src/webapp/events/auth.cljs
@@ -5,10 +5,11 @@
 
 (rf/reg-event-fx
  :auth->get-auth-link
- (fn []
+ (fn [_ [_ {:keys [prompt-login?]}]]
    (let [on-success #(.replace js/window.location (:login_url %))
+         base-uri (if prompt-login? "/login?prompt=login&redirect=" "/login?redirect=")
          get-email [:fetch {:method "GET"
-                            :uri (str "/login?prompt=login&redirect="
+                            :uri (str base-uri
                                       (str (. (. js/window -location) -origin)
                                            (routes/url-for :auth-callback-hoop)))
                             :on-success on-success}]]
@@ -42,10 +43,10 @@
 
 (rf/reg-event-fx
  :auth->logout
- (fn [{:keys [db]}]
-   (let [auth0-logout-url (str "https://hoophq.us.auth0.com"
+ (fn [{:keys [db]} [_ {:keys [idp?]}]]
+   (let [auth0-logout-url (str "https://auth-testing.hoop.dev"
                                "/v2/logout?"
-                               "client_id=DatIOCxntNv8AZrQLVnLb3tr1Y3oVwGW"
+                               "client_id=Th53Ge2qcL0qm3z8QD6RvzEjIWfIckid"
                                "&returnTo=" (js/encodeURIComponent
                                              (str (. (. js/window -location) -origin)
                                                   (routes/url-for :login-hoop)))
@@ -58,5 +59,7 @@
 
        (do
          (.removeItem js/localStorage "jwt-token")
-         {:fx [[:dispatch [:navigate :logout-hoop]]]
-          :db {}})))))
+         (set! (.. js/window -location -href) (routes/url-for (if idp?
+                                                                :idplogin-hoop
+                                                                :login-hoop)))
+         {:db {}})))))

--- a/webapp/src/webapp/events/auth.cljs
+++ b/webapp/src/webapp/events/auth.cljs
@@ -44,9 +44,9 @@
 (rf/reg-event-fx
  :auth->logout
  (fn [{:keys [db]} [_ {:keys [idp?]}]]
-   (let [auth0-logout-url (str "https://auth-testing.hoop.dev"
+   (let [auth0-logout-url (str "https://hoophq.us.auth0.com"
                                "/v2/logout?"
-                               "client_id=Th53Ge2qcL0qm3z8QD6RvzEjIWfIckid"
+                               "client_id=DatIOCxntNv8AZrQLVnLb3tr1Y3oVwGW"
                                "&returnTo=" (js/encodeURIComponent
                                              (str (. (. js/window -location) -origin)
                                                   (routes/url-for :login-hoop)))

--- a/webapp/src/webapp/routes.cljs
+++ b/webapp/src/webapp/routes.cljs
@@ -27,6 +27,7 @@
      "/dashboard" :dashboard
      "/hoop-app" :hoop-app
      "/login" :login-hoop
+     "/idplogin" :idplogin-hoop
      "/logout" :logout-hoop
      "/organization" [["/users" :users]]
      "/guardrails" [["" :guardrails]

--- a/webapp/src/webapp/shared_ui/sidebar/navigation.cljs
+++ b/webapp/src/webapp/shared_ui/sidebar/navigation.cljs
@@ -24,12 +24,11 @@
         current-route (rf/subscribe [:routes->route])]
     (fn [user my-plugins]
       (let [gateway-version (:version (:data @gateway-info))
+            auth-method (:auth_method (:data @gateway-info))
             user-data (:data user)
             plugins-routes-enabled (filterv (fn [plugin]
                                               (some #(= (:name plugin) (:name %)) my-plugins))
                                             sidebar-constants/plugins-routes)
-            is-plugin-enabled? (fn [plugin-name]
-                                 (some #(= plugin-name (:name %)) my-plugins))
             admin? (:admin? user-data)
             free-license? (:free-license? user-data)
             current-route @current-route]
@@ -246,7 +245,7 @@
                 "Contact support"]]
               [:li
                [:> (.-Button ui/Disclosure) {:as "a"
-                                             :onClick #(rf/dispatch [:auth->logout])
+                                             :onClick #(rf/dispatch [:auth->logout {:idp? (= auth-method "idp")}])
                                              :href "#"
                                              :class "group -mx-2 flex items-center gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-300 hover:bg-gray-800 hover:text-white"}
                 [:> hero-outline-icon/ArrowLeftOnRectangleIcon {:class "h-6 w-6 shrink-0 text-white"


### PR DESCRIPTION
This PR will ensure that sessions are reused when redirecting failed attempts to authenticate (401). It removes the `prompt=login` option when redirecting users to their identity providers.

Additionally, it makes sure to always prompt for the login screen when the user clicks on Logout.

More information in the [OpenID specification](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)

- Tested with local auth method
- Tested with Azure Entra ID
- Tested with Auth0
- Tested with multi tenant setup