### PR TITLE
Secure the Intercom messenger with Identity Verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,7 @@ jobs:
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SEGMENT_API_KEY: ${{ secrets.SEGMENT_API_KEY }}
+          INTERCOM_HMAC_KEY: ${{ secrets.INTERCOM_HMAC_KEY }}
         run: GOOS=linux GOARCH=amd64 make build
 
       - uses: actions/upload-artifact@v3
@@ -244,6 +245,7 @@ jobs:
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SEGMENT_API_KEY: ${{ secrets.SEGMENT_API_KEY }}
+          INTERCOM_HMAC_KEY: ${{ secrets.INTERCOM_HMAC_KEY }}
         run: GOOS=linux GOARCH=arm64 make build
 
       - uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ LDFLAGS := "-s -w \
 -X github.com/hoophq/hoop/common/version.buildDate=${DATE} \
 -X github.com/hoophq/hoop/common/monitoring.honeycombApiKey=${HONEYCOMB_API_KEY} \
 -X github.com/hoophq/hoop/common/monitoring.sentryDSN=${SENTRY_DSN} \
--X github.com/hoophq/hoop/gateway/analytics.segmentApiKey=${SEGMENT_API_KEY}"
+-X github.com/hoophq/hoop/gateway/analytics.segmentApiKey=${SEGMENT_API_KEY} \
+-X github.com/hoophq/hoop/gateway/analytics.intercomHmacKey=${INTERCOM_HMAC_KEY}"
 
 postgrest-link:
 	echo https://github.com/PostgREST/postgrest/releases/download/v11.2.2/postgrest-v11.2.2-${POSTREST_ARCH_SUFFIX}

--- a/gateway/analytics/intercom.go
+++ b/gateway/analytics/intercom.go
@@ -1,0 +1,21 @@
+package analytics
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// https://www.intercom.com/help/en/articles/183-set-up-identity-verification-for-web-and-mobile
+func GenerateIntercomHmacDigest(email string) (string, error) {
+	key := []byte(intercomHmacKey)
+	message := []byte(email)
+	hash := hmac.New(sha256.New, key)
+	if _, err := hash.Write(message); err != nil {
+		return "", fmt.Errorf("failed generating hmac signature for %v, hmac-key-length=%v, reason=%v",
+			email, len(intercomHmacKey), err)
+	}
+	sha := hash.Sum(nil)
+	return hex.EncodeToString(sha), nil
+}

--- a/gateway/analytics/runtime.go
+++ b/gateway/analytics/runtime.go
@@ -1,3 +1,6 @@
 package analytics
 
-var segmentApiKey string
+var (
+	segmentApiKey   string
+	intercomHmacKey string
+)

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -101,7 +101,8 @@ type UserInfo struct {
 	// Enable or disable Webapp users management
 	// * on - Enable the users management view on Webapp
 	// * on - Disable the users management view on Webapp
-	WebAppUsersManagement string `json:"webapp_users_management" enums:"on,off" default:"on"`
+	WebAppUsersManagement  string `json:"webapp_users_management" enums:"on,off" default:"on"`
+	IntercomUserHmacDigest string `json:"intercom_hmac_digest"`
 }
 
 type ServiceAccountStatusType string

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -463,16 +463,14 @@ func GetUserInfo(c *gin.Context) {
 			SlackID:  ctx.SlackID,
 			Groups:   groupList,
 		},
-		IsAdmin:               ctx.IsAdminUser(), // DEPRECATED in flavor of role (admin)
-		IsMultitenant:         isOrgMultiTenant,  // DEPRECATED is flavor of tenancy_type
-		TenancyType:           tenancyType,
-		OrgID:                 ctx.OrgID,
-		OrgName:               ctx.OrgName,
-		OrgLicense:            ctx.OrgLicense,
-		FeatureAskAI:          askAIFeatureStatus,
-		WebAppUsersManagement: appconfig.Get().WebappUsersManagement(),
-		// TODO: change to use hmac digest from user email
-		// IntercomUserHmacDigest: "a682351b1946a315d77ac06715fb5e3fd788c395c51b448817bc3c296cd8a492",
+		IsAdmin:                ctx.IsAdminUser(), // DEPRECATED in flavor of role (admin)
+		IsMultitenant:          isOrgMultiTenant,  // DEPRECATED is flavor of tenancy_type
+		TenancyType:            tenancyType,
+		OrgID:                  ctx.OrgID,
+		OrgName:                ctx.OrgName,
+		OrgLicense:             ctx.OrgLicense,
+		FeatureAskAI:           askAIFeatureStatus,
+		WebAppUsersManagement:  appconfig.Get().WebappUsersManagement(),
 		IntercomUserHmacDigest: intercomUserHash,
 	}
 	if ctx.IsAnonymous() {

--- a/webapp/src/webapp/events.cljs
+++ b/webapp/src/webapp/events.cljs
@@ -114,8 +114,6 @@
  :initialize-intercom
  (fn
    [{:keys [db]} [_ user]]
-   (js/console.log "DB -->>", (clj->js db))
-   (js/console.log "USER -->>", (clj->js user))
    (js/window.Intercom
     "boot"
     (clj->js {:api_base "https://api-iam.intercom.io"

--- a/webapp/src/webapp/events.cljs
+++ b/webapp/src/webapp/events.cljs
@@ -114,9 +114,14 @@
  :initialize-intercom
  (fn
    [{:keys [db]} [_ user]]
+   (js/console.log "DB -->>", (clj->js db))
+   (js/console.log "USER -->>", (clj->js user))
    (js/window.Intercom
     "boot"
-    (clj->js {:app_id "ryuapdmp"
+    (clj->js {:api_base "https://api-iam.intercom.io"
+              :app_id "ryuapdmp"
               :name (:name user)
-              :email (:email user)}))
+              :email (:email user)
+              :user_id (:email user)
+              :user_hash (:intercom_hmac_digest user)}))
    {}))


### PR DESCRIPTION
Identity Verification stops anyone impersonating logged-in users or seeing their conversations.