### PR TITLE
[gateway] propagate exit code properly when persisting sessions

### DIFF
--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -23,18 +23,13 @@ import (
 	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
 )
 
-var (
-	memorySessionStore = memory.New()
-	internalExitCode   = func() *int { v := 254; return &v }()
-)
+var memorySessionStore = memory.New()
 
-type (
-	auditPlugin struct {
-		walSessionStore memory.Store
-		started         bool
-		mu              sync.RWMutex
-	}
-)
+type auditPlugin struct {
+	walSessionStore memory.Store
+	started         bool
+	mu              sync.RWMutex
+}
 
 func New() *auditPlugin             { return &auditPlugin{walSessionStore: memory.New()} }
 func (p *auditPlugin) Name() string { return plugintypes.PluginAuditName }
@@ -154,13 +149,6 @@ func (p *auditPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 			log.Warnf("failed writing agent packet response, err=%v", err)
 		}
 		return nil, nil
-	case pbclient.SessionClose:
-		exitCode := parseExitCode(pctx.SID, pkt)
-		if len(pkt.Payload) > 0 {
-			p.closeSession(pctx, exitCode, fmt.Errorf(string(pkt.Payload)))
-			return nil, nil
-		}
-		p.closeSession(pctx, exitCode, nil)
 	case pbagent.ExecWriteStdin,
 		pbagent.TerminalWriteStdin,
 		pbagent.TCPConnectionWrite:
@@ -169,16 +157,10 @@ func (p *auditPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 	return nil, nil
 }
 
-func (p *auditPlugin) OnDisconnect(pctx plugintypes.Context, errMsg error) error {
+func (p *auditPlugin) OnDisconnect(pctx plugintypes.Context, err error) error {
 	log.With("sid", pctx.SID, "origin", pctx.ClientOrigin, "agent", pctx.AgentName).
 		Debugf("processing disconnect")
-	// Since we lack the exit code in this state,
-	// a successful operation (0) is considered if the error is empty.
-	// The caller should always be responsible in propagating the error properly
-	exitCode := func() *int { v := 0; return &v }()
-	if errMsg != nil {
-		exitCode = internalExitCode
-	}
+
 	switch pctx.ClientOrigin {
 	case pb.ConnectionOriginAgent:
 		log.With("agent", pctx.AgentName).Infof("agent shutdown, graceful closing session")
@@ -187,20 +169,20 @@ func (p *auditPlugin) OnDisconnect(pctx plugintypes.Context, errMsg error) error
 				continue
 			}
 			pctx.SID = msid
-			p.closeSession(pctx, exitCode, errMsg)
+			p.closeSession(pctx, err)
 		}
 	default:
-		p.closeSession(pctx, exitCode, errMsg)
+		p.closeSession(pctx, err)
 	}
 	return nil
 }
 
