### PR TITLE
Jira: Implementation of Pagination for CMDB Data

### DIFF
--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -1357,6 +1357,65 @@ const docTemplate = `{
                 }
             }
         },
+        "/integrations/jira/assets/objects": {
+            "get": {
+                "description": "Get objects from the Jira Service Management (JSM) Assets API",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Jira"
+                ],
+                "summary": "Get Asset Objects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The Jira object type to filter values for",
+                        "name": "object_type_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The Jira object schema id to fetch values for",
+                        "name": "object_schema_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Specify a name to filter",
+                        "name": "name",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.JiraAssetObjects"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/integrations/jira/issuetemplates": {
             "get": {
                 "description": "List Issue Templates",
@@ -1560,61 +1619,6 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/integrations/jira/issuetemplates/{id}/objects": {
-            "get": {
-                "description": "Get values for a specific Jira object type in an Issue Template",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Jira"
-                ],
-                "summary": "Get Object Type Values for Issue Template",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "The id of the template",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "The Jira object type to fetch values for",
-                        "name": "object_type",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
                     },
                     "404": {
                         "description": "Not Found",
@@ -4957,6 +4961,42 @@ const docTemplate = `{
                     "description": "Region is the AWS region where the IAM user is operating",
                     "type": "string",
                     "example": "us-west-2"
+                }
+            }
+        },
+        "openapi.JiraAssetObjectValue": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "The object identifier",
+                    "type": "string",
+                    "example": "c1ee84ab-76c8-40d9-a956-13a705d4e605:11013"
+                },
+                "name": {
+                    "description": "Name of the object value",
+                    "type": "string",
+                    "example": "mycomputer-asset"
+                }
+            }
+        },
+        "openapi.JiraAssetObjects": {
+            "type": "object",
+            "properties": {
+                "has_next_page": {
+                    "description": "Indicate if it has more items",
+                    "type": "boolean"
+                },
+                "total": {
+                    "description": "Total amount of records found",
+                    "type": "integer",
+                    "example": 22
+                },
+                "values": {
+                    "description": "The object values found",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.JiraAssetObjectValue"
+                    }
                 }
             }
         },

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1049,6 +1049,22 @@ type JiraIssueTemplateRequest struct {
 	ConnectionIDs []string `json:"connection_ids"`
 }
 
+type JiraAssetObjectValue struct {
+	// The object identifier
+	ID string `json:"id" example:"c1ee84ab-76c8-40d9-a956-13a705d4e605:11013"`
+	// Name of the object value
+	Name string `json:"name" example:"mycomputer-asset"`
+}
+
+type JiraAssetObjects struct {
+	// The object values found
+	Values []JiraAssetObjectValue `json:"values"`
+	// Total amount of records found
+	Total int64 `json:"total" example:"22"`
+	// Indicate if it has more items
+	HasNextPage bool `json:"has_next_page"`
+}
+
 type GuardRailRuleRequest struct {
 	// Unique name for the rule
 	Name string `json:"name" binding:"required" example:"my-strict-rule"`

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -569,15 +569,15 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		apijiraintegration.GetIssueTemplatesByID,
 	)
-	r.GET("/integrations/jira/issuetemplates/:id/objecttype-values",
-		r.AuthMiddleware,
-		apijiraintegration.GetIssueTemplateObjectTypeValues)
-
 	r.DELETE("/integrations/jira/issuetemplates/:id",
 		apiroutes.AdminOnlyAccessRole,
 		r.AuthMiddleware,
 		apijiraintegration.DeleteIssueTemplates,
 	)
+
+	r.GET("/integrations/jira/assets/objects",
+		r.AuthMiddleware,
+		apijiraintegration.GetAssetObjects)
 
 	// AWS routes
 	r.GET("/integrations/aws/iam/userinfo",

--- a/gateway/jira/assetsapi.go
+++ b/gateway/jira/assetsapi.go
@@ -2,11 +2,13 @@ package jira
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/hoophq/hoop/gateway/models"
 )
@@ -17,41 +19,48 @@ const (
 	maxPaginationRequests int    = 50
 )
 
+var defaultRequestTimeout = time.Second * 50
+
+type ErrTimeoutReached struct {
+	apiResource string
+	query       string
+}
+
+func (e ErrTimeoutReached) Error() string {
+	return fmt.Sprintf("request timeout (%v) reached fetching resource %q, query=%q",
+		defaultRequestTimeout, e.apiResource, e.query)
+}
+
 // FetchObjectsByAQL list objects paginated based in the Jira AQL query expression
 // https://support.atlassian.com/jira-service-management-cloud/docs/use-assets-query-language-aql/
