### PR TITLE
AWS Connect: Tag connection resources after provisioning

### DIFF
--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -1215,6 +1215,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/openapi.HTTPError"
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
                     }
                 }
             }
@@ -3930,6 +3936,17 @@ const docTemplate = `{
                     "description": "AvailabilityZone is the AWS availability zone where the database is deployed",
                     "type": "string",
                     "example": "us-west-2a"
+                },
+                "connection_resources": {
+                    "description": "Contains the connection resources that were already provisioned.\nThe resources are marked with a specific tag after completion.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "pgtest1",
+                        "pgtest2"
+                    ]
                 },
                 "engine": {
                     "description": "Engine is the database engine type (e.g., MySQL, PostgreSQL)",

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1287,6 +1287,9 @@ type AWSDBInstance struct {
 	Engine string `json:"engine" example:"postgres"`
 	// Status indicates the current state of the database instance
 	Status string `json:"status" example:"available"`
+	// Contains the connection resources that were already provisioned.
+	// The resources are marked with a specific tag after completion.
+	ConnectionResources []string `json:"connection_resources" example:"pgtest1,pgtest2"`
 	// Contains an error in case it was not able to list the db instances from the account id
 	Error *string `json:"error" example:"IAM account does not have permission to list db instances in this account"`
 }


### PR DESCRIPTION
- Add connection_resources attribute to list db instances to identify which resources were already provisioned