-func (p *auditPlugin) closeSession(pctx plugintypes.Context, exitCode *int, errMsg error) {
+func (p *auditPlugin) closeSession(pctx plugintypes.Context, err error) {
 	log.With("sid", pctx.SID, "origin", pctx.ClientOrigin, "verb", pctx.ClientVerb).
-		Infof("closing session, exit_code=%v, reason=%v", debugExitCode(exitCode), errMsg)
+		Infof("closing session, reason=%v", err)
 	go func() {
 		defer memorySessionStore.Del(pctx.SID)
-		if err := p.writeOnClose(pctx, exitCode, errMsg); err != nil {
+		if err := p.writeOnClose(pctx, err); err != nil {
 			log.With("sid", pctx.SID, "origin", pctx.ClientOrigin, "verb", pctx.ClientVerb).
 				Warnf("failed closing session, reason=%v", err)
 		}
@@ -256,22 +238,4 @@ func parseSpecAsEventMetadata(pkt *pb.Packet) map[string][]byte {
 		return map[string][]byte{spectypes.DataMaskingInfoKey: infoEnc}
 	}
 	return nil
-}
-
-func parseExitCode(sid string, pkt *pb.Packet) (exitCode *int) {
-	exitCodeStr, ok := pkt.Spec[pb.SpecClientExitCodeKey]
-	if ok {
-		if ecode, err := strconv.Atoi(string(exitCodeStr)); err == nil {
-			exitCode = &ecode
-		}
-	}
-	log.With("sid", sid).Debugf("raw exit code value=%q, has_exit_code_spec=%v", exitCodeStr, ok)
-	return
-}
-
-func debugExitCode(exitCode *int) string {
-	if exitCode == nil {
-		return "<nil>"
-	}
-	return fmt.Sprintf("%v", *exitCode)
 }

--- a/gateway/transport/plugins/audit/wal.go
+++ b/gateway/transport/plugins/audit/wal.go
@@ -26,6 +26,8 @@ const (
 	eventLogTypeName string = "_footer_error"
 )
 
+var internalExitCode = func() *int { v := 254; return &v }()
+
 type walLogRWMutex struct {
 	log        *sessionwal.WalLog
 	mu         sync.RWMutex
@@ -78,7 +80,7 @@ func (p *auditPlugin) dropWalLog(sid string) {
 	walogm.mu.Unlock()
 }
 
-func (p *auditPlugin) writeOnClose(pctx plugintypes.Context, exitCode *int, errMsg error) error {
+func (p *auditPlugin) writeOnClose(pctx plugintypes.Context, errMsg error) error {
 	walLogObj := p.walSessionStore.Pop(pctx.SID)
 	walogm, ok := walLogObj.(*walLogRWMutex)
 	if !ok {
@@ -179,11 +181,11 @@ func (p *auditPlugin) writeOnClose(pctx plugintypes.Context, exitCode *int, errM
 		Metrics:    sessionMetrics,
 		BlobStream: json.RawMessage(rawJSONBlobStream),
 		Status:     string(openapi.SessionStatusDone),
-		ExitCode:   exitCode,
+		ExitCode:   parseExitCodeFromErr(errMsg),
 		EndSession: &endDate,
 	})
 	log.With("sid", pctx.SID, "origin", pctx.ClientOrigin, "verb", pctx.ClientVerb).
-		Infof("finished persisting session to store, exit_code=%v, reason=%v", debugExitCode(exitCode), errMsg)
+		Infof("finished persisting session to store, err=%v", errMsg)
 
 	if err != nil {
 		_ = walogm.log.Write(eventlogv1.NewCommitError(endDate, err.Error()))
@@ -200,4 +202,16 @@ func (p *auditPlugin) truncateTCPEventStream(eventStream []byte, connType string
 		return eventStream[0:5000]
 	}
 	return eventStream
+}
+
+func parseExitCodeFromErr(err error) (exitCode *int) {
+	switch v := err.(type) {
+	case *plugintypes.PacketErr:
+		exitCode = v.ExitCode()
+	case nil:
+		exitCode = func() *int { v := 0; return &v }()
+	default:
+		exitCode = internalExitCode
+	}
+	return
 }

--- a/gateway/transport/plugins/audit/wal.go
+++ b/gateway/transport/plugins/audit/wal.go
@@ -171,7 +171,7 @@ func (p *auditPlugin) writeOnClose(pctx plugintypes.Context, exitCode *int, errM
 	endDate := time.Now().UTC()
 	sessionMetrics, err := metrics.toMap()
 	if err != nil {
-		log.Warnf("failed parsing session metrics to map, reason=%v", err)
+		log.With("sid", pctx.SID).Warnf("failed parsing session metrics to map, reason=%v", err)
 	}
 	err = models.UpdateSessionEventStream(models.SessionDone{
 		ID:         wh.SessionID,
@@ -182,6 +182,8 @@ func (p *auditPlugin) writeOnClose(pctx plugintypes.Context, exitCode *int, errM
 		ExitCode:   exitCode,
 		EndSession: &endDate,
 	})
+	log.With("sid", pctx.SID, "origin", pctx.ClientOrigin, "verb", pctx.ClientVerb).
+		Infof("finished persisting session to store, exit_code=%v, reason=%v", debugExitCode(exitCode), errMsg)
 
 	if err != nil {
 		_ = walogm.log.Write(eventlogv1.NewCommitError(endDate, err.Error()))

--- a/gateway/transport/plugins/types/types.go
+++ b/gateway/transport/plugins/types/types.go
@@ -12,6 +12,18 @@ import (
 
 type GenericMap map[string]any
 
+type PacketErr struct {
+	exitCode *int
+	msg      string
+}
+
+func (e PacketErr) Error() string  { return e.msg }
+func (e PacketErr) ExitCode() *int { return e.exitCode }
+
+func NewPacketErr(msg string, exitCode *int) error {
+	return &PacketErr{msg: msg, exitCode: exitCode}
+}
+
 type Context struct {
 	Context context.Context
 	// Session ID

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp",
-  "version": "1.35.9",
+  "version": "1.35.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp",
-      "version": "1.35.9",
+      "version": "1.35.12",
       "dependencies": {
         "@codemirror/commands": "^6.3.2",
         "@codemirror/lang-javascript": "^6.2.1",


### PR DESCRIPTION
The session closure function was executing multiple times concurrently, causing race conditions where incorrect exit codes would propagate through the system. Each subsequent execution would overwrite the previous exit code state, potentially masking the true process outcome.