### PR TITLE
Bidirectional Association Between Jira Issue Templates and Connections

### DIFF
--- a/gateway/api/integrations/issuetemplates.go
+++ b/gateway/api/integrations/issuetemplates.go
@@ -34,6 +34,14 @@ func ListIssueTemplates(c *gin.Context) {
 
 	issues := []openapi.JiraIssueTemplate{}
 	for _, issue := range issueList {
+		// Get associated connections
+		connectionIDs, err := getConnectionIDs(ctx.OrgID, issue.ID)
+		if err != nil {
+			log.Errorf("failed getting associated connections for template %s: %v", issue.ID, err)
+			// Continue with empty list if this fails
+			connectionIDs = []string{}
+		}
+
 		issues = append(issues, openapi.JiraIssueTemplate{
 			ID:                         issue.ID,
 			Name:                       issue.Name,
@@ -46,6 +54,7 @@ func ListIssueTemplates(c *gin.Context) {
 			CmdbTypes:                  issue.CmdbTypes,
 			CreatedAt:                  issue.CreatedAt,
 			UpdatedAt:                  issue.UpdatedAt,
+			ConnectionIDs:              connectionIDs,
 		})
 	}
 	c.JSON(http.StatusOK, issues)
@@ -74,6 +83,15 @@ func GetIssueTemplatesByID(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"message": "failed listing objects from Jira assets api"})
 			return
 		}
