### PR TITLE
Allow applying review filters to sessions

### DIFF
--- a/client/cmd/admin/apiutils.go
+++ b/client/cmd/admin/apiutils.go
@@ -97,7 +97,12 @@ func parseResourceOrDie(args []string, method, outputFlag string) *apiResource {
 		}()
 		apir.name = "_"
 	case "sessions":
-		apir.resourceList = false
+		defer func() {
+			if outputFlag == "" {
+				apir.decodeTo = "object"
+			}
+		}()
+		apir.resourceList = true
 		apir.suffixEndpoint = path.Join("/api/sessions", apir.name)
 	case "users":
 		apir.resourceUpdate = true

--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -262,14 +262,14 @@ func Delete(c *gin.Context) {
 //	@Description	List all connections.
 //	@Tags			Connections
 //	@Produce		json
-//	@Param			agent_id	query		string	false	"Filter by agent id"																	Format(uuid)
-//	@Param			tags		query		string	false	"DEPRECATED: Filter by tags, separated by comma"										Format(string)
-//	@Param			tagSelector	query		string	false	"Selector tags to fo filter on, supports '=' and '!=' (e.g. key1=value1,key2=value2)"	Format(string)
-//	@Param			type		query		string	false	"Filter by type"																		Format(string)
-//	@Param			subtype		query		string	false	"Filter by subtype"																		Format(string)
-//	@Param			managed_by	query		string	false	"Filter by managed by"																	Format(string)
-//	@Success		200			{array}		openapi.Connection
-//	@Failure		422,500		{object}	openapi.HTTPError
+//	@Param			agent_id		query		string	false	"Filter by agent id"																	Format(uuid)
+//	@Param			tags			query		string	false	"DEPRECATED: Filter by tags, separated by comma"										Format(string)
+//	@Param			tag_selector	query		string	false	"Selector tags to fo filter on, supports '=' and '!=' (e.g. key1=value1,key2=value2)"	Format(string)
+//	@Param			type			query		string	false	"Filter by type"																		Format(string)
+//	@Param			subtype			query		string	false	"Filter by subtype"																		Format(string)
+//	@Param			managed_by		query		string	false	"Filter by managed by"																	Format(string)
+//	@Success		200				{array}		openapi.Connection
+//	@Failure		422,500			{object}	openapi.HTTPError
 //	@Router			/connections [get]
 func List(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)

--- a/gateway/api/connections/helpers.go
+++ b/gateway/api/connections/helpers.go
@@ -171,7 +171,7 @@ func validateListOptions(urlValues url.Values) (o models.ConnectionFilterOption,
 			o.SubType = values[0]
 		case "managed_by":
 			o.ManagedBy = values[0]
-		case "tagSelector":
+		case "tag_selector":
 			o.TagSelector = values[0]
 		case "tags":
 			if len(values[0]) > 0 {
@@ -186,7 +186,7 @@ func validateListOptions(urlValues url.Values) (o models.ConnectionFilterOption,
 		default:
 			continue
 		}
-		if key != "tagSelector" && !reSanitize.MatchString(values[0]) {
+		if key != "tag_selector" && !reSanitize.MatchString(values[0]) {
 			return o, errInvalidOptionVal
 		}
 	}

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -240,7 +240,7 @@ const docTemplate = `{
                         "type": "string",
                         "format": "string",
                         "description": "Selector tags to fo filter on, supports '=' and '!=' (e.g. key1=value1,key2=value2)",
-                        "name": "tagSelector",
+                        "name": "tag_selector",
                         "in": "query"
                     },
                     {
@@ -2831,6 +2831,18 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by connection's type",
                         "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by the approver's email of a review",
+                        "name": "review.approver",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by the review status",
+                        "name": "review.status",
                         "in": "query"
                     },
                     {
@@ -6017,7 +6029,7 @@ const docTemplate = `{
                     "description": "Review of this session. In case the review doesn't exist this field will be null",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/openapi.Review"
+                            "$ref": "#/definitions/openapi.SessionReview"
                         }
                     ]
                 },
@@ -6141,6 +6153,66 @@ const docTemplate = `{
                     "description": "The total transformed bytes performed by this info type",
                     "type": "integer",
                     "example": 30012
+                }
+            }
+        },
+        "openapi.SessionReview": {
+            "type": "object",
+            "properties": {
+                "access_duration": {
+                    "description": "The amount of time (nanoseconds) to allow access to the connection. It's valid only for ` + "`" + `jit` + "`" + ` type reviews` + "`" + `",
+                    "type": "integer",
+                    "default": 1800000000000,
+                    "readOnly": true,
+                    "example": 0
+                },
+                "created_at": {
+                    "description": "The time the resource was created",
+                    "type": "string",
+                    "readOnly": true,
+                    "example": "2024-07-25T15:56:35.317601Z"
+                },
+                "id": {
+                    "description": "Reousrce identifier",
+                    "type": "string",
+                    "format": "uuid",
+                    "readOnly": true,
+                    "example": "9F9745B4-C77B-4D52-84D3-E24F67E3623C"
+                },
+                "review_groups_data": {
+                    "description": "Contains the groups that requires to approve this review",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.ReviewGroup"
+                    },
+                    "readOnly": true
+                },
+                "revoke_at": {
+                    "description": "The time when this review was revoked",
+                    "type": "string",
+                    "readOnly": true,
+                    "example": ""
+                },
+                "status": {
+                    "description": "The status of the review\n* PENDING - The resource is waiting to be reviewed\n* APPROVED - The resource is fully approved\n* REJECTED - The resource is fully rejected\n* REVOKED - The resource was revoked after being approved\n* PROCESSING - The review is being executed\n* EXECUTED - The review was executed\n* UNKNOWN - Unable to know the status of the review",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.ReviewStatusType"
+                        }
+                    ]
+                },
+                "type": {
+                    "description": "The type of this review\n* onetime - Represents a one time execution\n* jit - Represents a time based review",
+                    "enum": [
+                        "onetime",
+                        "jit"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.ReviewType"
+                        }
+                    ],
+                    "readOnly": true
                 }
             }
         },

--- a/gateway/api/session/run-exec.go
+++ b/gateway/api/session/run-exec.go
@@ -92,10 +92,11 @@ func RunReviewedExec(c *gin.Context) {
 		return
 	}
 
-	if session.UserEmail != ctx.UserEmail {
-		c.JSON(http.StatusBadRequest, gin.H{"message": "only the creator can trigger this action"})
+	if session.UserEmail != ctx.UserEmail || !ctx.IsAuditorOrAdminUser() {
+		c.JSON(http.StatusForbidden, gin.H{"message": "unable to execute session"})
 		return
 	}
+
 	if review.Status != types.ReviewStatusApproved {
 		c.JSON(http.StatusBadRequest, gin.H{"message": "review not approved or already executed"})
 		return

--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -36,13 +36,15 @@ func (b *BlobInputType) Scan(value any) error {
 }
 
 type SessionOption struct {
-	User           string
-	ConnectionType string
-	ConnectionName string
-	StartDate      sql.NullString
-	EndDate        sql.NullString
-	Offset         int
-	Limit          int
+	User                string
+	ConnectionType      string
+	ConnectionName      string
+	ReviewStatus        string
+	ReviewApproverEmail *string
+	StartDate           sql.NullString
+	EndDate             sql.NullString
+	Offset              int
+	Limit               int
 }
 
 func NewSessionOption() SessionOption {
@@ -50,6 +52,7 @@ func NewSessionOption() SessionOption {
 		User:           "%",
 		ConnectionType: "%",
 		ConnectionName: "%",
+		ReviewStatus:   "%",
 		Limit:          20,
 		Offset:         0,
 	}
@@ -67,14 +70,15 @@ type Session struct {
 	IntegrationsMetadata map[string]any    `gorm:"column:integrations_metadata;serializer:json"`
 	Metrics              map[string]any    `gorm:"column:metrics;serializer:json"`
 	BlobInputID          sql.NullString    `gorm:"column:blob_input_id"`
-	BlobInput            BlobInputType     `gorm:"column:blob_input;->"`
-	BlobStream           json.RawMessage   `gorm:"column:blob_stream;->"`
+	BlobInput            BlobInputType     `gorm:"-"`
+	BlobStream           json.RawMessage   `gorm:"-"`
 	BlobStreamSize       int64             `gorm:"column:blob_stream_size;->"`
 	UserID               string            `gorm:"column:user_id"`
 	UserName             string            `gorm:"column:user_name"`
 	UserEmail            string            `gorm:"column:user_email"`
 	Status               string            `gorm:"column:status"`
 	ExitCode             *int              `gorm:"column:exit_code"`
+	Review               *Review           `gorm:"column:review;->"`
 
 	CreatedAt  time.Time  `gorm:"column:created_at"`
 	EndSession *time.Time `gorm:"column:ended_at"`
@@ -114,26 +118,130 @@ type Blob struct {
 	Type       string          `gorm:"column:type"`
 }
 
-func GetSessionByID(orgID, sid string) (*Session, error) {
-	var session Session
+type ReviewGroups struct {
+	ID           string     `json:"id"`
+	ReviewID     string     `json:"review_id"`
+	GroupName    string     `json:"group_name"`
+	Status       string     `json:"status"`
+	OwnerID      *string    `json:"owner_id"`
+	OwnerEmail   *string    `json:"owner_email"`
+	OwnerName    *string    `json:"owner_name"`
+	OwnerSlackID *string    `json:"owner_slack_id"`
+	ReviewedAt   *time.Time `json:"reviewed_at"`
+}
+
+type Review struct {
+	ID                string         `json:"id"`
+	SessionID         string         `gorm:"column:session_id"`
+	Type              string         `json:"type"`
+	Status            string         `json:"status"`
+	CreatedAt         time.Time      `json:"created_at"`
+	RevokedAt         *time.Time     `json:"revoked_at"`
+	AccessDurationSec int64          `json:"access_duration_sec"`
+	ReviewGroups      []ReviewGroups `json:"review_groups"`
+}
+
+func (r *Review) Scan(value any) error {
+	if value == nil {
+		return nil
+	}
+
+	var data []byte
+	switch v := value.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return fmt.Errorf("unsupported data type: %T", value)
+	}
+	return json.Unmarshal(data, r)
+}
+
+func (s *Session) getBlobInput() (string, error) {
+	var blob Blob
 	err := DB.Raw(`
+	SELECT b.id, b.org_id, b.blob_stream, b.type
+	FROM private.sessions s
+	LEFT JOIN private.blobs AS b ON b.type = 'session-input' AND  b.id = s.blob_input_id
+	WHERE s.org_id = ? AND s.id = ?`, s.OrgID, s.ID).
+		First(&blob).Error
+	if err != nil {
+		return "", err
+	}
+
+	result := []string{}
+	if err := json.Unmarshal(blob.BlobStream, &result); err != nil {
+		return "", fmt.Errorf("failed decoding blob input to []string: %v", err)
+	}
+	if len(result) == 0 {
+		return "", nil
+	}
+	return result[0], nil
+}
+
+func (s *Session) GetBlobStream() (*Blob, error) {
+	var blob Blob
+	return &blob, DB.Raw(`
+	SELECT b.id, b.org_id, b.blob_stream, b.type
+	FROM private.sessions s
+	LEFT JOIN private.blobs AS b ON b.type = 'session-stream' AND  b.id = s.blob_stream_id
+	WHERE s.org_id = ? AND s.id = ?`, s.OrgID, s.ID).
+		First(&blob).Error
+}
+
+func GetSessionByID(orgID, sid string) (*Session, error) {
+	session := &Session{}
+	err := DB.Debug().Raw(`
 	SELECT
 		s.id, s.org_id, s.connection, s.connection_type, s.connection_subtype, s.verb, s.labels, s.exit_code,
 		s.user_id, s.user_name, s.user_email, s.status, s.metadata, s.integrations_metadata, s.metrics,
-		bi.blob_stream AS blob_input, bs.blob_stream AS blob_stream, metrics->>'event_size' AS blob_stream_size,
+		metrics->>'event_size' AS blob_stream_size, s.blob_input_id,
+		CASE
+			WHEN rv.id IS NULL THEN NULL
+			ELSE jsonb_build_object(
+				'id', rv.id,
+				'type', rv.type,
+				'access_duration_sec', rv.access_duration_sec,
+				'status', rv.status,
+				'created_at', to_char(rv.created_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+				'revoked_at', to_char(rv.revoked_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+				'review_groups', (
+					SELECT jsonb_agg(
+						jsonb_build_object(
+							'id', rg.id,
+							'group_name', rg.group_name,
+							'status', rg.status,
+							'owner_id', rg.owner_id,
+							'owner_email', rg.owner_email,
+							'owner_name', rg.owner_name,
+							'owner_slack_id', rg.owner_slack_id,
+							'reviewed_at', to_char(rg.reviewed_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+						)
+					)
+					FROM private.review_groups AS rg
+					WHERE rg.review_id = rv.id
+				)
+			)
+		END AS review,
 		s.created_at, s.ended_at
 	FROM private.sessions s
-	LEFT JOIN private.blobs AS bi ON bi.type = 'session-input' AND  bi.id = s.blob_input_id
-	LEFT JOIN private.blobs AS bs ON bs.type = 'session-stream' AND  bs.id = s.blob_stream_id
+	LEFT JOIN private.reviews AS rv ON rv.session_id = s.id
 	WHERE s.org_id = ? AND s.id = ?
-	`, orgID, sid).First(&session).Error
+	`, orgID, sid).First(session).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
 		return nil, err
 	}
-	return &session, nil
+
+	blobInput, err := session.getBlobInput()
+	if err != nil {
+		return nil, fmt.Errorf("failed obtaining blob input: %v", err)
+	}
+	session.BlobInput = BlobInputType(blobInput)
+	return session, nil
 }
 
 func ListSessions(orgID string, opt SessionOption) (*SessionList, error) {
@@ -142,22 +250,36 @@ func ListSessions(orgID string, opt SessionOption) (*SessionList, error) {
 		err := tx.Raw(`
 		SELECT COUNT(s.id)
 		FROM private.sessions s
+		LEFT JOIN private.reviews AS rv ON rv.session_id = s.id
 		WHERE s.org_id = @org_id AND
 		(
 			COALESCE(s.user_id::text, '') LIKE @user_id AND
 			COALESCE(s.connection::text, '') LIKE @connection AND
 			COALESCE(s.connection_type::text, '')::TEXT LIKE @connection_type AND
+			COALESCE(rv.status::text, '')::TEXT LIKE @review_status AND
+			CASE WHEN (@review_approver_email)::TEXT IS NOT NULL
+				THEN
+					EXISTS (
+						SELECT 1 FROM private.review_groups rg
+						INNER JOIN private.users u ON u.email = s.user_email
+						INNER JOIN private.user_groups ug ON ug.user_id = u.id AND ug.name = rg.group_name
+						WHERE rg.review_id = rv.id AND u.email = @review_approver_email
+					)
+				ELSE true
+			END AND
 			CASE WHEN (@start_date)::text IS NOT NULL
 				THEN s.created_at BETWEEN @start_date AND @end_date
 				ELSE true
 			END
 		)`, map[string]any{
-			"org_id":          orgID,
-			"user_id":         opt.User,
-			"connection":      opt.ConnectionName,
-			"connection_type": opt.ConnectionType,
-			"start_date":      opt.StartDate,
-			"end_date":        opt.EndDate,
+			"org_id":                orgID,
+			"user_id":               opt.User,
+			"connection":            opt.ConnectionName,
+			"connection_type":       opt.ConnectionType,
+			"review_status":         opt.ReviewStatus,
+			"review_approver_email": opt.ReviewApproverEmail,
+			"start_date":            opt.StartDate,
+			"end_date":              opt.EndDate,
 		}).First(&sessionList.Total).Error
 		if err != nil {
 			return fmt.Errorf("unable to obtain total count of sessions, reason=%v", err)
@@ -167,14 +289,53 @@ func ListSessions(orgID string, opt SessionOption) (*SessionList, error) {
 		SELECT
 			s.id, s.org_id, s.connection, s.connection_type, s.connection_subtype, s.verb, s.labels, s.exit_code,
 			s.user_id, s.user_name, s.user_email, s.status, s.metadata, s.integrations_metadata, s.metrics,
-			metrics->>'event_size' AS blob_stream_size,
+			metrics->>'event_size' AS blob_stream_size, s.blob_input_id, s.blob_stream_id,
+			CASE
+				WHEN rv.id IS NULL THEN NULL
+				ELSE jsonb_build_object(
+					'id', rv.id,
+					'type', rv.type,
+					'access_duration_sec', rv.access_duration_sec,
+					'status', rv.status,
+					'created_at', to_char(rv.created_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+					'revoked_at', to_char(rv.revoked_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+					'review_groups', (
+						SELECT jsonb_agg(
+							jsonb_build_object(
+								'id', rg.id,
+								'group_name', rg.group_name,
+								'status', rg.status,
+								'owner_id', rg.owner_id,
+								'owner_email', rg.owner_email,
+								'owner_name', rg.owner_name,
+								'owner_slack_id', rg.owner_slack_id,
+								'reviewed_at', to_char(rg.reviewed_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+							)
+						)
+						FROM private.review_groups AS rg
+						WHERE rg.review_id = rv.id
+					)
+				)
+			END AS review,
 			s.created_at, s.ended_at
 		FROM private.sessions s
+		LEFT JOIN private.reviews AS rv ON rv.session_id = s.id
 		WHERE s.org_id = @org_id AND
 		(
 			COALESCE(s.user_id::text, '') LIKE @user_id AND
 			COALESCE(s.connection::text, '') LIKE @connection AND
 			COALESCE(s.connection_type::text, '')::TEXT LIKE @connection_type AND
+			COALESCE(rv.status::text, '')::TEXT LIKE @review_status AND
+			CASE WHEN (@review_approver_email)::TEXT IS NOT NULL
+				THEN
+					EXISTS (
+						SELECT 1 FROM private.review_groups rg
+						INNER JOIN private.users u ON u.email = s.user_email
+						INNER JOIN private.user_groups ug ON ug.user_id = u.id AND ug.name = rg.group_name
+						WHERE rg.review_id = rv.id AND u.email = @review_approver_email
+					)
+				ELSE true
+			END AND
 			CASE WHEN (@start_date)::text IS NOT NULL
 				THEN s.created_at BETWEEN @start_date AND @end_date
 				ELSE true
@@ -184,14 +345,16 @@ func ListSessions(orgID string, opt SessionOption) (*SessionList, error) {
 		LIMIT @limit
 		OFFSET @offset
 		`, map[string]any{
-			"org_id":          orgID,
-			"user_id":         opt.User,
-			"connection":      opt.ConnectionName,
-			"connection_type": opt.ConnectionType,
-			"start_date":      opt.StartDate,
-			"end_date":        opt.EndDate,
-			"limit":           opt.Limit,
-			"offset":          opt.Offset,
+			"org_id":                orgID,
+			"user_id":               opt.User,
+			"connection":            opt.ConnectionName,
+			"connection_type":       opt.ConnectionType,
+			"review_status":         opt.ReviewStatus,
+			"review_approver_email": opt.ReviewApproverEmail,
+			"start_date":            opt.StartDate,
+			"end_date":              opt.EndDate,
+			"limit":                 opt.Limit,
+			"offset":                opt.Offset,
 		}).Find(&sessionList.Items).Error
 		if err == nil {
 			sessionList.HasNextPage = len(sessionList.Items) == opt.Limit
@@ -206,7 +369,7 @@ func UpsertSession(sess Session) error {
 	return DB.Transaction(func(tx *gorm.DB) error {
 		// generate deterministic uuid based on the session id to avoid duplicates
 		blobInputID := sql.NullString{
-			String: uuid.NewSHA1(uuid.NameSpaceURL, []byte(fmt.Sprintf("blobinput:%s", sess.ID))).String(),
+			String: uuid.NewSHA1(uuid.NameSpaceURL, fmt.Appendf(nil, "blobinput:%s", sess.ID)).String(),
 			Valid:  true,
 		}
 
@@ -255,7 +418,7 @@ func UpdateSessionEventStream(sess SessionDone) error {
 	return DB.Transaction(func(tx *gorm.DB) error {
 		// generate deterministic uuid based on the session id to avoid duplicates
 		blobStreamID := sql.NullString{
-			String: uuid.NewSHA1(uuid.NameSpaceURL, []byte(fmt.Sprintf("blobstream:%s", sess.ID))).String(),
+			String: uuid.NewSHA1(uuid.NameSpaceURL, fmt.Appendf(nil, "blobstream:%s", sess.ID)).String(),
 			Valid:  true,
 		}
 


### PR DESCRIPTION
- Allow applying filter the status and the approver e-mail of a review
- Regular users lists all sessions, the output is only displayed for owners or administrators
- Return review information when listing sessions
- Change tagSelector to `tag_selector` on connections
- [cli] Add session tabview to sessions
- [cli] Add query string parameter to query endpoints -q/--query