### PR TITLE
[gateway] encode session response manually to obtain any error beforehand

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/getsentry/sentry-go v0.18.0
 	github.com/go-co-op/gocron v1.18.1
 	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.6.0
 	github.com/hoophq/hoop/agent v0.0.0-00010101000000-000000000000
 	github.com/hoophq/hoop/gateway v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.63.2
@@ -100,7 +101,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/deploy/docker-compose/.env-sample
+++ b/deploy/docker-compose/.env-sample
@@ -6,11 +6,21 @@
 # openssl rand 128 | base64
 JWT_SECRET_KEY=
 
+# To configure the gateway with TLS, use the prefix base64://<pembase64-content>
+TLS_KEY=
+TLS_CERT=
+TLS_CA=
+
+# To configure the agent to load a custom certificate authority,
+# make sure this env is set and the certificate contain the SAN: gateway
+HOOP_TLSCA=
+
 # IDP Configuration, set it if you wish to test it with your custom identity provider
-#IDP_ISSUER=
-#IDP_CLIENT_ID=
-#IDP_CLIENT_SECRET=
-#IDP_AUDIENCE=
+IDP_ISSUER=
+IDP_CLIENT_ID=
+IDP_CLIENT_SECRET=
+IDP_AUDIENCE=
+IDP_CUSTOM_SCOPES=
 
 # ai query builder feature (openid credentials)
 ASK_AI_CREDENTIALS=

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       db:
         condition: "service_healthy"
     healthcheck:
-      test: "curl http://127.0.0.1:8009/api/healthz"
+      test: "gateway-healthcheck.sh"
       interval: "2s"
       timeout: "30s"
       retries: 10
@@ -51,6 +51,7 @@ services:
     #   - ./rootfs/usr/local/bin/run-agent.sh:/usr/local/bin/run-agent.sh
     networks:
       - hoopdev
+    env_file: ".env"
     environment:
       - POSTGRES_DB_URI=postgres://postgres:postgres@db:5432/hoopdb?sslmode=disable
       - LOG_LEVEL=info

--- a/deploy/docker-compose/rootfs/usr/local/bin/gateway-healthcheck.sh
+++ b/deploy/docker-compose/rootfs/usr/local/bin/gateway-healthcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+PROTO=https
+if [ -z $TLS_KEY ]; then
+    PROTO=http
+fi
+
+curl -k -s $PROTO://127.0.0.1:8009/api/healthz

--- a/deploy/docker-compose/rootfs/usr/local/bin/run-agent.sh
+++ b/deploy/docker-compose/rootfs/usr/local/bin/run-agent.sh
@@ -14,7 +14,10 @@ INSERT INTO agents (id, org_id, name, mode, key_hash, status)
 COMMIT;
 EOF
 
-SCHEME=grpc
+SCHEME=grpcs
+if [ -z $TLS_KEY ]; then
+    SCHEME=grpc
+fi
 export GRPC_URL=gateway:8010
 
 export HOOP_KEY=${SCHEME}://system:$(printenv SECRET_KEY | tr -d '\n')@${GRPC_URL}?mode=standard

--- a/gateway/analytics/segment.go
+++ b/gateway/analytics/segment.go
@@ -7,17 +7,19 @@ import (
 	"github.com/segmentio/analytics-go/v3"
 )
 
-var environmentName = appconfig.Get().ApiHostname()
-
 type Segment struct {
 	analytics.Client
+	environmentName string
 }
 
 func New() *Segment {
 	if segmentApiKey == "" {
 		return &Segment{}
 	}
-	return &Segment{analytics.New(segmentApiKey)}
+	return &Segment{
+		Client:          analytics.New(segmentApiKey),
+		environmentName: appconfig.Get().ApiHostname(),
+	}
 }
 
 func (s *Segment) Identify(ctx *types.APIContext) {
@@ -30,26 +32,26 @@ func (s *Segment) Identify(ctx *types.APIContext) {
 		// Segment recommends using an unique id for user id
 		// However we use the e-mail to avoid having to associate the
 		// user id with the e-mail.
-		UserId: ctx.UserEmail,
+		UserId:      ctx.UserEmail,
 		AnonymousId: ctx.UserAnonSubject,
 		Traits: analytics.NewTraits().
 			SetName(ctx.UserName).
 			SetEmail(ctx.UserEmail).
 			Set("groups", ctx.UserGroups).
 			Set("is-admin", ctx.IsAdminUser()).
-			Set("environment", environmentName).
+			Set("environment", s.environmentName).
 			Set("status", ctx.UserStatus),
 	})
 
 	orgName := ctx.OrgName
 	if orgName == pb.DefaultOrgName {
 		// use the name of the environment on self-hosted setups
-		orgName = environmentName
+		orgName = s.environmentName
 	}
 	_ = s.Client.Enqueue(analytics.Group{
-		GroupId: ctx.OrgID,
+		GroupId:     ctx.OrgID,
 		AnonymousId: ctx.UserAnonSubject,
-		UserId:  ctx.UserID,
+		UserId:      ctx.UserID,
 		Traits: analytics.NewTraits().
 			SetName(orgName),
 	})
