### PR TITLE
Add Vault Secrets Provider integration to AWS Connect setup

### DIFF
--- a/webapp/src/webapp/config.cljs
+++ b/webapp/src/webapp/config.cljs
@@ -47,6 +47,7 @@
                            :environment-variables "https://hoop.dev/docs/setup/configuration/environment-variables"
                            :reverse-proxy "https://hoop.dev/docs/setup/configuration/reverse-proxy"
                            :identity-providers "https://hoop.dev/docs/setup/configuration/identity-providers"
+                           :secrets-manager "https://hoop.dev/docs/setup/configuration/secrets-manager-configuration"
                            :ai-data-masking "https://hoop.dev/docs/setup/configuration/ai-data-masking"}
            :apis "https://hoop.dev/docs/setup/apis"
            :license-management "https://hoop.dev/docs/setup/license-management"}

--- a/webapp/src/webapp/onboarding/aws_connect.cljs
+++ b/webapp/src/webapp/onboarding/aws_connect.cljs
@@ -239,8 +239,10 @@
                "connected before proceeding to create connections.")]]])]))
 
 (defn create-connection-config []
-  (let [create-connection @(rf/subscribe [:aws-connect/create-connection])]
-    [:> Box {:class "w-full max-w-[600px] space-y-3"}
+  (let [create-connection @(rf/subscribe [:aws-connect/create-connection])
+        enable-secrets-manager @(rf/subscribe [:aws-connect/enable-secrets-manager])
+        secrets-path @(rf/subscribe [:aws-connect/secrets-path])]
+    [:> Box {:class "w-full max-w-[600px] space-y-6"}
      [:> Heading {:as "h3" :size "4" :weight "bold" :class "text-[--gray-12]"}
       "Additional Configuration"]
 
@@ -251,7 +253,33 @@
        [:> Text {:as "p" :size "3" :weight "medium" :class "text-[--gray-12]"}
         "Create Connection"]
        [:> Text {:as "p" :size "2" :class "text-[--gray-12]"}
-        "When enabled, connections will be automatically created after configuring the resources."]]]]))
+        "When enabled, connections will be automatically created after configuring the resources."]]]
+
+     [:> Flex {:align "center" :gap "4" :class "text-[--accent-a11] cursor-pointer" :mt "4"}
+      [:> Switch {:checked enable-secrets-manager
+                  :on-checked-change #(rf/dispatch [:aws-connect/toggle-secrets-manager %])}]
+      [:> Box
+       [:> Text {:as "p" :size "3" :weight "medium" :class "text-[--gray-12]"}
+        "Enable Secrets Manager Provider"]
+       [:> Text {:as "p" :size "2" :class "text-[--gray-12]"}
+        "Integrate with a configured secrets manager, allowing the connection environment variable to be dynamically expanded"]
+
+       [:> Box {:my "2"}
+        [:> Link {:href (get-in config/docs-url [:setup :configuration :secrets-manager])
+                  :target "_blank"}
+         [:> Flex {:gap "2" :align "center"}
+          [:> Text {:as "a"
+                    :size "2"}
+           "Learn more about Secrets Manager Configuration"]
+          [:> ArrowUpRight {:size 16}]]]]
+
+       (when enable-secrets-manager
+         [:> Box {:mt "3"}
+          [forms/input
+           {:placeholder "e.g. vaultkv1:/k/v/pgprod:dbhost"
+            :label "Secrets Path"
+            :value secrets-path
+            :on-change #(rf/dispatch [:aws-connect/set-secrets-path (-> % .-target .-value)])}]])]]]))
 
 (defn review-step []
   (let [resources @(rf/subscribe [:aws-connect/resources])

--- a/webapp/src/webapp/onboarding/aws_connect.cljs
+++ b/webapp/src/webapp/onboarding/aws_connect.cljs
@@ -260,9 +260,9 @@
                   :on-checked-change #(rf/dispatch [:aws-connect/toggle-secrets-manager %])}]
       [:> Box
        [:> Text {:as "p" :size "3" :weight "medium" :class "text-[--gray-12]"}
-        "Enable Secrets Manager Provider"]
+        "Enable Vault Secrets Provider"]
        [:> Text {:as "p" :size "2" :class "text-[--gray-12]"}
-        "Integrate with a configured secrets manager, allowing the connection environment variable to be dynamically expanded"]
+        "Integrate with HashiCorp Vault to dynamically expand environment variables in your connections. Currently, only Vault is supported."]
 
        [:> Box {:my "2"}
         [:> Link {:href (get-in config/docs-url [:setup :configuration :secrets-manager])
@@ -277,7 +277,7 @@
          [:> Box {:mt "3"}
           [forms/input
            {:placeholder "e.g. vaultkv1:/k/v/pgprod:dbhost"
-            :label "Secrets Path"
+            :label "Vault Path"
             :value secrets-path
             :on-change #(rf/dispatch [:aws-connect/set-secrets-path (-> % .-target .-value)])}]])]]]))
 

--- a/webapp/src/webapp/onboarding/aws_connect.cljs
+++ b/webapp/src/webapp/onboarding/aws_connect.cljs
@@ -276,7 +276,7 @@
        (when enable-secrets-manager
          [:> Box {:mt "3"}
           [forms/input
-           {:placeholder "e.g. vaultkv1:/k/v/pgprod:dbhost"
+           {:placeholder "e.g. dbsecrets/data/"
             :label "Vault Path"
             :value secrets-path
             :on-change #(rf/dispatch [:aws-connect/set-secrets-path (-> % .-target .-value)])}]])]]]))

--- a/webapp/src/webapp/onboarding/events/aws_connect_events.cljs
+++ b/webapp/src/webapp/onboarding/events/aws_connect_events.cljs
@@ -22,7 +22,9 @@
                                             :security-groups {}}
                                 :agents {:data nil
                                          :assignments nil}
-                                :create-connection true})
+                                :create-connection true
+                                :enable-secrets-manager false
+                                :secrets-path ""})
     :dispatch [:aws-connect/fetch-agents]}))
 
 (rf/reg-event-db
@@ -228,22 +230,30 @@
    (let [total-resources (count resources)
          create-connection (get-in db [:aws-connect :create-connection] true)
          job-steps (if create-connection ["create-connections" "send-webhook"] ["send-webhook"])
+         enable-secrets-manager (get-in db [:aws-connect :enable-secrets-manager] false)
+         secrets-path (get-in db [:aws-connect :secrets-path] "")
+
          dispatch-requests (for [resource resources
                                  :let [agent-id (get agent-assignments (:id resource) "default")
                                        resource-arn (:id resource)
                                        security-group (get security-groups (:id resource) "")
                                        connection-prefix (or (get connection-names (:id resource))
-                                                             (str (:name resource) "-" (:account-id resource)))]]
+                                                             (str (:name resource) "-" (:account-id resource)))
+                                       payload {:agent_id agent-id
+                                                :aws {:instance_arn resource-arn
+                                                      :default_security_group (if (empty? security-group)
+                                                                                nil
+                                                                                {:ingress_cidr security-group})}
+                                                :connection_prefix_name (str connection-prefix "-")
+                                                :job_steps job-steps}
+                                       ;; Add vault provider to payload if enabled
+                                       final-payload (if (and enable-secrets-manager (not (empty? secrets-path)))
+                                                       (assoc payload :vault_provider {:secret_id secrets-path})
+                                                       payload)]]
                              [:fetch
                               {:method "POST"
                                :uri "/dbroles/jobs"
-                               :body {:agent_id agent-id
-                                      :aws {:instance_arn resource-arn
-                                            :default_security_group (if (empty? security-group)
-                                                                      nil
-                                                                      {:ingress_cidr security-group})}
-                                      :connection_prefix_name (str connection-prefix "-")
-                                      :job_steps job-steps}
+                               :body final-payload
                                :on-success #(rf/dispatch [:aws-connect/connection-created-success % resource])
                                :on-failure #(rf/dispatch [:aws-connect/connection-created-failure % resource])}])]
      {:db (assoc-in db [:aws-connect :resources :total-to-process] total-resources)
@@ -461,3 +471,24 @@
  :aws-connect/accounts-error
  (fn [db _]
    (get-in db [:aws-connect :accounts :api-error :message])))
+
+;; New events and subscriptions for Secrets Manager
+(rf/reg-event-db
+ :aws-connect/toggle-secrets-manager
+ (fn [db [_ value]]
+   (assoc-in db [:aws-connect :enable-secrets-manager] value)))
+
+(rf/reg-event-db
+ :aws-connect/set-secrets-path
+ (fn [db [_ path]]
+   (assoc-in db [:aws-connect :secrets-path] path)))
+
+(rf/reg-sub
+ :aws-connect/enable-secrets-manager
+ (fn [db _]
+   (get-in db [:aws-connect :enable-secrets-manager] false)))
+
+(rf/reg-sub
+ :aws-connect/secrets-path
+ (fn [db _]
+   (get-in db [:aws-connect :secrets-path] "")))


### PR DESCRIPTION
This PR adds integration with HashiCorp Vault Secrets Provider to the AWS Connect workflow, allowing users to expand environment variables in their connections using Vault dynamically.

## Changes

- Added a new "Enable Vault Secrets Provider" toggle in the AWS Connect review step
- Added a Vault Path input field that appears when the toggle is enabled
- Created new re-frame events and subscriptions to manage Vault Secrets Provider state:
  - `:aws-connect/toggle-secrets-manager`
  - `:aws-connect/set-secrets-path`
  - `:aws-connect/enable-secrets-manager`
  - `:aws-connect/secrets-path`
- Updated the connection creation payload to include vault provider information when enabled:
  ```clojure
  {:agent_id ""
   :aws {:instance_arn ""
         :default_security_group {:ingress_cidr ""}}
   :connection_prefix_name ""
   :job_steps []
   :vault_provider {:secret_id "dbsecrets/data/"}}
  ```

## Screenshots

![Screenshot 2025-04-07 at 20 36 43](https://github.com/user-attachments/assets/c7d7fbf0-e4de-44e8-a827-61e23bba1c12)
![Screenshot 2025-04-07 at 20 36 54](https://github.com/user-attachments/assets/eb66a723-c538-43c5-9ad5-c1aed8fc8299)
