### PR TITLE
AWS Connect: Add custom webhooks when finishing the provisioning job

### DIFF
--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4317,19 +4317,13 @@ const docTemplate = `{
         "openapi.CreateDBRoleJobAWSProviderSG": {
             "type": "object",
             "required": [
-                "ingress_cidr",
-                "target_port"
+                "ingress_cidr"
             ],
             "properties": {
                 "ingress_cidr": {
                     "description": "The ingress inbound CIDR rule to allow traffic to",
                     "type": "string",
                     "example": "192.168.1.0/24"
-                },
-                "target_port": {
-                    "description": "The target port to be configured for the security group",
-                    "type": "integer",
-                    "example": 5432
                 }
             }
         },
@@ -4466,7 +4460,7 @@ const docTemplate = `{
                 "secret_id": {
                     "description": "The secret identifier that contains the secret data.\nThis value is always empty for the database type.",
                     "type": "string",
-                    "example": "dbsecrets/data"
+                    "example": "dbsecrets/data/pgprod"
                 },
                 "secret_keys": {
                     "description": "The keys that were saved in the secrets manager.\nThis value is always empty for the database type.",
@@ -5358,7 +5352,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "access_duration": {
-                    "description": "The amount of time (nanoseconds) to allow access to the connection. It's valid only for ` + "`" + `jit` + "`" + ` type reviews` + "`" + `",
+                    "description": "The amount of time (nanoseconds) to allow access to the connection. It's valid only for ` + "`" + `jit` + "`" + ` type reviews",
                     "type": "integer",
                     "default": 1800000000000,
                     "readOnly": true,
@@ -5371,7 +5365,7 @@ const docTemplate = `{
                     "example": "2024-07-25T15:56:35.317601Z"
                 },
                 "id": {
-                    "description": "Reousrce identifier",
+                    "description": "Resource identifier",
                     "type": "string",
                     "format": "uuid",
                     "readOnly": true,
@@ -5449,7 +5443,7 @@ const docTemplate = `{
                     ]
                 },
                 "type": {
-                    "description": "The type of this review\n* onetime - Represents a one time execution\n* jit - Represents a time based review",
+                    "description": "The type of the review\n* onetime - Represents a one time execution\n* jit - Represents a time based review",
                     "enum": [
                         "onetime",
                         "jit"
@@ -6160,7 +6154,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "access_duration": {
-                    "description": "The amount of time (nanoseconds) to allow access to the connection. It's valid only for ` + "`" + `jit` + "`" + ` type reviews` + "`" + `",
+                    "description": "The amount of time (nanoseconds) to allow access to the connection. It's valid only for ` + "`" + `jit` + "`" + ` type reviews",
                     "type": "integer",
                     "default": 1800000000000,
                     "readOnly": true,
@@ -6173,7 +6167,7 @@ const docTemplate = `{
                     "example": "2024-07-25T15:56:35.317601Z"
                 },
                 "id": {
-                    "description": "Reousrce identifier",
+                    "description": "Resource identifier",
                     "type": "string",
                     "format": "uuid",
                     "readOnly": true,
@@ -6202,7 +6196,7 @@ const docTemplate = `{
                     ]
                 },
                 "type": {
-                    "description": "The type of this review\n* onetime - Represents a one time execution\n* jit - Represents a time based review",
+                    "description": "The type of the review\n* onetime - Represents a one time execution\n* jit - Represents a time based review",
                     "enum": [
                         "onetime",
                         "jit"

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1259,8 +1259,6 @@ type AWSDBInstance struct {
 }
 
 type CreateDBRoleJobAWSProviderSG struct {
-	// The target port to be configured for the security group
-	TargetPort int32 `json:"target_port" example:"5432" binding:"required"`
 	// The ingress inbound CIDR rule to allow traffic to
 	IngressCIDR string `json:"ingress_cidr" example:"192.168.1.0/24" binding:"required"`
 }
@@ -1358,7 +1356,7 @@ type DBRoleJobStatusResultCredentialsInfo struct {
 	SecretsManagerProvider SecretsManagerProviderType `json:"secrets_manager_provider" example:"database"`
 	// The secret identifier that contains the secret data.
 	// This value is always empty for the database type.
-	SecretID string `json:"secret_id" example:"dbsecrets/data"`
+	SecretID string `json:"secret_id" example:"dbsecrets/data/pgprod"`
 	// The keys that were saved in the secrets manager.
 	// This value is always empty for the database type.
 	SecretKeys []string `json:"secret_keys" example:"HOST,PORT,USER,PASSWORD,DB"`

--- a/gateway/transport/plugins/webhooks/const.go
+++ b/gateway/transport/plugins/webhooks/const.go
@@ -1,9 +1,10 @@
 package webhooks
 
 const (
-	eventSessionOpenType         = "session.open"
-	eventSessionCloseType        = "session.close"
-	eventMSTeamsReviewCreateType = "microsoftteams.review.create"
-	EventDBRoleJobFinishedType   = "dbroles.job.finished"
-	maxInputSize                 = 10 * 1000 // 10KB
+	eventSessionOpenType             = "session.open"
+	eventSessionCloseType            = "session.close"
+	eventMSTeamsReviewCreateType     = "microsoftteams.review.create"
+	EventDBRoleJobFinishedType       = "dbroles.job.finished"
+	EventDBRoleJobCustomFinishedType = "dbroles.custom.job.finished"
+	maxInputSize                     = 10 * 1000 // 10KB
 )


### PR DESCRIPTION
- Use the port from the db instances instead of relying of the input from client