### PR TITLE
Audit the postgres wire protocol instead of performing pre-parsing input queries

### DIFF
--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -136,7 +136,7 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 			}
 			if sshHostKeySigner == nil || err != nil {
 				log.Debug("unable to parse SSH host key received from server, using random key")
-				log.Debug("parse host key error=%v", err)
+				log.Debugf("parse host key error=%v", err)
 			}
 			connnectionType := pb.ConnectionType(pkt.Spec[pb.SpecConnectionType])
 			switch connnectionType {

--- a/common/pgtypes/packet_test.go
+++ b/common/pgtypes/packet_test.go
@@ -1,0 +1,47 @@
+package pgtypes
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseQuery(t *testing.T) {
+	for _, tt := range []struct {
+		msg      string
+		hexQuery string
+		expected []byte
+	}{
+		{
+			msg:      "it must match extended query format",
+			hexQuery: "50000000100053454c4543542031000000",
+			expected: []byte("SELECT 1"),
+		},
+		{
+			msg:      "it must match extended query format with complex query",
+			hexQuery: "50000000ad002d2d204d657461626173653a3a207573657249443a2031207175657279547970653a204d42514c207175657279486173683a20356437313564636230343139343830626630363138653661353763623632353931303537646237393161653632353236333962373932333665343830653834640a53454c45435420434f554e54282a292041532022636f756e74222046524f4d20227075626c6963222e226f726465727322000000",
+			expected: []byte(`-- Metabase:: userID: 1 queryType: MBQL queryHash: 5d715dcb0419480bf0618e6a57cb62591057db791ae6252639b79236e480e84d
+SELECT COUNT(*) AS "count" FROM "public"."orders"`),
+		},
+		{
+			msg:      "it must match extended query format with named query",
+			hexQuery: "500000003f6765745f757365725f62795f69640053454c454354202a2046524f4d207573657273205748455245206964203d20243100000100000017",
+			expected: []byte(`SELECT * FROM users WHERE id = $1`),
+		},
+		{
+			msg:      "it must match simple query format",
+			hexQuery: "510000003673656c656374202a2066726f6d20637573746f6d65727320776865726520656d61696c206c696b652027256a6f686e252700",
+			expected: []byte(`select * from customers where email like '%john%'`),
+		},
+	} {
+		t.Run(tt.msg, func(t *testing.T) {
+			data, err := hex.DecodeString(tt.hexQuery)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := ParseQuery(data)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -1986,7 +1986,7 @@ const docTemplate = `{
         },
         "/plugins/runbooks/connections/{name}/exec": {
             "post": {
-                "description": "Start a execution using a Runbook as input",
+                "description": "Start a execution using a Runbook as input. If the connection has a JIRA issue template configured, it will create a JIRA issue.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3026,10 +3026,15 @@ const docTemplate = `{
                     {
                         "enum": [
                             "utf8",
-                            "base64"
+                            "base64",
+                            "raw-queries"
                         ],
                         "type": "string",
-                        "description": "This option will parse the session output (o) and error (e) events as an utf-8 content in the session payload",
+                        "x-enum-varnames": [
+                            "SessionEventStreamUTF8Type",
+                            "SessionEventStreamBase64Type",
+                            "SessionEventStreamRawQueriesType"
+                        ],
                         "name": "event_stream",
                         "in": "query"
                     },
@@ -3092,8 +3097,20 @@ const docTemplate = `{
                             "$ref": "#/definitions/openapi.Session"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "schema": {
                             "$ref": "#/definitions/openapi.HTTPError"
                         }
@@ -5833,6 +5850,13 @@ const docTemplate = `{
                     "type": "string",
                     "example": "myrunbooks/run-backup.runbook.sql"
                 },
+                "jira_fields": {
+                    "description": "Jira fields to create a Jira issue",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "metadata": {
                     "description": "Metadata attributes to add in the session",
                     "type": "object",
@@ -6252,6 +6276,19 @@ const docTemplate = `{
                     ]
                 }
             }
+        },
+        "openapi.SessionEventStreamType": {
+            "type": "string",
+            "enum": [
+                "utf8",
+                "base64",
+                "raw-queries"
+            ],
+            "x-enum-varnames": [
+                "SessionEventStreamUTF8Type",
+                "SessionEventStreamBase64Type",
+                "SessionEventStreamRawQueriesType"
+            ]
         },
         "openapi.SessionLabelsType": {
             "type": "object",

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -399,6 +399,18 @@ type (
 	SessionOptionKey                     string
 )
 
+// Parse available options for the event stream
+// * utf8 - parse the session output (o) and error (e) events as utf-8 content in the session payload
+// * base64 - parse the session output (o) and error (e) events as base64 content in the session payload
+// * raw-queries - encode each event stream parsing the input of queries based on the database wire protocol (available databases: postgres)
+type SessionEventStreamType string
+
+const (
+	SessionEventStreamUTF8Type       SessionEventStreamType = "utf8"
+	SessionEventStreamBase64Type     SessionEventStreamType = "base64"
+	SessionEventStreamRawQueriesType SessionEventStreamType = "raw-queries"
+)
+
 type SessionGetByIDParams struct {
 	// The file extension to donwload the session as a file content.
 	// * `csv` - it will parse the content to format in csv format
@@ -413,9 +425,8 @@ type SessionGetByIDParams struct {
 	// Construct the file content adding a break line when parsing each event
 	NewLine string `json:"new_line" enums:"0,1" example:"1" default:"0"`
 	// Construct the file content adding the event time as prefix when parsing each event
-	EventTime string `json:"event-time" enums:"0,1" example:"1" default:"0"`
-	// This option will parse the session output (o) and error (e) events as an utf-8 content in the session payload
-	EventStream string `json:"event_stream" enums:"utf8,base64" default:""`
+	EventTime   string                 `json:"event-time" enums:"0,1" example:"1" default:"0"`
+	EventStream SessionEventStreamType `json:"event_stream" default:""`
 	// Expand the given attributes
 	Expand string `json:"expand" enums:"event_stream" example:"event_stream" default:""`
 }

--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -7,14 +7,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
-const (
-	tableSessions string = "private.sessions"
-	tableBlobs    string = "private.blobs"
-)
+// indicates the blob is stored in database wire protocol
+const BlobFormatWireProtoType string = "wire-proto"
 
 type BlobInputType string
 
@@ -72,7 +71,7 @@ type Session struct {
 	Metrics              map[string]any    `gorm:"column:metrics;serializer:json"`
 	BlobInputID          sql.NullString    `gorm:"column:blob_input_id"`
 	BlobInput            BlobInputType     `gorm:"-"`
-	BlobStream           json.RawMessage   `gorm:"-"`
+	BlobStream           *Blob             `gorm:"-"`
 	BlobStreamSize       int64             `gorm:"column:blob_stream_size;->"`
 	UserID               string            `gorm:"column:user_id"`
 	UserName             string            `gorm:"column:user_name"`
@@ -90,6 +89,7 @@ type SessionDone struct {
 	OrgID      string
 	Metrics    map[string]any
 	BlobStream json.RawMessage
+	BlobFormat *string
 	ExitCode   *int
 	Status     string
 	EndSession *time.Time
@@ -117,6 +117,7 @@ type Blob struct {
 	OrgID      string          `gorm:"column:org_id"`
 	BlobStream json.RawMessage `gorm:"column:blob_stream"`
 	Type       string          `gorm:"column:type"`
+	BlobFormat *string         `gorm:"column:format"`
 }
 type SessionReview struct {
 	ID                string         `json:"id"`
@@ -149,7 +150,7 @@ func (r *SessionReview) Scan(value any) error {
 func (s *Session) getBlobInput() (string, error) {
 	var blob Blob
 	err := DB.Raw(`
-	SELECT b.id, b.org_id, b.blob_stream, b.type
+	SELECT b.id, b.org_id, b.blob_stream, b.type, b.format
 	FROM private.sessions s
 	LEFT JOIN private.blobs AS b ON b.type = 'session-input' AND  b.id = s.blob_input_id
 	WHERE s.org_id = ? AND s.id = ?`, s.OrgID, s.ID).
@@ -171,12 +172,15 @@ func (s *Session) getBlobInput() (string, error) {
 func (s *Session) GetBlobStream() (*Blob, error) {
 	var blob Blob
 	return &blob, DB.Raw(`
-	SELECT b.id, b.org_id, b.blob_stream, b.type
+	SELECT b.id, b.org_id, b.blob_stream, b.type, b.format
 	FROM private.sessions s
 	LEFT JOIN private.blobs AS b ON b.type = 'session-stream' AND  b.id = s.blob_stream_id
 	WHERE s.org_id = ? AND s.id = ?`, s.OrgID, s.ID).
 		First(&blob).Error
 }
+
+// Report if the blob is stored as database wire protocol format
+func (b Blob) IsWireProtocol() bool { return b.BlobFormat == ptr.String(BlobFormatWireProtoType) }
 
 func GetSessionByID(orgID, sid string) (*Session, error) {
 	session := &Session{}
@@ -367,17 +371,17 @@ func UpsertSession(sess Session) error {
 			Type:       "session-input",
 			BlobStream: json.RawMessage(fmt.Sprintf("[%q]", sess.BlobInput)),
 		}
-		res := tx.Table(tableBlobs).
+		res := tx.Table("private.blobs").
 			Where("org_id = ? AND id = ?", sess.OrgID, blobInputID.String).
 			Updates(blobInput)
 		if res.Error == nil && res.RowsAffected == 0 {
-			res.Error = tx.Table(tableBlobs).Create(blobInput).Error
+			res.Error = tx.Table("private.blobs").Create(blobInput).Error
 		}
 
 		if res.Error != nil {
 			return fmt.Errorf("failed creating session blob input, reason=%v", res.Error)
 		}
-		return tx.Table(tableSessions).Save(
+		return tx.Table("private.sessions").Save(
 			Session{
 				ID:                   sess.ID,
 				OrgID:                sess.OrgID,
@@ -416,12 +420,13 @@ func UpdateSessionEventStream(sess SessionDone) error {
 			OrgID:      sess.OrgID,
 			BlobStream: sess.BlobStream,
 			Type:       "session-stream",
+			BlobFormat: sess.BlobFormat,
 		}
-		res := tx.Table(tableBlobs).
+		res := tx.Table("private.blobs").
 			Where("org_id = ? AND id = ?", sess.OrgID, blobStreamID.String).
 			Updates(blobStream)
 		if res.Error == nil && res.RowsAffected == 0 {
-			res.Error = tx.Table(tableBlobs).Create(blobStream).Error
+			res.Error = tx.Table("private.blobs").Create(blobStream).Error
 		}
 
 		if res.Error != nil {
@@ -429,7 +434,7 @@ func UpdateSessionEventStream(sess SessionDone) error {
 		}
 
 		// update: status, labels, metrics, end_date, exit_code, event_stream
-		return tx.Table(tableSessions).
+		return tx.Table("private.sessions").
 			Where("org_id = ? AND id = ?", sess.OrgID, sess.ID).
 			Updates(sessionDone{
 				ID:           sess.ID,
@@ -445,7 +450,7 @@ func UpdateSessionEventStream(sess SessionDone) error {
 }
 
 func UpdateSessionIntegrationMetadata(orgID, sid string, metadata map[string]any) error {
-	res := DB.Table(tableSessions).
+	res := DB.Table("private.sessions").
 		Where("org_id = ? AND id = ?", orgID, sid).
 		Updates(Session{IntegrationsMetadata: metadata})
 	if res.Error == nil && res.RowsAffected == 0 {
@@ -455,7 +460,7 @@ func UpdateSessionIntegrationMetadata(orgID, sid string, metadata map[string]any
 }
 
 func UpdateSessionMetadata(orgID, userEmail, sid string, metadata map[string]any) error {
-	res := DB.Table(tableSessions).
+	res := DB.Table("private.sessions").
 		Where("org_id = ? AND id = ? AND user_email = ?", orgID, sid, userEmail).
 		Updates(Session{Metadata: metadata})
 	if res.Error == nil && res.RowsAffected == 0 {
@@ -472,6 +477,7 @@ func UpdateSessionInput(orgID, sid, blobInput string) error {
 			OrgID:      orgID,
 			Type:       "session-input",
 			BlobStream: json.RawMessage(fmt.Sprintf("[%q]", blobInput)),
+			BlobFormat: nil,
 		}
 		res := tx.Table("private.blobs").
 			Where("org_id = ? AND id = ?", orgID, blobInputID).

--- a/gateway/session/wal/header.go
+++ b/gateway/session/wal/header.go
@@ -9,15 +9,7 @@ type Header struct {
 	EventLogVersion string     `json:"log_version"`
 	OrgID           string     `json:"org_id"`
 	SessionID       string     `json:"session_id"`
-	UserID          string     `json:"user_id"`
-	UserName        string     `json:"user_name"`
-	UserEmail       string     `json:"user_email"`
-	ConnectionName  string     `json:"connection_name"`
-	ConnectionType  string     `json:"connection_type"`
 	Status          string     `json:"status"`
-	Script          string     `json:"script"`
-	Labels          string     `json:"labels"` // we save it as string and convert at storage layer
-	Verb            string     `json:"verb"`
 	StartDate       *time.Time `json:"start_date"`
 }
 

--- a/gateway/session/wal/wal_test.go
+++ b/gateway/session/wal/wal_test.go
@@ -14,11 +14,9 @@ import (
 func newFakeHeader(orgID string) *Header {
 	t := time.Now().UTC()
 	return &Header{
-		OrgID:          orgID,
-		SessionID:      uuid.NewString(),
-		ConnectionName: "fake-conn",
-		ConnectionType: "command-line",
-		StartDate:      &t,
+		OrgID:     orgID,
+		SessionID: uuid.NewString(),
+		StartDate: &t,
 	}
 }
 

--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/common/memory"
 	mssqltypes "github.com/hoophq/hoop/common/mssqltypes"
-	pgtypes "github.com/hoophq/hoop/common/pgtypes"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbagent "github.com/hoophq/hoop/common/proto/agent"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
@@ -113,15 +112,7 @@ func (p *auditPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 			return nil, p.writeOnReceive(pctx.SID, eventlogv1.OutputType, nil, eventMetadata)
 		}
 	case pbagent.PGConnectionWrite:
-		isSimpleQuery, queryBytes, err := pgtypes.SimpleQueryContent(pkt.Payload)
-		if !isSimpleQuery {
-			break
-		}
-		if err != nil {
-			log.With("sid", pctx.SID).Errorf("failed parsing simple query data, err=%v", err)
-			return nil, fmt.Errorf("failed obtaining simple query data, reason=%v", err)
-		}
-		return nil, p.writeOnReceive(pctx.SID, eventlogv1.InputType, queryBytes, eventMetadata)
+		return nil, p.writeOnReceive(pctx.SID, eventlogv1.InputType, pkt.Payload, eventMetadata)
 	case pbagent.MySQLConnectionWrite:
 		if queryBytes := decodeMySQLCommandQuery(pkt.Payload); queryBytes != nil {
 			return nil, p.writeOnReceive(pctx.SID, eventlogv1.InputType, queryBytes, eventMetadata)

--- a/gateway/transport/plugins/types/types.go
+++ b/gateway/transport/plugins/types/types.go
@@ -108,6 +108,10 @@ func (c *Context) Validate() error {
 	return nil
 }
 
+func (c Context) ProtoConnectionType() pb.ConnectionType {
+	return pb.ToConnectionType(c.ConnectionType, c.ConnectionSubType)
+}
+
 func (m GenericMap) Get(key string) any { return m[key] }
 func (m GenericMap) GetString(key string) string {
 	val, ok := m[key]

--- a/rootfs/app/migrations/000037_blob_format.down.sql
+++ b/rootfs/app/migrations/000037_blob_format.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE private.blobs DROP COLUMN format;

--- a/rootfs/app/migrations/000037_blob_format.up.sql
+++ b/rootfs/app/migrations/000037_blob_format.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE private.blobs ADD COLUMN format VARCHAR(40) NULL;


### PR DESCRIPTION
- Audit extended query protocol
- Add event stream option `raw-queries` which parses the native database wire protocol to input queries
- Add backward compatibility with older postgres session formats
- Add attribute into blobs table to specify which format the blob is stored