### PR TITLE
Add AWS Accounts Selection Step to Connect Workflow

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.38.9",
+  "version": "1.38.10",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/onboarding/aws_connect.cljs
+++ b/webapp/src/webapp/onboarding/aws_connect.cljs
@@ -442,6 +442,8 @@
      "Follow the steps to setup your AWS resources."]]])
 
 (defn main []
+  (rf/dispatch [:aws-connect/fetch-agents])
+
   (fn [form-type]
     (let [current-step @(rf/subscribe [:aws-connect/current-step])
           loading @(rf/subscribe [:aws-connect/loading])]

--- a/webapp/src/webapp/onboarding/aws_connect.cljs
+++ b/webapp/src/webapp/onboarding/aws_connect.cljs
@@ -162,7 +162,7 @@
                               (sync-selection new-value)))]
 
     (let [_ @update-counter]
-      [:> Flex {:direction "column" :align "center" :gap "7" :mb "4" :class "w-full"}
+      [:> Flex {:direction "column" :align "center" :gap "7" :mb "4" :class "w-full relative"}
        [loading-screen]
 
        [:> Box {:class "max-w-[600px] space-y-3"}

--- a/webapp/src/webapp/onboarding/events/aws_connect_events.cljs
+++ b/webapp/src/webapp/onboarding/events/aws_connect_events.cljs
@@ -12,6 +12,7 @@
                                 :credentials nil
                                 :accounts {:data nil
                                            :status nil
+                                           :selected #{}
                                            :api-error nil}
                                 :resources {:data nil
                                             :selected nil
@@ -132,12 +133,16 @@
 (rf/reg-event-fx
  :aws-connect/fetch-rds-instances
  (fn [{:keys [db]} _]
-   {:dispatch [:fetch
-               {:method "POST"
-                :uri "/integrations/aws/rds/describe-db-instances"
-                :body {}
-                :on-success #(rf/dispatch [:aws-connect/fetch-rds-instances-success %])
-                :on-failure #(rf/dispatch [:aws-connect/fetch-rds-instances-failure %])}]}))
+   (let [selected-accounts (get-in db [:aws-connect :accounts :selected])]
+     {:db (-> db
+              (assoc-in [:aws-connect :loading :active?] true)
+              (assoc-in [:aws-connect :loading :message] "Retrieving AWS resources in your environment..."))
+      :dispatch [:fetch
+                 {:method "POST"
+                  :uri "/integrations/aws/rds/describe-db-instances"
+                  :body {:account_ids (vec selected-accounts)}
+                  :on-success #(rf/dispatch [:aws-connect/fetch-rds-instances-success %])
+                  :on-failure #(rf/dispatch [:aws-connect/fetch-rds-instances-failure %])}]})))
 
 (rf/reg-event-fx
  :aws-connect/fetch-rds-instances-success
@@ -339,8 +344,9 @@
               (assoc-in [:aws-connect :accounts :data] accounts)
               (assoc-in [:aws-connect :accounts :status] :loaded)
               (assoc-in [:aws-connect :accounts :api-error] nil)
-              (assoc-in [:aws-connect :loading :message] "Retrieving AWS resources in your environment..."))
-      :dispatch [:aws-connect/fetch-rds-instances]})))
+              (assoc-in [:aws-connect :loading :active?] false)
+              (assoc-in [:aws-connect :loading :message] nil))
+      :dispatch [:aws-connect/set-current-step :accounts]})))
 
 (rf/reg-event-fx
  :aws-connect/fetch-accounts-failure
@@ -356,9 +362,32 @@
               (assoc-in [:aws-connect :loading :active?] false)
               (assoc-in [:aws-connect :loading :message] nil))
       :dispatch [:show-snackbar {:level :error
-                                 :text "Failed to retrieve AWS accounts. Proceeding to fetch resources."}]
-      ;; Continue with resources anyway
-      :dispatch-later [{:ms 500 :dispatch [:aws-connect/fetch-rds-instances]}]})))
+                                 :text "Failed to retrieve AWS accounts. Please check your credentials and try again."}]})))
+
+;; Toggle selection of an account
+(rf/reg-event-db
+ :aws-connect/toggle-account-selection
+ (fn [db [_ account-id selected?]]
+   (if selected?
+     (update-in db [:aws-connect :accounts :selected] conj account-id)
+     (update-in db [:aws-connect :accounts :selected] disj account-id))))
+
+;; Select or deselect all accounts
+(rf/reg-event-db
+ :aws-connect/select-all-accounts
+ (fn [db [_ selected?]]
+   (let [accounts (get-in db [:aws-connect :accounts :data] [])
+         all-account-ids (map :account_id accounts)]
+     (assoc-in db [:aws-connect :accounts :selected]
+               (if selected?
+                 (set all-account-ids)
+                 #{})))))
+
+;; Set the selected accounts
+(rf/reg-event-db
+ :aws-connect/set-selected-accounts
+ (fn [db [_ selected]]
+   (assoc-in db [:aws-connect :accounts :selected] selected)))
 
 ;; Subscriptions
 (rf/reg-sub
@@ -483,3 +512,19 @@
  :aws-connect/create-connection
  (fn [db _]
    (get-in db [:aws-connect :create-connection] true)))
+
+;; New subscriptions for accounts step
+(rf/reg-sub
+ :aws-connect/accounts
+ (fn [db _]
+   (get-in db [:aws-connect :accounts :data])))
+
+(rf/reg-sub
+ :aws-connect/selected-accounts
+ (fn [db _]
+   (get-in db [:aws-connect :accounts :selected])))
+
+(rf/reg-sub
+ :aws-connect/accounts-error
+ (fn [db _]
+   (get-in db [:aws-connect :accounts :api-error :message])))


### PR DESCRIPTION
This PR enhances the AWS Connect workflow by adding a new Accounts selection step between Credentials and Resources. Users can now select specific AWS accounts to scan for database resources, providing a more targeted discovery process.

### Changes

- Added a new "Accounts" step in the AWS Connect workflow
- Implemented account selection UI with multi-select table
- Modified the RDS instances API call to filter by selected account IDs
- Fixed the loading screen to properly overlay only the content area while preserving the header and footer
- Improved error handling and display in resources data table
- Streamlined the workflow by removing the verify-credentials step

### Screenshots
![Screenshot 2025-03-27 at 16 12 20](https://github.com/user-attachments/assets/11ac1ca7-8b9d-42d9-b846-a7b25191624b)
![Screenshot 2025-03-27 at 16 12 45](https://github.com/user-attachments/assets/631a7760-371b-4c2f-81ea-2d6dcfae4d27)
![Screenshot 2025-03-27 at 16 12 55](https://github.com/user-attachments/assets/d0ebf59a-2dce-4e41-9693-0e888a631499)