-func FetchObjectsByAQL(config *models.JiraIntegration, query string, a ...any) (items []AqlResponse, err error) {
-	vals := url.Values{}
-	vals.Set("maxResults", fmt.Sprintf("%v", defaultMaxResults))
-	for i := 0; ; i++ {
-		vals.Set("startAt", fmt.Sprintf("%v", defaultMaxResults*i))
-		resp, err := fetchObjectsByAQL(config, vals, query, a...)
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, *resp)
-		if resp.Last {
-			break
-		}
-		if i >= maxPaginationRequests {
-			return nil, fmt.Errorf("reached max (%v) pagination requests", maxPaginationRequests)
-		}
-
+func FetchObjectsByAQL(config *models.JiraIntegration, limit, offset int, query string) (*AqlResponse, error) {
+	if limit > defaultMaxResults {
+		limit = defaultMaxResults
 	}
-	return
+	vals := url.Values{}
+	vals.Set("maxResults", fmt.Sprintf("%v", limit))
+	vals.Set("startAt", fmt.Sprintf("%v", offset))
+	vals.Set("includeAttributes", "false")
+	return fetchObjectsByAQL(config, vals, query)
 }
 
 // https://developer.atlassian.com/cloud/assets/rest/api-group-object/#api-object-aql-post
-func fetchObjectsByAQL(config *models.JiraIntegration, queryVals url.Values, query string, a ...any) (*AqlResponse, error) {
-	query = fmt.Sprintf(query, a...)
-	workspaceID, err := fetchWorkspaceID(config)
+func fetchObjectsByAQL(config *models.JiraIntegration, queryVals url.Values, query string) (*AqlResponse, error) {
+	ctx, cancelFn := context.WithTimeoutCause(context.Background(), defaultRequestTimeout, &ErrTimeoutReached{})
+	defer cancelFn()
+	workspaceID, err := fetchWorkspaceID(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	totalCount, err := fetchTotalCountObjects(ctx, config, queryVals, workspaceID, query)
 	if err != nil {
 		return nil, err
 	}
 
 	queryPayload := map[string]any{"qlQuery": query}
 	requestBody, _ := json.Marshal(queryPayload)
-	apiURL := fmt.Sprintf("%s/%s/v1/object/aql?maxResults=%v", baseAssetsAPI, workspaceID, defaultMaxResults)
-	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(requestBody))
+	apiURL := fmt.Sprintf("%s/%s/v1/object/aql?maxResults=%v&includeAttributes=false", baseAssetsAPI, workspaceID, defaultMaxResults)
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed creating objects aql query request, reason=%v", err)
 	}
@@ -62,6 +71,11 @@ func fetchObjectsByAQL(config *models.JiraIntegration, queryVals url.Values, que
 	req.SetBasicAuth(config.User, config.APIToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		if errCtx, ok := context.Cause(ctx).(*ErrTimeoutReached); ok {
+			errCtx.apiResource = "objects-aql"
+			errCtx.query = query
+			return nil, errCtx
+		}
 		return nil, fmt.Errorf("failed fetching asset objects, query=%v, reason=%v", query, err)
 	}
 	defer resp.Body.Close()
@@ -74,12 +88,13 @@ func fetchObjectsByAQL(config *models.JiraIntegration, queryVals url.Values, que
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, fmt.Errorf("failed decoding objects aql query response, reason=%v", err)
 	}
+	response.TotalCount = totalCount
 	return &response, nil
 }
 
-func fetchWorkspaceID(config *models.JiraIntegration) (string, error) {
+func fetchWorkspaceID(ctx context.Context, config *models.JiraIntegration) (string, error) {
 	apiURL := fmt.Sprintf("%s/rest/servicedeskapi/assets/workspace", config.URL)
-	req, err := http.NewRequest("GET", apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed creating request to obtain workspace id, reason=%v", err)
 	}
@@ -88,6 +103,10 @@ func fetchWorkspaceID(config *models.JiraIntegration) (string, error) {
 	req.SetBasicAuth(config.User, config.APIToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		if errCtx, ok := context.Cause(ctx).(*ErrTimeoutReached); ok {
+			errCtx.apiResource = "workspace"
+			return "", errCtx
+		}
 		return "", fmt.Errorf("failed perform request to obtain workspace id, reason=%v", err)
 	}
 	defer resp.Body.Close()
@@ -97,6 +116,47 @@ func fetchWorkspaceID(config *models.JiraIntegration) (string, error) {
 			apiURL, resp.StatusCode, string(body))
 	}
 	return decodeWorkspaceID(resp.Body)
+}
+
+func fetchTotalCountObjects(ctx context.Context, config *models.JiraIntegration, queryVals url.Values, workspaceID, query string) (int64, error) {
+	apiURL := fmt.Sprintf("%s/%s/v1/object/aql/totalcount", baseAssetsAPI, workspaceID)
+	queryPayload := map[string]any{"qlQuery": query}
+	requestBody, _ := json.Marshal(queryPayload)
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return 0, fmt.Errorf("failed creating objects aql query total count request, reason=%v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	req.URL.RawQuery = queryVals.Encode()
+	req.SetBasicAuth(config.User, config.APIToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if errCtx, ok := context.Cause(ctx).(*ErrTimeoutReached); ok {
+			errCtx.apiResource = "aql-totalcount"
+			errCtx.query = query
+			return 0, errCtx
+		}
+		return 0, fmt.Errorf("failed obtaining aql total count, query=%v, reason=%v", query, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("unable to fetch aql query total count, api-url=%v, status=%v, body=%v",
+			apiURL, resp.StatusCode, string(body))
+	}
+	var response map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return 0, fmt.Errorf("failed decoding objects aql query total count response, reason=%v", err)
+	}
+	totalCount, ok := response["totalCount"].(float64)
+	if !ok {
+		return 0, fmt.Errorf("unable to decode totalCount attribute from aql query, type=%T, value=%#q",
+			response["totalCount"], response["totalCount"])
+	}
+	return int64(totalCount), nil
 }
 
 func decodeWorkspaceID(body io.Reader) (string, error) {

--- a/gateway/jira/types.go
+++ b/gateway/jira/types.go
@@ -110,6 +110,7 @@ type AqlResponse struct {
 	Total          int  `json:"total"`
 	Last           bool `json:"last"`
 	HasMoreResults bool `json:"hasMoreResults"`
+	TotalCount     int64
 
 	Values []AqlResponseValue `json:"values"`
 }

--- a/webapp/src/webapp/components/forms.cljs
+++ b/webapp/src/webapp/components/forms.cljs
@@ -1,7 +1,7 @@
 (ns webapp.components.forms
   (:require
    ["@heroicons/react/24/outline" :as hero-outline-icon]
-   ["@radix-ui/themes" :refer [IconButton Select TextArea TextField]]
+   ["@radix-ui/themes" :refer [Select]]
    ["lucide-react" :refer [Eye EyeOff]]
    [clojure.string :as cs]
    [reagent.core :as r]))
@@ -25,24 +25,6 @@
                         "p-2 text-xs text-gray-700 leading-none whitespace-no-wrap shadow-lg")}
      text]
     [:div {:class "w-3 h-3 -mt-2 border-r border-b border-gray-300 bg-white transform rotate-45"}]]])
