### PR TITLE
AWS Connect: Add Vault integration

### DIFF
--- a/agent/controller/sys/mssql.go
+++ b/agent/controller/sys/mssql.go
@@ -104,7 +104,8 @@ func provisionMSSQLRoles(r pbsys.DBProvisionerRequest) *pbsys.DBProvisionerRespo
 	res := pbsys.NewDbProvisionerResponse(r.SID, "", "")
 	for _, roleName := range roleNames {
 		result := provisionMSSQLRole(db, r, roleName)
-		res.Result = append(res.Result, *result)
+
+		res.Result = append(res.Result, result)
 	}
 	return res
 }
@@ -132,11 +133,13 @@ func provisionMSSQLRole(db *sql.DB, r pbsys.DBProvisionerRequest, roleName roleN
 		Message:        "",
 		CompletedAt:    time.Now().UTC(),
 		Credentials: &pbsys.DBCredentials{
-			Host:     r.DatabaseHostname,
-			Port:     r.Port(),
-			User:     userRole,
-			Password: randomPasswd,
-			Options:  map[string]string{},
+			SecretsManagerProvider: pbsys.SecretsManagerProviderDatabase,
+			Host:                   r.DatabaseHostname,
+			Port:                   r.Port(),
+			User:                   userRole,
+			Password:               randomPasswd,
+			DefaultDatabase:        "master",
+			Options:                map[string]string{},
 		},
 	}
 }

--- a/agent/controller/sys/mysql.go
+++ b/agent/controller/sys/mysql.go
@@ -61,7 +61,7 @@ func provisionMySQLRoles(r pbsys.DBProvisionerRequest) *pbsys.DBProvisionerRespo
 	res := pbsys.NewDbProvisionerResponse(r.SID, "", "")
 	for _, roleName := range roleNames {
 		result := provisionMySQLRole(db, r, roleName)
-		res.Result = append(res.Result, *result)
+		res.Result = append(res.Result, result)
 	}
 	return res
 }
@@ -89,11 +89,13 @@ func provisionMySQLRole(db *sql.DB, r pbsys.DBProvisionerRequest, roleName roleN
 		Message:        "",
 		CompletedAt:    time.Now().UTC(),
 		Credentials: &pbsys.DBCredentials{
-			Host:     r.DatabaseHostname,
-			Port:     r.Port(),
-			User:     userRole,
-			Password: randomPasswd,
-			Options:  map[string]string{},
+			SecretsManagerProvider: pbsys.SecretsManagerProviderDatabase,
+			Host:                   r.DatabaseHostname,
+			Port:                   r.Port(),
+			User:                   userRole,
+			Password:               randomPasswd,
+			DefaultDatabase:        "mysql",
+			Options:                map[string]string{},
 		},
 	}
 }

--- a/agent/controller/sys/postgres.go
+++ b/agent/controller/sys/postgres.go
@@ -97,7 +97,7 @@ func provisionPostgresRoles(r pbsys.DBProvisionerRequest) *pbsys.DBProvisionerRe
 	res := pbsys.NewDbProvisionerResponse(r.SID, "", "")
 	for _, roleName := range roleNames {
 		result := provisionPostgresRole(r, dbNames, roleName)
-		res.Result = append(res.Result, *result)
+		res.Result = append(res.Result, result)
 	}
 
 	return res
@@ -142,11 +142,13 @@ func provisionPostgresRole(r pbsys.DBProvisionerRequest, dbNames []string, roleN
 		Message:        "",
 		CompletedAt:    time.Now().UTC(),
 		Credentials: &pbsys.DBCredentials{
-			Host:     r.DatabaseHostname,
-			Port:     r.Port(),
-			User:     userRole,
-			Password: randomPasswd,
-			Options:  map[string]string{},
+			SecretsManagerProvider: pbsys.SecretsManagerProviderDatabase,
+			Host:                   r.DatabaseHostname,
+			Port:                   r.Port(),
+			User:                   userRole,
+			Password:               randomPasswd,
+			DefaultDatabase:        "postgres",
+			Options:                map[string]string{},
 		},
 	}
 }

--- a/common/proto/sys/sys.go
+++ b/common/proto/sys/sys.go
@@ -16,7 +16,12 @@ const (
 
 	MessageCompleted            string = "All user roles have been successfully provisioned"
 	MessageOneOrMoreRolesFailed string = "One or more user roles failed to be provisioned"
+	MessageVaultSaveError       string = "One or more user roles could not be saved to the Vault key-value store"
 )
