### PR TITLE
feat: allow to set Docker agent env vars externally

### DIFF
--- a/deploy/docker-compose/rootfs/usr/local/bin/run-agent.sh
+++ b/deploy/docker-compose/rootfs/usr/local/bin/run-agent.sh
@@ -14,11 +14,16 @@ INSERT INTO agents (id, org_id, name, mode, key_hash, status)
 COMMIT;
 EOF
 
-SCHEME=grpcs
-if [ -z $TLS_KEY ]; then
-    SCHEME=grpc
+if [ -z $SCHEME ]; then
+    SCHEME=grpcs
+    if [ -z $TLS_KEY ]; then
+        SCHEME=grpc
+    fi
 fi
-export GRPC_URL=gateway:8010
+
+if [ -z $GRPC_URL ]; then
+    export GRPC_URL=gateway:8010
+fi
 
 export HOOP_KEY=${SCHEME}://system:$(printenv SECRET_KEY | tr -d '\n')@${GRPC_URL}?mode=standard
 hoop start agent


### PR DESCRIPTION
I'm working on setting up Hoop using AWS ECS (instead of EC2 instances), and I'm running into a problem running the system agent due to not being able to override `gateway:8010` with a valid DNS entry which can resolve.

This change allows you to pass in values for `SCHEME` and `GRPC_URL` if desired. Otherwise, the default behavior remains unchanged.