### PR TITLE
Enhance Jira Templates with Connection Tags Mapping

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.41.4",
+  "version": "1.42.0",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/jira_templates/create_update_form.cljs
+++ b/webapp/src/webapp/jira_templates/create_update_form.cljs
@@ -52,12 +52,12 @@
           [:> Box
            [:> Flex {:align "center" :gap "2"}
             [:> Heading {:as "h3" :size "4" :weight "bold" :class "text-[--gray-12]"}
-             "Configure automated mapping"]]
+             "Configure connection tags mapping"]]
            [:> Text {:size "3" :class "text-[--gray-11]"}
-            "Append additional information to your Jira cards when executing a command in your connections."]]
+            "Match key-value information in Jira fields with your connection tags."]]
 
           [:> Box {:class "space-y-radix-7"}
-           [mapping-table/main
+           [preset-mapping-table/main
             (merge
              {:state (:mapping state)
               :select-state (:mapping-select-state state)}
@@ -73,12 +73,12 @@
           [:> Box
            [:> Flex {:align "center" :gap "2"}
             [:> Heading {:as "h3" :size "4" :weight "bold" :class "text-[--gray-12]"}
-             "Configure connection tags mapping"]]
+             "Configure automated mapping"]]
            [:> Text {:size "3" :class "text-[--gray-11]"}
-            "Map connection tags to Jira fields for automatic field population."]]
+            "Append additional information to your Jira cards when executing a command in your connections."]]
 
           [:> Box {:class "space-y-radix-7"}
-           [preset-mapping-table/main
+           [mapping-table/main
             (merge
              {:state (:mapping state)
               :select-state (:mapping-select-state state)}

--- a/webapp/src/webapp/jira_templates/create_update_form.cljs
+++ b/webapp/src/webapp/jira_templates/create_update_form.cljs
@@ -9,6 +9,7 @@
    [webapp.jira-templates.form-header :as form-header]
    [webapp.jira-templates.helpers :as helpers]
    [webapp.jira-templates.mapping-table :as mapping-table]
+   [webapp.jira-templates.preset-mapping-table :as preset-mapping-table]
    [webapp.jira-templates.prompts-table :as prompts-table]
    [webapp.jira-templates.workflow-info :as workflow-info]))
 
@@ -68,6 +69,26 @@
                            :on-mapping-delete
                            :on-mapping-add]))]]]
 
