### PR TITLE
[security] prevent leaking sensitive information from connections by removing secrets on listing

### DIFF
--- a/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
@@ -39,6 +39,7 @@ stringData:
   MSPRESIDIO_ANONYMIZER_URL: '{{ .Values.config.MSPRESIDIO_ANALYZER_URL }}'
   WEBHOOK_APPKEY: '{{ .Values.config.WEBHOOK_APPKEY }}'
   WEBHOOK_APPURL: '{{ .Values.config.WEBHOOK_APPURL }}'
+  INTEGRATION_AWS_INSTANCE_ROLE_ALLOW: '{{ .Values.config.INTEGRATION_AWS_INSTANCE_ROLE_ALLOW }}'
   ADMIN_USERNAME: '{{ .Values.config.ADMIN_USERNAME | default "admin" }}'
   PLUGIN_AUDIT_PATH: '{{ .Values.config.PLUGIN_AUDIT_PATH | default "/opt/hoop/sessions" }}'
   PLUGIN_INDEX_PATH: '{{ .Values.config.PLUGIN_INDEX_PATH | default "/opt/hoop/sessions/indexes" }}'

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -3929,6 +3929,10 @@ const docTemplate = `{
                         "/bin/bash"
                     ]
                 },
+                "default_database": {
+                    "description": "Default databases returns the configured value of the attribute secrets-\u003e'DB'",
+                    "type": "string"
+                },
                 "guardrail_rules": {
                     "description": "The guard rail association id rules",
                     "type": "array",

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -208,6 +208,8 @@ type Connection struct {
 	// * { envvar:[env-key]: _aws:[secret-name]:[secret-key] } - Obtain the value dynamically in the AWS secrets manager and expose as environment variable
 	// * { envvar:[env-key]: _envjson:[json-env-name]:[json-env-key] } - Obtain the value dynamically from a JSON env in the agent runtime. Example: MYENV={"KEY": "val"}
 	Secrets map[string]any `json:"secret"`
+	// Default databases returns the configured value of the attribute secrets->'DB'
+	DefaultDatabase string `json:"default_database"`
 	// The agent associated with this connection
 	AgentId string `json:"agent_id" binding:"required" format:"uuid" example:"1837453e-01fc-46f3-9e4c-dcf22d395393"`
 	// Status is a read only field that informs if the connection is available for interaction

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -101,7 +101,7 @@ cp .env.sample .env
 **Run it**
 
 ```sh
-npm run dev:hoop-ui
+npm run dev
 ````
 
 Please be patient; it may take over 20 seconds to see any output, and over 40 seconds to complete.

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp",
-  "version": "1.37.8",
+  "version": "1.37.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp",
-      "version": "1.37.8",
+      "version": "1.37.10",
       "dependencies": {
         "@codemirror/commands": "^6.3.2",
         "@codemirror/lang-javascript": "^6.2.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -7,6 +7,7 @@
     "shadow:watch:hoop-ui": "npx shadow-cljs watch hoop-ui browser-test karma-test",
     "postcss:watch": "cross-env postcss src/css/tailwind.css -o ./resources/public/css/site.css --verbose -w",
     "dev:hoop-ui": "source .env && run-p -l genversion shadow:watch:hoop-ui postcss:watch",
+    "dev": "source .env && run-p -l genversion shadow:watch:hoop-ui postcss:watch",
     "shadow:release:hoop-ui": "npx shadow-cljs release hoop-ui",
     "postcss:build": "cross-env TAILWIND_MODE=build postcss src/css/tailwind.css -o ./resources/public/css/site.css --verbose",
     "postcss:release": "cross-env NODE_ENV=production postcss src/css/tailwind.css -o ./resources/public/css/site.css --verbose",

--- a/webapp/src/webapp/events/editor_plugin.cljs
+++ b/webapp/src/webapp/events/editor_plugin.cljs
@@ -35,7 +35,7 @@
    (let [connection-list-cached (read-string (.getItem js/localStorage "run-connection-list-selected"))
          is-cached? (fn [current-connection-name]
                       (not-empty (filter #(= (:name %) current-connection-name) connection-list-cached)))
-         connections-parsed (mapv (fn [{:keys [name type subtype status access_schema secret jira_issue_template_id]}]
+         connections-parsed (mapv (fn [{:keys [name type subtype status access_schema default_database jira_issue_template_id]}]
                                     {:name name
                                      :type type
                                      :subtype subtype
@@ -44,7 +44,7 @@
                                      :access_schema access_schema
                                      :database_name (when (and (= type "database")
                                                                (= subtype "postgres"))
-                                                      (js/atob (:envvar:DB secret)))
+                                                      default_database)
                                      :selected (if (is-cached? name)
                                                  true
                                                  false)})
@@ -59,7 +59,7 @@
    (let [connection-list-cached (read-string (.getItem js/localStorage "run-connection-list-selected"))
          is-cached? (fn [current-connection-name]
                       (not-empty (filter #(= (:name %) current-connection-name) connection-list-cached)))
-         connections-parsed (mapv (fn [{:keys [name type subtype status selected access_schema secret jira_issue_template_id]}]
+         connections-parsed (mapv (fn [{:keys [name type subtype status selected access_schema default_database jira_issue_template_id]}]
                                     {:name name
                                      :type type
                                      :subtype subtype
@@ -68,7 +68,7 @@
                                      :access_schema access_schema
                                      :database_name (when (and (= type "database")
                                                                (= subtype "postgres"))
-                                                      (js/atob (:envvar:DB secret)))
+                                                      default_database)
                                      :selected (if (is-cached? name)
                                                  true
                                                  selected)})


### PR DESCRIPTION
- Add `default_database` attribute to prevent Webapp from obtaining the default database by parsing secrets attribute
- Add `npm run dev` instruction
- Add `INTEGRATION_AWS_INSTANCE_ROLE_ALLOW` configuration to helm