+
+		// Get associated connections
+		connectionIDs, err := getConnectionIDs(ctx.GetOrgID(), issue.ID)
+		if err != nil {
+			log.Errorf("failed getting associated connections, reason=%v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"message": "failed getting associated connections"})
+			return
+		}
+
 		c.JSON(http.StatusOK, &openapi.JiraIssueTemplate{
 			ID:                         issue.ID,
 			Name:                       issue.Name,
@@ -86,6 +104,7 @@ func GetIssueTemplatesByID(c *gin.Context) {
 			CmdbTypes:                  cmdbTypes,
 			CreatedAt:                  issue.CreatedAt,
 			UpdatedAt:                  issue.UpdatedAt,
+			ConnectionIDs:              connectionIDs,
 		})
 	default:
 		log.Errorf("failed listing issue templates, reason=%v", err)
@@ -236,9 +255,27 @@ func CreateIssueTemplates(c *gin.Context) {
 	switch err {
 	case models.ErrNotFound:
 		c.JSON(http.StatusBadRequest, gin.H{"message": "jira integration is not enabled"})
+		return
 	case models.ErrAlreadyExists:
 		c.JSON(http.StatusConflict, gin.H{"message": err.Error()})
+		return
 	case nil:
+		// Update connection associations if provided
+		if req.ConnectionIDs != nil {
+			if err := updateConnectionAssociations(ctx.GetOrgID(), issue.ID, req.ConnectionIDs); err != nil {
+				log.Errorf("failed updating connection associations: %v", err)
+				// Don't fail the whole operation if connections update fails
+			}
+		}
+
+		// Get associated connections for response
+		connectionIDs, err := getConnectionIDs(ctx.GetOrgID(), issue.ID)
+		if err != nil {
+			log.Errorf("failed getting associated connections: %v", err)
+			// Continue with empty list if this fails
+			connectionIDs = []string{}
+		}
+
 		c.JSON(http.StatusOK, &openapi.JiraIssueTemplate{
 			ID:                         issue.ID,
 			Name:                       issue.Name,
@@ -251,12 +288,12 @@ func CreateIssueTemplates(c *gin.Context) {
 			CmdbTypes:                  req.CmdbTypes,
 			CreatedAt:                  issue.CreatedAt,
 			UpdatedAt:                  issue.UpdatedAt,
+			ConnectionIDs:              connectionIDs,
 		})
 	default:
 		log.Errorf("failed creting issue templates, reason=%v, err=%T", err, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 	}
-
 }
 
 // UpdateIssueTemplates
@@ -296,6 +333,23 @@ func UpdateIssueTemplates(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"message": err.Error()})
 		return
 	case nil:
+		// Update connection associations
+		// If the field is present in the request (even if empty), update the associations
+		if req.ConnectionIDs != nil {
+			if err := updateConnectionAssociations(ctx.GetOrgID(), issue.ID, req.ConnectionIDs); err != nil {
+				log.Errorf("failed updating connection associations: %v", err)
+				// Don't fail the whole operation if connections update fails
+			}
+		}
+
+		// Get associated connections for response
+		connectionIDs, err := getConnectionIDs(ctx.GetOrgID(), issue.ID)
+		if err != nil {
+			log.Errorf("failed getting associated connections: %v", err)
+			// Continue with empty list if this fails
+			connectionIDs = []string{}
+		}
+
 		c.JSON(http.StatusOK, &openapi.JiraIssueTemplate{
 			ID:                         issue.ID,
 			Name:                       issue.Name,
@@ -308,12 +362,12 @@ func UpdateIssueTemplates(c *gin.Context) {
 			CmdbTypes:                  issue.CmdbTypes,
 			CreatedAt:                  issue.CreatedAt,
 			UpdatedAt:                  issue.UpdatedAt,
+			ConnectionIDs:              connectionIDs,
 		})
 	default:
 		log.Errorf("failed updating jira issue templates, reason=%v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 	}
-
 }
 
 // DeleteIssueTemplates
@@ -328,7 +382,16 @@ func UpdateIssueTemplates(c *gin.Context) {
 //	@Router			/integrations/jira/issuetemplates/{id} [delete]
 func DeleteIssueTemplates(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
-	err := models.DeleteJiraIssueTemplates(ctx.GetOrgID(), c.Param("id"))
+	templateID := c.Param("id")
+
+	// First, clear any connection associations
+	err := updateConnectionAssociations(ctx.GetOrgID(), templateID, []string{})
+	if err != nil {
+		log.Errorf("failed clearing connection associations: %v", err)
+		// Continue with deletion even if this fails
+	}
+
+	err = models.DeleteJiraIssueTemplates(ctx.GetOrgID(), templateID)
 	switch err {
 	case models.ErrNotFound:
 		c.JSON(http.StatusNotFound, gin.H{"message": "resource not found"})
@@ -400,4 +463,58 @@ func cmdbTypesWithExternalObjects(ctx *gin.Context, config *models.JiraIntegrati
 		item["jira_values"] = jiraValues
 	}
 	return cmdbTypes, nil
+}
+
+// getConnectionIDs fetches connections associated with a template
+func getConnectionIDs(orgID, templateID string) ([]string, error) {
+	connections, err := models.ListConnections(orgID, models.ConnectionFilterOption{})
+	if err != nil {
+		return nil, fmt.Errorf("failed fetching connections: %v", err)
+	}
+
+	var connectionIDs []string
+	for _, conn := range connections {
+		if conn.JiraIssueTemplateID.Valid && conn.JiraIssueTemplateID.String == templateID {
+			connectionIDs = append(connectionIDs, conn.ID)
+		}
+	}
+	return connectionIDs, nil
+}
+
+// updateConnectionAssociations updates the connections associated with a template
+func updateConnectionAssociations(orgID, templateID string, connectionIDs []string) error {
+	// Get all connections
+	connections, err := models.ListConnections(orgID, models.ConnectionFilterOption{})
+	if err != nil {
+		return fmt.Errorf("failed fetching connections: %v", err)
+	}
+
+	// Create a map for faster lookups
+	connIDMap := make(map[string]bool)
+	for _, id := range connectionIDs {
+		connIDMap[id] = true
+	}
+
+	// Update each connection
+	for _, conn := range connections {
+		shouldBeAssociated := connIDMap[conn.ID]
+		isCurrentlyAssociated := conn.JiraIssueTemplateID.Valid && conn.JiraIssueTemplateID.String == templateID
+
+		if shouldBeAssociated && !isCurrentlyAssociated {
+			// Associate this connection with the template
+			conn.JiraIssueTemplateID.String = templateID
+			conn.JiraIssueTemplateID.Valid = true
+			if err := models.UpsertConnection(&conn); err != nil {
+				return fmt.Errorf("failed updating connection %s: %v", conn.ID, err)
+			}
+		} else if !shouldBeAssociated && isCurrentlyAssociated {
+			// Remove association
+			conn.JiraIssueTemplateID.Valid = false
+			conn.JiraIssueTemplateID.String = ""
+			if err := models.UpsertConnection(&conn); err != nil {
+				return fmt.Errorf("failed updating connection %s: %v", conn.ID, err)
+			}
+		}
+	}
+	return nil
 }

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -948,6 +948,8 @@ type JiraIssueTemplate struct {
 	CreatedAt time.Time `json:"created_at"`
 	// The time when the template was updated
 	UpdatedAt time.Time `json:"updated_at"`
+	// The connection IDs associated with this template
+	ConnectionIDs []string `json:"connection_ids,omitempty"`
 }
 
 type JiraIssueTemplateRequest struct {
@@ -1024,6 +1026,8 @@ type JiraIssueTemplateRequest struct {
 		}
 	*/
 	CmdbTypes map[string]any `json:"cmdb_types"`
+	// The connection IDs to associate with this template
+	ConnectionIDs []string `json:"connection_ids"`
 }
 
 type GuardRailRuleRequest struct {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -949,7 +949,7 @@ type JiraIssueTemplate struct {
 	// The time when the template was updated
 	UpdatedAt time.Time `json:"updated_at"`
 	// The connection IDs associated with this template
-	ConnectionIDs []string `json:"connection_ids,omitempty"`
+	ConnectionIDs []string `json:"connection_ids"`
 }
 
 type JiraIssueTemplateRequest struct {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp",
-  "version": "1.41.2",
+  "version": "1.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp",
-      "version": "1.41.2",
+      "version": "1.42.1",
       "dependencies": {
         "@codemirror/commands": "^6.3.2",
         "@codemirror/lang-javascript": "^6.2.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.42.2",
+  "version": "1.42.3",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -284,8 +284,8 @@
 (defmethod routes/panels :edit-jira-template-panel []
   (let [pathname (.. js/window -location -pathname)
         current-route (bidi/match-route @routes/routes pathname)
-        guardrail-id (:jira-template-id (:route-params current-route))]
-    (rf/dispatch [:jira-templates->get-by-id guardrail-id])
+        jira-template-id (:jira-template-id (:route-params current-route))]
+    (rf/dispatch [:jira-templates->get-by-id jira-template-id])
     [layout :application-hoop
      [:div {:class "bg-gray-1 min-h-full h-max relative"}
       [routes/wrap-admin-only

--- a/webapp/src/webapp/events/jira_templates.cljs
+++ b/webapp/src/webapp/events/jira_templates.cljs
@@ -67,7 +67,7 @@
                               :uri (str "/integrations/jira/issuetemplates/" id)
                               :on-success (fn [template]
                                             (rf/dispatch [:jira-templates->set-submit-template template])
-                                         ;; Dispara requests para cada item CMDB
+                                            ;; Dispara requests para cada item CMDB
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item])))
                               :on-failure #(rf/dispatch [:jira-templates->set-submit-template nil])}]}]]}))
@@ -83,7 +83,7 @@
                               :uri (str "/integrations/jira/issuetemplates/" id)
                               :on-success (fn [template]
                                             (rf/dispatch [:jira-templates->set-submit-template-re-run template])
-                                         ;; Dispara requests para cada item CMDB
+                                            ;; Dispara requests para cada item CMDB
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item])))
                               :on-failure #(rf/dispatch [:jira-templates->set-submit-template-re-run nil])}]}]]}))
@@ -193,6 +193,26 @@
  (fn [db [_ value]]
    (assoc-in db [:jira-templates :submitting?] value)))
 
+;; Connections
+(rf/reg-event-fx
+ :jira-templates->get-connections
+ (fn [{:keys [db]} _]
+   {:db (assoc db :jira-templates->connections-list {:status :loading :data []})
+    :fx [[:dispatch [:fetch {:method "GET"
+                             :uri "/connections"
+                             :on-success #(rf/dispatch [:jira-templates->set-connections %])
+                             :on-failure #(rf/dispatch [:jira-templates->set-connections-error %])}]]]}))
+
+(rf/reg-event-db
+ :jira-templates->set-connections
+ (fn [db [_ connections]]
+   (assoc db :jira-templates->connections-list {:status :ready :data connections})))
+
+(rf/reg-event-db
+ :jira-templates->set-connections-error
+ (fn [db [_ error]]
+   (assoc db :jira-templates->connections-list {:status :error :error error :data []})))
+
 ;; Subs
 (rf/reg-sub
  :jira-templates->list
@@ -213,3 +233,8 @@
  :jira-templates->submitting?
  (fn [db]
    (get-in db [:jira-templates :submitting?])))
+
+(rf/reg-sub
+ :jira-templates->connections-list
+ (fn [db _]
+   (:jira-templates->connections-list db)))

--- a/webapp/src/webapp/events/jira_templates.cljs
+++ b/webapp/src/webapp/events/jira_templates.cljs
@@ -67,7 +67,6 @@
                               :uri (str "/integrations/jira/issuetemplates/" id)
                               :on-success (fn [template]
                                             (rf/dispatch [:jira-templates->set-submit-template template])
-                                            ;; Dispara requests para cada item CMDB
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item])))
                               :on-failure #(rf/dispatch [:jira-templates->set-submit-template nil])}]}]]}))
@@ -83,7 +82,6 @@
                               :uri (str "/integrations/jira/issuetemplates/" id)
                               :on-success (fn [template]
                                             (rf/dispatch [:jira-templates->set-submit-template-re-run template])
-                                            ;; Dispara requests para cada item CMDB
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item])))
                               :on-failure #(rf/dispatch [:jira-templates->set-submit-template-re-run nil])}]}]]}))

--- a/webapp/src/webapp/jira_templates/connections_section.cljs
+++ b/webapp/src/webapp/jira_templates/connections_section.cljs
@@ -1,0 +1,37 @@
+(ns webapp.jira-templates.connections-section
+  (:require
+   [re-frame.core :as rf]
+   ["@radix-ui/themes" :refer [Box Heading Grid Flex]]
+   [webapp.components.multiselect :as multiselect]))
+
+(defn- format-connections-for-select [connections]
+  (mapv (fn [connection]
+          {"value" (:id connection)
+           "label" (:name connection)})
+        connections))
+
+(defn main [props]
+  (let [connections-atom (:connection-ids props)
+        on-change (:on-connections-change props)
+        connections-list (rf/subscribe [:jira-templates->connections-list])]
+    (fn []
+      (let [connections-data (:data @connections-list)
+            connections-options (format-connections-for-select connections-data)
+            selected-values (mapv (fn [id]
+                                    (first (filter #(= (get % "value") id) connections-options)))
+                                  @connections-atom)]
+        [:> Flex {:direction "column" :gap "5"}
+         [:> Box
+          [:> Heading {:as "h3" :size "4" :weight "bold" :class "text-[--gray-12]"}
+           "Associate Connections"]
+          [:> Box {:class "text-sm text-gray-500 mb-2"}
+           "Select connections where this template should be applied"]]
+
+         [:> Box {:class "mb-5"}
+          [multiselect/main
+           {:label "Connections"
+            :options connections-options
+            :default-value (if (empty? selected-values) nil selected-values)
+            :on-change (fn [selected-options]
+                         (let [connection-ids (mapv #(get % "value") (js->clj selected-options))]
+                           (on-change connection-ids)))}]]]))))

--- a/webapp/src/webapp/jira_templates/create_update_form.cljs
+++ b/webapp/src/webapp/jira_templates/create_update_form.cljs
@@ -6,6 +6,7 @@
    [webapp.components.loaders :as loaders]
    [webapp.jira-templates.basic-info :as basic-info]
    [webapp.jira-templates.cmdb-table :as cmdb-table]
+   [webapp.jira-templates.connections-section :as connections-section]
    [webapp.jira-templates.form-header :as form-header]
    [webapp.jira-templates.helpers :as helpers]
    [webapp.jira-templates.mapping-table :as mapping-table]
@@ -47,6 +48,12 @@
          [workflow-info/main
           {:status (:issue_transition_name_on_close state)
            :on-status-change #(reset! (:issue_transition_name_on_close state) %)}]
+
+         (println "connection_ids" (:connection_ids state))
+         ;; Connections section
+         [connections-section/main
+          {:connection-ids (:connection_ids state)
+           :on-connections-change (:on-connections-change handlers)}]
 
          [:> Flex {:direction "column" :gap "5"}
           [:> Box
@@ -139,6 +146,8 @@
 (defn main [form-type]
   (let [jira-template (rf/subscribe [:jira-templates->active-template])
         scroll-pos (r/atom 0)]
+
+    (rf/dispatch [:jira-templates->get-connections])
     (fn []
       (r/with-let [handle-scroll #(reset! scroll-pos (.-scrollY js/window))]
         (.addEventListener js/window "scroll" handle-scroll)

--- a/webapp/src/webapp/jira_templates/helpers.cljs
+++ b/webapp/src/webapp/jira_templates/helpers.cljs
@@ -87,6 +87,7 @@
    :project_key (r/atom (or (:project_key initial-data) ""))
    :request_type_id (r/atom (or (:request_type_id initial-data) ""))
    :issue_transition_name_on_close (r/atom (or (:issue_transition_name_on_close initial-data) ""))
+   :connection_ids (r/atom (or (:connection_ids initial-data) []))
    :mapping (r/atom (format-mapping-rules (get-in initial-data [:mapping_types :items])))
    :prompts (r/atom (format-prompts (get-in initial-data [:prompt_types :items])))
    :cmdb (r/atom (format-cmdbs (get-in initial-data [:cmdb_types :items])))
@@ -192,7 +193,10 @@
                     (swap! prompts-atom conj (create-empty-prompt)))
 
    :on-cmdb-add (fn [cmdbs-atom]
-                  (swap! cmdbs-atom conj (create-empty-cmdb)))})
+                  (swap! cmdbs-atom conj (create-empty-cmdb)))
+
+   :on-connections-change (fn [connections]
+                            (reset! (:connection_ids state) connections))})
 
 (defn remove-empty-mapping [mappings]
   (remove (fn [rule]
@@ -228,6 +232,7 @@
    :project_key @(:project_key state)
    :request_type_id @(:request_type_id state)
    :issue_transition_name_on_close @(:issue_transition_name_on_close state)
+   :connection_ids @(:connection_ids state)
    :mapping_types {:items (vec (remove-empty-mapping @(:mapping state)))}
    :prompt_types {:items (vec (remove-empty-prompts @(:prompts state)))}
    :cmdb_types {:items (vec (remove-empty-cmdb @(:cmdb state)))}})


### PR DESCRIPTION
This PR implements the backend changes necessary to support bidirectional relationships between Jira Issue Templates and Connections. Previously, connections could reference a Jira Issue Template, but there was no way to get or set associated connections directly from the template.

Also, this PR adds the ability to associate connections with Jira templates in the frontend, enabling users to select which connections a template should be applied to. This feature enhances the workflow by allowing template configurations to be connection-specific.

## Backend Changes

- Added `connection_ids` field to `JiraIssueTemplate` response to return associated connections
- Added `connection_ids` field to `JiraIssueTemplateRequest` to allow setting connections during template creation/update
- Implemented helper functions to manage connection relationships:
  - `getConnectionIDs`: Retrieves connections associated with a template
  - `updateConnectionAssociations`: Updates connection associations based on request
- Modified API endpoints to handle connection associations:
  - `GET /integrations/jira/issuetemplates`: Includes associated connections
  - `GET /integrations/jira/issuetemplates/{id}`: Includes associated connections
  - `POST /integrations/jira/issuetemplates`: Handles connection associations
  - `PUT /integrations/jira/issuetemplates/{id}`: Updates connection associations
  - `DELETE /integrations/jira/issuetemplates/{id}`: Clears connection associations before deletion

### Implementation Details

- Used existing database structure (no schema changes required)
- Leveraged the existing `jira_issue_template_id` field in connections table
- Maintaining references through bidirectional updates

## Frontend Changes

- Added `connection_ids` field support in Jira template state management
- Created a connection selection component for the Jira template form
- Added API integration to fetch available connections
- Updated the template creation/editing form to include connection selection
- Added handlers for managing connection selections
- Ensured proper serialization of connection IDs in the template payload

### Implementation Details

- Connections are fetched when the form loads and displayed in a multiselect component
- Selected connections are stored in the template's `connection_ids` field
- Previously selected connections are preserved when editing templates
- The backend will use this information to apply templates only to their associated connections

### Screenshots