+         [:> Flex {:direction "column" :gap "5"}
+          [:> Box
+           [:> Flex {:align "center" :gap "2"}
+            [:> Heading {:as "h3" :size "4" :weight "bold" :class "text-[--gray-12]"}
+             "Configure connection tags mapping"]]
+           [:> Text {:size "3" :class "text-[--gray-11]"}
+            "Map connection tags to Jira fields for automatic field population."]]
+
+          [:> Box {:class "space-y-radix-7"}
+           [preset-mapping-table/main
+            (merge
+             {:state (:mapping state)
+              :select-state (:mapping-select-state state)}
+             (select-keys handlers
+                          [:on-mapping-field-change
+                           :on-mapping-select
+                           :on-toggle-mapping-select
+                           :on-toggle-all-mapping
+                           :on-mapping-delete
+                           :on-mapping-add]))]]]
 
          [:> Flex {:direction "column" :gap "5"}
           [:> Box

--- a/webapp/src/webapp/jira_templates/preset_mapping_table.cljs
+++ b/webapp/src/webapp/jira_templates/preset_mapping_table.cljs
@@ -1,0 +1,102 @@
+(ns webapp.jira-templates.preset-mapping-table
+  (:require
+   ["@radix-ui/themes" :refer [Box Table Text Strong]]
+   [webapp.components.forms :as forms]
+   [webapp.jira-templates.rule-buttons :as rule-buttons]
+   [clojure.string :as str]))
+
+(def tag-value-options
+  [{:value "session.connection_tags.env" :text "Environment Tag"}
+   {:value "session.connection_tags.team" :text "Team Tag"}
+   {:value "session.connection_tags.product" :text "Product Tag"}
+   {:value "session.connection_tags.service" :text "Service Tag"}])
+
+(defn- is-connection-tag? [rule]
+  (and (:value rule)
+       (str/starts-with? (:value rule) "session.connection_tags.")))
+
+(defn- jira-field-input [rule state idx on-rule-field-change]
+  [forms/input
+   {:size "2"
+    :placeholder "e.g. customfield_0410"
+    :value (:jira_field rule)
+    :not-margin-bottom? true
+    :on-change #(on-rule-field-change state idx :jira_field (-> % .-target .-value))}])
+
+(defn- value-field [rule state idx on-rule-field-change]
+  [forms/select
+   {:size "2"
+    :variant "ghost"
+    :not-margin-bottom? true
+    :on-change #(on-rule-field-change state idx :value %)
+    :selected (:value rule)
+    :full-width? true
+    :options tag-value-options}])
+
+(defn- details-input [rule state idx on-rule-field-change]
+  [forms/input
+   {:size "2"
+    :placeholder "e.g. Environment"
+    :value (:description rule)
+    :not-margin-bottom? true
+    :on-change #(on-rule-field-change state idx :description (-> % .-target .-value))}])
+
+(defn main [{:keys [state
+                    select-state
+                    on-mapping-field-change
+                    on-mapping-select
+                    on-toggle-mapping-select
+                    on-toggle-all-mapping
+                    on-mapping-delete
+                    on-mapping-add]}]
+  (let [add-preset-rule (fn []
+                          (on-mapping-add state (fn [rule]
+                                                  (assoc rule
+                                                         :type "preset"
+                                                         :value "session.connection_tags.env"))))
+        toggle-all-preset-rules (fn []
+                                  (on-toggle-all-mapping state is-connection-tag?))
+        delete-preset-rules (fn []
+                              (on-mapping-delete state is-connection-tag?))]
+    [:> Box {:class "space-y-radix-5"}
+     [:> Box
+      [:> Table.Root {:size "2" :variant "surface"}
+       [:> Table.Header
+        [:> Table.Row {:align "center"}
+         (when @select-state
+           [:> Table.ColumnHeaderCell ""])
+         [:> Table.ColumnHeaderCell "Tag"]
+         [:> Table.ColumnHeaderCell "Jira Field"]
+         [:> Table.ColumnHeaderCell "Description (Optional)"]]]
+
+       [:> Table.Body
+        (doall
+         (for [[idx rule] (map-indexed vector @state)
+               :when (is-connection-tag? rule)]
+           ^{:key idx}
+           [:> Table.Row {:align "center"}
+            (when @select-state
+              [:> Table.RowHeaderCell {:p "2" :width "20px"}
+               [:input {:type "checkbox"
+                        :checked (:selected rule)
+                        :on-change #(on-mapping-select state idx)}]])
+
+            [:> Table.Cell {:p "4"}
+             [value-field rule state idx on-mapping-field-change]]
+
+            [:> Table.Cell {:p "4"}
+             [jira-field-input rule state idx on-mapping-field-change]]
+
+            [:> Table.Cell {:p "4"}
+             [details-input rule state idx on-mapping-field-change]]]))]]
+
+      [:> Text {:as "p" :size "2" :mt "1" :class "text-[--gray-10]"}
+       "Relate connection tags with Jira fields for automated mapping."]]
+
+     [rule-buttons/main
+      {:on-rule-add add-preset-rule
+       :on-toggle-select #(on-toggle-mapping-select select-state)
+       :select-state select-state
+       :selected? (every? :selected (filter is-connection-tag? @state))
+       :on-toggle-all toggle-all-preset-rules
+       :on-rules-delete delete-preset-rules}]]))

--- a/webapp/src/webapp/jira_templates/preset_mapping_table.cljs
+++ b/webapp/src/webapp/jira_templates/preset_mapping_table.cljs
@@ -7,7 +7,6 @@
    [reagent.core :as r]
    [clojure.string :as str]))
 
-;; Event para carregar as tags
 (rf/reg-event-fx
  :jira-templates/get-connection-tags
  (fn [{:keys [db]} [_]]
@@ -17,7 +16,6 @@
                              :on-success (fn [response]
                                            (rf/dispatch [:jira-templates/set-connection-tags (:items response)]))}]]]}))
 
-;; Event para armazenar as tags carregadas
 (rf/reg-event-db
  :jira-templates/set-connection-tags
  (fn [db [_ tags]]
@@ -25,26 +23,17 @@
        (assoc-in [:jira-templates :tags] tags)
        (assoc-in [:jira-templates :tags-loading] false))))
 
-;; Subscription para acessar as tags
 (rf/reg-sub
  :jira-templates/tags
  (fn [db]
    (get-in db [:jira-templates :tags])))
 
-;; Subscription para verificar o estado de carregamento
-(rf/reg-sub
- :jira-templates/tags-loading?
- (fn [db]
-   (get-in db [:jira-templates :tags-loading])))
-
-;; Função para extrair o nome simples de uma tag
 (defn extract-tag-name [key]
   (let [parts (str/split key #"\.")]
     (if (empty? parts)
       key
       (last parts))))
 
-;; Função para transformar as tags em opções de select
 (defn tags-to-select-options [tags]
   (reduce (fn [options tag]
             (let [key (:key tag)]
@@ -68,8 +57,7 @@
     :on-change #(on-rule-field-change state idx :jira_field (-> % .-target .-value))}])
 
 (defn- value-field [rule state idx on-rule-field-change]
-  (let [tags-loading? @(rf/subscribe [:jira-templates/tags-loading?])
-        tags @(rf/subscribe [:jira-templates/tags])
+  (let [tags @(rf/subscribe [:jira-templates/tags])
         tag-options (tags-to-select-options tags)]
     [forms/select
      {:size "2"

--- a/webapp/src/webapp/jira_templates/preset_mapping_table.cljs
+++ b/webapp/src/webapp/jira_templates/preset_mapping_table.cljs
@@ -3,13 +3,57 @@
    ["@radix-ui/themes" :refer [Box Table Text Strong]]
    [webapp.components.forms :as forms]
    [webapp.jira-templates.rule-buttons :as rule-buttons]
+   [re-frame.core :as rf]
+   [reagent.core :as r]
    [clojure.string :as str]))
 
-(def tag-value-options
-  [{:value "session.connection_tags.env" :text "Environment Tag"}
-   {:value "session.connection_tags.team" :text "Team Tag"}
-   {:value "session.connection_tags.product" :text "Product Tag"}
-   {:value "session.connection_tags.service" :text "Service Tag"}])
+;; Event para carregar as tags
+(rf/reg-event-fx
+ :jira-templates/get-connection-tags
+ (fn [{:keys [db]} [_]]
+   {:db (assoc-in db [:jira-templates :tags-loading] true)
+    :fx [[:dispatch [:fetch {:method "GET"
+                             :uri "/connection-tags"
+                             :on-success (fn [response]
+                                           (rf/dispatch [:jira-templates/set-connection-tags (:items response)]))}]]]}))
+
+;; Event para armazenar as tags carregadas
+(rf/reg-event-db
+ :jira-templates/set-connection-tags
+ (fn [db [_ tags]]
+   (-> db
+       (assoc-in [:jira-templates :tags] tags)
+       (assoc-in [:jira-templates :tags-loading] false))))
+
+;; Subscription para acessar as tags
+(rf/reg-sub
+ :jira-templates/tags
+ (fn [db]
+   (get-in db [:jira-templates :tags])))
+
+;; Subscription para verificar o estado de carregamento
+(rf/reg-sub
+ :jira-templates/tags-loading?
+ (fn [db]
+   (get-in db [:jira-templates :tags-loading])))
+
+;; Função para extrair o nome simples de uma tag
+(defn extract-tag-name [key]
+  (let [parts (str/split key #"\.")]
+    (if (empty? parts)
+      key
+      (last parts))))
+
+;; Função para transformar as tags em opções de select
+(defn tags-to-select-options [tags]
+  (reduce (fn [options tag]
+            (let [key (:key tag)]
+              (if (some #(= (:value %) (str "session.connection_tags." key)) options)
+                options
+                (conj options {:value (str "session.connection_tags." key)
+                               :text (extract-tag-name key)}))))
+          []
+          tags))
 
 (defn- is-connection-tag? [rule]
   (and (:value rule)
@@ -24,14 +68,17 @@
     :on-change #(on-rule-field-change state idx :jira_field (-> % .-target .-value))}])
 
 (defn- value-field [rule state idx on-rule-field-change]
-  [forms/select
-   {:size "2"
-    :variant "ghost"
-    :not-margin-bottom? true
-    :on-change #(on-rule-field-change state idx :value %)
-    :selected (:value rule)
-    :full-width? true
-    :options tag-value-options}])
+  (let [tags-loading? @(rf/subscribe [:jira-templates/tags-loading?])
+        tags @(rf/subscribe [:jira-templates/tags])
+        tag-options (tags-to-select-options tags)]
+    [forms/select
+     {:size "2"
+      :variant "ghost"
+      :not-margin-bottom? true
+      :on-change #(on-rule-field-change state idx :value %)
+      :selected (:value rule)
+      :full-width? true
+      :options tag-options}]))
 
 (defn- details-input [rule state idx on-rule-field-change]
   [forms/input
@@ -49,54 +96,69 @@
                     on-toggle-all-mapping
                     on-mapping-delete
                     on-mapping-add]}]
-  (let [add-preset-rule (fn []
-                          (on-mapping-add state (fn [rule]
-                                                  (assoc rule
-                                                         :type "preset"
-                                                         :value "session.connection_tags.env"))))
-        toggle-all-preset-rules (fn []
-                                  (on-toggle-all-mapping state is-connection-tag?))
-        delete-preset-rules (fn []
-                              (on-mapping-delete state is-connection-tag?))]
-    [:> Box {:class "space-y-radix-5"}
-     [:> Box
-      [:> Table.Root {:size "2" :variant "surface"}
-       [:> Table.Header
-        [:> Table.Row {:align "center"}
-         (when @select-state
-           [:> Table.ColumnHeaderCell ""])
-         [:> Table.ColumnHeaderCell "Tag"]
-         [:> Table.ColumnHeaderCell "Jira Field"]
-         [:> Table.ColumnHeaderCell "Description (Optional)"]]]
+  (r/create-class
+   {:component-did-mount
+    (fn []
+      ;; Iniciar carregamento das tags quando o componente for montado
+      (rf/dispatch [:jira-templates/get-connection-tags]))
 
-       [:> Table.Body
-        (doall
-         (for [[idx rule] (map-indexed vector @state)
-               :when (is-connection-tag? rule)]
-           ^{:key idx}
-           [:> Table.Row {:align "center"}
-            (when @select-state
-              [:> Table.RowHeaderCell {:p "2" :width "20px"}
-               [:input {:type "checkbox"
-                        :checked (:selected rule)
-                        :on-change #(on-mapping-select state idx)}]])
+    :reagent-render
+    (fn [{:keys [state
+                 select-state
+                 on-mapping-field-change
+                 on-mapping-select
+                 on-toggle-mapping-select
+                 on-toggle-all-mapping
+                 on-mapping-delete
+                 on-mapping-add]}]
+      (let [add-preset-rule (fn []
+                              (on-mapping-add state (fn [rule]
+                                                      (assoc rule
+                                                             :type "preset"
+                                                             :value ""))))
+            toggle-all-preset-rules (fn []
+                                      (on-toggle-all-mapping state is-connection-tag?))
+            delete-preset-rules (fn []
+                                  (on-mapping-delete state is-connection-tag?))]
+        [:> Box {:class "space-y-radix-5"}
+         [:> Box
+          [:> Table.Root {:size "2" :variant "surface"}
+           [:> Table.Header
+            [:> Table.Row {:align "center"}
+             (when @select-state
+               [:> Table.ColumnHeaderCell ""])
+             [:> Table.ColumnHeaderCell "Tag"]
+             [:> Table.ColumnHeaderCell "Jira Field"]
+             [:> Table.ColumnHeaderCell "Description (Optional)"]]]
 
-            [:> Table.Cell {:p "4"}
-             [value-field rule state idx on-mapping-field-change]]
+           [:> Table.Body
+            (doall
+             (for [[idx rule] (map-indexed vector @state)
+                   :when (is-connection-tag? rule)]
+               ^{:key idx}
+               [:> Table.Row {:align "center"}
+                (when @select-state
+                  [:> Table.RowHeaderCell {:p "2" :width "20px"}
+                   [:input {:type "checkbox"
+                            :checked (:selected rule)
+                            :on-change #(on-mapping-select state idx)}]])
 
-            [:> Table.Cell {:p "4"}
-             [jira-field-input rule state idx on-mapping-field-change]]
+                [:> Table.Cell {:p "4"}
+                 [value-field rule state idx on-mapping-field-change]]
 
-            [:> Table.Cell {:p "4"}
-             [details-input rule state idx on-mapping-field-change]]]))]]
+                [:> Table.Cell {:p "4"}
+                 [jira-field-input rule state idx on-mapping-field-change]]
 
-      [:> Text {:as "p" :size "2" :mt "1" :class "text-[--gray-10]"}
-       "Relate connection tags with Jira fields for automated mapping."]]
+                [:> Table.Cell {:p "4"}
+                 [details-input rule state idx on-mapping-field-change]]]))]]
 
-     [rule-buttons/main
-      {:on-rule-add add-preset-rule
-       :on-toggle-select #(on-toggle-mapping-select select-state)
-       :select-state select-state
-       :selected? (every? :selected (filter is-connection-tag? @state))
-       :on-toggle-all toggle-all-preset-rules
-       :on-rules-delete delete-preset-rules}]]))
+          [:> Text {:as "p" :size "2" :mt "1" :class "text-[--gray-10]"}
+           "Relate connection tags with Jira fields for automated mapping."]]
+
+         [rule-buttons/main
+          {:on-rule-add add-preset-rule
+           :on-toggle-select #(on-toggle-mapping-select select-state)
+           :select-state select-state
+           :selected? (every? :selected (filter is-connection-tag? @state))
+           :on-toggle-all toggle-all-preset-rules
+           :on-rules-delete delete-preset-rules}]]))}))

--- a/webapp/src/webapp/jira_templates/preset_mapping_table.cljs
+++ b/webapp/src/webapp/jira_templates/preset_mapping_table.cljs
@@ -88,18 +88,10 @@
     :not-margin-bottom? true
     :on-change #(on-rule-field-change state idx :description (-> % .-target .-value))}])
 
-(defn main [{:keys [state
-                    select-state
-                    on-mapping-field-change
-                    on-mapping-select
-                    on-toggle-mapping-select
-                    on-toggle-all-mapping
-                    on-mapping-delete
-                    on-mapping-add]}]
+(defn main []
   (r/create-class
    {:component-did-mount
     (fn []
-      ;; Iniciar carregamento das tags quando o componente for montado
       (rf/dispatch [:jira-templates/get-connection-tags]))
 
     :reagent-render
@@ -150,10 +142,7 @@
                  [jira-field-input rule state idx on-mapping-field-change]]
 
                 [:> Table.Cell {:p "4"}
-                 [details-input rule state idx on-mapping-field-change]]]))]]
-
-          [:> Text {:as "p" :size "2" :mt "1" :class "text-[--gray-10]"}
-           "Relate connection tags with Jira fields for automated mapping."]]
+                 [details-input rule state idx on-mapping-field-change]]]))]]]
 
          [rule-buttons/main
           {:on-rule-add add-preset-rule


### PR DESCRIPTION
This PR implements connection tags mapping functionality for Jira templates, providing a more intuitive way to map connection tags to Jira fields. The implementation includes a preset mapping table, improved UI components, and better descriptions for the mapping process.

## Changes
- Add preset mapping table for connection tags to Jira fields
- Implement connection tags loading and mapping functionality
- Refactor Jira templates to improve connection tags mapping descriptions
- Restructure components for better organization and maintainability
- Clean up unused event subscriptions and comments
- Bump package version to 1.42.0

## Additional Info
This PR enhances the integration between our connection system and Jira, making it easier for users to configure and use Jira templates with proper field mappings.

## Screenshots
![Screenshot 2025-04-11 at 10 49 37](https://github.com/user-attachments/assets/6fa51cc5-16cf-4436-a33a-523929c86434)