### PR TITLE
[WIP] Jira: refactor jira assets objects api to list paginated resources

### DIFF
--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -1357,6 +1357,65 @@ const docTemplate = `{
                 }
             }
         },
+        "/integrations/jira/assets/objects": {
+            "get": {
+                "description": "Get objects from the Jira Service Management (JSM) Assets API",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Jira"
+                ],
+                "summary": "Get Asset Objects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The Jira object type to filter values for",
+                        "name": "object_type_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The Jira object schema id to fetch values for",
+                        "name": "object_schema_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Specify a name to filter",
+                        "name": "name",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.JiraAssetObjects"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/integrations/jira/issuetemplates": {
             "get": {
                 "description": "List Issue Templates",
@@ -1560,61 +1619,6 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/integrations/jira/issuetemplates/{id}/objects": {
-            "get": {
-                "description": "Get values for a specific Jira object type in an Issue Template",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Jira"
-                ],
-                "summary": "Get Object Type Values for Issue Template",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "The id of the template",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "The Jira object type to fetch values for",
-                        "name": "object_type",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
                     },
                     "404": {
                         "description": "Not Found",
@@ -4957,6 +4961,42 @@ const docTemplate = `{
                     "description": "Region is the AWS region where the IAM user is operating",
                     "type": "string",
                     "example": "us-west-2"
+                }
+            }
+        },
+        "openapi.JiraAssetObjectValue": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "The object identifier",
+                    "type": "string",
+                    "example": "c1ee84ab-76c8-40d9-a956-13a705d4e605:11013"
+                },
+                "name": {
+                    "description": "Name of the object value",
+                    "type": "string",
+                    "example": "mycomputer-asset"
+                }
+            }
+        },
+        "openapi.JiraAssetObjects": {
+            "type": "object",
+            "properties": {
+                "has_next_page": {
+                    "description": "Indicate if it has more items",
+                    "type": "boolean"
+                },
+                "total": {
+                    "description": "Total amount of records found",
+                    "type": "integer",
+                    "example": 22
+                },
+                "values": {
+                    "description": "The object values found",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.JiraAssetObjectValue"
+                    }
                 }
             }
         },

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1049,6 +1049,22 @@ type JiraIssueTemplateRequest struct {
 	ConnectionIDs []string `json:"connection_ids"`
 }
 
+type JiraAssetObjectValue struct {
+	// The object identifier
+	ID string `json:"id" example:"c1ee84ab-76c8-40d9-a956-13a705d4e605:11013"`
+	// Name of the object value
+	Name string `json:"name" example:"mycomputer-asset"`
+}
+
+type JiraAssetObjects struct {
+	// The object values found
+	Values []JiraAssetObjectValue `json:"values"`
+	// Total amount of records found
+	Total int64 `json:"total" example:"22"`
+	// Indicate if it has more items
+	HasNextPage bool `json:"has_next_page"`
+}
+
 type GuardRailRuleRequest struct {
 	// Unique name for the rule
 	Name string `json:"name" binding:"required" example:"my-strict-rule"`

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -569,15 +569,15 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		apijiraintegration.GetIssueTemplatesByID,
 	)
-	r.GET("/integrations/jira/issuetemplates/:id/objecttype-values",
-		r.AuthMiddleware,
-		apijiraintegration.GetIssueTemplateObjectTypeValues)
-
 	r.DELETE("/integrations/jira/issuetemplates/:id",
 		apiroutes.AdminOnlyAccessRole,
 		r.AuthMiddleware,
 		apijiraintegration.DeleteIssueTemplates,
 	)
+
+	r.GET("/integrations/jira/assets/objects",
+		r.AuthMiddleware,
+		apijiraintegration.GetAssetObjects)
 
 	// AWS routes
 	r.GET("/integrations/aws/iam/userinfo",

--- a/gateway/jira/assetsapi.go
+++ b/gateway/jira/assetsapi.go
@@ -2,11 +2,13 @@ package jira
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/hoophq/hoop/gateway/models"
 )
@@ -17,41 +19,48 @@ const (
 	maxPaginationRequests int    = 50
 )
 
+var defaultRequestTimeout = time.Second * 50
+
+type ErrTimeoutReached struct {
+	apiResource string
+	query       string
+}
+
+func (e ErrTimeoutReached) Error() string {
+	return fmt.Sprintf("request timeout (%v) reached fetching resource %q, query=%q",
+		defaultRequestTimeout, e.apiResource, e.query)
+}
+
 // FetchObjectsByAQL list objects paginated based in the Jira AQL query expression
 // https://support.atlassian.com/jira-service-management-cloud/docs/use-assets-query-language-aql/
