### PR TITLE
Enhance command input with argument-based interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ client/cmd/custom.go
 deploy/docker-compose/hoopdata/terraform/outputs/
 deploy/docker-compose/hoopdata/sessions
 deploy/docker-compose/hoopdata/zitadel-admin-sa.json
+
+**/.claude/settings.local.json
+**/.mcp.json

--- a/webapp/src/webapp/connections/views/setup/events/db_events.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/db_events.cljs
@@ -94,6 +94,16 @@
  (fn [db [_ command]]
    (assoc-in db [:connection-setup :command] command)))
 
+(rf/reg-event-db
+ :connection-setup/set-command-args
+ (fn [db [_ args]]
+   (assoc-in db [:connection-setup :command-args] args)))
+
+(rf/reg-event-db
+ :connection-setup/set-command-current-arg
+ (fn [db [_ arg]]
+   (assoc-in db [:connection-setup :command-current-arg] arg)))
+
 ;; Review and Data Masking events
 (rf/reg-event-db
  :connection-setup/set-review-groups

--- a/webapp/src/webapp/connections/views/setup/events/effects.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/effects.cljs
@@ -9,9 +9,13 @@
  :connection-setup/initialize-state
  (fn [db [_ initial-data]]
    (if initial-data
-     (assoc db :connection-setup (assoc initial-data :ssh-auth-method
-                                        (get initial-data :ssh-auth-method "password")))
-     (assoc db :connection-setup {:ssh-auth-method "password"}))))
+     (assoc db :connection-setup (assoc initial-data 
+                                        :ssh-auth-method (get initial-data :ssh-auth-method "password")
+                                        :command-args (get initial-data :command-args [{"value" "bash" "label" "bash"}])
+                                        :command "bash"))
+     (assoc db :connection-setup {:ssh-auth-method "password"
+                                 :command-args [{"value" "bash" "label" "bash"}]
+                                 :command "bash"}))))
 
 (defn filter-valid-tags
   [tags]

--- a/webapp/src/webapp/connections/views/setup/events/subs.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/subs.cljs
@@ -45,6 +45,16 @@
  (fn [db]
    (get-in db [:connection-setup :command] "")))
 
+(rf/reg-sub
+ :connection-setup/command-args
+ (fn [db]
+   (get-in db [:connection-setup :command-args] [])))
+
+(rf/reg-sub
+ :connection-setup/command-current-arg
+ (fn [db]
+   (get-in db [:connection-setup :command-current-arg] "")))
+
 ;; Configuration and features
 (rf/reg-sub
  :connection-setup/config

--- a/webapp/src/webapp/connections/views/setup/server.cljs
+++ b/webapp/src/webapp/connections/views/setup/server.cljs
@@ -43,15 +43,11 @@
 
    ;; Additional Command Section
     [:> Box {:class "space-y-4"}
-     [:> Heading {:size "3"} "Command Configuration"]
+     [:> Heading {:size "3"} "Additional command"]
      [:> Text {:size "2" :color "gray"}
-      "Command is specified as a list of arguments."
-      [:br]
       "Each argument should be entered separately."
       [:br]
-      "Press Enter after each argument to add it to the list."
-      [:br]
-      "Example: 'python', '-m', 'http.server', '8000'"]
+      "Press Enter after each argument to add it to the list."]
      [:> Box
       [multi-select/text-input
        {:value @(rf/subscribe [:connection-setup/command-args])
@@ -60,7 +56,9 @@
         :on-input-change #(rf/dispatch [:connection-setup/set-command-current-arg %])
         :label "Command Arguments"
         :id "command-args"
-        :name "command-args"}]]]
+        :name "command-args"}]
+      [:> Text {:size "2" :color "gray" :mt "2"}
+       "Example: 'python', '-m', 'http.server', '8000'"]]]
 
    ;; Agent Section
     [agent-selector/main]]])

--- a/webapp/src/webapp/connections/views/setup/server.cljs
+++ b/webapp/src/webapp/connections/views/setup/server.cljs
@@ -43,11 +43,15 @@
 
    ;; Additional Command Section
     [:> Box {:class "space-y-4"}
-     [:> Heading {:size "3"} "Additional command"]
+     [:> Heading {:size "3"} "Command Configuration"]
      [:> Text {:size "2" :color "gray"}
-      "Add an additional command that will run on your connection."
+      "Command is specified as a list of arguments."
       [:br]
-      "Environment variables loaded above can also be used here."]
+      "Each argument should be entered separately."
+      [:br]
+      "Press Enter after each argument to add it to the list."
+      [:br]
+      "Example: 'python', '-m', 'http.server', '8000'"]
      [:> Box
       [multi-select/text-input
        {:value @(rf/subscribe [:connection-setup/command-args])

--- a/webapp/src/webapp/connections/views/setup/server.cljs
+++ b/webapp/src/webapp/connections/views/setup/server.cljs
@@ -6,6 +6,7 @@
    [re-frame.core :as rf]
    [reagent.core :as r]
    [webapp.components.forms :as forms]
+   [webapp.components.multiselect :as multi-select]
    [webapp.connections.constants :refer [connection-configs-required]]
    [webapp.connections.views.setup.additional-configuration :as additional-configuration]
    [webapp.connections.views.setup.agent-selector :as agent-selector]
@@ -47,12 +48,15 @@
       "Add an additional command that will run on your connection."
       [:br]
       "Environment variables loaded above can also be used here."]
-     [forms/textarea
-      {:label "Command"
-       :placeholder "$ bash"
-       :value @(rf/subscribe [:connection-setup/command])
-       :on-change #(rf/dispatch [:connection-setup/set-command
-                                 (-> % .-target .-value)])}]]
+     [:> Box
+      [multi-select/text-input
+       {:value @(rf/subscribe [:connection-setup/command-args])
+        :input-value @(rf/subscribe [:connection-setup/command-current-arg])
+        :on-change #(rf/dispatch [:connection-setup/set-command-args %])
+        :on-input-change #(rf/dispatch [:connection-setup/set-command-current-arg %])
+        :label "Command Arguments"
+        :id "command-args"
+        :name "command-args"}]]]
 
    ;; Agent Section
     [agent-selector/main]]])

--- a/webapp/src/webapp/db.cljs
+++ b/webapp/src/webapp/db.cljs
@@ -28,7 +28,8 @@
                       :subtype nil
                       :current-step :type
                       :credentials {}
-                      :tags {}}
+                      :tags {}
+                      :command-args []}
    :database-schema {:status :loading, :schema-tree nil, :indexes-tree nil}
    :dialog {:status :closed
             :type :info


### PR DESCRIPTION
Introduce an argument-based interface for command input, improving flexibility and usability.

The API expects a list, and current behavior splits the string input by space. We should let the user input a string and so giving users more power while removing the magic from the process.

![2025-05-13 15 40 50](https://github.com/user-attachments/assets/e134f417-b12d-48a0-94d2-16b087d8df3a)

