### PR TITLE
[libhoop] Implement Postgres native redaction with MSPresidio

### DIFF
--- a/agent/controller/postgres.go
+++ b/agent/controller/postgres.go
@@ -49,14 +49,17 @@ func (a *Agent) processPGProtocol(pkt *pb.Packet) {
 
 	log.Infof("session=%v - starting postgres connection at %v:%v", sessionID, connenv.host, connenv.port)
 	opts := map[string]string{
-		"hostname":              connenv.host,
-		"port":                  connenv.port,
-		"username":              connenv.user,
-		"password":              connenv.pass,
-		"sslmode":               connenv.postgresSSLMode,
-		"dlp_gcp_credentials":   a.getGCPCredentials(),
-		"dlp_info_types":        strings.Join(connParams.DLPInfoTypes, ","),
-		"dlp_masking_character": "#",
+		"hostname":                  connenv.host,
+		"port":                      connenv.port,
+		"username":                  connenv.user,
+		"password":                  connenv.pass,
+		"sslmode":                   connenv.postgresSSLMode,
+		"dlp_provider":              a.getDlpProvider(),
+		"mspresidio_analyzer_url":   a.getMSPresidioAnalyzerURL(),
+		"mspresidio_anonymizer_url": a.getMSPresidioAnonymizerURL(),
+		"dlp_gcp_credentials":       a.getGCPCredentials(),
+		"dlp_info_types":            strings.Join(connParams.DLPInfoTypes, ","),
+		"dlp_masking_character":     "#",
 	}
 	serverWriter, err := libhoop.NewDBCore(context.Background(), streamClient, opts).Postgres()
 	if err != nil {

--- a/agent/controller/terminal.go
+++ b/agent/controller/terminal.go
@@ -37,8 +37,11 @@ func (a *Agent) doTerminalWriteAgentStdin(pkt *pb.Packet) {
 	spec := map[string][]byte{pb.SpecGatewaySessionID: []byte(sid)}
 	stdoutWriter := pb.NewStreamWriter(a.client, pbclient.WriteStdout, spec)
 	opts := map[string]string{
-		"dlp_gcp_credentials": a.getGCPCredentials(),
-		"dlp_info_types":      strings.Join(connParams.DLPInfoTypes, ","),
+		"dlp_provider":              a.getDlpProvider(),
+		"mspresidio_analyzer_url":   a.getMSPresidioAnalyzerURL(),
+		"mspresidio_anonymizer_url": a.getMSPresidioAnonymizerURL(),
+		"dlp_gcp_credentials":       a.getGCPCredentials(),
+		"dlp_info_types":            strings.Join(connParams.DLPInfoTypes, ","),
 	}
 	args := append(connParams.CmdList, connParams.ClientArgs...)
 	cmd, err := libhoop.NewConsole(connParams.EnvVars, args, stdoutWriter, opts)

--- a/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
@@ -25,6 +25,7 @@ stringData:
   IDP_CLIENT_ID: '{{ required "config.IDP_CLIENT_ID is required" .Values.config.IDP_CLIENT_ID }}'
   IDP_CLIENT_SECRET: '{{ required "config.IDP_CLIENT_SECRET is required" .Values.config.IDP_CLIENT_SECRET }}'
   IDP_CUSTOM_SCOPES: '{{ .Values.config.IDP_CUSTOM_SCOPES }}'
+  IDP_GROUPS_CLAIM: '{{ .Values.config.IDP_GROUPS_CLAIM }}'
   {{- end }}
   IDP_AUDIENCE: '{{ .Values.config.IDP_AUDIENCE }}'
   TLS_KEY: '{{ .Values.config.TLS_KEY }}'

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -5734,12 +5734,12 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "admin_username": {
-                    "description": "The role name of the admin group",
+                    "description": "The group name that has administrator permissions",
                     "type": "string",
                     "example": "admin"
                 },
                 "api_url": {
-                    "description": "API URL advertise to clients",
+                    "description": "API_URL advertise to clients",
                     "type": "string",
                     "example": "https://api.johnwick.org"
                 },
@@ -5784,7 +5784,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "has_postgrest_role": {
-                    "description": "Report if IDP_CUSTOM_SCOPES env is set",
+                    "description": "Report if PGREST_ROLE env is set",
                     "type": "boolean"
                 },
                 "has_redact_credentials": {
@@ -5814,7 +5814,7 @@ const docTemplate = `{
                     "example": "INFO"
                 },
                 "redact_provider": {
-                    "description": "DLP provider used by the server",
+                    "description": "Redact Provider used by the server",
                     "type": "string",
                     "enum": [
                         "gcp",
@@ -5833,7 +5833,7 @@ const docTemplate = `{
                 "version": {
                     "description": "Version of the server",
                     "type": "string",
-                    "example": "1.23.15"
+                    "example": "1.35.0"
                 }
             }
         },

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -849,18 +849,18 @@ type PublicServerInfo struct {
 
 type ServerInfo struct {
 	// Version of the server
-	Version string `json:"version" example:"1.23.15"`
+	Version string `json:"version" example:"1.35.0"`
 	// Commit SHA of the version
 	Commit string `json:"commit_sha" example:"e6b94e86352e934b66d9c7ab2821a267dc18dfee"`
 	// Log level of the server
 	LogLevel string `json:"log_level" enums:"INFO,WARN,DEBUG,ERROR" example:"INFO"`
 	// Expose `GODEBUG` flags enabled
 	GoDebug string `json:"go_debug" example:"http2debug=2"`
-	// The role name of the admin group
+	// The group name that has administrator permissions
 	AdminUsername string `json:"admin_username" example:"admin"`
 	// Auth method used by the server
 	AuthMethod string `json:"auth_method" enums:"oidc,local" example:"local"`
-	// DLP provider used by the server
+	// Redact Provider used by the server
 	RedactProvider string `json:"redact_provider" enums:"gcp,mspresidio" example:"gcp"`
 	// Report if GOOGLE_APPLICATION_CREDENTIALS_JSON or MSPRESIDIO is set
 	HasRedactCredentials bool `json:"has_redact_credentials"`
@@ -870,13 +870,13 @@ type ServerInfo struct {
 	HasIDPAudience bool `json:"has_idp_audience"`
 	// Report if IDP_CUSTOM_SCOPES env is set
 	HasIDPCustomScopes bool `json:"has_idp_custom_scopes"`
-	// Report if IDP_CUSTOM_SCOPES env is set
+	// Report if PGREST_ROLE env is set
 	HasPostgresRole bool `json:"has_postgrest_role"`
 	// Report if ASK_AI_CREDENTIALS is set (openapi credentials)
 	HasAskiAICredentials bool `json:"has_ask_ai_credentials"`
 	// Report if SSH_CLIENT_HOST_KEY is set
 	HasSSHClientHostKey bool `json:"has_ssh_client_host_key"`
-	// API URL advertise to clients
+	// API_URL advertise to clients
 	ApiURL string `json:"api_url" example:"https://api.johnwick.org"`
 	// The GRPC_URL advertise to clients
 	GrpcURL string `json:"grpc_url" example:"127.0.0.1:8009"`

--- a/gateway/security/idp/authenticator.go
+++ b/gateway/security/idp/authenticator.go
@@ -158,7 +158,10 @@ func setProviderConfFromEnvs(p *Provider) error {
 	p.ClientSecret = os.Getenv("IDP_CLIENT_SECRET")
 	p.Audience = os.Getenv("IDP_AUDIENCE")
 	p.CustomScopes = os.Getenv("IDP_CUSTOM_SCOPES")
-	p.GroupsClaim = proto.CustomClaimGroups
+	p.GroupsClaim = os.Getenv("IDP_GROUPS_CLAIM")
+	if p.GroupsClaim == "" {
+		p.GroupsClaim = proto.CustomClaimGroups
+	}
 
 	issuerURL, err := url.Parse(p.Issuer)
 	if err != nil {

--- a/gateway/transport/plugins/audit/wal.go
+++ b/gateway/transport/plugins/audit/wal.go
@@ -140,7 +140,7 @@ func (p *auditPlugin) writeOnClose(pctx plugintypes.Context, errMsg error) error
 						}
 					}
 					if ts.InfoType == "" {
-						// ignore it, this should only happened
+						// ignore it, this should only happens
 						// for legacy transformation summary records
 						continue
 					}


### PR DESCRIPTION
- [libhoop] Refactor redact provider to support generic clients with codec types for various use cases
- [libhoop] Add MSPresidio statistics collection and propagation
- [libhoop] Configure partial content redaction in MSPresidio
- [libhoop] Enable structured content redaction via YAML encoder
- [libhoop] Implement context propagation for timeout control during redaction
- Add MSPresidio configuration to terminal console and Postgres
- Add IDP_GROUPS_CLAIM env configuration