### PR TITLE
Add bidirectional relationship between GuardRails and Connections

### DIFF
--- a/gateway/api/guardrails/guardrails.go
+++ b/gateway/api/guardrails/guardrails.go
@@ -61,7 +61,7 @@ func Post(c *gin.Context) {
 			}
 
 			if len(validIDs) > 0 {
-				if err := models.SyncGuardRailConnections(ctx.GetOrgID(), rule.ID, validIDs); err != nil {
+				if err := models.SyncGuardRailConnectionAssociations(ctx.GetOrgID(), rule.ID, validIDs); err != nil {
 					log.Errorf("Failed to sync connections for guardrail %s: %v", rule.ID, err)
 					// Continue but we'll warn in the response
 				}
@@ -141,7 +141,7 @@ func Put(c *gin.Context) {
 			}
 
 			if len(validIDs) > 0 {
-				if err := models.SyncGuardRailConnections(ctx.GetOrgID(), rule.ID, validIDs); err != nil {
+				if err := models.SyncGuardRailConnectionAssociations(ctx.GetOrgID(), rule.ID, validIDs); err != nil {
 					log.Errorf("Failed to sync connections for guardrail %s: %v", rule.ID, err)
 					// Continue but we'll warn in the response
 				}

--- a/gateway/api/guardrails/guardrails.go
+++ b/gateway/api/guardrails/guardrails.go
@@ -52,8 +52,6 @@ func Post(c *gin.Context) {
 		c.JSON(http.StatusConflict, gin.H{"message": err.Error()})
 		return
 	case nil:
-		rule.ID, len(rule.ConnectionIDs))
-
 		c.JSON(http.StatusCreated, &openapi.GuardRailRuleResponse{
 			ID:            rule.ID,
 			Name:          rule.Name,
@@ -109,8 +107,6 @@ func Put(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"message": err.Error()})
 		return
 	case nil:
-		rule.ID, len(rule.ConnectionIDs))
-
 		c.JSON(http.StatusOK, &openapi.GuardRailRuleResponse{
 			ID:            rule.ID,
 			Name:          rule.Name,

--- a/gateway/api/guardrails/guardrails.go
+++ b/gateway/api/guardrails/guardrails.go
@@ -43,7 +43,7 @@ func Post(c *gin.Context) {
 		CreatedAt:   time.Now().UTC(),
 		UpdatedAt:   time.Now().UTC(),
 	}
-	
+
 	// Create guardrail and associate connections in a single transaction
 	err := models.UpsertGuardRailRuleWithConnections(rule, validConnectionIDs, true)
 
@@ -109,8 +109,7 @@ func Put(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"message": err.Error()})
 		return
 	case nil:
-		log.Infof("Guardrail %s updated successfully with %d connection IDs",
-			rule.ID, len(rule.ConnectionIDs))
+		rule.ID, len(rule.ConnectionIDs))
 
 		c.JSON(http.StatusOK, &openapi.GuardRailRuleResponse{
 			ID:            rule.ID,

--- a/gateway/api/guardrails/guardrails.go
+++ b/gateway/api/guardrails/guardrails.go
@@ -195,7 +195,12 @@ func List(c *gin.Context) {
 	rules := []openapi.GuardRailRuleResponse{}
 	for _, rule := range ruleList {
 		// Get connections for each rule
-		connectionIDs, _ := models.GetConnectionIDsForGuardRail(ctx.GetOrgID(), rule.ID)
+		connectionIDs, err := models.GetConnectionIDsForGuardRail(ctx.GetOrgID(), rule.ID)
+		if err != nil {
+			log.Errorf("Error fetching connection IDs for guardrail %s: %v", rule.ID, err)
+			// Continue with empty connection IDs
+			connectionIDs = []string{}
+		}
 
 		rules = append(rules, openapi.GuardRailRuleResponse{
 			ID:            rule.ID,
@@ -230,7 +235,12 @@ func Get(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"message": "resource not found"})
 	case nil:
 		// Get connections for this rule
-		connectionIDs, _ := models.GetConnectionIDsForGuardRail(ctx.GetOrgID(), rule.ID)
+		connectionIDs, err := models.GetConnectionIDsForGuardRail(ctx.GetOrgID(), rule.ID)
+		if err != nil {
+			log.Errorf("Error fetching connection IDs for guardrail %s: %v", rule.ID, err)
+			// Continue with empty connection IDs
+			connectionIDs = []string{}
+		}
 
 		c.JSON(http.StatusOK, &openapi.GuardRailRuleResponse{
 			ID:            rule.ID,

--- a/gateway/api/guardrails/guardrails.go
+++ b/gateway/api/guardrails/guardrails.go
@@ -43,9 +43,7 @@ func Post(c *gin.Context) {
 		CreatedAt:   time.Now().UTC(),
 		UpdatedAt:   time.Now().UTC(),
 	}
-
-	log.Infof("Creating guardrail %s with connections: %v", rule.Name, validConnectionIDs)
-
+	
 	// Create guardrail and associate connections in a single transaction
 	err := models.UpsertGuardRailRuleWithConnections(rule, validConnectionIDs, true)
 
@@ -54,8 +52,7 @@ func Post(c *gin.Context) {
 		c.JSON(http.StatusConflict, gin.H{"message": err.Error()})
 		return
 	case nil:
-		log.Infof("Guardrail %s created successfully with %d connection IDs",
-			rule.ID, len(rule.ConnectionIDs))
+		rule.ID, len(rule.ConnectionIDs))
 
 		c.JSON(http.StatusCreated, &openapi.GuardRailRuleResponse{
 			ID:            rule.ID,
@@ -103,8 +100,6 @@ func Put(c *gin.Context) {
 		Output:      req.Output,
 		UpdatedAt:   time.Now().UTC(),
 	}
-
-	log.Infof("Updating guardrail %s with connections: %v", rule.ID, validConnectionIDs)
 
 	// Update guardrail and associate connections in a single transaction
 	err := models.UpsertGuardRailRuleWithConnections(rule, validConnectionIDs, false)

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4648,7 +4648,7 @@ const docTemplate = `{
             ],
             "properties": {
                 "connection_ids": {
-                    "description": "List of connection IDs or names that this guardrail applies to",
+                    "description": "List of connection IDs that this guardrail applies to",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -4684,7 +4684,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "connection_ids": {
-                    "description": "List of connection IDs or names that this guardrail applies to",
+                    "description": "List of connection IDs that this guardrail applies to",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4647,6 +4647,17 @@ const docTemplate = `{
                 "name"
             ],
             "properties": {
+                "connection_ids": {
+                    "description": "List of connection IDs or names that this guardrail applies to",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7",
+                        "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D8"
+                    ]
+                },
                 "description": {
                     "description": "The rule description",
                     "type": "string",
@@ -4672,6 +4683,17 @@ const docTemplate = `{
         "openapi.GuardRailRuleResponse": {
             "type": "object",
             "properties": {
+                "connection_ids": {
+                    "description": "List of connection IDs or names that this guardrail applies to",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7",
+                        "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D8"
+                    ]
+                },
                 "created_at": {
                     "description": "The time the resource was created",
                     "type": "string",

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1069,7 +1069,7 @@ type GuardRailRuleRequest struct {
 	*/
 	Output map[string]any `json:"output"`
 
-	// List of connection IDs or names that this guardrail applies to
+	// List of connection IDs that this guardrail applies to
 	ConnectionIDs []string `json:"connection_ids" example:"15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7,15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D8"`
 }
 
@@ -1118,7 +1118,7 @@ type GuardRailRuleResponse struct {
 	*/
 	Output map[string]any `json:"output"`
 
-	// List of connection IDs or names that this guardrail applies to
+	// List of connection IDs that this guardrail applies to
 	ConnectionIDs []string `json:"connection_ids" example:"15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7,15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D8"`
 
 	// The time the resource was created

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1070,7 +1070,7 @@ type GuardRailRuleRequest struct {
 	Output map[string]any `json:"output"`
 
 	// List of connection IDs or names that this guardrail applies to
-	ConnectionIDs []string `json:"connection_ids" example:"pgdemo,redis-prod"`
+	ConnectionIDs []string `json:"connection_ids" example:"15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7,15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D8"`
 }
 
 type GuardRailRuleResponse struct {
@@ -1119,7 +1119,7 @@ type GuardRailRuleResponse struct {
 	Output map[string]any `json:"output"`
 
 	// List of connection IDs or names that this guardrail applies to
-	ConnectionIDs []string `json:"connection_ids" example:"pgdemo,redis-prod"`
+	ConnectionIDs []string `json:"connection_ids" example:"15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7,15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D8"`
 
 	// The time the resource was created
 	CreatedAt time.Time `json:"created_at" readonly:"true" example:"2024-07-25T15:56:35.317601Z"`

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1068,6 +1068,9 @@ type GuardRailRuleRequest struct {
 		}
 	*/
 	Output map[string]any `json:"output"`
+
+	// List of connection IDs or names that this guardrail applies to
+	ConnectionIDs []string `json:"connection_ids" example:"pgdemo,redis-prod"`
 }
 
 type GuardRailRuleResponse struct {
@@ -1114,6 +1117,9 @@ type GuardRailRuleResponse struct {
 		}
 	*/
 	Output map[string]any `json:"output"`
+
+	// List of connection IDs or names that this guardrail applies to
+	ConnectionIDs []string `json:"connection_ids" example:"pgdemo,redis-prod"`
 
 	// The time the resource was created
 	CreatedAt time.Time `json:"created_at" readonly:"true" example:"2024-07-25T15:56:35.317601Z"`

--- a/gateway/models/guadrails.go
+++ b/gateway/models/guadrails.go
@@ -148,14 +148,6 @@ func DeleteGuardRailRules(orgID, ruleID string) error {
 
 // UpsertGuardRailRuleWithConnections creates or updates a guardrail rule and its connections in a single transaction
 func UpsertGuardRailRuleWithConnections(rule *GuardRailRules, connectionIDs []string, isNew bool) error {
-	// Clean empty connection IDs
-	var validConnectionIDs []string
-	for _, id := range connectionIDs {
-		if id != "" {
-			validConnectionIDs = append(validConnectionIDs, id)
-		}
-	}
-
 	return DB.Transaction(func(tx *gorm.DB) error {
 		// 1. Create or update the guardrail rule
 		var err error
@@ -196,7 +188,7 @@ func UpsertGuardRailRuleWithConnections(rule *GuardRailRules, connectionIDs []st
 		}
 
 		// 3. Add new connections
-		for _, connNameOrID := range validConnectionIDs {
+		for _, connNameOrID := range connectionIDs {
 			// Find the connection
 			var conn Connection
 			err := tx.Table("private.connections").

--- a/gateway/models/guadrails.go
+++ b/gateway/models/guadrails.go
@@ -2,13 +2,17 @@ package models
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/log"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
 const tableGuardRails = "private.guardrail_rules"
+const tableGuardRailsConnections = "private.guardrail_rules_connections"
 
 type GuardRailRules struct {
 	OrgID       string         `gorm:"column:org_id"`
@@ -19,6 +23,14 @@ type GuardRailRules struct {
 	Output      map[string]any `gorm:"column:output;serializer:json"`
 	CreatedAt   time.Time      `gorm:"column:created_at"`
 	UpdatedAt   time.Time      `gorm:"column:updated_at"`
+}
+
+type GuardRailConnection struct {
+	ID           string    `gorm:"column:id"`
+	OrgID        string    `gorm:"column:org_id"`
+	RuleID       string    `gorm:"column:rule_id"`
+	ConnectionID string    `gorm:"column:connection_id"`
+	CreatedAt    time.Time `gorm:"column:created_at"`
 }
 
 func ListGuardRailRules(orgID string) ([]*GuardRailRules, error) {
@@ -38,6 +50,96 @@ func GetGuardRailRules(orgID, ruleID string) (*GuardRailRules, error) {
 		return nil, err
 	}
 	return &rule, nil
+}
+
+// GetConnectionIDsForGuardRail returns all connection IDs associated with a guardrail
+func GetConnectionIDsForGuardRail(orgID, ruleID string) ([]string, error) {
+
+	// Return connection IDs as expected by the function name and API contract
+	var connectionIDs []string
+	err := DB.Raw(`
+		SELECT c.id 
+		FROM private.connections c
+		JOIN private.guardrail_rules_connections grc ON grc.connection_id = c.id
+		WHERE grc.org_id = ? AND grc.rule_id = ?
+	`, orgID, ruleID).Pluck("id", &connectionIDs).Error
+
+	if err != nil {
+		log.Errorf("Error retrieving connection IDs for guardrail %s: %v", ruleID, err)
+		return nil, err
+	}
+
+	return connectionIDs, nil
+}
+
+// SyncGuardRailConnections updates the connections associated with a guardrail
+func SyncGuardRailConnections(orgID, ruleID string, connectionIDs []string) error {
+	if len(connectionIDs) == 0 {
+		return nil // Nothing to do
+	}
+
+	// Start a transaction
+	tx := DB.Begin()
+	if tx.Error != nil {
+		return tx.Error
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
+
+	// Delete existing connections
+	if err := tx.Exec("DELETE FROM "+tableGuardRailsConnections+" WHERE org_id = ? AND rule_id = ?",
+		orgID, ruleID).Error; err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	// Keep track of successful associations
+	var successCount int
+
+	// Try to find connections by ID or name and add associations
+	for _, connNameOrID := range connectionIDs {
+		// Try to get the connection directly if it's a UUID
+		var conn *Connection
+		var err error
+
+		// Try to find the connection
+		conn, err = GetConnectionByNameOrID(orgID, connNameOrID)
+		if err != nil || conn == nil {
+			log.Warnf("Connection not found by ID/name '%s': %v", connNameOrID, err)
+			continue
+		}
+
+		// Add the association
+		newID := uuid.NewString()
+		result := tx.Exec(`
+			INSERT INTO `+tableGuardRailsConnections+` (id, org_id, rule_id, connection_id, created_at)
+			VALUES (?, ?, ?, ?, ?)
+		`, newID, orgID, ruleID, conn.ID, time.Now().UTC())
+
+		if result.Error != nil {
+			log.Errorf("Error associating connection %s with guardrail: %v", conn.Name, result.Error)
+			continue
+		}
+
+		if result.RowsAffected == 0 {
+			log.Warnf("No rows affected when associating connection %s with guardrail", conn.Name)
+			continue
+		}
+
+		successCount++
+	}
+
+	// If no connections were added but some were specified, return an error
+	if successCount == 0 && len(connectionIDs) > 0 {
+		log.Errorf("Failed to add any connections to guardrail %s", ruleID)
+		tx.Rollback()
+		return fmt.Errorf("could not add any connections to guardrail")
+	}
+
+	return tx.Commit().Error
 }
 
 func CreateGuardRailRules(rule *GuardRailRules) error {
@@ -71,6 +173,8 @@ func DeleteGuardRailRules(orgID, ruleID string) error {
 	if _, err := GetGuardRailRules(orgID, ruleID); err != nil {
 		return err
 	}
+
+	// The associations will be deleted automatically due to the ON DELETE CASCADE
 	return DB.Table(tableGuardRails).
 		Where(`org_id = ? and id = ?`, orgID, ruleID).
 		Delete(&GuardRailRules{}).Error

--- a/gateway/models/guadrails.go
+++ b/gateway/models/guadrails.go
@@ -187,11 +187,11 @@ func UpsertGuardRailRuleWithConnections(rule *GuardRailRules, connectionIDs []st
 		}
 
 		// 3. Add new connections
-		for _, connNameOrID := range connectionIDs {
+		for _, connID := range connectionIDs {
 			// Find the connection
 			var conn Connection
 			err := tx.Table("private.connections").
-				Where("org_id = ? AND (name = ? OR id = ?)", rule.OrgID, connNameOrID, connNameOrID).
+				Where("org_id = ? AND id = ?", rule.OrgID, connID).
 				First(&conn).Error
 
 			if err != nil {

--- a/gateway/models/guadrails.go
+++ b/gateway/models/guadrails.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hoophq/hoop/common/log"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -53,8 +52,6 @@ func GetGuardRailRules(orgID, ruleID string) (*GuardRailRules, error) {
 
 // GetConnectionIDsForGuardRail returns all connection IDs associated with a guardrail
 func GetConnectionIDsForGuardRail(orgID, ruleID string) ([]string, error) {
-
-	// Return connection IDs as expected by the function name and API contract
 	var connectionIDs []string
 	err := DB.Raw(`
 		SELECT c.id 
@@ -64,7 +61,6 @@ func GetConnectionIDsForGuardRail(orgID, ruleID string) ([]string, error) {
 	`, orgID, ruleID).Pluck("id", &connectionIDs).Error
 
 	if err != nil {
-		log.Errorf("Error retrieving connection IDs for guardrail %s: %v", ruleID, err)
 		return nil, err
 	}
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.42.1",
+  "version": "1.42.2",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/db.cljs
+++ b/webapp/src/webapp/db.cljs
@@ -59,6 +59,7 @@
                                   :description ""
                                   :input [{:type "" :rule "" :details ""}]
                                   :output [{:type "" :rule "" :details ""}]}
+   :guardrails->connections-list {:status :loading :data []}
    :jira-integration->details {:loading true, :data {}}
    :modal-radix {:open? false, :content nil}
    :modal-status :closed

--- a/webapp/src/webapp/guardrails/connections_section.cljs
+++ b/webapp/src/webapp/guardrails/connections_section.cljs
@@ -1,0 +1,41 @@
+(ns webapp.guardrails.connections-section
+  (:require
+   [re-frame.core :as rf]
+   ["@radix-ui/themes" :refer [Box Heading Grid Flex]]
+   [webapp.components.multiselect :as multiselect]))
+
+(defn format-connections-for-select [connections]
+  (mapv (fn [connection]
+          {"value" (:id connection)
+           "label" (:name connection)})
+        connections))
+
+(defn main
+  "Render the connections selection component for guardrails
+
+   Parameters:
+   - connections-ids: atom containing array of connection IDs
+   - on-connections-change: function to call when connections are changed"
+  [{:keys [connection-ids on-connections-change]}]
+  (let [connections-list (rf/subscribe [:guardrails->connections-list])]
+    (fn []
+      (let [connections-data (:data @connections-list)
+            connections-options (format-connections-for-select connections-data)
+            selected-values (mapv (fn [id]
+                                    (first (filter #(= (get % "value") id) connections-options)))
+                                  @connection-ids)]
+        [:> Grid {:columns "7" :gap "7"}
+         [:> Box {:grid-column "span 2 / span 2"}
+          [:> Heading {:as "h3" :size "4" :weight "medium"} "Associate Connections"]
+          [:p {:class "text-sm text-gray-500"}
+           "Select the connections where this guardrail should be applied."]]
+
+         [:> Box {:class "space-y-radix-7" :grid-column "span 5 / span 5"}
+          [:> Flex {:direction "column" :gap "2"}
+           [multiselect/main
+            {:label "Connections"
+             :options connections-options
+             :default-value (if (empty? selected-values) nil selected-values)
+             :on-change (fn [selected-options]
+                          (let [new-connection-ids (mapv #(get % "value") (js->clj selected-options))]
+                            (on-connections-change connection-ids new-connection-ids)))}]]]]))))

--- a/webapp/src/webapp/guardrails/create_update_form.cljs
+++ b/webapp/src/webapp/guardrails/create_update_form.cljs
@@ -7,6 +7,7 @@
    [webapp.guardrails.helpers :as helpers]
    [webapp.guardrails.form-header :as form-header]
    [webapp.guardrails.basic-info :as basic-info]
+   [webapp.guardrails.connections-section :as connections-section]
    [webapp.guardrails.rules-table :as rules-table]))
 
 (defn guardrail-form [form-type guardrails scroll-pos]
@@ -20,6 +21,7 @@
                             (let [data {:id @(:id state)
                                         :name @(:name state)
                                         :description @(:description state)
+                                        :connection_ids @(:connection-ids state)
                                         :input @(:input state)
                                         :output @(:output state)}]
                               (if (= :edit form-type)
@@ -36,6 +38,11 @@
            :description (:description state)
            :on-name-change #(reset! (:name state) %)
            :on-description-change #(reset! (:description state) %)}]
+
+         ;; Connections section
+         [connections-section/main
+          {:connection-ids (:connection-ids state)
+           :on-connections-change (:on-connections-change handlers)}]
 
         ;; Rules section
          [:> Grid {:columns "7" :gap "7"}
@@ -76,6 +83,8 @@
 (defn main [form-type]
   (let [guardrails->active-guardrail (rf/subscribe [:guardrails->active-guardrail])
         scroll-pos (r/atom 0)]
+
+    (rf/dispatch [:guardrails->get-connections])
     (fn []
       (r/with-let [handle-scroll #(reset! scroll-pos (.-scrollY js/window))]
         (.addEventListener js/window "scroll" handle-scroll)

--- a/webapp/src/webapp/guardrails/helpers.cljs
+++ b/webapp/src/webapp/guardrails/helpers.cljs
@@ -69,6 +69,7 @@
     {:id (r/atom (or (:id initial-data) ""))
      :name (r/atom (or (:name initial-data) ""))
      :description (r/atom (or (:description initial-data) ""))
+     :connection-ids (r/atom (or (:connection_ids initial-data) []))
      :input (r/atom input-rules)
      :output (r/atom output-rules)
      :input-pattern (r/atom (create-pattern-state input-rules))
@@ -102,4 +103,6 @@
                                   [(create-empty-rule)]
                                   filtered-rules))))
    :on-rule-add (fn [rules-atom]
-                  (swap! rules-atom conj (create-empty-rule)))})
+                  (swap! rules-atom conj (create-empty-rule)))
+   :on-connections-change (fn [connections-atom connections]
+                            (reset! connections-atom connections))})


### PR DESCRIPTION
# Backend
This PR enhances the GuardRails API to support bidirectional relationships with Connections. Previously, Connections could reference GuardRails through their `GuardRailRules` array, but GuardRails couldn't directly reference their associated Connections.

## Changes
- Added functionality to associate connections with guardrails directly through the API
- Modified `GetConnectionIDsForGuardRail` to return connection IDs instead of names
- Enhanced `SyncGuardRailConnections` to properly handle both connection IDs and names
- Fixed HTTP status code in POST response to match API documentation (201 Created)
- Improved error handling and added more detailed logging
- Made sure all connections are properly synced when creating or updating a guardrail

## Testing
- Tested creating guardrails with connections (POST)
- Tested updating guardrails with connections (PUT)
- Verified that connection IDs are properly returned in API responses

## Technical Details
- Used the existing `guardrail_rules_connections` table for persistent storage
- Improved the robustness of connection ID resolution
- Enhanced error reporting to make debugging easier

# Frontend 
This PR adds support for associating connections with guardrails in the frontend, allowing users to select which connections a guardrail should be applied to. The feature includes a new component for connection selection and updates to the guardrail creation/editing flow.

### Changes

- Added `connection_ids` field support in guardrail state management
- Created a new component for selecting connections 
- Added API integration to fetch available connections
- Updated create/edit form to include connection selection section
- Added form handler for connection changes
- Ensured proper serialization and deserialization of connection IDs

### Technical Details

- The connection selection uses the existing multiselect component 
- Connection IDs are stored in the guardrail object and sent to the backend
- Selected connections are persisted when editing existing guardrails

### Screenshots

![Screenshot 2025-04-14 at 16 49 13](https://github.com/user-attachments/assets/3853f9f4-731c-49e5-b912-f48f11c0df1d)
