### PR TITLE
[gateway] Add computed event size when listing sessions

### DIFF
--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -36,9 +36,10 @@ import (
 )
 
 var (
-	downloadTokenStore        = memory.New()
-	defaultDownloadExpireTime = time.Minute * 5
-	internalExitCode          = 254
+	downloadTokenStore         = memory.New()
+	defaultDownloadExpireTime  = time.Minute * 5
+	internalExitCode           = 254
+	defaultMaxSessionListLimit = 100
 )
 
 type SessionPostBody struct {
@@ -318,6 +319,10 @@ func List(c *gin.Context) {
 				option.Offset, _ = strconv.Atoi(queryOptVal)
 			}
 		}
+	}
+
+	if option.Limit > defaultMaxSessionListLimit {
+		option.Limit = defaultMaxSessionListLimit
 	}
 
 	// scope listing to the authenticated user

--- a/gateway/transport/plugins/audit/wal.go
+++ b/gateway/transport/plugins/audit/wal.go
@@ -109,7 +109,6 @@ func (p *auditPlugin) writeOnClose(pctx plugintypes.Context, exitCode *int, errM
 		if err != nil {
 			return err
 		}
-		metrics.EventSize += int64(len(ev.Payload))
 		if infoEnc := ev.GetMetadata(spectypes.DataMaskingInfoKey); infoEnc != nil {
 			dataMaskingInfo, err := spectypes.Decode(infoEnc)
 			if err != nil {
@@ -168,6 +167,7 @@ func (p *auditPlugin) writeOnClose(pctx plugintypes.Context, exitCode *int, errM
 		return err
 	}
 	rawJSONBlobStream = fmt.Sprintf("[%v]", strings.TrimSuffix(rawJSONBlobStream, ","))
+	metrics.EventSize = int64(len(rawJSONBlobStream))
 	endDate := time.Now().UTC()
 	sessionMetrics, err := metrics.toMap()
 	if err != nil {


### PR DESCRIPTION
This change speed the listing session endpoint pre-computing the size of events