### PR TITLE
Add Support for do_not_track Flag

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -67,6 +67,6 @@ POSTGRES_DB_URI=postgres://hoopdevuser:1a2b3c4d@host.docker.internal:5449/hoopde
 DISABLE_SESSIONS_DOWNLOAD=false
 
 # Tracking control
-# Set to 'true' to enable analytics and tracking scripts on the frontend (default)
-# Set to 'false' to disable all analytics and tracking scripts
-TRACKING=true
+# Set to 'true' to disable all analytics and tracking scripts on the frontend
+# Set to 'false' to allow analytics and tracking scripts (default)
+DO_NOT_TRACK=false

--- a/.env.sample
+++ b/.env.sample
@@ -61,11 +61,12 @@ ADMIN_USERNAME=admin
 # xtdb connection configuration - legacy
 POSTGRES_DB_URI=postgres://hoopdevuser:1a2b3c4d@host.docker.internal:5449/hoopdevdb?sslmode=disable
 
-# Tracking
-# for development, let this as true
-DO_NOT_TRACK=true
-
 # Sessions download control
 # Set to 'true' to disable sessions download
 # Set to 'false' to allow sessions download (default)
 DISABLE_SESSIONS_DOWNLOAD=false
+
+# Tracking control
+# Set to 'true' to enable analytics and tracking scripts on the frontend (default)
+# Set to 'false' to disable all analytics and tracking scripts
+TRACKING=true

--- a/.env.sample
+++ b/.env.sample
@@ -66,7 +66,11 @@ POSTGRES_DB_URI=postgres://hoopdevuser:1a2b3c4d@host.docker.internal:5449/hoopde
 # Set to 'false' to allow sessions download (default)
 DISABLE_SESSIONS_DOWNLOAD=false
 
+# Tracking
+# for development, let this as true
+DO_NOT_TRACK=true
+
 # Tracking control
-# Set to 'true' to disable all analytics and tracking scripts on the frontend
-# Set to 'false' to allow analytics and tracking scripts (default)
-DO_NOT_TRACK=false
+# Set to 'disabled' to disable all analytics and tracking scripts on the frontend
+# Set to 'enabled' to allow analytics and tracking scripts (default)
+ANALYTICS_TRACKING=enabled

--- a/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
@@ -47,3 +47,4 @@ stringData:
   PLUGIN_AUDIT_PATH: '{{ .Values.config.PLUGIN_AUDIT_PATH | default "/opt/hoop/sessions" }}'
   PLUGIN_INDEX_PATH: '{{ .Values.config.PLUGIN_INDEX_PATH | default "/opt/hoop/sessions/indexes" }}'
   WEBAPP_USERS_MANAGEMENT: '{{ .Values.config.WEBAPP_USERS_MANAGEMENT }}'
+  ANALYTICS_TRACKING: '{{ .Values.config.ANALYTICS_TRACKING | default "enabled" }}'

