### PR TITLE
AWS Connect: Add prefix with Hoop to static cross account role

### DIFF
--- a/gateway/api/integrations/aws/aws.go
+++ b/gateway/api/integrations/aws/aws.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hoophq/hoop/gateway/storagev2"
 )
 
-const staticCrossAccountRoleArn = "arn:aws:iam::%s:role/OrganizationAccountAccessRole"
+const staticCrossAccountRoleArn = "arn:aws:iam::%s:role/HoopOrganizationAccountAccessRole"
 
 // IAMUpdateAccessKey
 //


### PR DESCRIPTION
Prevents conflicts with customers that already have this role set