### PR TITLE
Fix/jira templates

### DIFF
--- a/webapp/src/webapp/components/searchbox.cljs
+++ b/webapp/src/webapp/components/searchbox.cljs
@@ -101,10 +101,12 @@
 
 (defn- search-options [options pattern searchable-keys]
   (filter #(string/includes?
-            (string/replace (string/join " " (vals
-                                              (select-keys % searchable-keys)))
-                            #"-|_" "")
-            (string/replace pattern #" |-|_" "")) options))
+            (string/lower-case
+             (string/replace (string/join " " (vals
+                                               (select-keys % searchable-keys)))
+                             #"-|_" ""))
+            (string/lower-case
+             (string/replace pattern #" |-|_" ""))) options))
 
 (defn- search-in-multiple-options [options pattern searchable-keys]
   (reduce (fn [acc [list-key list-value]]

--- a/webapp/src/webapp/events/jira_templates.cljs
+++ b/webapp/src/webapp/events/jira_templates.cljs
@@ -50,6 +50,11 @@
    (assoc db :jira-templates->submit-template {:status :ready :data template})))
 
 (rf/reg-event-db
+ :jira-templates->clear-active-template
+ (fn [db _]
+   (assoc db :jira-templates->active-template {:status :loading :data nil})))
+
+(rf/reg-event-db
  :jira-templates->clear-submit-template
  (fn [db _]
    (assoc db :jira-templates->submit-template {:status :loading :data nil})))
@@ -63,8 +68,8 @@
                    :body template
                    :on-success (fn []
                                  (rf/dispatch [:jira-templates->get-all])
-                                 (rf/dispatch [:navigate :jira-templates]))
-                   :on-failure #(println :jira-templates->create template %)}]]]}))
+                                 (rf/dispatch [:navigate :jira-templates])
+                                 (rf/dispatch [:jira-templates->clear-active-template]))}]]]}))
 
 (rf/reg-event-fx
  :jira-templates->update-by-id
@@ -75,8 +80,8 @@
                    :body template
                    :on-success (fn []
                                  (rf/dispatch [:jira-templates->get-all])
-                                 (rf/dispatch [:navigate :jira-templates]))
-                   :on-failure #(println :jira-templates->update-by-id template %)}]]]}))
+                                 (rf/dispatch [:navigate :jira-templates])
+                                 (rf/dispatch [:jira-templates->clear-active-template]))}]]]}))
 
 (rf/reg-event-fx
  :jira-templates->delete-by-id
@@ -86,8 +91,7 @@
                    :uri (str "/integrations/jira/issuetemplates/" id)
                    :on-success (fn []
                                  (rf/dispatch [:jira-templates->get-all])
-                                 (rf/dispatch [:navigate :jira-templates]))
-                   :on-failure #(println :jira-templates->delete-by-id id %)}]]]}))
+                                 (rf/dispatch [:navigate :jira-templates]))}]]]}))
 
 ;; Subs
 (rf/reg-sub

--- a/webapp/src/webapp/jira_templates/basic_info.cljs
+++ b/webapp/src/webapp/jira_templates/basic_info.cljs
@@ -21,29 +21,29 @@
    [:> Box {:class "space-y-radix-7" :grid-column "span 5 / span 5"}
     [forms/input
      {:label "Name"
-      :placeholder "banking+prod_mongpdb"
+      :placeholder "e.g. squad-postgresql"
       :required true
       :value @name
       :on-change #(on-name-change (-> % .-target .-value))}]
 
     [forms/input
      {:label "Description (Optional)"
-      :placeholder "Describe how this is used in your connections"
+      :placeholder "Describe how this templated will be used."
       :required false
       :value @description
       :on-change #(on-description-change (-> % .-target .-value))}]
 
     [forms/input
      {:label "Project Key"
-      :placeholder "PKEY"
+      :placeholder "e.g. PKEY"
       :required true
       :value @project-key
       :on-change #(on-project-key-change (-> % .-target .-value))}]
 
     [:div
      [forms/input
-      {:label "Request Type"
-       :placeholder "Name"
+      {:label "Request Type ID"
+       :placeholder "e.g. 10005"
        :required true
        :value @issue-type
        :not-margin-bottom? true

--- a/webapp/src/webapp/jira_templates/create_update_form.cljs
+++ b/webapp/src/webapp/jira_templates/create_update_form.cljs
@@ -13,7 +13,8 @@
 
 (defn jira-form [form-type template scroll-pos]
   (let [state (helpers/create-form-state template)
-        handlers (helpers/create-form-handlers state)]
+        handlers (helpers/create-form-handlers state)
+        submitting? (rf/subscribe [:jira-templates->submitting?])]
     (fn []
       [:> Box {:class "min-h-screen bg-gray-1"}
        [:form {:id "jira-form"
@@ -27,7 +28,8 @@
         [form-header/main
          {:form-type form-type
           :id @(:id state)
-          :scroll-pos scroll-pos}]
+          :scroll-pos scroll-pos
+          :loading? @submitting?}]
 
         [:> Box {:p "7" :class "space-y-radix-9"}
          [basic-info/main
@@ -117,6 +119,9 @@
         (finally
           (.removeEventListener js/window "scroll" handle-scroll)))
 
-      (if (= :loading (:status @jira-template))
-        [loading]
-        [jira-form form-type (:data @jira-template) scroll-pos]))))
+      (r/with-let [_ nil]
+        (if (= :loading (:status @jira-template))
+          [loading]
+          [jira-form form-type (:data @jira-template) scroll-pos])
+        (finally
+          (rf/dispatch [:jira-templates->clear-active-template]))))))

--- a/webapp/src/webapp/jira_templates/form_header.cljs
+++ b/webapp/src/webapp/jira_templates/form_header.cljs
@@ -4,7 +4,7 @@
    [webapp.components.button :as button]
    [re-frame.core :as rf]))
 
-(defn main [{:keys [form-type id scroll-pos]}]
+(defn main [{:keys [form-type loading? id scroll-pos]}]
   [:<>
    [:> Flex {:p "5" :gap "2"}
     [button/HeaderBack]]
@@ -22,9 +22,12 @@
         [:> Button {:size "4"
                     :variant "ghost"
                     :color "red"
+                    :disabled loading?
                     :type "button"
                     :on-click #(rf/dispatch [:jira-templates->delete-by-id id])}
          "Delete"])
       [:> Button {:size "3"
+                  :loading loading?
+                  :disabled loading?
                   :type "submit"}
        "Save"]]]]])

--- a/webapp/src/webapp/jira_templates/helpers.cljs
+++ b/webapp/src/webapp/jira_templates/helpers.cljs
@@ -176,7 +176,6 @@
 (defn remove-empty-cmdb [cmdbs]
   (remove (fn [cmdb]
             (or (empty? (:label cmdb))
-                (empty? (:value cmdb))
                 (empty? (:jira_field cmdb))
                 (empty? (:jira_object_type cmdb))))
           cmdbs))

--- a/webapp/src/webapp/jira_templates/mapping_table.cljs
+++ b/webapp/src/webapp/jira_templates/mapping_table.cljs
@@ -17,7 +17,9 @@
    {:value "session.connection" :text "Connection name"}
    {:value "session.status" :text "Session status"}
    {:value "session.start_date" :text "Session start date"}
-   {:value "session.verb" :text "Session type"}])
+   {:value "session.verb" :text "Session type"}
+   {:value "session.script" :text "Session Script"}
+   {:value "review.id" :text "Review ID"}])
 
 (defn- value-field [rule state idx on-rule-field-change]
   (when-not (empty? (:type rule))

--- a/webapp/src/webapp/jira_templates/mapping_table.cljs
+++ b/webapp/src/webapp/jira_templates/mapping_table.cljs
@@ -117,7 +117,7 @@
      "Relates hoop.dev fields with Jira fields. "
      [:> Strong
       "Custom: "]
-     "Append a custom key-value relation to Jira cards."]]
+     "Appends a custom key-value relation to Jira cards."]]
 
    [rule-buttons/main
     {:on-rule-add #(on-mapping-add state)

--- a/webapp/src/webapp/jira_templates/mapping_table.cljs
+++ b/webapp/src/webapp/jira_templates/mapping_table.cljs
@@ -18,8 +18,7 @@
    {:value "session.status" :text "Session status"}
    {:value "session.start_date" :text "Session start date"}
    {:value "session.verb" :text "Session type"}
-   {:value "session.script" :text "Session Script"}
-   {:value "review.id" :text "Review ID"}])
+   {:value "session.script" :text "Session Script"}])
 
 (defn- value-field [rule state idx on-rule-field-change]
   (when-not (empty? (:type rule))

--- a/webapp/src/webapp/jira_templates/prompt_form.cljs
+++ b/webapp/src/webapp/jira_templates/prompt_form.cljs
@@ -39,7 +39,6 @@
          ;; Prompt Fields
          (when (seq prompts)
            [:> Box {:class "space-y-4"}
-            [:> Text {:as "h4" :size "3" :weight "medium" :mb "2"} "Command Information"]
             (for [{:keys [label required jira_field]} prompts]
               ^{:key jira_field}
               [forms/input
@@ -54,7 +53,6 @@
                                                             (not (some #(= (:name %) value) jira_values))))
                                                      cmdb-items))]
            [:> Box {:class "space-y-4"}
-            [:> Text {:as "h4" :size "3" :weight "medium" :mb "2"} "CMDB Information"]
             (doall
              (for [{:keys [label jira_field jira_values required]} cmdb-fields-to-show]
                ^{:key jira_field}

--- a/webapp/src/webapp/jira_templates/prompts_table.cljs
+++ b/webapp/src/webapp/jira_templates/prompts_table.cljs
@@ -1,6 +1,6 @@
 (ns webapp.jira-templates.prompts-table
   (:require
-   ["@radix-ui/themes" :refer [Box Table Text]]
+   ["@radix-ui/themes" :refer [Box Table]]
    [webapp.components.forms :as forms]
    [webapp.jira-templates.rule-buttons :as rule-buttons]))
 

--- a/webapp/src/webapp/webclient/panel.cljs
+++ b/webapp/src/webapp/webclient/panel.cljs
@@ -106,7 +106,6 @@
 
     (letfn [(handle-submit [form-data]
               (rf/dispatch [:modal->close])
-              (rf/dispatch [:jira-templates->clear-submit-template])
               (let [exec-data {:script final-script
                                :connection-name (:name connection)
                                :metadata (metadata->json-stringify metadata)}


### PR DESCRIPTION
- Removed case sensitive from search inputs
- Clearing the form after updating or creating a template Jira
- Added loading and disabled the save button while the request to create or update Jira templates is still pending.
- Added new preset values: Session Script and Review ID
- Fix the behavior that doesn't allow the exec a new script after the first exec with the Jira template in the editor.
- Change label names and placeholders