+
+type VaultProvider struct {
+	SecretID string `json:"secret_id"`
+}
 
 type DBProvisionerRequest struct {
 	OrgID            string `json:"org_id"`
@@ -27,15 +32,27 @@ type DBProvisionerRequest struct {
 	MasterUsername   string `json:"master_user"`
 	MasterPassword   string `json:"master_password"`
 	DatabaseType     string `json:"database_type"`
-	StoreInVault     bool   `json:"store_in_vault"`
+
+	Vault *VaultProvider `json:"vault_provider"`
 }
 
+type SecretsManagerProviderType string
+
+const (
+	SecretsManagerProviderDatabase SecretsManagerProviderType = "database"
+	SecretsManagerProviderVault    SecretsManagerProviderType = "vault"
+)
+
 type DBCredentials struct {
-	Host     string            `json:"host"`
-	Port     string            `json:"port"`
-	User     string            `json:"user"`
-	Password string            `json:"password"`
-	Options  map[string]string `json:"options"`
+	Host                   string                     `json:"host"`
+	Port                   string                     `json:"port"`
+	User                   string                     `json:"user"`
+	Password               string                     `json:"password"`
+	DefaultDatabase        string                     `json:"default_database"`
+	Options                map[string]string          `json:"options"`
+	SecretsManagerProvider SecretsManagerProviderType `json:"secrets_manager_provider"`
+	SecretID               string                     `json:"secret_id"`
+	SecretKeys             []string                   `json:"secret_keys"`
 }
 
 type Result struct {
@@ -54,10 +71,10 @@ type DBProvisionerStatus struct {
 }
 
 type DBProvisionerResponse struct {
-	SID     string   `json:"sid"`
-	Status  string   `json:"status"`
-	Message string   `json:"message"`
-	Result  []Result `json:"result"`
+	SID     string    `json:"sid"`
+	Status  string    `json:"status"`
+	Message string    `json:"message"`
+	Result  []*Result `json:"result"`
 }
 
 func (r *DBProvisionerRequest) Address() string {
@@ -107,7 +124,7 @@ func NewDbProvisionerResponse(sid, status, message string) *DBProvisionerRespons
 		SID:     sid,
 		Status:  status,
 		Message: message,
-		Result:  []Result{},
+		Result:  []*Result{},
 	}
 }
 

--- a/gateway/api/integrations/aws/aws.go
+++ b/gateway/api/integrations/aws/aws.go
@@ -523,9 +523,14 @@ func toDBRoleOpenAPI(o *models.DBRole) *openapi.DBRoleJob {
 		var result []openapi.DBRoleJobStatusResult
 		for _, r := range o.Status.Result {
 			result = append(result, openapi.DBRoleJobStatusResult{
-				UserRole:    r.UserRole,
-				Status:      r.Status,
-				Message:     r.Message,
+				UserRole: r.UserRole,
+				Status:   r.Status,
+				Message:  r.Message,
+				CredentialsInfo: openapi.DBRoleJobStatusResultCredentialsInfo{
+					SecretsManagerProvider: openapi.SecretsManagerProviderType(r.CredentialsInfo.SecretsManagerProvider),
+					SecretID:               r.CredentialsInfo.SecretID,
+					SecretKeys:             r.CredentialsInfo.SecretKeys,
+				},
 				CompletedAt: r.CompletedAt,
 			})
 		}

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4224,6 +4224,14 @@ const docTemplate = `{
                         "create-connections",
                         "send-webhook"
                     ]
+                },
+                "vault_provider": {
+                    "description": "Vault Provider uses HashiCorp Vault to store the provisioned credentials.\nThe target agent must be configured with the Vault Credentials in order for this operation to work",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.DBRoleJobVaultProvider"
+                        }
+                    ]
                 }
             }
         },
@@ -4364,6 +4372,14 @@ const docTemplate = `{
                     "type": "string",
                     "example": "2025-02-28T12:34:56Z"
                 },
+                "credentials_info": {
+                    "description": "Credentials information about the stored secrets",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.DBRoleJobStatusResultCredentialsInfo"
+                        }
+                    ]
+                },
                 "message": {
                     "description": "Human-readable description of this role's provisioning status or error details",
                     "type": "string",
@@ -4386,18 +4402,62 @@ const docTemplate = `{
                 }
             }
         },
+        "openapi.DBRoleJobStatusResultCredentialsInfo": {
+            "type": "object",
+            "properties": {
+                "secret_id": {
+                    "description": "The secret identifier that contains the secret data.\nThis value is always empty for the database type.",
+                    "type": "string",
+                    "example": "dbsecrets/data"
+                },
+                "secret_keys": {
+                    "description": "The keys that were saved in the secrets manager.\nThis value is always empty for the database type.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "HOST",
+                        "PORT",
+                        "USER",
+                        "PASSWORD",
+                        "DB"
+                    ]
+                },
+                "secrets_manager_provider": {
+                    "description": "The secrets manager provider that was used to store the credentials",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.SecretsManagerProviderType"
+                        }
+                    ],
+                    "example": "database"
+                }
+            }
+        },
         "openapi.DBRoleJobStepType": {
             "type": "string",
             "enum": [
                 "create-connections",
-                "send-webhook",
-                "store-in-vault"
+                "send-webhook"
             ],
             "x-enum-varnames": [
                 "DBRoleJobStepCreateConnections",
-                "DBRoleJobStepSendWebhook",
-                "DBRoleJobStepStoreInVault"
+                "DBRoleJobStepSendWebhook"
             ]
+        },
+        "openapi.DBRoleJobVaultProvider": {
+            "type": "object",
+            "required": [
+                "secret_id"
+            ],
+            "properties": {
+                "secret_id": {
+                    "description": "The path to store the credentials in Vault",
+                    "type": "string",
+                    "example": "dbsecrets/data"
+                }
+            }
         },
         "openapi.DBTag": {
             "type": "object",
@@ -5592,6 +5652,17 @@ const docTemplate = `{
                     "example": "20320ebbf9fc612256b67dc9e899bbd6e4745c77"
                 }
             }