--- a/gateway/analytics/segment.go
+++ b/gateway/analytics/segment.go
@@ -24,7 +24,7 @@ func New() *Segment {
 
 func (s *Segment) Identify(ctx *types.APIContext) {
 	if s.Client == nil || ctx == nil || ctx.UserEmail == "" || ctx.OrgID == "" ||
-		appconfig.Get().DoNotTrack() {
+		!appconfig.Get().AnalyticsTracking() {
 		return
 	}
 
@@ -64,7 +64,7 @@ func (s *Segment) Identify(ctx *types.APIContext) {
 // - https://segment.com/docs/connections/spec/best-practices-identify/#anonymousid-generation
 // - https://segment.com/docs/connections/spec/best-practices-identify/#merging-identified-and-anonymous-user-profiles
 func (s *Segment) AnonymousTrack(anonymousId, eventName string, properties map[string]any) {
-	if s.Client == nil || appconfig.Get().DoNotTrack() {
+	if s.Client == nil || !appconfig.Get().AnalyticsTracking() {
 		return
 	}
 	if properties == nil {
@@ -83,7 +83,7 @@ func (s *Segment) AnonymousTrack(anonymousId, eventName string, properties map[s
 
 // Track generates an event to segment
 func (s *Segment) Track(userEmail, eventName string, properties map[string]any) {
-	if s.Client == nil || appconfig.Get().DoNotTrack() {
+	if s.Client == nil || !appconfig.Get().AnalyticsTracking() {
 		return
 	}
 	if properties == nil {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -812,6 +812,13 @@ const (
 	FeatureStatusDisabled FeatureStatusType = "disabled"
 )
 
+type AnalyticsTrackingStatusType string
+
+const (
+	AnalyticsTrackingEnabled  AnalyticsTrackingStatusType = "enabled"
+	AnalyticsTrackingDisabled AnalyticsTrackingStatusType = "disabled"
+)
+
 var FeatureList = []string{"ask-ai"}
 
 type FeatureRequest struct {
@@ -892,10 +899,10 @@ type ServerInfo struct {
 	// * true - Session download is disabled and not available to users
 	// * false - Session download is enabled and available to users
 	DisableSessionsDownload bool `json:"disable_sessions_download"`
-	// Indicates if all tracking and analytics should be disabled
-	// * true - All tracking/analytics are disabled
-	// * false - Tracking/analytics are enabled
-	DoNotTrack bool `json:"do_not_track"`
+	// Indicates if all tracking and analytics should be enabled or disabled
+	// * enabled - Analytics/tracking are enabled (ANALYTICS_TRACKING=enabled)
+	// * disabled - Analytics/tracking are disabled (ANALYTICS_TRACKING=disabled)
+	AnalyticsTracking string `json:"analytics_tracking" enums:"enabled,disabled" example:"enabled"`
 }
 
 type LivenessCheck struct {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -892,6 +892,10 @@ type ServerInfo struct {
 	// * true - Session download is disabled and not available to users
 	// * false - Session download is enabled and available to users
 	DisableSessionsDownload bool `json:"disable_sessions_download"`
+	// Indicates if all tracking and analytics should be disabled
+	// * true - All tracking/analytics are disabled
+	// * false - Tracking/analytics are enabled
+	DoNotTrack bool `json:"do_not_track"`
 }
 
 type LivenessCheck struct {

--- a/gateway/api/serverinfo/serverinfo.go
+++ b/gateway/api/serverinfo/serverinfo.go
@@ -31,7 +31,7 @@ var (
 		HasIDPCustomScopes:      isEnvSet("IDP_CUSTOM_SCOPES"),
 		HasPostgresRole:         isEnvSet("PGREST_ROLE"),
 		DisableSessionsDownload: os.Getenv("DISABLE_SESSIONS_DOWNLOAD") == "true",
-		DoNotTrack:              os.Getenv("DO_NOT_TRACK") == "true",
+		AnalyticsTracking:       getAnalyticsTrackingStatus(),
 	}
 )
 
@@ -109,4 +109,11 @@ func defaultOSSLicense() *license.License {
 func isEnvSet(key string) bool {
 	val, isset := os.LookupEnv(key)
 	return isset && val != ""
+}
+
+func getAnalyticsTrackingStatus() string {
+	if os.Getenv("ANALYTICS_TRACKING") == "disabled" {
+		return string(openapi.AnalyticsTrackingDisabled)
+	}
+	return string(openapi.AnalyticsTrackingEnabled)
 }

--- a/gateway/api/serverinfo/serverinfo.go
+++ b/gateway/api/serverinfo/serverinfo.go
@@ -31,7 +31,7 @@ var (
 		HasIDPCustomScopes:      isEnvSet("IDP_CUSTOM_SCOPES"),
 		HasPostgresRole:         isEnvSet("PGREST_ROLE"),
 		DisableSessionsDownload: os.Getenv("DISABLE_SESSIONS_DOWNLOAD") == "true",
-		DoNotTrack:              os.Getenv("TRACKING") != "true",
+		DoNotTrack:              os.Getenv("DO_NOT_TRACK") == "true",
 	}
 )
 

--- a/gateway/api/serverinfo/serverinfo.go
+++ b/gateway/api/serverinfo/serverinfo.go
@@ -31,6 +31,7 @@ var (
 		HasIDPCustomScopes:      isEnvSet("IDP_CUSTOM_SCOPES"),
 		HasPostgresRole:         isEnvSet("PGREST_ROLE"),
 		DisableSessionsDownload: os.Getenv("DISABLE_SESSIONS_DOWNLOAD") == "true",
+		DoNotTrack:              os.Getenv("TRACKING") != "true",
 	}
 )
 

--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -190,7 +190,7 @@ func Load() error {
 		licenseSignerOrgID:              allowedOrgID,
 		gcpDLPJsonCredentials:           gcpJsonCred,
 		orgMultitenant:                  os.Getenv("ORG_MULTI_TENANT") == "true",
-		doNotTrack:                      os.Getenv("DO_NOT_TRACK") == "true",
+		doNotTrack:                      os.Getenv("TRACKING") != "true",
 		dlpProvider:                     os.Getenv("DLP_PROVIDER"),
 		dlpMode:                         dlpMode,
 		hasRedactCredentials:            hasRedactCredentials,

--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -190,7 +190,7 @@ func Load() error {
 		licenseSignerOrgID:              allowedOrgID,
 		gcpDLPJsonCredentials:           gcpJsonCred,
 		orgMultitenant:                  os.Getenv("ORG_MULTI_TENANT") == "true",
-		doNotTrack:                      os.Getenv("TRACKING") != "true",
+		doNotTrack:                      os.Getenv("DO_NOT_TRACK") == "true",
 		dlpProvider:                     os.Getenv("DLP_PROVIDER"),
 		dlpMode:                         dlpMode,
 		hasRedactCredentials:            hasRedactCredentials,

--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -44,7 +44,7 @@ type Config struct {
 	licenseSignerOrgID              string
 	migrationPathFiles              string
 	orgMultitenant                  bool
-	doNotTrack                      bool
+	analyticsTracking               bool
 	apiURL                          string
 	grpcURL                         string
 	apiHostname                     string
@@ -190,7 +190,7 @@ func Load() error {
 		licenseSignerOrgID:              allowedOrgID,
 		gcpDLPJsonCredentials:           gcpJsonCred,
 		orgMultitenant:                  os.Getenv("ORG_MULTI_TENANT") == "true",
-		doNotTrack:                      os.Getenv("DO_NOT_TRACK") == "true",
+		analyticsTracking:               os.Getenv("ANALYTICS_TRACKING") == "enabled",
 		dlpProvider:                     os.Getenv("DLP_PROVIDER"),
 		dlpMode:                         dlpMode,
 		hasRedactCredentials:            hasRedactCredentials,
@@ -352,7 +352,7 @@ func (c Config) MSPresidioAnomymizerURL() string       { return c.msPresidioAnon
 func (c Config) PgUsername() string                    { return c.pgCred.username }
 func (c Config) PgURI() string                         { return c.pgCred.connectionString }
 func (c Config) PostgRESTRole() string                 { return c.pgCred.postgrestRole }
-func (c Config) DoNotTrack() bool                      { return c.doNotTrack }
+func (c Config) AnalyticsTracking() bool               { return c.analyticsTracking }
 func (c Config) DisableSessionsDownload() bool         { return c.disableSessionsDownload }
 func (c Config) MigrationPathFiles() string            { return c.migrationPathFiles }
 func (c Config) OrgMultitenant() bool                  { return c.orgMultitenant }

--- a/webapp/resources/public/index.html
+++ b/webapp/resources/public/index.html
@@ -5,40 +5,6 @@
 </script>
 
 <head>
-    <!-- Download Canny SDK -->
-    <script>!function (w, d, i, s) { function l() { if (!d.getElementById(i)) { var f = d.getElementsByTagName(s)[0], e = d.createElement(s); e.type = "text/javascript", e.async = !0, e.src = "https://canny.io/sdk.js", f.parentNode.insertBefore(e, f) } } if ("function" != typeof w.Canny) { var c = function () { c.q.push(arguments) }; c.q = [], w.Canny = c, "complete" === d.readyState ? l() : w.attachEvent ? w.attachEvent("onload", l) : w.addEventListener("load", l, !1) } }(window, document, "canny-jssdk", "script");</script>
-    <!-- End download Candy SDK -->
-
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZS8J67B1SX"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-        gtag('config', 'G-ZS8J67B1SX');
-    </script>
-    <!-- End Google tag (gtag.js) -->
-
-    <!-- Profitwell/Paddle integration -->
-    <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
-    <script type="text/javascript">
-        Paddle.Initialize({
-            token: 'live_fb0003b8e4345ffca9e35f0e34b',
-            pwCustomer: {}
-        });
-    </script>
-    <!-- End Profitwell/Paddle integration -->
-
-    <!-- Clarity integration -->
-    <script type="text/javascript">
-        (function (c, l, a, r, i, t, y) {
-            c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
-            t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
-            y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
-        })(window, document, "clarity", "script", "h9osgp95be");
-    </script>
-
-    <!-- End clarity intregration -->
     <script type="text/javascript">
         const {
             setTimeout,

--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -531,8 +531,8 @@
 (defn sentry-monitor []
   (let [sentry-dsn config/sentry-dsn
         sentry-sample-rate config/sentry-sample-rate
-        do-not-track @(rf/subscribe [:gateway->do-not-track])]
-    (when (and sentry-dsn sentry-sample-rate (not do-not-track))
+        analytics-tracking @(rf/subscribe [:gateway->analytics-tracking])]
+    (when (and sentry-dsn sentry-sample-rate (not analytics-tracking))
       (.init Sentry #js {:dsn sentry-dsn
                          :release config/app-version
                          :sampleRate sentry-sample-rate
@@ -559,27 +559,20 @@
   (let [active-panel (rf/subscribe [::subs/active-panel])
         gateway-public-info (rf/subscribe [:gateway->public-info])
         gateway-info (rf/subscribe [:gateway->info])
-        do-not-track (rf/subscribe [:gateway->do-not-track])]
+        analytics-tracking (rf/subscribe [:gateway->analytics-tracking])]
     (rf/dispatch [:gateway->get-public-info])
     (rf/dispatch [:gateway->get-info])
     (.registerPlugin gsap Draggable)
 
-    ;; Only initialize Sentry when gateway info is loaded and we know do_not_track status
+    ;; Only initialize Sentry when gateway info is loaded and we know analytics_tracking status
     (fn []
       (cond
         (-> @gateway-public-info :loading)
         [loading-transition]
 
         :else
-        ;; Initialize Sentry only when gateway info is loaded
-        (do
-          (when (and (not (-> @gateway-info :loading))
-                     (not (-> @gateway-public-info :loading)))
-            (sentry-monitor))
-
-          (when (not (-> @gateway-public-info :loading))
-            [:> Theme {:radius "large" :panelBackground "solid"}
-             ;; Hidden element to display do_not_track value for testing
-             [:div {:style {:display "none"}}
-              [:span {:id "do-not-track-value"} (str @do-not-track)]]
-             [routes/panels @active-panel @gateway-public-info]]))))))
+        [:> Theme {:radius "large" :panelBackground "solid"}
+         ;; Hidden element to display analytics_tracking value for testing
+         [:div {:style {:display "none"}}
+          [:span {:id "analytics-tracking-value"} (str @analytics-tracking)]]
+         [routes/panels @active-panel @gateway-public-info]]))))

--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -566,6 +566,11 @@
 
     ;; Only initialize Sentry when gateway info is loaded and we know analytics_tracking status
     (fn []
+      ;; Initialize Sentry only when gateway info is loaded
+      (when (and (not (-> @gateway-info :loading))
+                 (not (-> @gateway-public-info :loading)))
+        (sentry-monitor))
+
       (cond
         (-> @gateway-public-info :loading)
         [loading-transition]

--- a/webapp/src/webapp/events.cljs
+++ b/webapp/src/webapp/events.cljs
@@ -117,9 +117,9 @@
  :initialize-intercom
  (fn
    [{:keys [db]} [_ user]]
-   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
-     (if do-not-track
-       ;; If do_not_track is enabled, don't initialize Intercom
+   (let [analytics-tracking @(rf/subscribe [:gateway->analytics-tracking])]
+     (if (not analytics-tracking)
+       ;; If analytics tracking is disabled, don't initialize Intercom
        {}
        ;; Otherwise, initialize Intercom
        (do

--- a/webapp/src/webapp/events.cljs
+++ b/webapp/src/webapp/events.cljs
@@ -117,12 +117,18 @@
  :initialize-intercom
  (fn
    [{:keys [db]} [_ user]]
-   (js/window.Intercom
-    "boot"
-    (clj->js {:api_base "https://api-iam.intercom.io"
-              :app_id "ryuapdmp"
-              :name (:name user)
-              :email (:email user)
-              :user_id (:email user)
-              :user_hash (:intercom_hmac_digest user)}))
-   {}))
+   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
+     (if do-not-track
+       ;; If do_not_track is enabled, don't initialize Intercom
+       {}
+       ;; Otherwise, initialize Intercom
+       (do
+         (js/window.Intercom
+          "boot"
+          (clj->js {:api_base "https://api-iam.intercom.io"
+                    :app_id "ryuapdmp"
+                    :name (:name user)
+                    :email (:email user)
+                    :user_id (:email user)
+                    :user_hash (:intercom_hmac_digest user)}))
+         {})))))

--- a/webapp/src/webapp/events/clarity.cljs
+++ b/webapp/src/webapp/events/clarity.cljs
@@ -4,13 +4,26 @@
 
 (rf/reg-event-fx
  :clarity->verify-environment
- (fn [_ [_ user]]
-   (let [hostname (.-hostname js/window.location)]
-     (cond
-       (= hostname "localhost") (.clarity js/window "stop")
-       (= hostname "127.0.0.1") (.clarity js/window "stop")
-       (= hostname "appdemo.hoop.dev") (.clarity js/window "stop")
-       (= hostname "tryrunops.hoop.dev") (.clarity js/window "stop")
-       (= (:org_name user) "hoopdev") (.clarity js/window "stop")
-       :else (.clarity js/window "start")))
+ (fn [{:keys [db]} [_ user]]
+   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)
+         hostname (.-hostname js/window.location)
+         clarity-available? (and (exists? js/window.clarity)
+                                 (= (type js/window.clarity) js/Function))]
+     (if do-not-track
+       ;; If do_not_track is enabled, always stop clarity
+       (try
+         (when clarity-available?
+           (.clarity js/window "stop"))
+         (catch :default _ nil))
+       ;; Otherwise, apply normal logic
+       (try
+         (when clarity-available?
+           (cond
+             (= hostname "localhost") (.clarity js/window "stop")
+             (= hostname "127.0.0.1") (.clarity js/window "stop")
+             (= hostname "appdemo.hoop.dev") (.clarity js/window "stop")
+             (= hostname "tryrunops.hoop.dev") (.clarity js/window "stop")
+             (= (:org_name user) "hoopdev") (.clarity js/window "stop")
+             :else (.clarity js/window "start")))
+         (catch :default _ nil))))
    {}))

--- a/webapp/src/webapp/events/clarity.cljs
+++ b/webapp/src/webapp/events/clarity.cljs
@@ -5,12 +5,12 @@
 (rf/reg-event-fx
  :clarity->verify-environment
  (fn [{:keys [db]} [_ user]]
-   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)
+   (let [analytics-tracking @(rf/subscribe [:gateway->analytics-tracking])
          hostname (.-hostname js/window.location)
          clarity-available? (and (exists? js/window.clarity)
                                  (= (type js/window.clarity) js/Function))]
-     (if do-not-track
-       ;; If do_not_track is enabled, always stop clarity
+     (if (not analytics-tracking)
+       ;; If analytics tracking is disabled, always stop clarity
        (try
          (when clarity-available?
            (.clarity js/window "stop"))

--- a/webapp/src/webapp/events/gateway_info.cljs
+++ b/webapp/src/webapp/events/gateway_info.cljs
@@ -38,8 +38,8 @@
    {:db (assoc db :gateway->public-info {:loading false
                                          :data info})}))
 
-;; Subscription for do_not_track
+;; Subscription for analytics_tracking
 (rf/reg-sub
- :gateway->do-not-track
+ :gateway->analytics-tracking
  (fn [db _]
-   (get-in db [:gateway->info :data :do_not_track] false)))
+   (= "enabled" (get-in db [:gateway->info :data :analytics_tracking] "disabled"))))

--- a/webapp/src/webapp/events/gateway_info.cljs
+++ b/webapp/src/webapp/events/gateway_info.cljs
@@ -17,7 +17,8 @@
  (fn
    [{:keys [db]} [_ info]]
    {:db (assoc db :gateway->info {:loading false
-                                  :data info})}))
+                                  :data info})
+    :fx [[:dispatch [:tracking->initialize-if-allowed]]]}))
 
 (rf/reg-event-fx
  :gateway->get-public-info
@@ -36,3 +37,9 @@
    [{:keys [db]} [_ info]]
    {:db (assoc db :gateway->public-info {:loading false
                                          :data info})}))
+
+;; Subscription for do_not_track
+(rf/reg-sub
+ :gateway->do-not-track
+ (fn [db _]
+   (get-in db [:gateway->info :data :do_not_track] false)))

--- a/webapp/src/webapp/events/segment.cljs
+++ b/webapp/src/webapp/events/segment.cljs
@@ -7,35 +7,49 @@
 (rf/reg-event-fx
  :segment->load
  (fn [{:keys [db]} [_ event-callback]]
-   (let [segment-analytics (.load AnalyticsBrowser #js{:writeKey config/segment-write-key})]
-     (merge
-      {:db (assoc db :segment->analytics segment-analytics)}
-      (when event-callback
-        {:fx [[:dispatch event-callback]]})))))
+   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
+     (if do-not-track
+       ;; If do_not_track is enabled, don't load segment
+       {}
+       ;; Otherwise, load segment
+       (let [segment-analytics (.load AnalyticsBrowser #js{:writeKey config/segment-write-key})]
+         (merge
+          {:db (assoc db :segment->analytics segment-analytics)}
+          (when event-callback
+            {:fx [[:dispatch event-callback]]})))))))
 
 (rf/reg-event-fx
  :segment->identify
  (fn [{:keys [db]} [_ user]]
-   (let [user-id (:id user)
-         analytics (-> db :segment->analytics)]
-     (if (nil? analytics)
-       {:fx [[:dispatch [:segment->load [:segment->identify user]]]]}
-       (do
-         (.identify analytics user-id (clj->js user))
-         {})))))
+   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
+     (if do-not-track
+       ;; If do_not_track is enabled, don't send identify events
+       {}
+       ;; Otherwise, send identify events
+       (let [user-id (:id user)
+             analytics (-> db :segment->analytics)]
+         (if (nil? analytics)
+           {:fx [[:dispatch [:segment->load [:segment->identify user]]]]}
+           (do
+             (.identify analytics user-id (clj->js user))
+             {})))))))
 
 (rf/reg-event-fx
  :segment->track
  (fn [{:keys [db]} [_ event-name properties]]
-   (let [analytics (-> db :segment->analytics)
-         user (-> db :users->current-user :data)]
-
-     (if (nil? analytics)
-       {:fx [[:dispatch [:segment->load [:segment->track event-name properties]]]]}
-       (do
-         (.track analytics event-name (clj->js (merge
-                                                {:hostname (.-hostname js/location)}
-                                                user
-                                                properties)))
-         {})))))
+   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
+     (if do-not-track
+       ;; If do_not_track is enabled, don't send track events
+       {}
+       ;; Otherwise, send track events
+       (let [analytics (-> db :segment->analytics)
+             user (-> db :users->current-user :data)]
+         (if (nil? analytics)
+           {:fx [[:dispatch [:segment->load [:segment->track event-name properties]]]]}
+           (do
+             (.track analytics event-name (clj->js (merge
+                                                    {:hostname (.-hostname js/location)}
+                                                    user
+                                                    properties)))
+             {})))))))
 

--- a/webapp/src/webapp/events/segment.cljs
+++ b/webapp/src/webapp/events/segment.cljs
@@ -7,9 +7,9 @@
 (rf/reg-event-fx
  :segment->load
  (fn [{:keys [db]} [_ event-callback]]
-   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
-     (if do-not-track
-       ;; If do_not_track is enabled, don't load segment
+   (let [analytics-tracking @(rf/subscribe [:gateway->analytics-tracking])]
+     (if (not analytics-tracking)
+       ;; If analytics tracking is disabled, don't load segment
        {}
        ;; Otherwise, load segment
        (let [segment-analytics (.load AnalyticsBrowser #js{:writeKey config/segment-write-key})]
@@ -21,9 +21,9 @@
 (rf/reg-event-fx
  :segment->identify
  (fn [{:keys [db]} [_ user]]
-   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
-     (if do-not-track
-       ;; If do_not_track is enabled, don't send identify events
+   (let [analytics-tracking @(rf/subscribe [:gateway->analytics-tracking])]
+     (if (not analytics-tracking)
+       ;; If analytics tracking is disabled, don't send identify events
        {}
        ;; Otherwise, send identify events
        (let [user-id (:id user)
@@ -37,9 +37,9 @@
 (rf/reg-event-fx
  :segment->track
  (fn [{:keys [db]} [_ event-name properties]]
-   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
-     (if do-not-track
-       ;; If do_not_track is enabled, don't send track events
+   (let [analytics-tracking @(rf/subscribe [:gateway->analytics-tracking])]
+     (if (not analytics-tracking)
+       ;; If analytics tracking is disabled, don't send track events
        {}
        ;; Otherwise, send track events
        (let [analytics (-> db :segment->analytics)

--- a/webapp/src/webapp/events/tracking.cljs
+++ b/webapp/src/webapp/events/tracking.cljs
@@ -22,8 +22,8 @@
  :tracking->initialize-if-allowed
  (fn
    [{:keys [db]} _]
-   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
-     (if do-not-track
+   (let [analytics-tracking @(rf/subscribe [:gateway->analytics-tracking])]
+     (if (not analytics-tracking)
        ;; Tracking is disabled, ensure all tracking is stopped
        {:fx [[:dispatch [:tracking->disable-all-tracking]]]}
        ;; Tracking is allowed, initialize all tracking components
@@ -65,8 +65,8 @@
 (rf/reg-event-fx
  :tracking->ensure-canny-available
  (fn [{:keys [db]} [_ user-data]]
-   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
-     (if do-not-track
+   (let [analytics-tracking @(rf/subscribe [:gateway->analytics-tracking])]
+     (if (not analytics-tracking)
        ;; Tracking is disabled, do nothing
        {}
        ;; Otherwise, identify user in Canny if available

--- a/webapp/src/webapp/events/tracking.cljs
+++ b/webapp/src/webapp/events/tracking.cljs
@@ -1,0 +1,139 @@
+(ns webapp.events.tracking
+  (:require
+   [re-frame.core :as rf]
+   [webapp.config :as config]))
+
+(defn- create-script-element [src id async defer]
+  (let [script-element (.createElement js/document "script")]
+    (when id (.setAttribute script-element "id" id))
+    (.setAttribute script-element "src" src)
+    (.setAttribute script-element "type" "text/javascript")
+    (when async (.setAttribute script-element "async" "true"))
+    (when defer (.setAttribute script-element "defer" "true"))
+    script-element))
+
+(defn- inject-script [src id async defer]
+  (let [script-element (create-script-element src id async defer)
+        head-element (.getElementsByTagName js/document "head")
+        head (aget head-element 0)]
+    (.appendChild head script-element)))
+
+(rf/reg-event-fx
+ :tracking->initialize-if-allowed
+ (fn
+   [{:keys [db]} _]
+   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
+     (if do-not-track
+       ;; Tracking is disabled, ensure all tracking is stopped
+       {:fx [[:dispatch [:tracking->disable-all-tracking]]]}
+       ;; Tracking is allowed, initialize all tracking components
+       {:fx [[:dispatch [:tracking->load-scripts]]
+             [:dispatch [:segment->load]]]}))))
+
+(rf/reg-event-fx
+ :tracking->disable-all-tracking
+ (fn [_ _]
+   ;; Disable Sentry if it was initialized
+   (when (exists? js/Sentry)
+     ;; Try to close the Sentry client
+     (try
+       (when-let [hub (.-getCurrentHub js/Sentry)]
+         (when-let [client (.getClient hub)]
+           (when-let [close (.-close client)]
+             (.close client))))
+       (catch :default e
+         (js/console.warn "Error trying to close Sentry:", e)))
+
+     ;; Also try to cancel all future transmissions
+     (try
+       (when (exists? js/Sentry.configureScope)
+         (.configureScope js/Sentry
+                          (fn [scope]
+                            (.setUser scope nil)
+                            (.clear scope))))
+       (catch :default _ nil)))
+
+   ;; Disable Segment if it was initialized
+   (when (exists? js/analytics)
+     (try
+       (when (exists? (.-reset js/analytics))
+         (.reset js/analytics))
+       (catch :default _ nil)))
+
+   {}))
+
+(rf/reg-event-fx
+ :tracking->ensure-canny-available
+ (fn [{:keys [db]} [_ user-data]]
+   (let [do-not-track (get-in db [:gateway->info :data :do_not_track] false)]
+     (if do-not-track
+       ;; Tracking is disabled, do nothing
+       {}
+       ;; Otherwise, identify user in Canny if available
+       (do
+         (when (and (exists? js/Canny) (= (type js/Canny) js/Function))
+           (js/Canny "identify"
+                     #js{:appID config/canny-id
+                         :user #js{:email (:email user-data)
+                                   :name (:name user-data)
+                                   :id (:id user-data)}}))
+         {})))))
+
+(rf/reg-event-fx
+ :tracking->load-scripts
+ (fn
+   [_ _]
+   ;; Only inject scripts if they don't already exist
+   (when-not (.getElementById js/document "google-tag-manager")
+     (inject-script "https://www.googletagmanager.com/gtag/js?id=G-ZS8J67B1SX" "google-tag-manager" true false)
+     (let [gtag-script (.createElement js/document "script")]
+       (.setAttribute gtag-script "type" "text/javascript")
+       (set! (.-innerHTML gtag-script) "window.dataLayer = window.dataLayer || []; function gtag() { dataLayer.push(arguments); } gtag('js', new Date()); gtag('config', 'G-ZS8J67B1SX');")
+       (let [head-element (.getElementsByTagName js/document "head")
+             head (aget head-element 0)]
+         (.appendChild head gtag-script))))
+
+   (when-not (.getElementById js/document "paddle-js")
+     (inject-script "https://cdn.paddle.com/paddle/v2/paddle.js" "paddle-js" true false)
+     (let [paddle-script (.createElement js/document "script")]
+       (.setAttribute paddle-script "type" "text/javascript")
+       (set! (.-innerHTML paddle-script) "Paddle.Initialize({ token: 'live_fb0003b8e4345ffca9e35f0e34b', pwCustomer: {} });")
+       (let [head-element (.getElementsByTagName js/document "head")
+             head (aget head-element 0)]
+         (.appendChild head paddle-script))))
+
+   (when-not (.getElementById js/document "clarity-script")
+     (let [clarity-script (.createElement js/document "script")]
+       (.setAttribute clarity-script "id" "clarity-script")
+       (.setAttribute clarity-script "type" "text/javascript")
+       (set! (.-innerHTML clarity-script)
+             (str
+              ;; We don't define window.clarity directly to avoid recursion
+              "(function (c, l, a, r, i, t, y) { "
+              "  c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) }; "
+              "  t = l.createElement(r); t.async = 1; t.src = \"https://www.clarity.ms/tag/\" + i; "
+              "  y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y); "
+              "})(window, document, \"clarity\", \"script\", \"h9osgp95be\");"))
+       (let [head-element (.getElementsByTagName js/document "head")
+             head (aget head-element 0)]
+         (.appendChild head clarity-script))))
+
+   (when-not (.getElementById js/document "intercom-script")
+     (let [intercom-script (.createElement js/document "script")]
+       (.setAttribute intercom-script "id" "intercom-script")
+       (.setAttribute intercom-script "type" "text/javascript")
+       (set! (.-innerHTML intercom-script) "(function () { var w = window; var ic = w.Intercom; if (typeof ic === \"function\") { ic('reattach_activator'); ic('update', w.intercomSettings); } else { var d = document; var i = function () { i.c(arguments); }; i.q = []; i.c = function (args) { i.q.push(args); }; w.Intercom = i; var l = function () { var s = d.createElement('script'); s.type = 'text/javascript'; s.async = true; s.src = 'https://widget.intercom.io/widget/ryuapdmp'; var x = d.getElementsByTagName('script')[0]; x.parentNode.insertBefore(s, x); }; if (w.attachEvent) { w.attachEvent('onload', l); } else { w.addEventListener('load', l, false); } } })();")
+       (let [head-element (.getElementsByTagName js/document "head")
+             head (aget head-element 0)]
+         (.appendChild head intercom-script))))
+
+   (when-not (.getElementById js/document "canny-sdk")
+     (let [canny-script (.createElement js/document "script")]
+       (.setAttribute canny-script "id" "canny-sdk")
+       (.setAttribute canny-script "type" "text/javascript")
+       (set! (.-innerHTML canny-script) "!function (w, d, i, s) { function l() { if (!d.getElementById(i)) { var f = d.getElementsByTagName(s)[0], e = d.createElement(s); e.type = \"text/javascript\", e.async = !0, e.src = \"https://canny.io/sdk.js\", f.parentNode.insertBefore(e, f) } } if (\"function\" != typeof w.Canny) { var c = function () { c.q.push(arguments) }; c.q = [], w.Canny = c, \"complete\" === d.readyState ? l() : w.attachEvent ? w.attachEvent(\"onload\", l) : w.addEventListener(\"load\", l, !1) } }(window, document, \"canny-jssdk\", \"script\");")
+       (let [head-element (.getElementsByTagName js/document "head")
+             head (aget head-element 0)]
+         (.appendChild head canny-script))))
+
+   {}))

--- a/webapp/src/webapp/shared_ui/sidebar/main.cljs
+++ b/webapp/src/webapp/shared_ui/sidebar/main.cljs
@@ -242,11 +242,11 @@
 
     (rf/dispatch [:plugins->get-my-plugins])
     (rf/dispatch [:connections->get-connections])
-    (js/Canny "identify"
-              #js{:appID config/canny-id
-                  :user #js{:email (some-> @user :data :email)
-                            :name (some-> @user :data :name)
-                            :id (some-> @user :data :id)}})
+
+    ;; Use the tracking event to handle Canny identification
+    (when-let [user-data (:data @user)]
+      (rf/dispatch [:tracking->ensure-canny-available user-data]))
+
     (fn []
       (if (empty? (:data @user))
         [:<>]


### PR DESCRIPTION
This PR supports the `do_not_track` flag from the serverinfo API, allowing complete disabling of all tracking and analytics tools when enabled.

## Changes

### Core Implementation
- Added subscription for `do_not_track` flag from serverinfo API response
- Removed hardcoded tracking scripts from `index.html`
- Created a dynamic tracking initialization system that only loads scripts when tracking is allowed
- Implemented a centralized mechanism for tracking management

### Tracking Tools Integration
- **Segment**: Conditionally loads and initializes based on `do_not_track` setting
- **Clarity**: Added safe verification before calls and respects the tracking preference
- **Intercom**: Updated initialization to check tracking preferences
- **Canny**: Modified user identification to happen only when tracking is allowed
- **Sentry**: Delayed initialization until tracking preferences are known

## Testing
The changes have been tested with both `do_not_track: true` and `do_not_track: false` settings, confirming:
- No tracking scripts are loaded when disabled
- Network requests to tracking services are properly prevented
- Application functions normally in both modes