### PR TITLE
[gateway] Fix session details to decode base64 sessions to avoid invalid characters json error encoding

### DIFF
--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -2619,7 +2619,8 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            "utf8"
+                            "utf8",
+                            "base64"
                         ],
                         "type": "string",
                         "description": "This option will parse the session output (o) and error (e) events as an utf-8 content in the session payload",

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -370,7 +370,7 @@ type SessionGetByIDParams struct {
 	// Construct the file content adding the event time as prefix when parsing each event
 	EventTime string `json:"event-time" enums:"0,1" example:"1" default:"0"`
 	// This option will parse the session output (o) and error (e) events as an utf-8 content in the session payload
-	EventStream string `json:"event_stream" enums:"utf8" default:""`
+	EventStream string `json:"event_stream" enums:"utf8,base64" default:""`
 	// Expand the given attributes
 	Expand string `json:"expand" enums:"event_stream" example:"event_stream" default:""`
 }

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
@@ -417,17 +418,22 @@ func Get(c *gin.Context) {
 		return
 	}
 
-	if c.Query("event_stream") == "utf8" {
+	if option := c.Query("event_stream"); option != "" {
 		output, err := parseBlobStream(session, sessionParseOption{events: []string{"o", "e"}})
 		if err != nil {
 			log.With("sid", sessionID).Error(err)
 			c.JSON(http.StatusInternalServerError, gin.H{"message": "failed parsing blob stream"})
 			return
 		}
-		encOutput := base64.StdEncoding.EncodeToString(output)
-		session.BlobStream = json.RawMessage(fmt.Sprintf(`[%q]`, encOutput))
-		// override to give the parsed size
-		session.BlobStreamSize = int64(len(encOutput))
+		switch option {
+		case "utf8":
+			session.BlobStream = json.RawMessage(fmt.Sprintf(`[%q]`, string(output)))
+			session.BlobStreamSize = int64(int64(utf8.RuneCountInString(string(output))))
+		case "base64":
+			encOutput := base64.StdEncoding.EncodeToString(output)
+			session.BlobStream = json.RawMessage(fmt.Sprintf(`[%q]`, encOutput))
+			session.BlobStreamSize = int64(len(encOutput))
+		}
 	}
 
 	obj := toOpenApiSession(session)

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
@@ -425,9 +424,10 @@ func Get(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"message": "failed parsing blob stream"})
 			return
 		}
-		session.BlobStream = json.RawMessage(fmt.Sprintf(`[%q]`, string(output)))
+		encOutput := base64.StdEncoding.EncodeToString(output)
+		session.BlobStream = json.RawMessage(fmt.Sprintf(`[%q]`, encOutput))
 		// override to give the parsed size
-		session.BlobStreamSize = int64(utf8.RuneCountInString(string(output)))
+		session.BlobStreamSize = int64(len(encOutput))
 	}
 
 	obj := toOpenApiSession(session)

--- a/webapp/src/webapp/audit/views/session_data_raw.cljs
+++ b/webapp/src/webapp/audit/views/session_data_raw.cljs
@@ -4,12 +4,8 @@
             [webapp.audit.views.empty-event-stream :as empty-event-stream]
             [webapp.components.icon :as icon]
             [webapp.components.searchbox :as searchbox]
-            [webapp.formatters :as formatters]))
-
-(defn- decode-b64 [data]
-  (try
-    (string/replace (js/decodeURIComponent (js/escape (js/atob data))) #"∞" "\t")
-    (catch js/Error _ (str ""))))
+            [webapp.formatters :as formatters]
+            [webapp.utilities :as utilities]))
 
 (defn- event-item []
   (let [is-open? (r/atom false)]
@@ -51,7 +47,7 @@
                                                   parsed-new-date (new js/Date sum)]
                                               (formatters/time-parsed->full-date parsed-new-date))))
                             :event-type event-type
-                            :event-data (decode-b64 event-data)})
+                            :event-data (utilities/decode-b64 event-data)})
         searched-events-atom (r/atom event-stream-map)
         search-focused? (r/atom false)]
     (fn []

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -425,7 +425,7 @@
                   (if (= (:verb session) "exec")
                     [results-container/main
                      connection-name
-                     {:results (first (:event_stream session))
+                     {:results (js/atob (or (first (:event_stream session)) ""))
                       :results-status (:status @session-details)
                       :fixed-height? true
                       :results-id (:id session)}]

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -425,7 +425,7 @@
                   (if (= (:verb session) "exec")
                     [results-container/main
                      connection-name
-                     {:results (js/atob (or (first (:event_stream session)) ""))
+                     {:results (utilities/decode-b64 (or (first (:event_stream session)) ""))
                       :results-status (:status @session-details)
                       :fixed-height? true
                       :results-id (:id session)}]

--- a/webapp/src/webapp/events/audit.cljs
+++ b/webapp/src/webapp/events/audit.cljs
@@ -39,7 +39,7 @@
                            [:dispatch-later
                             {:ms 1000
                              :dispatch [:fetch {:method "GET"
-                                                :uri (str "/sessions/" session-id "?event_stream=utf8")
+                                                :uri (str "/sessions/" session-id "?event_stream=base64")
                                                 :on-success on-success
                                                 :on-failure on-failure}]}])
                          session-id-list)]
@@ -95,7 +95,7 @@
    (let [state {:status :loading
                 :session session
                 :session-logs {:status :loading}}
-         event-stream (if (= "exec" (:verb session)) "?event_stream=utf8" "")]
+         event-stream (if (= "exec" (:verb session)) "?event_stream=base64" "")]
      {:db (assoc db :audit->session-details state)
       :fx [[:dispatch [:fetch
                        {:method "GET"
@@ -109,7 +109,7 @@
  (fn
    [{:keys [db]} [_ session]]
    (let [event-size (:event_size session)
-         event-stream (if (= "exec" (:verb session)) "event_stream=utf8" "")]
+         event-stream (if (= "exec" (:verb session)) "event_stream=base64" "")]
      (if (and event-size (> event-size size-threshold))
        {:db (assoc db
                    :audit->session-details

--- a/webapp/src/webapp/utilities.cljs
+++ b/webapp/src/webapp/utilities.cljs
@@ -56,3 +56,8 @@
 
 (defn cn [& inputs]
   (twMerge (apply clsx inputs)))
+
+(defn decode-b64 [data]
+  (try
+    (string/replace (js/decodeURIComponent (js/escape (js/atob data))) #"∞" "\t")
+    (catch js/Error _ (str ""))))


### PR DESCRIPTION
- Introduced option `event_stream=base64` to obtain the parsed content as base64 to avoid breaking compatibility with clients
- The option `event_stream=utf8` will continue to work as is, but it will not work properly for shell connections that contains invalid characters
- Change the webapp to use `base64`option and decode the content when rendering the session details