### PR TITLE
Allow performing plain execution on connection over internal routes using clientexec

### DIFF
--- a/common/log/log.go
+++ b/common/log/log.go
@@ -99,7 +99,7 @@ func NewDefaultLogger(additionalWriterLogger io.Writer) *zap.Logger {
 		}),
 		zap.ErrorOutput(stderrSink),
 		zap.AddCaller(),
-		zap.AddStacktrace(zapcore.DPanicLevel),
+		zap.AddStacktrace(zapcore.ErrorLevel),
 	)
 	zap.ReplaceGlobals(logger)
 	return logger

--- a/common/proto/const.go
+++ b/common/proto/const.go
@@ -51,8 +51,9 @@ const (
 
 	ClientLoginCallbackAddress string = "127.0.0.1:3587"
 
-	ClientVerbConnect = "connect"
-	ClientVerbExec    = "exec"
+	ClientVerbConnect   = "connect"
+	ClientVerbExec      = "exec"
+	ClientVerbPlainExec = "plain-exec"
 
 	SessionPhaseClientConnect       = "client-connect"
 	SessionPhaseClientConnected     = "client-connected"

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -139,7 +139,7 @@ func Post(c *gin.Context) {
 					{0, "e", base64.StdEncoding.EncodeToString([]byte(err.Error()))},
 				},
 			}
-			if err = pgsession.New().Upsert(ctx, newSession); err != nil {
+			if err := pgsession.New().Upsert(ctx, newSession); err != nil {
 				log.Errorf("unable to update session, err=%v", err)
 			}
 			c.JSON(http.StatusOK, clientexec.Response{

--- a/gateway/transport/agent.go
+++ b/gateway/transport/agent.go
@@ -80,6 +80,7 @@ func (s *Server) listenAgentMessages(pctx *plugintypes.Context, stream *streamcl
 			OrgID:          pctx.OrgID,
 			SID:            pctx.SID,
 			ConnectionName: proxyStream.PluginContext().ConnectionName,
+			Verb:           proxyStream.PluginContext().ClientVerb,
 		}
 
 		if err := transportext.OnReceive(extContext, pkt); err != nil {

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -184,6 +184,7 @@ func (s *Server) processClientPacket(stream *streamclient.ProxyStream, pkt *pb.P
 		OrgID:          pctx.OrgID,
 		SID:            pctx.SID,
 		ConnectionName: pctx.ConnectionName,
+		Verb:           pctx.ClientVerb,
 	}
 
 	if err := transportext.OnReceive(extContext, pkt); err != nil {

--- a/gateway/transport/extensions/extension.go
+++ b/gateway/transport/extensions/extension.go
@@ -19,9 +19,14 @@ type Context struct {
 	SID            string
 	OrgID          string
 	ConnectionName string
+	Verb           string
 }
 
 func OnReceive(ctx Context, pkt *proto.Packet) error {
+	if ctx.Verb == proto.ClientVerbPlainExec {
+		return nil
+	}
+
 	switch pkt.Type {
 	case pbagent.SessionOpen:
 		conn, err := models.GetConnectionGuardRailRules(ctx.OrgID, ctx.ConnectionName)

--- a/gateway/transport/streamclient/pluginruntime.go
+++ b/gateway/transport/streamclient/pluginruntime.go
@@ -17,6 +17,9 @@ type runtimePlugin struct {
 
 func loadRuntimePlugins(ctx plugintypes.Context) ([]runtimePlugin, error) {
 	pluginsConfig := make([]runtimePlugin, 0)
+	if ctx.ClientVerb == pb.ClientVerbPlainExec {
+		return pluginsConfig, nil
+	}
 	var nonRegisteredPlugins []string
 	for _, p := range plugintypes.RegisteredPlugins {
 		p1, err := pgplugins.New().FetchOne(ctx, p.Name())


### PR DESCRIPTION
- Revert emitting stacktraces when logging errors
- Fix bug when guardrule returns a match over api execution