### PR TITLE
Disable copy functionality in specific components when disable download is on

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -487,7 +487,8 @@
                      {:results (utilities/decode-b64 (or (first (:event_stream session)) ""))
                       :results-status (:status @session-details)
                       :fixed-height? true
-                      :results-id (:id session)}]
+                      :results-id (:id session)
+                      :not-clipboard? disabled-download}]
                     [session-event-stream (:type session) session])])])]]
 
           (finally

--- a/webapp/src/webapp/components/data_grid_table.cljs
+++ b/webapp/src/webapp/components/data_grid_table.cljs
@@ -95,7 +95,7 @@
 (defn- data-grid
   "head -> is an array of strings where each string corresponds to each table title.
   body -> is an array matrix where each array corresponds to one line of the table"
-  [head body dark-theme?]
+  [head body dark-theme? allow-copy?]
   (let [!ref (atom {:current nil})
         head-formatted (map-indexed (fn [idx value] {:title value :source idx}) head)]
     (fn
@@ -112,6 +112,7 @@
                                                                                                      {}))
                                                                                    :allowEditCells false
                                                                                    :instantActivate false
+                                                                                   :allowCopy allow-copy?
                                                                                    :bottomBar []}))))
         :reagent-render
         (fn []
@@ -119,9 +120,9 @@
                  :ref (fn [el]
                         (swap! !ref assoc :current el))}])}))))
 
-(defn main [head body dark-theme? loading?]
+(defn main [head body dark-theme? loading? allow-copy?]
   (if loading?
     [:div {:class "flex justify-center items-center h-full"}
      [:figure.w-4
       [:img.animate-spin {:src (str config/webapp-url "/icons/icon-loader-circle-white.svg")}]]]
-    [data-grid head body dark-theme?]))
+    [data-grid head body dark-theme? allow-copy?]))

--- a/webapp/src/webapp/components/logs_container.cljs
+++ b/webapp/src/webapp/components/logs_container.cljs
@@ -67,11 +67,20 @@
      [:section
       {:class (str "relative bg-gray-900 font-mono overflow-auto h-full"
                    " whitespace-pre text-gray-200 text-sm"
-                   " px-regular pt-regular group")}
-      (when-not (:not-clipboard? config) (copy-clipboard (str "#" container-id)))
+                   " px-regular pt-regular group")
+       :on-copy (when (:not-clipboard? config)
+                  (fn [e] (.preventDefault e)))}
+      (when-not (:not-clipboard? config)
+        (copy-clipboard (str "#" container-id)))
       [:div
        {:id container-id
         :class (str (when (:classes config) (:classes config))
                     " overflow-auto whitespace-pre h-full"
-                    (when-not (:fixed-height? config) " max-h-80"))}
+                    (when-not (:fixed-height? config) " max-h-80")
+                    (when (:not-clipboard? config) " select-none"))
+        :style (when (:not-clipboard? config)
+                 #js {:WebkitUserSelect "none"
+                      :MozUserSelect "none"
+                      :msUserSelect "none"
+                      :userSelect "none"})}
        (logs-area (:status config) (:logs config))]]]))


### PR DESCRIPTION
This PR implements functionality to disable the copy capability (Ctrl+C) in two different components when download disable is on:
- DataGridTable: Added the allowCopy false parameter to prevent copying in the table
- LogsContainer: Enhanced the implementation of the existing, :not-clipboard? parameter to effectively prevent text copying

### Changes
- data_grid_table.cljs: Added parameter to disable copy functionality in DataGridXL
- logs_container.cljs: Implemented multiple protections against text copying when :not-clipboard? is true:
- Added :on-copy event to prevent copying directly in the section
- Added select-none class to the container
- Added cross-browser styles for user-select: none

