### PR TITLE
Improve Jira CMDB Error Handling and Fix Retry Loop

### DIFF
--- a/webapp/src/webapp/jira_templates/cmdb_error.cljs
+++ b/webapp/src/webapp/jira_templates/cmdb_error.cljs
@@ -1,0 +1,15 @@
+(ns webapp.jira-templates.cmdb-error
+  (:require
+   ["@radix-ui/themes" :refer [Box Button Flex Heading Text]]))
+
+(defn main [{:keys [on-retry on-cancel]}]
+  [:> Box
+   [:> Heading {:size "6" :mb "2" :class "text-[--gray-12]"}
+    "Jira CMDB Connection Issue"]
+   [:> Text {:as "p" :size "3" :mb "4" :class "text-[--gray-11]"}
+    "We couldn't retrieve some required CMDB data from your Jira server. This template requires valid CMDB fields to continue."]
+   [:> Text {:as "p" :size "2" :mb "7" :class "text-[--orange-11]"}
+    "This is usually due to Jira server availability or permission issues. Please contact your Jira administrator to ensure the CMDB service is functioning properly."]
+   [:> Flex {:gap "3" :justify "end"}
+    [:> Button {:variant "soft" :on-click on-cancel} "Cancel"]
+    [:> Button {:variant "solid" :on-click on-retry} "Try again"]]])

--- a/webapp/src/webapp/jira_templates/loading_jira_templates.cljs
+++ b/webapp/src/webapp/jira_templates/loading_jira_templates.cljs
@@ -5,9 +5,7 @@
 (defn main []
   [:> Box
    [:> Heading {:size "6" :mb "2" :class "text-[--gray-12]"}
-    "Verifying Jira Templates"]
+    "Loading Jira Template"]
    [:> Text {:as "p" :size "3" :mb "7" :class "text-[--gray-11]"}
-    (str "This connection has additional verification for Jira Templates "
-         "and might take a few seconds before proceeding. Please wait until "
-         "the verification is processed without closing this tab.")]
+    "Loading template data from Jira. If your template includes CMDB fields, this may take longer as we need to fetch additional data from your Jira server."]
    [:> Spinner {:size "3" :class "justify-self-end"}]])


### PR DESCRIPTION
## Problem
When executing a query for a connection with a Jira template that requires CMDB data, the system would get stuck in an infinite loading state if:
1. The initial CMDB request timed out
2. The user clicked "Try Again"
3. The retry was successful

This created a poor user experience as users were stuck in a loading screen with no way to proceed, even though the data was successfully retrieved.

## Solution
This PR enhances the error handling for Jira CMDB requests by:

1. Providing clearer messaging about CMDB loading and errors
2. Implementing a complete retry flow that properly handles both success and failure cases
3. Maintaining context across retry attempts to ensure the user can continue their workflow

## Technical Changes

### 1. Improved Loading Screen
- Updated text in `loading_jira_templates.cljs` to clarify that CMDB data is being loaded from Jira
- Made it clear that longer waits might be related to Jira server performance, not Hoop

### 2. Added Error UI Component
- Created `cmdb_error.cljs` to display user-friendly error messages
- Clearly explains the issue is with Jira's CMDB service, not Hoop
- Provides guidance to contact Jira administrators
- Offers options to retry or cancel

### 3. Enhanced CMDB Data Processing
- Modified `:jira-templates->merge-cmdb-values` to track and handle failed requests
- Added detection logic for request completion (both success and failure cases)
- Improved state management for retry attempts

### 4. Fixed Retry Flow
- Implemented context tracking between error and retry attempts
- Added `:jira-templates->continue-after-retry` event to handle successful retries
- Ensured proper flow continuation for both editor and runbooks plugins

### 5. Context-Aware Error Handling
- Updated error handling to preserve flow context (script, metadata, parameters)
- Ensured both editor and runbooks flows handle CMDB errors consistently

## Testing
The changes have been tested in various scenarios:
- Templates without CMDB dependencies (normal flow)
- Templates with CMDB, successful loading
- Templates with CMDB, failed loading (timeout)
- Templates with CMDB, failed then successful retry
- Templates with CMDB, failed then failed retry

## User Experience Improvements
- Users now receive clear information about what's happening during CMDB loading
- Error messages specifically indicate when problems are with Jira servers, not Hoop
- When retrying a failed CMDB request that succeeds, users are correctly returned to their workflow
- Users are instructed to contact their Jira administrators when appropriate

This PR resolves the issue where users would get stuck in a loading state after a successful retry.

## Screenshots
![Screen Recording 2025-05-27 at 16 57 26](https://github.com/user-attachments/assets/42b80961-d566-4283-860e-74f99c7a152a)
