### PR TITLE
Provide a way to specify GroupsClaim with environment variable

### DIFF
--- a/gateway/security/idp/authenticator.go
+++ b/gateway/security/idp/authenticator.go
@@ -159,6 +159,9 @@ func setProviderConfFromEnvs(p *Provider) error {
 	p.Audience = os.Getenv("IDP_AUDIENCE")
 	p.CustomScopes = os.Getenv("IDP_CUSTOM_SCOPES")
 	p.GroupsClaim = proto.CustomClaimGroups
+	if os.Getenv("IDP_GROUPS_CLAIM") != "" {
+		p.GroupsClaim = os.Getenv("IDP_GROUPS_CLAIM")
+	}
 
 	issuerURL, err := url.Parse(p.Issuer)
 	if err != nil {


### PR DESCRIPTION
As of now, if we are authenticating via an OIDC compliant IDP (I'm using Keycloak) we are not able to set the GroupsClaim, being forced to use claim `"https://app.hoop.dev/groups"` defined here: https://github.com/hoophq/hoop/blob/main/common/proto/const.go#L65.
With this PR you could use an environment variable in case you want to use the standard `groups` claim (or any other you want).

What do you think about this?