### PR TITLE
Allow SSH connections to work in the Webapp (ad-hoc executions)

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -1,12 +1,6 @@
-GITCOMMIT ?= $(shell git rev-parse HEAD)
-DIST_FOLDER ?= ./resources
+VERSION ?= unknown
 
-build:
-	echo -n "${GITCOMMIT}" > ${DIST_FOLDER}/commit.txt
-	npm install && npm run release:hoop-ui
-	tar -czf latest.tar.gz ${DIST_FOLDER}
+bump-version:
+	npm version ${VERSION}
 
-release: build
-	aws s3 cp latest.tar.gz s3://hoopartifacts/webapp/
-
-.PHONY: build release
+.PHONY: bump-version

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -171,6 +171,8 @@ Run a shadow-cljs action on this project's build id (without the colon, just `ap
 npx shadow-cljs <action> app
 ```
 
+> Make sure to bump the `package.json` version when making new Pull Requests running `npm version <new-sem-version>`
+
 ## Production
 
 Build the app with the `prod` profile:

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -171,7 +171,7 @@ Run a shadow-cljs action on this project's build id (without the colon, just `ap
 npx shadow-cljs <action> app
 ```
 
-> Make sure to bump the `package.json` version when making new Pull Requests running `npm version <new-sem-version>`
+> Make sure to bump the `package.json` version when making new Pull Requests running `VERSION=x.x.x make bump-version`
 
 ## Production
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp",
-  "version": "1.33.3",
+  "version": "1.34.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp",
-      "version": "1.33.3",
+      "version": "1.34.2",
       "dependencies": {
         "@codemirror/commands": "^6.3.2",
         "@codemirror/lang-javascript": "^6.2.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/connections/constants.cljs
+++ b/webapp/src/webapp/connections/constants.cljs
@@ -97,7 +97,7 @@
    "mssql" ""
    "mongodb" ""
    "custom" ""
-   "ssh" "ssh $SSH_URI -i $SSH_PRIVATE_KEY"
+   "ssh" "ssh -t -o StrictHostKeyChecking=accept-new $SSH_URI -i $SSH_PRIVATE_KEY bash"
    "oracledb" ""
    "" ""})
 


### PR DESCRIPTION
- Add the `-t` option that force pseudo terminal allocation
- Add `-o StrictHostKeyChecking=accept-new` to avoid prompting for accepting public keys interactively