### PR TITLE
[agent] Update bq command line tool to accept project id as environment variable

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Dockerfile.tools
-FROM hoophq/agent-tools:0.0.9
+FROM hoophq/agent-tools:0.0.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -15,6 +15,7 @@ RUN mkdir -p /app && \
     apt-get install -y \
     python3-dev \
     python3-pip \
+    python3.9 \
     locales \
     tini \
     apt-utils \

--- a/deploy/docker-compose/Dockerfile
+++ b/deploy/docker-compose/Dockerfile
@@ -72,9 +72,9 @@ RUN apt-get update -y && \
 
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
     locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 COPY dist/hoopgateway_* /tmp/
 RUN tar --extract --file /tmp/hoopgateway_*-Linux_$(dpkg --print-architecture).tar.gz -C / --strip 1 && rm -rf /tmp/*

--- a/gateway/transport/connectionstatus/connectionstatus.go
+++ b/gateway/transport/connectionstatus/connectionstatus.go
@@ -14,7 +14,7 @@ import (
 func InitConciliationProcess() {
 	log.Infof("initializing connection status conciliation process")
 	if err := models.UpdateAllAgentsToOffline(); err != nil {
-		log.Warnf("failed to updating connection and agent resources to offline status, reason=%v")
+		log.Warnf("failed updating connection and agent resources to offline status, reason=%v", err)
 	}
 	go func() {
 		for {

--- a/rootfs/usr/local/bin/bq
+++ b/rootfs/usr/local/bin/bq
@@ -1,8 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash
 
-: "${KEY_FILE:? Required environment variable not set}"
+set -eo pipefail
 
-gcloud auth activate-service-account --key-file=$KEY_FILE 2> /dev/null
+: "${GOOGLE_APPLICATION_CREDENTIALS:? Required environment variable not set}"
+export CLOUDSDK_PYTHON=${CLOUDSDK_PYTHON:-"/usr/bin/python3.9"}
+
+gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS 2> /dev/null
 touch $HOME/.bigqueryrc
 
 /usr/lib/google-cloud-sdk/bin/bq $@

--- a/scripts/dev/Dockerfile
+++ b/scripts/dev/Dockerfile
@@ -65,6 +65,7 @@ RUN mkdir -p /app && \
   apt-get install -y \
   python3-dev \
   python3-pip \
+  python3.9 \
   net-tools \
   iproute2 \
   xz-utils \
@@ -92,10 +93,12 @@ RUN echo 'root:1a2b3c4d' | chpasswd && \
 
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
   echo "deb [arch=amd64,arm64] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list && \
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
   curl -sL https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
   curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
   curl -sL https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - && \
-  curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+  curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+  curl -sL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
 RUN apt-get update -y && \
   apt-get install -y \
@@ -103,6 +106,7 @@ RUN apt-get update -y && \
   default-mysql-client \
   postgresql-client-15 \
   mongodb-mongosh mongodb-org-tools mongodb-org-shell mongocli \
+  google-cloud-cli \
   sqlcmd unixodbc-dev
 
 # Download and install Oracle Instant Client and SQL*Plus
@@ -157,6 +161,7 @@ RUN pip3 install -U \
   requests==2.27.1
 
 COPY rootfs/usr/local/bin/mongosh /usr/local/bin/mongosh
+COPY rootfs/usr/local/bin/bq /usr/local/bin/bq
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
   locale-gen
 ENV LANG=en_US.UTF-8

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp",
-  "version": "1.43.2",
+  "version": "1.43.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp",
-      "version": "1.43.2",
+      "version": "1.43.3",
       "dependencies": {
         "@codemirror/commands": "^6.3.2",
         "@codemirror/lang-javascript": "^6.2.1",


### PR DESCRIPTION
- [agent] Add python3.9 to agent tools to avoid printing warning when using the bq cli
- [agent] Bump agent tools to 0.0.10 containing python3.9