### PR TITLE
Add connection tags as key value attributes to connections

### DIFF
--- a/client/cmd/admin/create-conn.go
+++ b/client/cmd/admin/create-conn.go
@@ -136,6 +136,15 @@ var createConnectionCmd = &cobra.Command{
 			redactEnabled = true
 		}
 
+		connectionTags := map[string]string{}
+		for _, keyValTag := range connTagsFlag {
+			key, val, found := strings.Cut(keyValTag, "=")
+			if !found {
+				continue
+			}
+			connectionTags[key] = val
+		}
+
 		connectionBody := map[string]any{
 			"name":                   apir.name,
 			"type":                   connType,
@@ -146,7 +155,7 @@ var createConnectionCmd = &cobra.Command{
 			"reviewers":              reviewersFlag,
 			"redact_enabled":         redactEnabled,
 			"redact_types":           connRedactTypesFlag,
-			"tags":                   connTagsFlag,
+			"connection_tags":        connectionTags,
 			"guardrail_rules":        connGuardRailRules,
 			"jira_issue_template_id": connJiraIssueTemplateID,
 			"access_mode_runbooks":   verifyAccessModeStatus("runbooks"),

--- a/gateway/api/connections/connection_tags.go
+++ b/gateway/api/connections/connection_tags.go
@@ -1,0 +1,112 @@
+package apiconnections
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2"
+)
+
+// TODO(san): needs more testing, will add these endpoints later on
+// func CreateTag(c *gin.Context) {
+// 	ctx := storagev2.ParseContext(c)
+// 	var req openapi.ConnectionTagCreateRequest
+// 	if err := c.ShouldBindJSON(&req); err != nil {
+// 		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+// 		return
+// 	}
+
+// 	obj := &models.ConnectionTag{
+// 		OrgID:     ctx.OrgID,
+// 		ID:        uuid.NewString(),
+// 		Key:       req.Key,
+// 		Value:     req.Value,
+// 		CreatedAt: time.Now().UTC(),
+// 		UpdatedAt: time.Now().UTC(),
+// 	}
+// 	err := models.CreateConnectionTag(obj)
+// 	switch err {
+// 	case models.ErrAlreadyExists:
+// 		c.JSON(http.StatusConflict, gin.H{"message": err.Error()})
+// 	case nil:
+// 		c.JSON(http.StatusCreated, obj)
+// 	default:
+// 		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+// 	}
+// }
+
+// func UpdateTagByID(c *gin.Context) {
+// 	ctx := storagev2.ParseContext(c)
+// 	var req openapi.ConnectionTagUpdateRequest
+// 	if err := c.ShouldBindJSON(&req); err != nil {
+// 		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+// 		return
+// 	}
+// 	resourceID := c.Param("id")
+// 	obj, err := models.GetConnectionTagByID(ctx.OrgID, resourceID)
+// 	switch err {
+// 	case models.ErrNotFound:
+// 		c.JSON(http.StatusNotFound, gin.H{"message": err.Error()})
+// 	case nil:
+// 		err := models.UpdateConnectionTagValue(ctx.OrgID, resourceID, req.Value)
+// 		if err != nil {
+// 			log.Errorf("failed updating connection tags, reason=%v", err)
+// 			c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+// 			return
+// 		}
+// 		obj.Value = req.Value
+// 		c.JSON(http.StatusOK, obj)
+// 	default:
+// 		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+// 	}
+
+// }
+
+// func GetTagByID(c *gin.Context) {
+// 	ctx := storagev2.ParseContext(c)
+// 	obj, err := models.GetConnectionTagByID(ctx.OrgID, c.Param("id"))
+// 	switch err {
+// 	case models.ErrNotFound:
+// 		c.JSON(http.StatusNotFound, gin.H{"message": err.Error()})
+// 	case nil:
+// 		c.JSON(http.StatusOK, obj)
+// 	default:
+// 		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+// 	}
+// }
+
+// List Connection Tags
+//
+//	@Summary		List Connection Tags
+//	@Description	List all Connection Tags.
+//	@Tags			Connections
+//	@Produce		json
+//	@Success		200	{array}		openapi.ConnectionTag
+//	@Failure		500	{object}	openapi.HTTPError
+//	@Router			/connections-tags [get]
+func ListTags(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	items, err := models.ListConnectionTags(ctx.OrgID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+		return
+	}
+	var result openapi.ConnectionTagList
+	for _, c := range items {
+		result.Items = append(result.Items, toConnectionTags(c))
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+func toConnectionTags(c models.ConnectionTag) openapi.ConnectionTag {
+	return openapi.ConnectionTag{
+		ID:        c.ID,
+		Key:       c.Key,
+		Value:     c.Value,
+		UpdatedAt: c.UpdatedAt,
+		CreatedAt: c.CreatedAt,
+	}
+}

--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -92,6 +92,7 @@ func Post(c *gin.Context) {
 		AccessSchema:        req.AccessSchema,
 		GuardRailRules:      req.GuardRailRules,
 		JiraIssueTemplateID: sql.NullString{String: req.JiraIssueTemplateID, Valid: true},
+		ConnectionTags:      req.ConnectionTags,
 	})
 	if err != nil {
 		log.Errorf("failed creating connection, err=%v", err)
@@ -189,6 +190,7 @@ func Put(c *gin.Context) {
 		AccessSchema:        req.AccessSchema,
 		GuardRailRules:      req.GuardRailRules,
 		JiraIssueTemplateID: sql.NullString{String: req.JiraIssueTemplateID, Valid: true},
+		ConnectionTags:      req.ConnectionTags,
 	})
 	if err != nil {
 		switch err.(type) {
@@ -260,11 +262,12 @@ func Delete(c *gin.Context) {
 //	@Description	List all connections.
 //	@Tags			Connections
 //	@Produce		json
-//	@Param			agent_id	query		string	false	"Filter by agent id"					Format(uuid)
-//	@Param			tags		query		string	false	"Filter by tags, separated by comma"	Format(string)
-//	@Param			type		query		string	false	"Filter by type"						Format(string)
-//	@Param			subtype		query		string	false	"Filter by subtype"						Format(string)
-//	@Param			managed_by	query		string	false	"Filter by managed by"					Format(string)
+//	@Param			agent_id	query		string	false	"Filter by agent id"																	Format(uuid)
+//	@Param			tags		query		string	false	"DEPRECATED: Filter by tags, separated by comma"										Format(string)
+//	@Param			tagSelector	query		string	false	"Selector tags to fo filter on, supports '=' and '!=' (e.g. key1=value1,key2=value2)"	Format(string)
+//	@Param			type		query		string	false	"Filter by type"																		Format(string)
+//	@Param			subtype		query		string	false	"Filter by subtype"																		Format(string)
+//	@Param			managed_by	query		string	false	"Filter by managed by"																	Format(string)
 //	@Success		200			{array}		openapi.Connection
 //	@Failure		422,500		{object}	openapi.HTTPError
 //	@Router			/connections [get]
@@ -316,6 +319,7 @@ func List(c *gin.Context) {
 				RedactTypes:         conn.RedactTypes,
 				ManagedBy:           managedBy,
 				Tags:                conn.Tags,
+				ConnectionTags:      conn.ConnectionTags,
 				AccessModeRunbooks:  conn.AccessModeRunbooks,
 				AccessModeExec:      conn.AccessModeExec,
 				AccessModeConnect:   conn.AccessModeConnect,
@@ -342,7 +346,6 @@ func List(c *gin.Context) {
 func Get(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
 	conn, err := models.GetConnectionByNameOrID(ctx.OrgID, c.Param("nameOrID"))
-	// conn, err := pgconnections.New().FetchOneByNameOrID(ctx, c.Param("nameOrID"))
 	if err != nil {
 		log.Errorf("failed fetching connection, err=%v", err)
 		sentry.CaptureException(err)
@@ -384,6 +387,7 @@ func Get(c *gin.Context) {
 		RedactTypes:         conn.RedactTypes,
 		ManagedBy:           managedBy,
 		Tags:                conn.Tags,
+		ConnectionTags:      conn.ConnectionTags,
 		AccessModeRunbooks:  conn.AccessModeRunbooks,
 		AccessModeExec:      conn.AccessModeExec,
 		AccessModeConnect:   conn.AccessModeConnect,
@@ -395,7 +399,6 @@ func Get(c *gin.Context) {
 
 // FetchByName fetches a connection based in access control rules
 func FetchByName(ctx pgrest.Context, connectionName string) (*models.Connection, error) {
-	// conn, err := pgconnections.New().FetchOneByNameOrID(ctx, connectionName)
 	conn, err := models.GetConnectionByNameOrID(ctx.GetOrgID(), connectionName)
 	if err != nil {
 		return nil, err

--- a/gateway/api/connections/defaults.go
+++ b/gateway/api/connections/defaults.go
@@ -1,0 +1,44 @@
+package apiconnections
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/gateway/models"
+)
+
+var systemTags = map[string][]string{
+	"hoop.dev/infrastructure.cloud":          {"aws", "gcp", "azure", "digitalocean", "cloudflare"},
+	"hoop.dev/infrastructure.environment":    {"prod", "staging", "dev", "qa", "sandbox"},
+	"hoop.dev/infrastructure.service-type":   {"database", "cache", "compute", "storage", "cdn"},
+	"hoop.dev/infrastructure.backup-policy":  {"daily", "weekly", "monthly", "none"},
+	"hoop.dev/organization.team":             {"backend", "frontend", "platform", "devops", "security", "data"},
+	"hoop.dev/organization.department":       {"engineering", "marketing", "sales", "finance"},
+	"hoop.dev/security.compliance":           {"sox", "hipaa", "gdpr", "pci", "iso27001"},
+	"hoop.dev/security.access-level":         {"public", "private", "restricted", "confidential"},
+	"hoop.dev/security.data-classification":  {"public", "private", "restricted", "confidential"},
+	"hoop.dev/security.security-zone":        {"public", "private", "restricted", "confidential"},
+	"hoop.dev/operations.monitoring":         {"basic", "enhanced", "full"},
+	"hoop.dev/operations.sla":                {"99.9", "99.99", "99.999"},
+	"hoop.dev/operations.maintenance-window": {"weekend", "business-hours", "24x7"},
+	"hoop.dev/operations.priority":           {"p1", "p2", "p3", "p4"},
+	"hoop.dev/operations.impact":             {"high", "medium", "low"},
+	"hoop.dev/operations.criticality":        {"critical", "important", "normal"},
+	"hoop.dev/business.customer-facing":      {"yes", "no"},
+}
+
+func DefaultConnectionTags(orgID string) (items []models.ConnectionTag) {
+	for key, vals := range systemTags {
+		for _, val := range vals {
+			items = append(items, models.ConnectionTag{
+				OrgID:     orgID,
+				ID:        uuid.NewString(),
+				Key:       key,
+				Value:     val,
+				UpdatedAt: time.Now().UTC(),
+				CreatedAt: time.Now().UTC(),
+			})
+		}
+	}
+	return
+}

--- a/gateway/api/connections/helpers.go
+++ b/gateway/api/connections/helpers.go
@@ -142,6 +142,8 @@ func validateListOptions(urlValues url.Values) (o models.ConnectionFilterOption,
 			o.SubType = values[0]
 		case "managed_by":
 			o.ManagedBy = values[0]
+		case "tagSelector":
+			o.TagSelector = values[0]
 		case "tags":
 			if len(values[0]) > 0 {
 				for _, tagVal := range strings.Split(values[0], ",") {
@@ -155,7 +157,7 @@ func validateListOptions(urlValues url.Values) (o models.ConnectionFilterOption,
 		default:
 			continue
 		}
-		if !reSanitize.MatchString(values[0]) {
+		if key != "tagSelector" && !reSanitize.MatchString(values[0]) {
 			return o, errInvalidOptionVal
 		}
 	}

--- a/gateway/api/connections/helpers.go
+++ b/gateway/api/connections/helpers.go
@@ -21,7 +21,11 @@ import (
 	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
 )
 
-var tagsValRe, _ = regexp.Compile(`^[a-zA-Z0-9_]+(?:[-\.]?[a-zA-Z0-9_]+){0,128}$`)
+var (
+	tagsValRe, _           = regexp.Compile(`^[a-zA-Z0-9_]+(?:[-\.]?[a-zA-Z0-9_]+){0,128}$`)
+	connectionTagsKeyRe, _ = regexp.Compile(`^[a-zA-Z0-9_]+(?:[-\./]?[a-zA-Z0-9_]+){0,}$`)
+	connectionTagsValRe, _ = regexp.Compile(`^[a-zA-Z0-9-_\+=@\/:\s]+$`)
+)
 
 func accessControlAllowed(ctx pgrest.Context) (func(connName string) bool, error) {
 	p, err := pgplugins.New().FetchOne(ctx, plugintypes.PluginAccessControlName)
@@ -114,9 +118,34 @@ func validateConnectionRequest(req openapi.Connection) error {
 	if err := apivalidation.ValidateResourceName(req.Name); err != nil {
 		errors = append(errors, err.Error())
 	}
+	// TODO: deprecated
 	for _, val := range req.Tags {
 		if !tagsValRe.MatchString(val) {
 			errors = append(errors, "tags: values must contain between 1 and 128 alphanumeric characters, it may include (-), (_) or (.) characters")
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf(strings.Join(errors, "; "))
+	}
+
+	if len(req.ConnectionTags) > 10 {
+		return fmt.Errorf("max tag association reached (10)")
+	}
+
+	for key, val := range req.ConnectionTags {
+		if strings.HasPrefix(key, "hoop.dev/") {
+			errors = append(errors, "connection_tags: keys must not use the reserverd prefix hoop.dev/")
+			continue
+		}
+
+		if (len(key) < 1 || len(key) > 64) || !connectionTagsKeyRe.MatchString(key) {
+			errors = append(errors,
+				fmt.Sprintf("connection_tags (%v), keys must contain between 1 and 64 alphanumeric characters, ", key)+
+					"it may include (-), (_), (/), or (.) characters and it must not end with (-), (/) or (-)")
+		}
+		if (len(val) < 1 || len(val) > 256) || !connectionTagsValRe.MatchString(val) {
+			errors = append(errors, fmt.Sprintf("connection_tags (%v), values must contain between 1 and 256 alphanumeric characters, ", key)+
+				"it may include space, (-), (_), (/), (+), (@), (:), (=) or (.) characters")
 		}
 	}
 	if len(errors) > 0 {

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -3966,7 +3966,7 @@ const docTemplate = `{
                     ]
                 },
                 "connection_tags": {
-                    "description": "Tgas to classify the connection",
+                    "description": "Tags to identify the connection\n* keys must contain between 1 and 64 alphanumeric characters, it may include (-), (_), (/), or (.) characters and it must not end with (-), (/) or (-).\n* values must contain between 1 and 256 alphanumeric characters, it may include space, (-), (_), (/), (+), (@), (:), (=) or (.) characters.",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -232,8 +232,15 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "format": "string",
-                        "description": "Filter by tags, separated by comma",
+                        "description": "DEPRECATED: Filter by tags, separated by comma",
                         "name": "tags",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "string",
+                        "description": "Selector tags to fo filter on, supports '=' and '!=' (e.g. key1=value1,key2=value2)",
+                        "name": "tagSelector",
                         "in": "query"
                     },
                     {
@@ -283,7 +290,7 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "The connection resource allows exposing internal services from your internal infra structure to users.\n\n### Types of Connections\n\nThe definition of this resource represent how clients will be able to interact with internal resources.\n\nEach type/subtype may represent a distinct implementation:\n\n- ` + "`" + `application/\u003csubtype\u003e` + "`" + ` - An alias to map distinct types of shell applications (e.g.: python, ruby, etc)\n- ` + "`" + `application/tcp` + "`" + ` - Forward TCP connections\n\n    This type requires the following environment variables:\n    - ` + "`" + `HOST` + "`" + `: ip or dns of the internal service\n    - ` + "`" + `PORT` + "`" + `: the port of the internal service\n\n- ` + "`" + `custom` + "`" + ` - Any custom shell application\n- ` + "`" + `database/\u003csubtype\u003e` + "`" + ` - Allow connecting to databases through multiple clients (Webapp, cli, IDE's)\n\nEach ` + "`" + `\u003csubtype\u003e` + "`" + ` has distinct environment variables that are allowed to be configured, refer to our [documentation](https://hoop.dev/docs) for more information.\n",
+                "description": "The connection resource allows exposing internal services from your internal infra structure to users.\n\n### Types of Connections\n\nThe definition of this resource represent how clients will be able to interact with internal resources.\n\nEach type/subtype may represent a distinct implementation:\n\n- ` + "`" + `application/\u003csubtype\u003e` + "`" + ` - An alias to map distinct types of shell applications (e.g.: python, ruby, etc)\n- ` + "`" + `application/tcp` + "`" + ` - Forward TCP connections\n\n    This type requires the following environment variables:\n    - ` + "`" + `HOST` + "`" + `: ip or dns of the internal service\n    - ` + "`" + `PORT` + "`" + `: the port of the internal service\n\n- ` + "`" + `custom` + "`" + ` - Any custom shell application\n- ` + "`" + `database/\u003csubtype\u003e` + "`" + ` - Allow connecting to databases through multiple clients (Webapp, cli, IDE's)\n\nEach ` + "`" + `\u003csubtype\u003e` + "`" + ` has distinct environment variables that are allowed to be configured, refer to our [documentation](https://hoop.dev/docs) for more information.\n\n### Tags\n\nTags are key/value pairs that are attached to objects such as Connections. Tags are intended to be used to specify identifying attributes of objects that are meaningful and relevant to users, but do not directly imply semantics to the core system.\n\n` + "`" + `` + "`" + `` + "`" + `json\n{\n    \"connection_tags\": {\n        \"environment\": \"production\",\n        \"component\": \"backend\"\n    }\n}\n` + "`" + `` + "`" + `` + "`" + `\n\nEquality- or inequality-based requirements allow filtering by tags keys and values. Matching objects must satisfy all of the specified tag constraints, though they may have additional tags as well. Three kinds of operators are admitted ` + "`" + `=` + "`" + `,` + "`" + `!=` + "`" + `. The first represent equality, while the last represents inequality. For example:\n\n` + "`" + `` + "`" + `` + "`" + `\nenvironment = production\ntier != frontend\n` + "`" + `` + "`" + `` + "`" + `\n\nThe former selects all resources with key equal to ` + "`" + `environment` + "`" + ` and value equal to ` + "`" + `production` + "`" + `. The latter selects all resources with key equal to ` + "`" + `tier` + "`" + ` and value distinct from ` + "`" + `frontend` + "`" + `. One could filter for resources in production excluding frontend using the comma operator: environment=production,tier!=frontend\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -328,6 +335,35 @@ const docTemplate = `{
                         "description": "Unprocessable Entity",
                         "schema": {
                             "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/connections-tags": {
+            "get": {
+                "description": "List all Connection Tags.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "List Connection Tags",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/openapi.ConnectionTag"
+                            }
                         }
                     },
                     "500": {
@@ -3929,6 +3965,17 @@ const docTemplate = `{
                         "/bin/bash"
                     ]
                 },
+                "connection_tags": {
+                    "description": "Tgas to classify the connection",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "example": {
+                        "foo": "bar",
+                        "zika": "virus"
+                    }
+                },
                 "default_database": {
                     "description": "Default databases returns the configured value of the attribute secrets-\u003e'DB'",
                     "type": "string"
@@ -4011,7 +4058,7 @@ const docTemplate = `{
                     "example": "postgres"
                 },
                 "tags": {
-                    "description": "Tags to classify the connection",
+                    "description": "DEPRECATED: Tags to classify the connection",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -4099,6 +4146,36 @@ const docTemplate = `{
                 "name": {
                     "description": "The name of the table",
                     "type": "string"
+                }
+            }
+        },
+        "openapi.ConnectionTag": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "description": "CreatedAt is the timestamp when this tag was created",
+                    "type": "string",
+                    "example": "2023-08-15T14:30:45Z"
+                },
+                "id": {
+                    "description": "ID is the unique identifier for this specific tag",
+                    "type": "string",
+                    "example": "tag_01H7ZD5SJRZ7RPGQRMT4Y9HF"
+                },
+                "key": {
+                    "description": "Key is the identifier for the tag category (e.g., \"environment\", \"department\")",
+                    "type": "string",
+                    "example": "environment"
+                },
+                "updated_at": {
+                    "description": "UpdatedAt is the timestamp when this tag was last updated",
+                    "type": "string",
+                    "example": "2023-08-15T14:30:45Z"
+                },
+                "value": {
+                    "description": "Value is the specific tag value associated with the key (e.g., \"production\", \"finance\")",
+                    "type": "string",
+                    "example": "production"
                 }
             }
         },
@@ -4273,7 +4350,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "example": [
-                        "hello world"
+                        "--verbose"
                     ]
                 },
                 "connection": {
@@ -4296,7 +4373,7 @@ const docTemplate = `{
                 "script": {
                     "description": "The input of the execution",
                     "type": "string",
-                    "example": "echo"
+                    "example": "echo 'hello from hoop'"
                 }
             }
         },

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -3972,8 +3972,8 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "example": {
-                        "foo": "bar",
-                        "zika": "virus"
+                        "environment": "prod",
+                        "tier": "frontend"
                     }
                 },
                 "default_database": {

--- a/gateway/api/openapi/docs/api-connection.md
+++ b/gateway/api/openapi/docs/api-connection.md
@@ -17,3 +17,25 @@ Each type/subtype may represent a distinct implementation:
 - `database/<subtype>` - Allow connecting to databases through multiple clients (Webapp, cli, IDE's)
 
 Each `<subtype>` has distinct environment variables that are allowed to be configured, refer to our [documentation](https://hoop.dev/docs) for more information.
+
+### Tags
+
+Tags are key/value pairs that are attached to objects such as Connections. Tags are intended to be used to specify identifying attributes of objects that are meaningful and relevant to users, but do not directly imply semantics to the core system.
+
+```json
+{
+    "connection_tags": {
+        "environment": "production",
+        "component": "backend"
+    }
+}
+```
+
+Equality- or inequality-based requirements allow filtering by tags keys and values. Matching objects must satisfy all of the specified tag constraints, though they may have additional tags as well. Three kinds of operators are admitted `=`,`!=`. The first represent equality, while the last represents inequality. For example:
+
+```
+environment = production
+tier != frontend
+```
+
+The former selects all resources with key equal to `environment` and value equal to `production`. The latter selects all resources with key equal to `tier` and value distinct from `frontend`. One could filter for resources in production excluding frontend using the comma operator: environment=production,tier!=frontend

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -226,8 +226,10 @@ type Connection struct {
 	// Managed By is a read only field that indicates who is managing this resource.
 	// When this attribute is set, this resource is considered immutable
 	ManagedBy *string `json:"managed_by" readonly:"true" example:""`
-	// Tags to classify the connection
+	// DEPRECATED: Tags to classify the connection
 	Tags []string `json:"tags" example:"prod"`
+	// Tgas to classify the connection
+	ConnectionTags map[string]string `json:"connection_tags" example:"foo:bar,zika:virus"`
 	// Toggle Ad Hoc Runbooks Executions
 	// * enabled - Enable to run runbooks for this connection
 	// * disabled - Disable runbooks execution for this connection
@@ -248,6 +250,35 @@ type Connection struct {
 	GuardRailRules []string `json:"guardrail_rules" example:"5701046A-7B7A-4A78-ABB0-A24C95E6FE54,B19BBA55-8646-4D94-A40A-C3AFE2F4BAFD"`
 	// The jira issue templates ids associated to the connection
 	JiraIssueTemplateID string `json:"jira_issue_template_id" example:"B19BBA55-8646-4D94-A40A-C3AFE2F4BAFD"`
+}
+
+type ConnectionTagCreateRequest struct {
+	// Key is the identifier for the tag category (e.g., "environment", "department")
+	Key string `json:"key" binding:"required" example:"environment"`
+	// Value is the specific tag value associated with the key (e.g., "production", "finance")
+	Value string `json:"value" binding:"required" example:"production"`
+}
+
+type ConnectionTagUpdateRequest struct {
+	// Value is the new tag value to be assigned to the existing key
+	Value string `json:"value" binding:"required" example:"staging"`
+}
+
+type ConnectionTagList struct {
+	Items []ConnectionTag `json:"items"`
+}
+
+type ConnectionTag struct {
+	// ID is the unique identifier for this specific tag
+	ID string `json:"id" example:"tag_01H7ZD5SJRZ7RPGQRMT4Y9HF"`
+	// Key is the identifier for the tag category (e.g., "environment", "department")
+	Key string `json:"key" example:"environment"`
+	// Value is the specific tag value associated with the key (e.g., "production", "finance")
+	Value string `json:"value" example:"production"`
+	// UpdatedAt is the timestamp when this tag was last updated
+	UpdatedAt time.Time `json:"updated_at" example:"2023-08-15T14:30:45Z"`
+	// CreatedAt is the timestamp when this tag was created
+	CreatedAt time.Time `json:"created_at" example:"2023-08-15T14:30:45Z"`
 }
 
 type ExecRequest struct {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -252,7 +252,7 @@ type Connection struct {
 
 type ExecRequest struct {
 	// The input of the execution
-	Script string `json:"script" example:"echo"`
+	Script string `json:"script" example:"echo 'hello from hoop'"`
 	// The target connection
 	Connection string `json:"connection" example:"bash"`
 	// DEPRECATED in flavor of metadata
@@ -260,7 +260,7 @@ type ExecRequest struct {
 	// Metadata contains attributes that is going to be available in the Session resource
 	Metadata map[string]any `json:"metadata"`
 	// Additional arguments that will be joined when construction the command to be executed
-	ClientArgs []string `json:"client_args" example:"hello world"`
+	ClientArgs []string `json:"client_args" example:"--verbose"`
 }
 
 type ExecResponse struct {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -228,8 +228,10 @@ type Connection struct {
 	ManagedBy *string `json:"managed_by" readonly:"true" example:""`
 	// DEPRECATED: Tags to classify the connection
 	Tags []string `json:"tags" example:"prod"`
-	// Tgas to classify the connection
-	ConnectionTags map[string]string `json:"connection_tags" example:"foo:bar,zika:virus"`
+	// Tags to identify the connection
+	// * keys must contain between 1 and 64 alphanumeric characters, it may include (-), (_), (/), or (.) characters and it must not end with (-), (/) or (-).
+	// * values must contain between 1 and 256 alphanumeric characters, it may include space, (-), (_), (/), (+), (@), (:), (=) or (.) characters.
+	ConnectionTags map[string]string `json:"connection_tags" example:"environment:prod,tier:frontend"`
 	// Toggle Ad Hoc Runbooks Executions
 	// * enabled - Enable to run runbooks for this connection
 	// * disabled - Disable runbooks execution for this connection

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -275,6 +275,28 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		apiconnections.GetDatabaseSchemas)
 
+	// TODO(san): needs more testing, will add these endpoints later on
+	// r.POST("/connection-tags",
+	// 	r.AuthMiddleware,
+	// 	// api.TrackRequest(analytics.EventApiExecConnection),
+	// 	apiconnections.CreateTag,
+	// )
+	// r.PUT("/connection-tags/:id",
+	// 	r.AuthMiddleware,
+	// 	// api.TrackRequest(analytics.EventApiExecConnection),
+	// 	apiconnections.UpdateTagByID,
+	// )
+	// r.GET("/connection-tags/:id",
+	// 	r.AuthMiddleware,
+	// 	// api.TrackRequest(analytics.EventApiExecConnection),
+	// 	apiconnections.GetTagByID,
+	// )
+	r.GET("/connection-tags",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		apiconnections.ListTags,
+	)
+
 	r.POST("/proxymanager/connect",
 		r.AuthMiddleware,
 		api.TrackRequest(analytics.EventApiProxymanagerConnect),

--- a/gateway/api/signup/signup.go
+++ b/gateway/api/signup/signup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/gateway/agentcontroller"
 	"github.com/hoophq/hoop/gateway/analytics"
+	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/models"
@@ -111,6 +112,8 @@ func Post(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"message": "failed creating user group"})
 			return
 		}
+		// add default system tags
+		_ = models.UpsertBatchConnectionTags(apiconnections.DefaultConnectionTags(orgID))
 
 		log.With("org_name", req.OrgName, "org_id", orgID).Infof("user signup up with success")
 		identifySignup(user, req.OrgName, c.GetHeader("user-agent"), ctx.ApiURL)

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hoophq/hoop/common/version"
 	"github.com/hoophq/hoop/gateway/agentcontroller"
 	"github.com/hoophq/hoop/gateway/api"
+	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
 	apiorgs "github.com/hoophq/hoop/gateway/api/orgs"
 	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/indexer"
@@ -77,6 +78,11 @@ func Run() {
 		_, _, err = apiorgs.ProvisionOrgAgentKey(ctx, grpcURL)
 		if err != nil && err != apiorgs.ErrAlreadyExists {
 			log.Errorf("failed provisioning org agent key, reason=%v", err)
+		}
+
+		err = models.UpsertBatchConnectionTags(apiconnections.DefaultConnectionTags(ctx.GetOrgID()))
+		if err != nil {
+			log.Warnf("failed provisioning default system tags, reason=%v", err)
 		}
 	}
 

--- a/gateway/models/connection_tags.go
+++ b/gateway/models/connection_tags.go
@@ -1,0 +1,98 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const tableConnectionTags = "private.connection_tags"
+
+type ConnectionTag struct {
+	ID        string    `gorm:"column:id"`
+	OrgID     string    `gorm:"column:org_id"`
+	Key       string    `gorm:"column:key"`
+	Value     string    `gorm:"column:value"`
+	CreatedAt time.Time `gorm:"column:created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
+}
+
+func CreateConnectionTag(obj *ConnectionTag) error {
+	err := DB.Table(tableConnectionTags).Model(obj).Create(obj).Error
+	if err == gorm.ErrDuplicatedKey {
+		return ErrAlreadyExists
+	}
+	return err
+}
+
+func UpdateConnectionTagValue(orgID, id, val string) error {
+	res := DB.Table(tableConnectionTags).
+		Where("org_id = ? AND id = ?", orgID, id).
+		Updates(ConnectionTag{
+			Value:     val,
+			UpdatedAt: time.Now().UTC(),
+		})
+	if res.Error == nil && res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return res.Error
+}
+
+func GetConnectionTagByID(orgID, id string) (*ConnectionTag, error) {
+	var obj ConnectionTag
+	if err := DB.Table(tableConnectionTags).Where("org_id = ? AND id = ?", orgID, id).
+		First(&obj).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	return &obj, nil
+}
+
+func ListConnectionTags(orgID string) ([]ConnectionTag, error) {
+	var items []ConnectionTag
+	err := DB.Table(tableConnectionTags).
+		Where("org_id = ?", orgID).Find(&items).Error
+	if err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func updateBatchConnectionTags(tx *gorm.DB, orgID, connID string, tags map[string]string) error {
+	err := tx.Exec(
+		`DELETE FROM private.connection_tags_association WHERE org_id = ? AND connection_id = ?`,
+		orgID, connID).Error
+	if err != nil {
+		return fmt.Errorf("failed cleaning connection tags association, reason=%v", err)
+	}
+	for key, value := range tags {
+		tagID := uuid.NewString()
+		err := tx.Raw(`
+			INSERT INTO private.connection_tags (org_id, id, key, value, updated_at)
+			VALUES (?, ?, ?, ?, NOW())
+				-- TODO: fix set update_at, it should not update nothing
+				ON CONFLICT (org_id, key, value) DO UPDATE SET updated_at = NOW()
+        		RETURNING id;
+		`, orgID, tagID, key, value).Scan(&tagID).Error
+		if err != nil {
+			return fmt.Errorf("failed creating connection tags, reason=%v", err)
+		}
+
+		// assign tags to the connection
+		associationID := uuid.NewString()
+		err = tx.Exec(`
+			INSERT INTO private.connection_tags_association (org_id, id, connection_id, tag_id)
+			VALUES (?, ?, ?, ?)`, orgID, associationID, connID, tagID).
+			Error
+		if err != nil {
+			return fmt.Errorf("failed creating connection tags association, reason=%v", err)
+		}
+	}
+	return nil
+}

--- a/rootfs/app/migrations/000034_tags_key_val.down.sql
+++ b/rootfs/app/migrations/000034_tags_key_val.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE private.connection_tags;

--- a/rootfs/app/migrations/000034_tags_key_val.up.sql
+++ b/rootfs/app/migrations/000034_tags_key_val.up.sql
@@ -19,7 +19,6 @@ CREATE TABLE connection_tags_association(
     id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
     org_id UUID NULL REFERENCES orgs (id),
 
-    -- test it cascade
     tag_id UUID NOT NULL REFERENCES connection_tags (id) ON DELETE CASCADE,
     connection_id UUID NOT NULL REFERENCES connections (id) ON DELETE CASCADE,
 

--- a/rootfs/app/migrations/000034_tags_key_val.up.sql
+++ b/rootfs/app/migrations/000034_tags_key_val.up.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+SET search_path TO private;
+
+CREATE TABLE connection_tags(
+    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    org_id UUID NOT NULL REFERENCES orgs (id),
+
+    key VARCHAR(128) NOT NULL,
+    value VARCHAR(255) NOT NULL DEFAULT '',
+
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+
+    UNIQUE(org_id, key, value)
+);
+
+CREATE TABLE connection_tags_association(
+    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    org_id UUID NULL REFERENCES orgs (id),
+
+    -- test it cascade
+    tag_id UUID NOT NULL REFERENCES connection_tags (id) ON DELETE CASCADE,
+    connection_id UUID NOT NULL REFERENCES connections (id) ON DELETE CASCADE,
+
+    created_at TIMESTAMP DEFAULT NOW(),
+
+    UNIQUE(tag_id, connection_id)
+);
+
+COMMIT;


### PR DESCRIPTION
- Add new attribute (`connection_tags`) to persist tags when managing connections
- Add `GET /api/connection-tags` endpoint to list all available tags of an organization
- Update cli to filter connections by tag selector
- Add `tagSelector` query string to filter connections by tags
- Add default system tags when creating the default organization