### PR TITLE
Remove unused notification block from Helm values

### DIFF
--- a/deploy/helm-chart/chart/gateway/values.yaml
+++ b/deploy/helm-chart/chart/gateway/values.yaml
@@ -40,9 +40,6 @@ config:
   # GOOGLE_APPLICATION_CREDENTIALS_JSON: ''
   # PLUGIN_AUDIT_PATH: ''
   # PLUGIN_INDEX_PATH: ''
-  notification: {}
-  #   slackBotToken: ''
-  #   bridgeUrl: ''
 
 mainService:
   # -- Annotations to add in the main service


### PR DESCRIPTION
A search over the Helm chart shows that the`.Values.config.notification` map is declared but not used anywhere in the templates. It can be removed to avoid confusion.