-
-(defonce common-styles
-  "relative block w-full
-   py-3 px-2
-   border border-gray-300 rounded-md
-   focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm disabled:opacity-50")
-
-(defonce common-styles-dark
-  "relative block w-full bg-transparent
-   py-3 px-2 text-white
-   border border-gray-400 rounded-md
-   focus:ring-white focus:border-white sm:text-sm disabled:opacity-50")
-
-(defonce input-styles
-  (str common-styles " h-12"))
-
-(defonce input-styles-dark
-  (str common-styles-dark " h-12"))
 
 (defn input
   "Multi purpose HTML input component.
@@ -131,22 +113,6 @@
             (if @eye-open?
               [:> Eye {:size 16}]
               [:> EyeOff {:size 16}])]])]])))
-
-(defn input-metadata [{:keys [label name id placeholder disabled required value on-change]}]
-  [:div {:class "relative"}
-   [:label {:htmlFor label
-            :class "absolute -top-2 left-2 inline-block bg-white px-1 text-xs font-medium text-gray-900"}
-    label]
-   [:div {:class "rt-TextFieldRoot rt-r-size-1 rt-variant-surface dark"}
-    [:input {:type "text"
-             :name name
-             :id id
-             :class "rt-reset rt-TextFieldInput"
-             :placeholder placeholder
-             :disabled (or disabled false)
-             :required (or required false)
-             :on-change on-change
-             :value value}]]])
 
 (defn textarea
   [{:keys [label

--- a/webapp/src/webapp/components/paginated_dropdown.cljs
+++ b/webapp/src/webapp/components/paginated_dropdown.cljs
@@ -1,0 +1,122 @@
+(ns webapp.components.paginated-dropdown
+  (:require
+   ["@radix-ui/themes" :refer [Flex Box Text]]
+   [reagent.core :as r]
+   [re-frame.core :as rf]))
+
+(defn- search-icon []
+  [:svg.h-5.w-5.text-gray-400
+   {:xmlns "http://www.w3.org/2000/svg"
+    :viewBox "0 0 20 20"
+    :fill "currentColor"}
+   [:path
+    {:fill-rule "evenodd"
+     :d "M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+     :clip-rule "evenodd"}]])
+
+(defn- chevron-icon [open?]
+  [:svg.h-5.w-5
+   {:xmlns "http://www.w3.org/2000/svg"
+    :viewBox "0 0 20 20"
+    :fill "currentColor"}
+   [:path
+    {:fill-rule "evenodd"
+     :d (if open?
+          "M14.77 12.79a.75.75 0 01-1.06-.02L10 8.832 6.29 12.77a.75.75 0 11-1.08-1.04l4.25-4.5a.75.75 0 011.08 0l4.25 4.5a.75.75 0 01-.02 1.06z"
+          "M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z")}]])
+
+(defn paginated-dropdown
+  "Um dropdown paginado com funcionalidade de busca
+
+   Parâmetros:
+   - options: lista de opções [{:value \"id\" :label \"texto\" :description \"descrição\"}]
+   - loading?: booleano indicando se está carregando dados
+   - on-search: função chamada quando o usuário digita na busca
+   - on-page-change: função chamada quando o usuário muda de página
+   - on-select: função chamada quando o usuário seleciona uma opção
+   - selected-value: valor atualmente selecionado
+   - placeholder: texto a mostrar quando nada está selecionado
+   - total-items: número total de itens
+   - current-page: página atual
+   - items-per-page: itens por página"
+  [{:keys [options loading? on-search on-page-change
+           on-select selected-value placeholder
+           total-items current-page items-per-page]}]
+  (let [open? (r/atom false)
+        search-term (r/atom "")
+        debounce-timer (atom nil)]
+    (fn [{:keys [options loading? on-search on-page-change
+                 on-select selected-value placeholder
+                 total-items current-page items-per-page]}]
+      [:div.relative
+       ;; Header do dropdown (o que é mostrado quando fechado)
+       [:div.dropdown-header.cursor-pointer.flex.items-center.justify-between.px-4.py-2.border.rounded.shadow-sm
+        {:on-click #(swap! open? not)}
+        [:div
+         (if selected-value
+           (if-let [selected-option (first (filter #(= (:value %) selected-value) options))]
+             (:label selected-option)
+             (or placeholder "Select an option"))
+           (or placeholder "Select an option"))]
+        [chevron-icon @open?]]
+
+       ;; Conteúdo do dropdown (aparece quando aberto)
+       (when @open?
+         [:div.absolute.left-0.right-0.mt-1.border.rounded.bg-white.shadow-lg.z-50
+          ;; Campo de busca
+          [:div.p-2.border-b
+           [:div.relative
+            [:span.absolute.inset-y-0.left-0.flex.items-center.pl-2
+             [search-icon]]
+            [:input.w-full.pl-8.pr-2.py-2.border.rounded
+             {:type "text"
+              :placeholder "Search options..."
+              :value @search-term
+              :on-change (fn [e]
+                           (let [value (.. e -target -value)]
+                             (reset! search-term value)
+                             (when @debounce-timer
+                               (js/clearTimeout @debounce-timer))
+                             (reset! debounce-timer
+                                     (js/setTimeout #(on-search value) 300))))}]]]
+
+          ;; Lista de opções
+          (cond
+            loading?
+            [:div.p-4.text-center.text-sm.text-gray-500 "Loading..."]
+
+            (empty? options)
+            [:div.p-4.text-center.text-sm.text-gray-500 "No options found"]
+
+            :else
+            [:div.max-h-60.overflow-y-auto
+             (for [option options]
+               ^{:key (:value option)}
+               [:div.px-4.py-2.hover:bg-gray-100.cursor-pointer
+                {:on-click #(do (on-select (:value option))
+                                (reset! open? false))}
+                [:div.font-medium (:label option)]
+                (when (:description option)
+                  [:div.text-sm.text-gray-500 (:description option)])])])
+
+          ;; Paginação
+          [:div.flex.items-center.justify-between.px-4.py-2.border-t.text-sm
+           [:div.text-xs.text-gray-500
+            (str "Showing "
+                 (inc (* (dec current-page) items-per-page)) "-"
+                 (min (* current-page items-per-page) total-items)
+                 " of " total-items)]
+           [:div.flex.space-x-2
+            [:button.px-2.py-1.border.rounded
+             {:disabled (= current-page 1)
+              :class (if (= current-page 1) "opacity-50 cursor-not-allowed" "hover:bg-gray-100")
+              :on-click #(when (> current-page 1)
+                           (on-page-change (dec current-page)))}
+             "←"]
+            [:div (str current-page "/" (js/Math.ceil (/ total-items items-per-page)))]
+            [:button.px-2.py-1.border.rounded
+             {:disabled (>= (* current-page items-per-page) total-items)
+              :class (if (>= (* current-page items-per-page) total-items) "opacity-50 cursor-not-allowed" "hover:bg-gray-100")
+              :on-click #(when (< (* current-page items-per-page) total-items)
+                           (on-page-change (inc current-page)))}
+             "→"]]]])])))

--- a/webapp/src/webapp/components/paginated_dropdown.cljs
+++ b/webapp/src/webapp/components/paginated_dropdown.cljs
@@ -108,14 +108,16 @@
                  " of " total-items)]
            [:div.flex.space-x-2
             [:button.px-2.py-1.border.rounded
-             {:disabled (= current-page 1)
+             {:type "button"
+              :disabled (= current-page 1)
               :class (if (= current-page 1) "opacity-50 cursor-not-allowed" "hover:bg-gray-100")
               :on-click #(when (> current-page 1)
                            (on-page-change (dec current-page)))}
              "←"]
             [:div (str current-page "/" (js/Math.ceil (/ total-items items-per-page)))]
             [:button.px-2.py-1.border.rounded
-             {:disabled (>= (* current-page items-per-page) total-items)
+             {:type "button"
+              :disabled (>= (* current-page items-per-page) total-items)
               :class (if (>= (* current-page items-per-page) total-items) "opacity-50 cursor-not-allowed" "hover:bg-gray-100")
               :on-click #(when (< (* current-page items-per-page) total-items)
                            (on-page-change (inc current-page)))}

--- a/webapp/src/webapp/components/paginated_dropdown.cljs
+++ b/webapp/src/webapp/components/paginated_dropdown.cljs
@@ -1,74 +1,55 @@
 (ns webapp.components.paginated-dropdown
   (:require
-   ["@radix-ui/themes" :refer [Flex Box Text]]
+   ["@radix-ui/themes" :refer [Box IconButton DropdownMenu Text]]
+   ["lucide-react" :refer [ArrowRight ArrowLeft]]
    [reagent.core :as r]
-   [re-frame.core :as rf]))
-
-(defn- search-icon []
-  [:svg.h-5.w-5.text-gray-400
-   {:xmlns "http://www.w3.org/2000/svg"
-    :viewBox "0 0 20 20"
-    :fill "currentColor"}
-   [:path
-    {:fill-rule "evenodd"
-     :d "M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
-     :clip-rule "evenodd"}]])
-
-(defn- chevron-icon [open?]
-  [:svg.h-5.w-5
-   {:xmlns "http://www.w3.org/2000/svg"
-    :viewBox "0 0 20 20"
-    :fill "currentColor"}
-   [:path
-    {:fill-rule "evenodd"
-     :d (if open?
-          "M14.77 12.79a.75.75 0 01-1.06-.02L10 8.832 6.29 12.77a.75.75 0 11-1.08-1.04l4.25-4.5a.75.75 0 011.08 0l4.25 4.5a.75.75 0 01-.02 1.06z"
-          "M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z")}]])
+   [webapp.components.forms :as forms]))
 
 (defn paginated-dropdown
-  "Um dropdown paginado com funcionalidade de busca
+  "A paginated dropdown with search functionality
 
-   Parâmetros:
-   - options: lista de opções [{:value \"id\" :label \"texto\" :description \"descrição\"}]
-   - loading?: booleano indicando se está carregando dados
-   - on-search: função chamada quando o usuário digita na busca
-   - on-page-change: função chamada quando o usuário muda de página
-   - on-select: função chamada quando o usuário seleciona uma opção
-   - selected-value: valor atualmente selecionado
-   - placeholder: texto a mostrar quando nada está selecionado
-   - total-items: número total de itens
-   - current-page: página atual
-   - items-per-page: itens por página"
-  [{:keys [options loading? on-search on-page-change
-           on-select selected-value placeholder
-           total-items current-page items-per-page]}]
+   Parameters:
+   - options: list of options [{:value \"id\" :label \"text\" :description \"description\"}]
+   - loading?: boolean indicating if it's loading data
+   - on-search: function called when user types in the search box
+   - on-page-change: function called when user changes page
+   - on-select: function called when user selects an option
+   - selected-value: currently selected value
+   - placeholder: text to show when nothing is selected
+   - total-items: total number of items
+   - current-page: current page
+   - items-per-page: items per page"
+  []
   (let [open? (r/atom false)
         search-term (r/atom "")
         debounce-timer (atom nil)]
     (fn [{:keys [options loading? on-search on-page-change
                  on-select selected-value placeholder
                  total-items current-page items-per-page]}]
-      [:div.relative
-       ;; Header do dropdown (o que é mostrado quando fechado)
-       [:div.dropdown-header.cursor-pointer.flex.items-center.justify-between.px-4.py-2.border.rounded.shadow-sm
-        {:on-click #(swap! open? not)}
-        [:div
-         (if selected-value
-           (if-let [selected-option (first (filter #(= (:value %) selected-value) options))]
-             (:label selected-option)
-             (or placeholder "Select an option"))
-           (or placeholder "Select an option"))]
-        [chevron-icon @open?]]
+      [:> Box {:class "relative"}
 
-       ;; Conteúdo do dropdown (aparece quando aberto)
-       (when @open?
-         [:div.absolute.left-0.right-0.mt-1.border.rounded.bg-white.shadow-lg.z-50
-          ;; Campo de busca
-          [:div.p-2.border-b
-           [:div.relative
-            [:span.absolute.inset-y-0.left-0.flex.items-center.pl-2
-             [search-icon]]
-            [:input.w-full.pl-8.pr-2.py-2.border.rounded
+       [:> DropdownMenu.Root {:dir "ltr"}
+        [:> DropdownMenu.Trigger
+         [:> Box {:class "rt-reset rt-SelectTrigger rt-r-size-3 rt-variant-surface w-full "}
+          [:> Box
+           (if selected-value
+             (if-let [selected-option (first (filter #(= (:value %) selected-value) options))]
+               [:span {:class "rt-SelectTriggerInner"}
+                (:label selected-option)]
+
+               [:span {:class "rt-SelectTriggerInner opacity-50"}
+                (or placeholder "Select an option")])
+
+             [:span {:class "rt-SelectTriggerInner opacity-50"}
+              (or placeholder "Select an option")])]
+          [:> DropdownMenu.TriggerIcon]]]
+        [:> DropdownMenu.Content {:size "2" :class "w-[820px]"}
+         [:> Box {:class "mt-1 rounded bg-white"}
+          ;; Search field
+          [:> Box {:class ""}
+           [:> Box {:class "relative"}
+
+            [forms/input
              {:type "text"
               :placeholder "Search options..."
               :value @search-term
@@ -80,45 +61,53 @@
                              (reset! debounce-timer
                                      (js/setTimeout #(on-search value) 300))))}]]]
 
-          ;; Lista de opções
+          ;; Options list
           (cond
             loading?
-            [:div.p-4.text-center.text-sm.text-gray-500 "Loading..."]
+            [:> Box {:class "flex items-center justify-center h-full"}
+             [:> Text {:size "2" :class "text-gray-12"}
+              "Loading..."]]
 
             (empty? options)
-            [:div.p-4.text-center.text-sm.text-gray-500 "No options found"]
+            [:> Box {:class "flex items-center justify-center h-full"}
+             [:> Text {:size "2" :class "text-gray-12"}
+              "No options found"]]
 
             :else
-            [:div.max-h-60.overflow-y-auto
+            [:> Box {:class "max-h-60 overflow-y-auto"}
              (for [option options]
                ^{:key (:value option)}
-               [:div.px-4.py-2.hover:bg-gray-100.cursor-pointer
-                {:on-click #(do (on-select (:value option))
+               [:> DropdownMenu.Item
+                {:class "px-4 py-2 hover:bg-gray-100 cursor-pointer"
+                 :on-click #(do (on-select (:value option))
                                 (reset! open? false))}
-                [:div.font-medium (:label option)]
+                [:> Text {:size "2" :weight "medium" :class "text-gray-12"}
+                 (:label option)]
                 (when (:description option)
-                  [:div.text-sm.text-gray-500 (:description option)])])])
+                  [:> Text {:size "2" :class "text-gray-12"}
+                   (:description option)])])])
 
-          ;; Paginação
-          [:div.flex.items-center.justify-between.px-4.py-2.border-t.text-sm
-           [:div.text-xs.text-gray-500
+          ;; Pagination
+          [:> Box {:class "flex items-center justify-between px-4 py-2 border-t text-sm"}
+           [:> Text {:size "1" :class "text-gray-11"}
             (str "Showing "
                  (inc (* (dec current-page) items-per-page)) "-"
                  (min (* current-page items-per-page) total-items)
                  " of " total-items)]
-           [:div.flex.space-x-2
-            [:button.px-2.py-1.border.rounded
-             {:type "button"
+           [:> Box {:class "flex items-center space-x-2"}
+            [:> IconButton
+             {:variant "outline"
               :disabled (= current-page 1)
-              :class (if (= current-page 1) "opacity-50 cursor-not-allowed" "hover:bg-gray-100")
+              :class (when (= current-page 1) "cursor-not-allowed")
               :on-click #(when (> current-page 1)
                            (on-page-change (dec current-page)))}
-             "←"]
-            [:div (str current-page "/" (js/Math.ceil (/ total-items items-per-page)))]
-            [:button.px-2.py-1.border.rounded
-             {:type "button"
+             [:> ArrowLeft {:size 16}]]
+            [:> Text {:size "2" :class "text-gray-12"}
+             (str current-page "/" (js/Math.ceil (/ total-items items-per-page)))]
+            [:> IconButton
+             {:variant "outline"
               :disabled (>= (* current-page items-per-page) total-items)
-              :class (if (>= (* current-page items-per-page) total-items) "opacity-50 cursor-not-allowed" "hover:bg-gray-100")
+              :class (when (>= (* current-page items-per-page) total-items) "cursor-not-allowed")
               :on-click #(when (< (* current-page items-per-page) total-items)
                            (on-page-change (inc current-page)))}
-             "→"]]]])])))
+             [:> ArrowRight {:size 16}]]]]]]]])))

--- a/webapp/src/webapp/connections/views/connection_settings_modal.cljs
+++ b/webapp/src/webapp/connections/views/connection_settings_modal.cljs
@@ -9,7 +9,6 @@
 
 ;; Duration in minutes to nanoseconds conversion
 (defn minutes-to-ns [minutes]
-  (println "minutes" (type minutes))
   (* minutes 60 1000 1000 1000))
 
 (defn main [connection-name]

--- a/webapp/src/webapp/connections/views/setup/events/db_events.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/db_events.cljs
@@ -231,9 +231,7 @@
 (rf/reg-event-db
  :connection-setup/add-tag
  (fn [db [_ full-key value]]
-   (let [_ (println "full-key" full-key)
-         label (tags-utils/extract-label full-key)
-         _ (println "label" label)]
+   (let [label (tags-utils/extract-label full-key)]
      (if (and full-key
               (not (str/blank? full-key))
               value

--- a/webapp/src/webapp/connections/views/setup/events/process_form.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/process_form.cljs
@@ -251,7 +251,7 @@
         ;; Extrair tags no formato correto
         connection-tags (when-let [tags (:connection_tags connection)]
                           (cond
-                           ;; Se for um mapa, converte para array de {:key k :value v}
+                            ;; Se for um mapa, converte para array de {:key k :value v}
                             (map? tags)
                             (mapv (fn [[k v]]
                                     (let [key (str (namespace k) "/" (name k))
@@ -261,13 +261,13 @@
                                                        key)]
                                       {:key parsed-key :value v :label (tags-utils/extract-label parsed-key)})) tags)
 
-                           ;; Se for array simples, converte cada item para {:key item :value ""}
+                            ;; Se for array simples, converte cada item para {:key item :value ""}
                             (sequential? tags)
                             (mapv (fn [tag]
                                     (if (map? tag)
-                                    ;; Se já for no formato {:key k :value v}, usa diretamente
+                                      ;; Se já for no formato {:key k :value v}, usa diretamente
                                       tag
-                                    ;; Senão, é um valor simples que vira chave
+                                      ;; Senão, é um valor simples que vira chave
                                       {:key tag :value ""}))
                                   tags)
 
@@ -280,7 +280,6 @@
         http-env-vars (when (and (= (:type connection) "application")
                                  (= (:subtype connection) "httpproxy"))
                         (let [headers (process-connection-envvars (:secret connection) "envvar")
-                              _ (println "headers" headers)
                               remote-url? #(= (:key %) "REMOTE_URL")
                               header? #(str/starts-with? % "HEADER_")
                               processed-headers (map (fn [{:keys [key value]}]

--- a/webapp/src/webapp/events/connections.cljs
+++ b/webapp/src/webapp/events/connections.cljs
@@ -61,8 +61,8 @@
                         :body body
                         :on-success (fn [connection]
                                       (rf/dispatch [:close-modal])
-                                    ;; plugins might be updated in the connection
-                                    ;; creation action, so we get them again here
+                                      ;; plugins might be updated in the connection
+                                      ;; creation action, so we get them again here
                                       (rf/dispatch [:plugins->get-my-plugins])
                                       (rf/dispatch [:connections->get-connections])
                                       (rf/dispatch [:show-snackbar {:level :success
@@ -109,9 +109,8 @@
                                                                   :maxWidth "446px"
                                                                   :custom-on-click-out connection-connect/minimize-modal}]))
                         :on-success (fn [res]
-                                      (println :success :connections->connection-connect res)
                                       (cond
-                                       ;; Case 1: Review required
+                                        ;; Case 1: Review required
                                         (and (= (:status res) "disconnected")
                                              (:has_review res))
                                         (do
@@ -121,7 +120,7 @@
                                             (rf/dispatch [:modal->open {:content [connection-review-modal/main res]
                                                                         :maxWidth "446px"}])))
 
-                                       ;; Case 2: Connection failure
+                                        ;; Case 2: Connection failure
                                         (= (:status res) "disconnected")
                                         (do
                                           (rf/dispatch [:show-snackbar {:level :error
@@ -129,7 +128,7 @@
                                                                                    "to be connected, please contact your admin.")}])
                                           (rf/dispatch [:modal->close]))
 
-                                       ;; Case 3: Connection success
+                                        ;; Case 3: Connection success
                                         :else
                                         (do
                                           (rf/dispatch [:show-snackbar {:level :success
@@ -281,7 +280,7 @@ ORDER BY total_amount DESC;")
                                     (when connecting-status
                                       (rf/dispatch [:reset-connecting-status connecting-status]))
                                     (cond
-                                    ;; Case 1: Review required
+                                      ;; Case 1: Review required
                                       (and (= (:status res) "disconnected")
                                            (:has_review res))
                                       (do
@@ -290,13 +289,13 @@ ORDER BY total_amount DESC;")
                                         (rf/dispatch [:modal->open {:content [connection-review-modal/main res]
                                                                     :maxWidth "446px"}]))
 
-                                    ;; Case 2: Connection failure
+                                      ;; Case 2: Connection failure
                                       (= (:status res) "disconnected")
                                       (rf/dispatch [:show-snackbar {:level :error
                                                                     :text (str "The connection " (:connection_name connection) " is not able "
                                                                                "to be connected, please contact your admin.")}])
 
-                                    ;; Case 3: Connection success
+                                      ;; Case 3: Connection success
                                       :else
                                       (do
                                         (rf/dispatch [:show-snackbar {:level :success

--- a/webapp/src/webapp/events/jira_templates.cljs
+++ b/webapp/src/webapp/events/jira_templates.cljs
@@ -45,7 +45,7 @@
    (let [current-template (get-in db [:jira-templates->submit-template :data])
          cmdb-items (get-in current-template [:cmdb_types :items])
          updated-cmdb-items (map (fn [item]
-                                   (if (= (:jira_object_type item) (:jira_object_type cmdb-item))
+                                   (if (= (:jira_field item) (:jira_field cmdb-item))
                                      (assoc item :value value)
                                      item))
                                  cmdb-items)

--- a/webapp/src/webapp/jira_templates/create_update_form.cljs
+++ b/webapp/src/webapp/jira_templates/create_update_form.cljs
@@ -49,7 +49,6 @@
           {:status (:issue_transition_name_on_close state)
            :on-status-change #(reset! (:issue_transition_name_on_close state) %)}]
 
-         (println "connection_ids" (:connection_ids state))
          ;; Connections section
          [connections-section/main
           {:connection-ids (:connection_ids state)

--- a/webapp/src/webapp/jira_templates/prompt_form.cljs
+++ b/webapp/src/webapp/jira_templates/prompt_form.cljs
@@ -62,6 +62,7 @@
         search-term (rf/subscribe [:jira-templates->cmdb-search object-type])
         loading? (rf/subscribe [:jira-templates->cmdb-loading? object-type])
         options (create-cmdb-select-options (:jira_values cmdb-item))]
+
     [:div.mb-4
      [:label.block.text-xs.font-semibold.text-gray-800.mb-1
       (:label cmdb-item)
@@ -84,8 +85,9 @@
        :on-select (fn [value]
                     (rf/dispatch [:jira-templates->update-cmdb-value cmdb-item value]))}]]))
 
-(defn main [{:keys [prompts cmdb-items on-submit]}]
-  (let [form-data (r/atom (init-form-data cmdb-items))
+(defn main [{:keys [prompts on-submit]}]
+  (let [cmdb-items (rf/subscribe [:jira-templates->submit-template-cmdb-items])
+        form-data (r/atom (init-form-data @cmdb-items))
         template-id (rf/subscribe [:jira-templates->submit-template-id])]
     (fn []
       [:> Box {:class "p-6"}
@@ -125,10 +127,11 @@
                 :on-change #(swap! form-data assoc-in [:jira_fields jira_field] (.. % -target -value))}])])
 
          ;; CMDB Fields - Mostrar todos os campos CMDB com o novo dropdown paginado
-         (when (seq cmdb-items)
+         (println "cmdb-items" @cmdb-items)
+         (when (seq @cmdb-items)
            [:> Box {:class "space-y-4"}
             (doall
-             (for [item cmdb-items]
+             (for [item @cmdb-items]
                ^{:key (:jira_field item)}
                [cmdb-field item @template-id]))])]
 


### PR DESCRIPTION
# Paginated Dropdown for CMDB Values

## Problem
CMDB fields were loading all data simultaneously, causing significant performance issues when loading forms for clients with large volumes of data (15,000+ items).

## Solution
We implemented a paginated loading system with real-time search for CMDB selection dropdowns in the Jira templates form.

## How to test
1. Open a Jira template with CMDB types
2. Verify that the dropdown initially loads only the first page
3. Use search to filter values
4. Navigate between pages and confirm that data loads correctly
5. Select a value and verify that the form recognizes the selection

## Technical notes
- Breaking Change: remove route GET /api/integrations/jira/issuetemplates/123/objecttype-values
- Introduce new route to list object values from Jira Assets API
- Add default timeout (50s) when performing request to asset objects api
- Remove extend=cmdb-values attribute when listing issue templates
- Add better logging and propagate errors properly to the client
- Pagination parameters (current page, items per page) are stored in the state by the CMDB object type
- We implemented debounce in the search to avoid request overload

## Screenshots
![Screenshot 2025-05-30 at 16 13 08](https://github.com/user-attachments/assets/f327e9be-1eb0-40c0-9094-32f29ed9d8c4)
![Screen Recording 2025-05-30 at 16 13 21](https://github.com/user-attachments/assets/bf713e63-d9a2-45b0-9dde-bf217659f171)