-func FetchObjectsByAQL(config *models.JiraIntegration, query string, a ...any) (items []AqlResponse, err error) {
-	vals := url.Values{}
-	vals.Set("maxResults", fmt.Sprintf("%v", defaultMaxResults))
-	for i := 0; ; i++ {
-		vals.Set("startAt", fmt.Sprintf("%v", defaultMaxResults*i))
-		resp, err := fetchObjectsByAQL(config, vals, query, a...)
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, *resp)
-		if resp.Last {
-			break
-		}
-		if i >= maxPaginationRequests {
-			return nil, fmt.Errorf("reached max (%v) pagination requests", maxPaginationRequests)
-		}
-
+func FetchObjectsByAQL(config *models.JiraIntegration, limit, offset int, query string) (*AqlResponse, error) {
+	if limit > defaultMaxResults {
+		limit = defaultMaxResults
 	}
-	return
+	vals := url.Values{}
+	vals.Set("maxResults", fmt.Sprintf("%v", limit))
+	vals.Set("startAt", fmt.Sprintf("%v", offset))
+	vals.Set("includeAttributes", "false")
+	return fetchObjectsByAQL(config, vals, query)
 }
 
 // https://developer.atlassian.com/cloud/assets/rest/api-group-object/#api-object-aql-post
-func fetchObjectsByAQL(config *models.JiraIntegration, queryVals url.Values, query string, a ...any) (*AqlResponse, error) {
-	query = fmt.Sprintf(query, a...)
-	workspaceID, err := fetchWorkspaceID(config)
+func fetchObjectsByAQL(config *models.JiraIntegration, queryVals url.Values, query string) (*AqlResponse, error) {
+	ctx, cancelFn := context.WithTimeoutCause(context.Background(), defaultRequestTimeout, &ErrTimeoutReached{})
+	defer cancelFn()
+	workspaceID, err := fetchWorkspaceID(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	totalCount, err := fetchTotalCountObjects(ctx, config, queryVals, workspaceID, query)
 	if err != nil {
 		return nil, err
 	}
 
 	queryPayload := map[string]any{"qlQuery": query}
 	requestBody, _ := json.Marshal(queryPayload)
-	apiURL := fmt.Sprintf("%s/%s/v1/object/aql?maxResults=%v", baseAssetsAPI, workspaceID, defaultMaxResults)
-	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(requestBody))
+	apiURL := fmt.Sprintf("%s/%s/v1/object/aql?maxResults=%v&includeAttributes=false", baseAssetsAPI, workspaceID, defaultMaxResults)
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed creating objects aql query request, reason=%v", err)
 	}
@@ -62,6 +71,11 @@ func fetchObjectsByAQL(config *models.JiraIntegration, queryVals url.Values, que
 	req.SetBasicAuth(config.User, config.APIToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		if errCtx, ok := context.Cause(ctx).(*ErrTimeoutReached); ok {
+			errCtx.apiResource = "objects-aql"
+			errCtx.query = query
+			return nil, errCtx
+		}
 		return nil, fmt.Errorf("failed fetching asset objects, query=%v, reason=%v", query, err)
 	}
 	defer resp.Body.Close()
@@ -74,12 +88,13 @@ func fetchObjectsByAQL(config *models.JiraIntegration, queryVals url.Values, que
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, fmt.Errorf("failed decoding objects aql query response, reason=%v", err)
 	}
+	response.TotalCount = totalCount
 	return &response, nil
 }
 
-func fetchWorkspaceID(config *models.JiraIntegration) (string, error) {
+func fetchWorkspaceID(ctx context.Context, config *models.JiraIntegration) (string, error) {
 	apiURL := fmt.Sprintf("%s/rest/servicedeskapi/assets/workspace", config.URL)
-	req, err := http.NewRequest("GET", apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed creating request to obtain workspace id, reason=%v", err)
 	}
@@ -88,6 +103,10 @@ func fetchWorkspaceID(config *models.JiraIntegration) (string, error) {
 	req.SetBasicAuth(config.User, config.APIToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		if errCtx, ok := context.Cause(ctx).(*ErrTimeoutReached); ok {
+			errCtx.apiResource = "workspace"
+			return "", errCtx
+		}
 		return "", fmt.Errorf("failed perform request to obtain workspace id, reason=%v", err)
 	}
 	defer resp.Body.Close()
@@ -97,6 +116,47 @@ func fetchWorkspaceID(config *models.JiraIntegration) (string, error) {
 			apiURL, resp.StatusCode, string(body))
 	}
 	return decodeWorkspaceID(resp.Body)
+}
+
+func fetchTotalCountObjects(ctx context.Context, config *models.JiraIntegration, queryVals url.Values, workspaceID, query string) (int64, error) {
+	apiURL := fmt.Sprintf("%s/%s/v1/object/aql/totalcount", baseAssetsAPI, workspaceID)
+	queryPayload := map[string]any{"qlQuery": query}
+	requestBody, _ := json.Marshal(queryPayload)
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return 0, fmt.Errorf("failed creating objects aql query total count request, reason=%v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	req.URL.RawQuery = queryVals.Encode()
+	req.SetBasicAuth(config.User, config.APIToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if errCtx, ok := context.Cause(ctx).(*ErrTimeoutReached); ok {
+			errCtx.apiResource = "aql-totalcount"
+			errCtx.query = query
+			return 0, errCtx
+		}
+		return 0, fmt.Errorf("failed obtaining aql total count, query=%v, reason=%v", query, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("unable to fetch aql query total count, api-url=%v, status=%v, body=%v",
+			apiURL, resp.StatusCode, string(body))
+	}
+	var response map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return 0, fmt.Errorf("failed decoding objects aql query total count response, reason=%v", err)
+	}
+	totalCount, ok := response["totalCount"].(float64)
+	if !ok {
+		return 0, fmt.Errorf("unable to decode totalCount attribute from aql query, type=%T, value=%#q",
+			response["totalCount"], response["totalCount"])
+	}
+	return int64(totalCount), nil
 }
 
 func decodeWorkspaceID(body io.Reader) (string, error) {

--- a/gateway/jira/types.go
+++ b/gateway/jira/types.go
@@ -110,6 +110,7 @@ type AqlResponse struct {
 	Total          int  `json:"total"`
 	Last           bool `json:"last"`
 	HasMoreResults bool `json:"hasMoreResults"`
+	TotalCount     int64
 
 	Values []AqlResponseValue `json:"values"`
 }


### PR DESCRIPTION
- **Breaking Change:** remove route GET /api/integrations/jira/issuetemplates/123/objecttype-values
- Introduce new route to list object values from Jira Assets API
- Add default timeout (50s) when performing request to asset objects api
- Remove `extend=cmdb-values` attribute when listing issue templates
- Add better logging and propagate errors properly to the client