### PR TITLE
[helm-chart] Improve helm-chart to allow customizing service definition to work with GCP ingress

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,4 +11,5 @@ RUN tar -xf /tmp/hoop_*_$(uname -s)_$(uname -m).tar.gz -C /app/ && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
+ENTRYPOINT ["tini", "--"]
 CMD ["hoop", "start", "agent"]

--- a/deploy/helm-chart/chart/gateway/templates/deployment.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       {{- if .Values.defaultAgent.enabled }}
       - image: '{{ .Values.defaultAgent.imageRepository | default "hoophq/hoopdev" }}:{{ .Values.defaultAgent.imageTag | default "latest" }}'
         name: defaultagent
-        command:
+        args:
         - hoop-default-agent.sh
         imagePullPolicy: {{ .Values.defaultAgent.imagePullPolicy | default "Always" }}
         {{- if $.Values.persistence.enabled }}

--- a/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
@@ -10,6 +10,7 @@ stringData:
   POSTGRES_DB_URI: '{{ required "config.POSTGRES_DB_URI is required" .Values.config.POSTGRES_DB_URI }}'
   API_URL: '{{ required "config.API_URL is required" .Values.config.API_URL }}'
   GRPC_URL: '{{ .Values.config.GRPC_URL | default "" }}'
+  DEFAULT_AGENT_GRPC_HOST: '{{ .Values.defaultAgent.grpcHost }}'
   PGREST_ROLE: '{{ .Values.config.PGREST_ROLE }}'
   GIN_MODE: '{{ .Values.config.GIN_MODE | default "release" }}'
   LOG_ENCODING: '{{ .Values.config.LOG_ENCODING | default "json" }}'

--- a/deploy/helm-chart/chart/gateway/templates/service.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hoopgateway
+  {{- with .Values.mainService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     app: hoopgateway
@@ -14,3 +18,29 @@ spec:
       name: http
       protocol: TCP
       targetPort: 8009
+{{- with .Values.mainService.httpBackendConfig }}
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: hoopgateway-http
+spec:
+  timeoutSec: {{ .timeoutSec | default 30 }}
+  healthCheck:
+    type: {{ .healthCheckType | default "HTTPS" }}
+    requestPath: "/api/healthz"
+    port: 8009
+{{- end }}
+{{- with .Values.mainService.grpcBackendConfig }}
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: hoopgateway-grpc
+spec:
+  timeoutSec: {{ .timeoutSec | default 30 }}
+  healthCheck:
+    type: {{ .healthCheckType | default "HTTPS" }}
+    requestPath: "/api/healthz"
+    port: 8009
+{{- end }}

--- a/deploy/helm-chart/chart/gateway/values.yaml
+++ b/deploy/helm-chart/chart/gateway/values.yaml
@@ -17,6 +17,7 @@ defaultAgent:
   imageRepository: 'hoophq/hoopdev'
   imageTag: latest
   imagePullPolicy: Always
+  grpcHost: 127.0.0.1:8009
 
 ## Set pod annotations
 ##
@@ -42,6 +43,20 @@ config:
   notification: {}
   #   slackBotToken: ''
   #   bridgeUrl: ''
+
+mainService:
+  # -- Annotations to add in the main service
+  annotations: {}
+    # beta.cloud.google.com/backend-config: '{"ports": {"http": "hoopgateway-http", "grpc": "hoopgateway-grpc"}}'
+    # cloud.google.com/app-protocols: '{"http":"HTTPS", "grpc":"HTTP2"}'
+  # -- GCP BackendConfig resource
+  httpBackendConfig: {}
+    # healthCheckType: HTTPS
+    # timeoutSec: 30
+  # -- GCP BackendConfig resource
+  grpcBackendConfig: {}
+    # healthCheckType: HTTPS
+    # timeoutSec: 259200
 
 ingressApi:
   # -- Enables Ingress


### PR DESCRIPTION
- Improve the default agent to connect using TLS when `TLS_CA` env is set in the gateway
- Add `tini` to run agent under pid 1