### PR TITLE
Propagate connection tags to the session

### DIFF
--- a/client/cmd/config/config.go
+++ b/client/cmd/config/config.go
@@ -67,11 +67,29 @@ var createCmd = &cobra.Command{
 }
 
 var viewCmd = &cobra.Command{
-	Use:          "view",
+	Use:          "view [ATTRIBUTE]",
 	Short:        "Show the current configuration",
 	SilenceUsage: false,
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clientconfig.GetClientConfigOrDie()
+		if len(args) > 0 {
+			var value string
+			switch args[0] {
+			case "api_url":
+				value = c.ApiURL
+			case "grpc_url":
+				value = c.GrpcURL
+			case "token":
+				value = c.Token
+			case "tls_ca":
+				value = c.TlsCAB64Enc
+			default:
+				styles.PrintErrorAndExit("attribute not supported, accept only: api_url, grpc_url, token, tls_ca")
+			}
+			fmt.Println(value)
+			return
+		}
+
 		fmt.Printf("api_url=%s\n", c.ApiURL)
 		fmt.Printf("grpc_url=%s\n", c.GrpcURL)
 		if viewRawFlag {

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4976,7 +4976,7 @@ const docTemplate = `{
                     "default": "done"
                 },
                 "mapping_types": {
-                    "description": "The automated fields that will be sent when creating the issue.\nThere're two types\n- preset: obtain the value from a list of available fields that could be propagated\nThe list of available preset values are:\n\n\t\t- session.id\n\t\t- session.user_email\n\t\t- session.user_id\n\t\t- session.user_name\n\t\t- session.type\n\t\t- session.connection_subtype\n\t\t- session.connection\n\t\t- session.status\n\t\t- session.script\n\t\t- session.start_date\n\n- custom: use a custom static value\n\n\t\t{\n\t\t  \"items\": [\n\t\t    {\n\t\t      \"description\": \"Hoop Connection Name\",\n\t\t      \"jira_field\": \"customfield_10050\",\n\t\t      \"type\": \"preset\",\n\t\t      \"value\": \"session.connection\"\n\t\t    }\n\t\t  ]\n\t\t}",
+                    "description": "The automated fields that will be sent when creating the issue.\nThere're two types\n- preset: obtain the value from a list of available fields that could be propagated\nThe list of available preset values are:\n\n\t\t- session.id\n\t\t- session.user_email\n\t\t- session.user_id\n\t\t- session.user_name\n\t\t- session.type\n\t\t- session.connection_subtype\n\t\t- session.connection\n\t\t- session.connection_tags.[key1]\n\t\t- session.connection_tags.[key2]\n\t\t- session.status\n\t\t- session.script\n\t\t- session.start_date\n\n- custom: use a custom static value\n\n\t\t{\n\t\t  \"items\": [\n\t\t    {\n\t\t      \"description\": \"Hoop Connection Name\",\n\t\t      \"jira_field\": \"customfield_10050\",\n\t\t      \"type\": \"preset\",\n\t\t      \"value\": \"session.connection\"\n\t\t    }\n\t\t  ]\n\t\t}",
                     "type": "object",
                     "additionalProperties": {}
                 },
@@ -5963,6 +5963,16 @@ const docTemplate = `{
                     "description": "The subtype of the connection",
                     "type": "string",
                     "example": "postgres"
+                },
+                "connection_tags": {
+                    "description": "The tags of the connection resource",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "example": {
+                        "team": "banking;environment:prod"
+                    }
                 },
                 "end_date": {
                     "description": "When the execution ended. A null value indicates the session is still running",

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -476,6 +476,8 @@ type Session struct {
 	ConnectionSubtype string `json:"connection_subtype" example:"postgres"`
 	// The connection name of this resource
 	Connection string `json:"connection" example:"pgdemo"`
+	// The tags of the connection resource
+	ConnectionTags map[string]string `json:"connection_tags" example:"team:banking;environment:prod"`
 	// Review of this session. In case the review doesn't exist this field will be null
 	Review *SessionReview `json:"review"`
 	// Verb is how the client has interacted with this resource
@@ -972,6 +974,8 @@ type JiraIssueTemplateRequest struct {
 		- session.type
 		- session.connection_subtype
 		- session.connection
+		- session.connection_tags.[key1]
+		- session.connection_tags.[key2]
 		- session.status
 		- session.script
 		- session.start_date

--- a/gateway/api/session/parser.go
+++ b/gateway/api/session/parser.go
@@ -36,6 +36,7 @@ func toOpenApiSession(s *models.Session) *openapi.Session {
 		Type:                 s.ConnectionType,
 		ConnectionSubtype:    s.ConnectionSubtype,
 		Connection:           s.Connection,
+		ConnectionTags:       s.ConnectionTags,
 		Review:               topOpenApiReview(s.Review),
 		Verb:                 s.Verb,
 		Status:               openapi.SessionStatusType(s.Status),

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -115,6 +115,7 @@ func Post(c *gin.Context) {
 		ConnectionType:       conn.Type,
 		ConnectionSubtype:    conn.SubType.String,
 		Connection:           conn.Name,
+		ConnectionTags:       conn.ConnectionTags,
 		Verb:                 pb.ClientVerbExec,
 		Status:               string(openapi.SessionStatusOpen),
 		CreatedAt:            time.Now().UTC(),

--- a/gateway/jira/issuesapi_test.go
+++ b/gateway/jira/issuesapi_test.go
@@ -36,6 +36,11 @@ func TestParseIssueFields(t *testing.T) {
 							"value":      "session.connection",
 						},
 						map[string]any{
+							"jira_field": "customfield_10053",
+							"type":       "preset",
+							"value":      "session.connection_tags.env",
+						},
+						map[string]any{
 							"jira_field": "customfield_10051",
 							"type":       "custom",
 							"value":      "my-custom-value",
@@ -59,11 +64,16 @@ func TestParseIssueFields(t *testing.T) {
 				"customfield_10052": "my-prompt-value",
 				"customfield_10199": "cmdb-value",
 			},
-			session: models.Session{Connection: "myconnection"},
+			session: models.Session{
+				Connection: "myconnection",
+				ConnectionTags: map[string]string{
+					"env": "prod",
+				}},
 			want: CustomFields{
 				"customfield_10050": "myconnection",
 				"customfield_10051": "my-custom-value",
 				"customfield_10052": "my-prompt-value",
+				"customfield_10053": "prod",
 				"customfield_10199": []map[string]string{{"id": "cmdb-value"}},
 			},
 			err: nil,
@@ -116,6 +126,31 @@ func TestParseIssueFields(t *testing.T) {
 			tmpl: &models.JiraIssueTemplate{},
 			err:  nil,
 			want: CustomFields{},
+		},
+		{
+			name: "it must parse session.connection_tags preset as a best effort without returning error",
+			tmpl: &models.JiraIssueTemplate{
+				MappingTypes: map[string]any{
+					"items": []any{
+						map[string]any{
+							"jira_field": "customfield_10050",
+							"type":       "preset",
+							"value":      "session.connection_tags.env",
+						},
+						map[string]any{
+							"jira_field": "customfield_10051",
+							"type":       "preset",
+							"value":      "session.connection_tags.team",
+						},
+					},
+				},
+			},
+			input: map[string]string{
+				"customfield_10051": "dba",
+			},
+			session: models.Session{Connection: "myconnection", ConnectionTags: map[string]string{"team": "dba"}},
+			want:    CustomFields{"customfield_10051": "dba"},
+			err:     nil,
 		},
 	}
 

--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -64,6 +64,7 @@ type Session struct {
 	Connection           string            `gorm:"column:connection"`
 	ConnectionType       string            `gorm:"column:connection_type"`
 	ConnectionSubtype    string            `gorm:"column:connection_subtype"`
+	ConnectionTags       map[string]string `gorm:"column:connection_tags;serializer:json"`
 	Verb                 string            `gorm:"column:verb"`
 	Labels               map[string]string `gorm:"column:labels;serializer:json"`
 	Metadata             map[string]any    `gorm:"column:metadata;serializer:json"`
@@ -194,7 +195,7 @@ func GetSessionByID(orgID, sid string) (*Session, error) {
 	session := &Session{}
 	err := DB.Raw(`
 	SELECT
-		s.id, s.org_id, s.connection, s.connection_type, s.connection_subtype, s.verb, s.labels, s.exit_code,
+		s.id, s.org_id, s.connection, s.connection_type, s.connection_subtype, s.connection_tags, s.verb, s.labels, s.exit_code,
 		s.user_id, s.user_name, s.user_email, s.status, s.metadata, s.integrations_metadata, s.metrics,
 		metrics->>'event_size' AS blob_stream_size, s.blob_input_id,
 		CASE
@@ -287,7 +288,7 @@ func ListSessions(orgID string, opt SessionOption) (*SessionList, error) {
 
 		err = tx.Raw(`
 		SELECT
-			s.id, s.org_id, s.connection, s.connection_type, s.connection_subtype, s.verb, s.labels, s.exit_code,
+			s.id, s.org_id, s.connection, s.connection_type, s.connection_subtype, s.connection_tags, s.verb, s.labels, s.exit_code,
 			s.user_id, s.user_name, s.user_email, s.status, s.metadata, s.integrations_metadata, s.metrics,
 			metrics->>'event_size' AS blob_stream_size, s.blob_input_id, s.blob_stream_id,
 			CASE
@@ -400,6 +401,7 @@ func UpsertSession(sess Session) error {
 				Connection:           sess.Connection,
 				ConnectionType:       sess.ConnectionType,
 				ConnectionSubtype:    sess.ConnectionSubtype,
+				ConnectionTags:       sess.ConnectionTags,
 				Verb:                 sess.Verb,
 				UserID:               sess.UserID,
 				UserName:             sess.UserName,

--- a/gateway/storagev2/types/types.go
+++ b/gateway/storagev2/types/types.go
@@ -99,6 +99,7 @@ type ConnectionInfo struct {
 	SubType                          string
 	CmdEntrypoint                    []string
 	Secrets                          map[string]any
+	Tags                             map[string]string
 	AgentID                          string
 	AgentName                        string
 	AgentMode                        string

--- a/gateway/transport/interceptors/auth/auth.go
+++ b/gateway/transport/interceptors/auth/auth.go
@@ -247,6 +247,7 @@ func (i *interceptor) getConnection(name string, userCtx *pguserauth.Context) (*
 		SubType:                          conn.SubType.String,
 		CmdEntrypoint:                    conn.Command,
 		Secrets:                          conn.AsSecrets(),
+		Tags:                             conn.ConnectionTags,
 		AgentID:                          conn.AgentID.String,
 		AgentMode:                        conn.AgentMode,
 		AgentName:                        conn.AgentName,

--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -68,6 +68,7 @@ func (p *auditPlugin) OnConnect(pctx plugintypes.Context) error {
 			Connection:           pctx.ConnectionName,
 			ConnectionType:       pctx.ConnectionType,
 			ConnectionSubtype:    pctx.ConnectionSubType,
+			ConnectionTags:       pctx.ConnectionTags,
 			Verb:                 pctx.ClientVerb,
 			Labels:               nil,
 			Metadata:             nil,

--- a/gateway/transport/plugins/types/types.go
+++ b/gateway/transport/plugins/types/types.go
@@ -46,6 +46,7 @@ type Context struct {
 	ConnectionSubType                   string
 	ConnectionCommand                   []string
 	ConnectionSecret                    map[string]any
+	ConnectionTags                      map[string]string
 	ConnectionJiraTransitionNameOnClose string
 
 	// Agent attributes

--- a/gateway/transport/server.go
+++ b/gateway/transport/server.go
@@ -158,6 +158,7 @@ func (s *Server) Connect(stream pb.Transport_ConnectServer) (err error) {
 		ConnectionCommand:                   gwctx.Connection.CmdEntrypoint,
 		ConnectionSecret:                    gwctx.Connection.Secrets,
 		ConnectionJiraTransitionNameOnClose: gwctx.Connection.JiraTransitionNameOnSessionClose,
+		ConnectionTags:                      gwctx.Connection.Tags,
 
 		AgentID:   gwctx.Connection.AgentID,
 		AgentName: gwctx.Connection.AgentName,

--- a/rootfs/app/migrations/000035_session_connection_tags.down.sql
+++ b/rootfs/app/migrations/000035_session_connection_tags.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE private.sessions DROP COLUMN connection_tags;

--- a/rootfs/app/migrations/000035_session_connection_tags.up.sql
+++ b/rootfs/app/migrations/000035_session_connection_tags.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE private.sessions ADD COLUMN connection_tags JSONB NULL;


### PR DESCRIPTION
- Add new Jira preset attribute value: `session.connection_tags.[key]`
- [cli] Allow obtaining the configuration attributes partially via hoop config view

Example of a preset configuration:

```json
{
  "name": "mytemplate",
  "description": "my template",
  "project_key": "HT",
  "request_type_id": "10005",
  "issue_transition_name_on_close": "done",
  "mapping_types": {
    "items": [
      {
        "description": "Environment",
        "type": "preset",
        "value": "session.connection_tags.env",
        "jira_field": "customfield_10051"
      },
      {
        "description": "Team",
        "type": "preset",
        "value": "session.connection_tags.team",
        "jira_field": "customfield_10052"
      }
    ]
  }
}
```