### PR TITLE
feat: Allow setting arbitrary max JIT session duration

### DIFF
--- a/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
@@ -48,3 +48,4 @@ stringData:
   PLUGIN_INDEX_PATH: '{{ .Values.config.PLUGIN_INDEX_PATH | default "/opt/hoop/sessions/indexes" }}'
   WEBAPP_USERS_MANAGEMENT: '{{ .Values.config.WEBAPP_USERS_MANAGEMENT }}'
   ANALYTICS_TRACKING: '{{ .Values.config.ANALYTICS_TRACKING | default "enabled" }}'
+  MAX_ACCESS_DURATION_HOURS: '{{ .Values.config.MAX_ACCESS_DURATION_HOURS | default "48" }}'

--- a/deploy/helm-chart/chart/gateway/values.yaml
+++ b/deploy/helm-chart/chart/gateway/values.yaml
@@ -44,6 +44,7 @@ config:
   # GOOGLE_APPLICATION_CREDENTIALS_JSON: ''
   # PLUGIN_AUDIT_PATH: ''
   # PLUGIN_INDEX_PATH: ''
+  # MAX_ACCESS_DURATION_HOURS: '48'
 
 mainService:
   # -- Annotations to add in the main service


### PR DESCRIPTION
Currently max sesstion duration is hardcoded to 48 hours. Users may want to set custom value.
I'm adding a new `MAX_ACCESS_DURATION_HOURS` environment variable and using it in the `review.go` plugin. I'm not sure whether the `review.oss.go` file is used, so I've kept it intact.