@@ -68,14 +70,14 @@ func (s *Segment) AnonymousTrack(anonymousId, eventName string, properties map[s
 	if properties == nil {
 		properties = map[string]any{}
 	}
-	properties["environment"] = environmentName
+	properties["environment"] = s.environmentName
 	properties["auth-method"] = appconfig.Get().AuthMethod()
 	properties["api-url"] = appconfig.Get().ApiURL()
 
 	_ = s.Enqueue(analytics.Track{
 		AnonymousId: anonymousId,
-		Event:      eventName,
-		Properties: properties,
+		Event:       eventName,
+		Properties:  properties,
 	})
 }
 
@@ -87,7 +89,7 @@ func (s *Segment) Track(userEmail, eventName string, properties map[string]any) 
 	if properties == nil {
 		properties = map[string]any{}
 	}
-	properties["environment"] = environmentName
+	properties["environment"] = s.environmentName
 	properties["email"] = userEmail
 	properties["auth-method"] = appconfig.Get().AuthMethod()
 	properties["api-url"] = appconfig.Get().ApiURL()

--- a/gateway/api/apiroutes/tracing.go
+++ b/gateway/api/apiroutes/tracing.go
@@ -31,7 +31,11 @@ func contextTracerMiddleware() gin.HandlerFunc {
 				attribute.String("hoop.gateway.platform", vs.Platform),
 				attribute.String("hoop.gateway.version", vs.Version),
 			)
-			if ctx := storagev2.ParseContext(c); ctx != nil {
+			obj, ok := c.Get(storagev2.ContextKey)
+			if !ok {
+				return
+			}
+			if ctx, ok := obj.(*storagev2.Context); ok {
 				span.SetAttributes(
 					attribute.String("hoop.gateway.org-id", ctx.OrgID),
 					attribute.String("hoop.gateway.user-email", ctx.UserEmail),

--- a/gateway/api/middleware.go
+++ b/gateway/api/middleware.go
@@ -109,7 +109,7 @@ func CORSMiddleware() gin.HandlerFunc {
 		c.Writer.Header().Set("Server", fmt.Sprintf("hoopgateway/%s", vs.Version))
 		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
-		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, accept, origin, x-backend-api, user-client")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, accept, origin, user-client")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE, PATCH")
 
 		if c.Request.Method == "OPTIONS" {

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -437,7 +437,15 @@ func Get(c *gin.Context) {
 	if !slices.Contains(expandedFieldParts, "event_stream") {
 		obj.EventStream = nil
 	}
-	c.PureJSON(http.StatusOK, obj)
+	// encode the object manually to obtain any encoding errors.
+	c.Writer.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(c.Writer).Encode(obj); err != nil {
+		errMsg := fmt.Sprintf("failed encoding session, reason=%v", err)
+		log.With("sid", sessionID).Error(errMsg)
+		c.JSON(http.StatusInternalServerError, gin.H{"message": errMsg})
+		return
+	}
+	c.Writer.WriteHeader(http.StatusOK)
 }
 
 // DownloadSession

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.49.0
 	go.opentelemetry.io/otel v1.24.0
+	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.25.0
 	golang.org/x/crypto v0.27.0
 	golang.org/x/oauth2 v0.17.0
@@ -159,7 +160,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.21.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v0.41.0 // indirect
-	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect


### PR DESCRIPTION
- fix segment to propagate environment names properly
- prevent errors when parsing user context on http tracing
- remove legacy cors header x-backend-api


Related to #625: it improves the response from the server to avoid returning empty OK responses.