### PR TITLE
[Webapp] Allow desktop app to work with local installations

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	GrpcURL      string `toml:"grpc_url"`
 	TlsCAB64Enc  string `toml:"tls_ca"`
 	Mode         string `toml:"-"`
-	InsecureGRPC bool   `tom:"-"`
+	InsecureGRPC bool   `toml:"-"`
 	filepath     string `toml:"-"`
 }
 

--- a/webapp/src/webapp/events/connections.cljs
+++ b/webapp/src/webapp/events/connections.cljs
@@ -224,11 +224,10 @@ ORDER BY total_amount DESC;")
 (rf/reg-event-fx
  :connections->start-connect
  (fn [{:keys [db]} [_ connection-name]]
-   (let [gateway-info (-> db :gateway->info)
-         grpc-url (url-parse (-> gateway-info :data :grpc_url))]
+   (let [gateway-info (-> db :gateway->info)]
      {:db (assoc-in db [:connections->connection-connected] {:data {} :status :loading})
       :fx [[:dispatch [:hoop-app->update-my-configs {:apiUrl (-> gateway-info :data :api_url)
-                                                     :grpcUrl (.-host grpc-url)
+                                                     :grpcUrl (-> gateway-info :data :grpc_url)
                                                      :token (.getItem js/localStorage "jwt-token")}]]
            [:dispatch [:modal->close]]
            [:dispatch [:hoop-app->restart]]


### PR DESCRIPTION
It propagate the grpcURL properly when configuring the hoop command line by using the schema (grpc or grpcs).
Related to #563 