+        },
+        "openapi.SecretsManagerProviderType": {
+            "type": "string",
+            "enum": [
+                "database",
+                "vault"
+            ],
+            "x-enum-varnames": [
+                "SecretsManagerProviderDatabase",
+                "SecretsManagerProviderVault"
+            ]
         },
         "openapi.ServerInfo": {
             "type": "object",

--- a/gateway/api/openapi/ginvalidators.go
+++ b/gateway/api/openapi/ginvalidators.go
@@ -18,7 +18,7 @@ func validateDBRoleJobStep(fl validator.FieldLevel) bool {
 		return false
 	}
 	switch stepType {
-	case DBRoleJobStepCreateConnections, DBRoleJobStepSendWebhook, DBRoleJobStepStoreInVault:
+	case DBRoleJobStepCreateConnections, DBRoleJobStepSendWebhook:
 		return true
 	}
 	return false

--- a/gateway/models/dbroles.go
+++ b/gateway/models/dbroles.go
@@ -29,18 +29,18 @@ type DBRoleStatus struct {
 	Result  []DBRoleStatusResult `json:"result"`
 }
 
-type DBRoleStatusResult struct {
-	UserRole    string    `json:"user_role"`
-	Status      string    `json:"phase"`
-	Message     string    `json:"message"`
-	CompletedAt time.Time `json:"completed_at"`
+type DBRoleStatusResultCredentialsInfo struct {
+	SecretsManagerProvider string   `json:"secrets_manager_provider"`
+	SecretID               string   `json:"secret_id"`
+	SecretKeys             []string `json:"secret_keys"`
 }
 
-type DBRoleItem struct {
-	User        string            `json:"user"`
-	Permissions []string          `json:"permissions"`
-	Secrets     map[string]string `json:"secrets"`
-	Error       *string           `json:"error"`
+type DBRoleStatusResult struct {
+	UserRole        string                            `json:"user_role"`
+	CredentialsInfo DBRoleStatusResultCredentialsInfo `json:"credentials_info"`
+	Status          string                            `json:"phase"`
+	Message         string                            `json:"message"`
+	CompletedAt     time.Time                         `json:"completed_at"`
 }
 
 type DBRole struct {
@@ -79,12 +79,17 @@ func UpdateDBRoleJob(orgID string, completedAt *time.Time, resp *pbsys.DBProvisi
 
 	var result []DBRoleStatusResult
 	for _, r := range resp.Result {
-		var userRole string
+		var cred pbsys.DBCredentials
 		if r.Credentials != nil {
-			userRole = r.Credentials.User
+			cred = *r.Credentials
 		}
 		result = append(result, DBRoleStatusResult{
-			UserRole:    userRole,
+			UserRole: cred.User,
+			CredentialsInfo: DBRoleStatusResultCredentialsInfo{
+				SecretsManagerProvider: string(cred.SecretsManagerProvider),
+				SecretID:               cred.SecretID,
+				SecretKeys:             cred.SecretKeys,
+			},
 			Status:      r.Status,
 			Message:     r.Message,
 			CompletedAt: r.CompletedAt,


### PR DESCRIPTION
- Include credentials information with the information about the external secrets provider
- Add attribute to use Vault to store credentials at `POST /dbroles/jobs`