### PR TITLE
Add Cobra completion command. Add dynamic autocompletion for connect command

### DIFF
--- a/client/cmd/admin/get.go
+++ b/client/cmd/admin/get.go
@@ -234,6 +234,34 @@ var getCmd = &cobra.Command{
 	},
 }
 
+func GetConnections(toComplete string) []string {
+	conntype := []string{"conn"}
+	apir := parseResourceOrDie(conntype, "GET", outputFlag)
+	obj, _, err := httpRequest(apir)
+	if err != nil {
+		styles.PrintErrorAndExit(err.Error())
+	}
+	conns := []string{}
+	switch contents := obj.(type) {
+	case map[string]any:
+		m := contents
+		secrets, _ := m["secret"].(map[string]any)
+		if secrets == nil {
+			secrets, _ = m["secrets"].(map[string]any)
+		}
+		conns = append(conns, fmt.Sprintf("%s", m["name"]))
+	case []map[string]any:
+		for _, m := range contents {
+			secrets, _ := m["secret"].(map[string]any)
+			if secrets == nil {
+				secrets, _ = m["secrets"].(map[string]any)
+			}
+			conns = append(conns, fmt.Sprintf("%s", m["name"]))
+		}
+	}
+	return conns
+}
+
 func mapGetter(key string, obj any) string {
 	objMap, ok := obj.(map[string]any)
 	if !ok {

--- a/client/cmd/completion.go
+++ b/client/cmd/completion.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:                   "completion [bash|zsh|fish|powershell]",
+	Short:                 "Generate completion script",
+	Long:                  "To load completions",
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1)),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/getsentry/sentry-go"
+	clientadmin "github.com/hoophq/hoop/client/cmd/admin"
 	"github.com/hoophq/hoop/client/cmd/styles"
 	clientconfig "github.com/hoophq/hoop/client/config"
 	"github.com/hoophq/hoop/client/proxy"
@@ -61,6 +62,13 @@ var (
 				os.Exit(1)
 			}
 			runConnect(args, clientEnvVars)
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return clientadmin.GetConnections(toComplete), cobra.ShellCompDirectiveNoFileComp
+
 		},
 	}
 )


### PR DESCRIPTION
Added Cobra completion command to show available commands with `TAB`:
<img width="699" alt="image" src="https://github.com/user-attachments/assets/4d772436-ac92-49b7-8f64-baa5ed3f3e7f">
<img width="585" alt="image" src="https://github.com/user-attachments/assets/061f3a6a-30ab-4e37-87f8-2a2122cfc180">

Add `ValidArgsFunction` to `connect` command so it queries available connections with `TAB` and autocompletes them:
<img width="512" alt="image" src="https://github.com/user-attachments/assets/2f3e218c-c8d5-4c2d-9bf1-dec3f890c0b6">
