### PR TITLE
Display reviewer information in session audit details view

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -3,7 +3,7 @@
    ["@headlessui/react" :as ui]
    ["@heroicons/react/20/solid" :as hero-solid-icon]
    ["@heroicons/react/24/outline" :as hero-outline-icon]
-   ["@radix-ui/themes" :refer [Button Flex Text Tooltip]]
+   ["@radix-ui/themes" :refer [Button Box Flex Text Tooltip]]
    ["clipboard" :as clipboardjs]
    ["is-url-http" :as is-url-http?]
    ["lucide-react" :refer [Download FileDown]]
@@ -112,20 +112,22 @@
                                    (:group group)])
                      (reset! add-review-popover-open? false))]
     (fn [group _]
-      [:div
-       {:class (str "relative flex flex-grow items-center gap-small"
-                    " text-xs")}
-       [:div
+      [:> Box {:class "flex w-full relative items-center gap-small text-xs"}
+       [:> Box
         [icon/regular {:size 4
                        :icon-name "user-group"}]]
        [tooltip/truncate-tooltip {:text (:group group)}]
-       [:span {:class "text-xxs italic text-gray-500 text-right"}
-        (:status group)]
-       [:div
+       [:> Box
+        [:span {:class "text-xxs italic text-gray-500 text-right"}
+         (:status group)]
+        (when (or (= (:status group) "APPROVED")
+                  (= (:status group) "REJECTED"))
+          [:> Box {:class "text-xxs italic text-gray-500 text-right max-w-[100px]"}
+           [tooltip/truncate-tooltip {:text (-> group :reviewed_by :email)}]])]
+       [:> Box
         [icon/regular {:size 4
                        :icon-name (review-status-icon
                                    (cs/upper-case (:status group)))}]]
-       [:span {:class "w-5"}]
        [popover/right {:open @add-review-popover-open?
                        :component [add-review-popover add-review]
                        :on-click-outside #(reset! add-review-popover-open? false)}]])))
@@ -349,8 +351,7 @@
                [:div
                 {:class "py-small text-xs italic text-gray-500 text-left"}
                 "No review info"])
-             [:div {:class (str "rounded-lg "
-                                "flex flex-col")}
+             [:div {:class "rounded-lg w-full flex flex-col gap-2"}
               (doall
                (for [group review-groups]
                  ^{:key (:id group)}


### PR DESCRIPTION
This PR enhances the view of the session audit details by adding reviewer attribution information. Now, when sessions are approved or rejected, the system displays the email of the user who performed the review action, improving accountability and transparency in the audit workflow.

### Changes Made
- Added display of reviewer email in the review group items when status is "APPROVED" or "REJECTED"
- Implemented tooltip for reviewer emails to handle long email addresses gracefully
- Adjusted styling and layout of review group items to accommodate the new information
- Added "relative" class to review group items for proper positioning of elements

### UI Changes
- Review group items now display:
  - Group name with tooltip for longer names
  - Review status (PENDING, APPROVED, REJECTED)
  - **New**: Reviewer email (when approved/rejected) with truncation tooltip
  - Status icon reflecting the current review state

### Technical Details
- Added a conditional rendering block that shows reviewer email only when status is "APPROVED" or "REJECTED"
- Used `tooltip/truncate-tooltip` component to handle long email addresses elegantly
- Limited email display width to maintain clean UI with `max-w-[100px]` class
- Styled the email display with italic, small text in gray to differentiate it from other elements

### Screenshots
![Screenshot 2025-03-19 at 10 46 26](https://github.com/user-attachments/assets/e0f0bfc6-7d8b-499f-8e9e-f59369baaea6)
![Screenshot 2025-03-19 at 10 52 27](https://github.com/user-attachments/assets/11b9c926-686c-477f-b8cb-55a8d6d3cef9)
![Screenshot 2025-03-19 at 10 47 27](https://github.com/user-attachments/assets/b85a4856-d0c6-4af5-b369-0cf02daf206e)
![Screenshot 2025-03-19 at 10 46 32](https://github.com/user-attachments/assets/5f737f8e-e6ec-4365-8aa9-6a9ee16c16a6)

