### PR TITLE
Add Data Masking for MS Presidio

### DIFF
--- a/agent/controller/postgres.go
+++ b/agent/controller/postgres.go
@@ -48,6 +48,11 @@ func (a *Agent) processPGProtocol(pkt *pb.Packet) {
 	}
 
 	log.Infof("session=%v - starting postgres connection at %v:%v", sessionID, connenv.host, connenv.port)
+
+	var dataMaskingEntityTypesData string
+	if connParams.DataMaskingEntityTypesData != nil {
+		dataMaskingEntityTypesData = string(connParams.DataMaskingEntityTypesData)
+	}
 	opts := map[string]string{
 		"sid":                       sessionID,
 		"hostname":                  connenv.host,
@@ -62,6 +67,7 @@ func (a *Agent) processPGProtocol(pkt *pb.Packet) {
 		"dlp_gcp_credentials":       connParams.DlpGcpRawCredentialsJSON,
 		"dlp_info_types":            strings.Join(connParams.DLPInfoTypes, ","),
 		"dlp_masking_character":     "#",
+		"data_masking_entity_data":  dataMaskingEntityTypesData,
 	}
 	serverWriter, err := libhoop.NewDBCore(context.Background(), streamClient, opts).Postgres()
 	if err != nil {

--- a/agent/controller/terminal-exec.go
+++ b/agent/controller/terminal-exec.go
@@ -25,6 +25,11 @@ func (a *Agent) doExec(pkt *pb.Packet) {
 	spec := map[string][]byte{pb.SpecGatewaySessionID: []byte(sid)}
 	stdoutw := pb.NewStreamWriter(a.client, pbclient.WriteStdout, spec)
 	stderrw := pb.NewStreamWriter(a.client, pbclient.WriteStderr, spec)
+
+	var dataMaskingEntityTypesData string
+	if connParams.DataMaskingEntityTypesData != nil {
+		dataMaskingEntityTypesData = string(connParams.DataMaskingEntityTypesData)
+	}
 	opts := map[string]string{
 		"sid":                       sid,
 		"dlp_provider":              connParams.DlpProvider,
@@ -33,6 +38,7 @@ func (a *Agent) doExec(pkt *pb.Packet) {
 		"mspresidio_anonymizer_url": connParams.DlpPresidioAnonymizerURL,
 		"dlp_gcp_credentials":       connParams.DlpGcpRawCredentialsJSON,
 		"dlp_info_types":            strings.Join(connParams.DLPInfoTypes, ","),
+		"data_masking_entity_data":  dataMaskingEntityTypesData,
 	}
 	args := append(connParams.CmdList, connParams.ClientArgs...)
 	cmd, err := libhoop.NewAdHocExec(connParams.EnvVars, args, pkt.Payload, stdoutw, stderrw, opts)

--- a/agent/controller/terminal.go
+++ b/agent/controller/terminal.go
@@ -36,6 +36,11 @@ func (a *Agent) doTerminalWriteAgentStdin(pkt *pb.Packet) {
 
 	spec := map[string][]byte{pb.SpecGatewaySessionID: []byte(sid)}
 	stdoutWriter := pb.NewStreamWriter(a.client, pbclient.WriteStdout, spec)
+
+	var dataMaskingEntityTypesData string
+	if connParams.DataMaskingEntityTypesData != nil {
+		dataMaskingEntityTypesData = string(connParams.DataMaskingEntityTypesData)
+	}
 	opts := map[string]string{
 		"sid":                       sid,
 		"dlp_provider":              connParams.DlpProvider,
@@ -44,6 +49,7 @@ func (a *Agent) doTerminalWriteAgentStdin(pkt *pb.Packet) {
 		"mspresidio_anonymizer_url": connParams.DlpPresidioAnonymizerURL,
 		"dlp_gcp_credentials":       connParams.DlpGcpRawCredentialsJSON,
 		"dlp_info_types":            strings.Join(connParams.DLPInfoTypes, ","),
+		"data_masking_entity_data":  dataMaskingEntityTypesData,
 	}
 	args := append(connParams.CmdList, connParams.ClientArgs...)
 	cmd, err := libhoop.NewConsole(connParams.EnvVars, args, stdoutWriter, opts)

--- a/common/proto/types.go
+++ b/common/proto/types.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"io"
 	reflect "reflect"
@@ -47,6 +48,8 @@ type (
 		DlpGcpRawCredentialsJSON string
 		DlpPresidioAnalyzerURL   string
 		DlpPresidioAnonymizerURL string
+
+		DataMaskingEntityTypesData json.RawMessage
 	}
 
 	// TODO: remove it later, kept for compatibility issues

--- a/gateway/api/datamasking/datamasking.go
+++ b/gateway/api/datamasking/datamasking.go
@@ -271,10 +271,6 @@ func parseRequestPayload(c *gin.Context) *openapi.DataMaskingRuleRequest {
 			c.JSON(http.StatusBadRequest, gin.H{"message": "entity type name must be uppercase: " + e.Name})
 			return nil
 		}
-		// if len(e.DenyList) > 0 && e.Regex != "" {
-		// 	c.JSON(http.StatusBadRequest, gin.H{"message": "deny_list and regex cannot be used together in custom entity types"})
-		// 	return nil
-		// }
 	}
 	return &req
 }

--- a/gateway/api/datamasking/datamasking.go
+++ b/gateway/api/datamasking/datamasking.go
@@ -1,0 +1,280 @@
+package apigdatamasking
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2"
+)
+
+// CreateDataMaskingRule
+//
+//	@Summary		Create Data Masking Rule
+//	@Description	Create Data Masking Rule
+//	@Tags			Data Masking Rules
+//	@Accept			json
+//	@Produce		json
+//	@Param			request		body		openapi.DataMaskingRuleRequest	true	"The request body resource"
+//	@Success		201			{object}	openapi.DataMaskingRule
+//	@Failure		400,409,500	{object}	openapi.HTTPError
+//	@Router			/datamasking-rules [post]
+func Post(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	req := parseRequestPayload(c)
+	if req == nil {
+		return
+	}
+
+	supportedEntityTypes := []models.SupportedEntityTypesEntry{}
+	for _, entityType := range req.SupportedEntityTypes {
+		supportedEntityTypes = append(supportedEntityTypes, models.SupportedEntityTypesEntry{
+			Name:        entityType.Name,
+			EntityTypes: entityType.EntityTypes,
+		})
+	}
+	customEntityTypes := []models.CustomEntityTypesEntry{}
+	for _, entityType := range req.CustomEntityTypesEntrys {
+		customEntityTypes = append(customEntityTypes, models.CustomEntityTypesEntry{
+			Name:     entityType.Name,
+			Regex:    entityType.Regex,
+			DenyList: entityType.DenyList,
+			Score:    entityType.Score,
+		})
+	}
+
+	rule, err := models.CreateDataMaskingRule(&models.DataMaskingRule{
+		ID:                   uuid.NewString(),
+		OrgID:                ctx.OrgID,
+		Name:                 req.Name,
+		Description:          req.Description,
+		SupportedEntityTypes: supportedEntityTypes,
+		CustomEntityTypes:    customEntityTypes,
+		ConnectionIDs:        req.ConnectionIDs,
+		UpdatedAt:            time.Now().UTC(),
+	})
+
+	switch err {
+	case models.ErrAlreadyExists:
+		c.JSON(http.StatusConflict, gin.H{"message": err.Error()})
+	case models.ErrNotFound:
+		c.JSON(http.StatusBadRequest, gin.H{"message": "connection not found: a connection reference in the connection_ids field does not exist"})
+	case nil:
+		c.JSON(http.StatusCreated, toOpenApi(rule))
+	default:
+		log.Errorf("Failed creating data masking rule: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+	}
+}
+
+// UpdateDataMaskingRule
+//
+//	@Summary		Update Data Masking Rule
+//	@Description	Update Data Masking Rule
+//	@Tags			Data Masking Rules
+//	@Accept			json
+//	@Produce		json
+//	@Param			request		body		openapi.DataMaskingRuleRequest	true	"The request body resource"
+//	@Success		200			{object}	openapi.DataMaskingRule
+//	@Failure		400,404,500	{object}	openapi.HTTPError
+//	@Router			/datamasking-rules/{id} [put]
+func Put(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	req := parseRequestPayload(c)
+	if req == nil {
+		return
+	}
+
+	supportedEntityTypes := []models.SupportedEntityTypesEntry{}
+	for _, entityType := range req.SupportedEntityTypes {
+		supportedEntityTypes = append(supportedEntityTypes, models.SupportedEntityTypesEntry{
+			Name:        entityType.Name,
+			EntityTypes: entityType.EntityTypes,
+		})
+	}
+	customEntityTypes := []models.CustomEntityTypesEntry{}
+	for _, entityType := range req.CustomEntityTypesEntrys {
+		customEntityTypes = append(customEntityTypes, models.CustomEntityTypesEntry{
+			Name:     entityType.Name,
+			Regex:    entityType.Regex,
+			DenyList: entityType.DenyList,
+			Score:    entityType.Score,
+		})
+	}
+
+	fmt.Printf("CUSTOM ENTITY TYPES: %#v\n", customEntityTypes)
+
+	rule, err := models.UpdateDataMaskingRule(&models.DataMaskingRule{
+		ID:                   c.Param("id"),
+		OrgID:                ctx.GetOrgID(),
+		Name:                 req.Name,
+		Description:          req.Description,
+		SupportedEntityTypes: supportedEntityTypes,
+		CustomEntityTypes:    customEntityTypes,
+		ConnectionIDs:        req.ConnectionIDs,
+		UpdatedAt:            time.Now().UTC(),
+	})
+
+	switch err {
+	case models.ErrNotFound:
+		c.JSON(http.StatusNotFound, gin.H{"message": err.Error()})
+	case nil:
+		c.JSON(http.StatusOK, toOpenApi(rule))
+	default:
+		log.Errorf("Failed updating data masking rule: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+	}
+}
+
+// ListDataMaskingRules
+//
+//	@Summary		List Data Masking Rules
+//	@Description	List Data Masking Rules
+//	@Tags			Data Masking Rules
+//	@Accept			json
+//	@Produce		json
+//	@Success		200	{array}		openapi.DataMaskingRule
+//	@Failure		500	{object}	openapi.HTTPError
+//	@Router			/datamasking-rules [get]
+func List(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	ruleList, err := models.ListDataMaskingRules(ctx.GetOrgID())
+	if err != nil {
+		log.Errorf("failed listing data masking rules, reason=%v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+		return
+	}
+
+	rules := []openapi.DataMaskingRule{}
+	for _, rule := range ruleList {
+		rules = append(rules, *toOpenApi(&rule))
+	}
+	c.JSON(http.StatusOK, rules)
+}
+
+// GetDataMaskingRule
+//
+//	@Summary		Get Data Masking Rule
+//	@Description	Get Data Masking Rule
+//	@Tags			Data Masking Rules
+//	@Accept			json
+//	@Produce		json
+//	@Param			id			path		string	true	"The unique identifier of the resource"
+//	@Success		200			{object}	openapi.DataMaskingRule
+//	@Failure		400,404,500	{object}	openapi.HTTPError
+//	@Router			/datamasking-rules/{id} [get]
+func Get(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	rule, err := models.GetDataMaskingRuleByID(ctx.GetOrgID(), c.Param("id"))
+	switch err {
+	case models.ErrNotFound:
+		c.JSON(http.StatusNotFound, gin.H{"message": "resource not found"})
+	case nil:
+		c.JSON(http.StatusOK, toOpenApi(rule))
+	default:
+		log.Errorf("failed fetching data masking rule, reason=%v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+	}
+}
+
+// DeleteDataMaskingRule
+//
+//	@Summary		Delete Data Masking Rule
+//	@Description	Delete a Data Masking Rule resource.
+//	@Tags			Data Masking Rules
+//	@Produce		json
+//	@Param			id	path	string	true	"The unique identifier of the resource"
+//	@Success		204
+//	@Failure		404,500	{object}	openapi.HTTPError
+//	@Router			/datamasking-rules/{id} [delete]
+func Delete(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	err := models.DeleteDataMaskingRule(ctx.GetOrgID(), c.Param("id"))
+	switch err {
+	case models.ErrNotFound:
+		c.JSON(http.StatusNotFound, gin.H{"message": "resource not found"})
+	case nil:
+		c.Writer.WriteHeader(http.StatusNoContent)
+	default:
+		log.Errorf("failed removing data masking rule, reason=%v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+	}
+}
+
+func toOpenApi(obj *models.DataMaskingRule) *openapi.DataMaskingRule {
+	entityTypes := []openapi.SupportedEntityTypesEntry{}
+	for _, entry := range obj.SupportedEntityTypes {
+		entityTypes = append(entityTypes, openapi.SupportedEntityTypesEntry{
+			Name:        entry.Name,
+			EntityTypes: entry.EntityTypes,
+		})
+	}
+	customEntityTypes := []openapi.CustomEntityTypesEntry{}
+	for _, entry := range obj.CustomEntityTypes {
+		customEntityTypes = append(customEntityTypes, openapi.CustomEntityTypesEntry{
+			Name:     entry.Name,
+			Regex:    entry.Regex,
+			DenyList: entry.DenyList,
+			Score:    entry.Score,
+		})
+	}
+
+	return &openapi.DataMaskingRule{
+		ID: obj.ID,
+		DataMaskingRuleRequest: openapi.DataMaskingRuleRequest{
+			Name:                    obj.Name,
+			Description:             obj.Description,
+			SupportedEntityTypes:    entityTypes,
+			CustomEntityTypesEntrys: customEntityTypes,
+			ConnectionIDs:           obj.ConnectionIDs,
+			UpdatedAt:               obj.UpdatedAt,
+		},
+	}
+}
+
+func parseRequestPayload(c *gin.Context) *openapi.DataMaskingRuleRequest {
+	req := openapi.DataMaskingRuleRequest{}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		log.Errorf("failed parsing request payload, err=%v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return nil
+	}
+	fmt.Printf("REQUEST: %#v\n", req)
+	for _, connID := range req.ConnectionIDs {
+		if _, err := uuid.Parse(connID); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "invalid connection ID " + connID})
+			return nil
+		}
+	}
+	for _, e := range req.SupportedEntityTypes {
+		if len(e.EntityTypes) == 0 || e.Name == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "missing entity types or name in supported entity types"})
+			return nil
+		}
+		if e.Name != strings.ToUpper(e.Name) {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "entity type name must be uppercase: " + e.Name})
+			return nil
+		}
+	}
+	for _, e := range req.CustomEntityTypesEntrys {
+		if e.Name == "" || len(e.DenyList) == 0 && e.Regex == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "missing name, deny_list or regex in custom entity types"})
+			return nil
+		}
+		if e.Name != strings.ToUpper(e.Name) {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "entity type name must be uppercase: " + e.Name})
+			return nil
+		}
+		// if len(e.DenyList) > 0 && e.Regex != "" {
+		// 	c.JSON(http.StatusBadRequest, gin.H{"message": "deny_list and regex cannot be used together in custom entity types"})
+		// 	return nil
+		// }
+	}
+	return &req
+}

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4698,12 +4698,11 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "name",
-                "regex",
                 "score"
             ],
             "properties": {
                 "deny_list": {
-                    "description": "List of words to be returned as PII if found.",
+                    "description": "List of words to be returned as PII if found.\nEither this or the regex is required",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -4720,7 +4719,7 @@ const docTemplate = `{
                     "example": "ZIP_CODE"
                 },
                 "regex": {
-                    "description": "The regex pattern to match (python) the custom entity type",
+                    "description": "The regex pattern to match (python) the custom entity type.\nEither this or the deny_list is required",
                     "type": "string",
                     "example": "\\b\\d{5}(?:-\\d{4})?\\b"
                 },
@@ -4994,8 +4993,9 @@ const docTemplate = `{
                     }
                 },
                 "updated_at": {
-                    "description": "UpdatedAt is the timestamp when the resource was last updated",
+                    "description": "The timestamp when the rule was updated",
                     "type": "string",
+                    "readOnly": true,
                     "example": "2023-08-15T14:30:45Z"
                 }
             }
@@ -5042,8 +5042,9 @@ const docTemplate = `{
                     }
                 },
                 "updated_at": {
-                    "description": "UpdatedAt is the timestamp when the resource was last updated",
+                    "description": "The timestamp when the rule was updated",
                     "type": "string",
+                    "readOnly": true,
                     "example": "2023-08-15T14:30:45Z"
                 }
             }
@@ -6819,11 +6820,18 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "example": [
+                        "EMAIL_ADDRESS",
+                        "PERSON",
+                        "PHONE_NUMBER",
+                        "IP_ADDRESS"
+                    ]
                 },
                 "name": {
-                    "description": "The name of the entity type as uppercase",
-                    "type": "string"
+                    "description": "An identifier for this structure, it's used as an identifier of a collection of entities.",
+                    "type": "string",
+                    "example": "PII"
                 }
             }
         },

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -3387,7 +3387,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Core"
+                    "Session"
                 ],
                 "summary": "Reviewed Exec",
                 "parameters": [

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -7119,10 +7119,6 @@ const docTemplate = `{
             "name": "Authentication"
         },
         {
-            "description": "Core resources",
-            "name": "Core"
-        },
-        {
             "description": "Users are active and assigned to the default organization when they signup. A user could be set to an inactive state preventing it from accessing the platform, however it’s recommended to manage the state of users in the identity provider.\n\n- The ` + "`" + `sub` + "`" + ` claim is used as the main identifier of the user in the platform.\n- The profile of the user is derived from the id_token claims ` + "`" + `email` + "`" + ` and ` + "`" + `name` + "`" + `.\n\nWhen a user authenticates for the first time, it performs an automatic signup that persist the profile claims along with it’s unique identifier.\n​\n### Groups\n\nGroups allows defining who may access or interact with certain resources.\n\n- For connection resources it’s possible to define which groups has access to a specific connection, this is enforced when the Access Control feature is enabled.\n- For review resources, it’s possible to define which groups are allowed to approve an execution, this is enforced when the Review feature is enabled.\n\n\u003e This resource could be managed manually via Webapp or propagated by the identity provider via ID Token. In this mode, groups are sync when a user performs a login.\n\n### Roles\n\n- The ` + "`" + `admin` + "`" + ` group is a special role that grants full access to all resources\n\nThis role should be granted to users that are responsible for managing the Gateway. All other users are regular, meaning that they can access their own resources and interact with connections.\n",
             "name": "User Management"
         },

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -691,6 +691,224 @@ const docTemplate = `{
                 }
             }
         },
+        "/datamasking-rules": {
+            "get": {
+                "description": "List Data Masking Rules",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Data Masking Rules"
+                ],
+                "summary": "List Data Masking Rules",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/openapi.DataMaskingRule"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create Data Masking Rule",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Data Masking Rules"
+                ],
+                "summary": "Create Data Masking Rule",
+                "parameters": [
+                    {
+                        "description": "The request body resource",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/openapi.DataMaskingRuleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.DataMaskingRule"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/datamasking-rules/{id}": {
+            "get": {
+                "description": "Get Data Masking Rule",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Data Masking Rules"
+                ],
+                "summary": "Get Data Masking Rule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The unique identifier of the resource",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.DataMaskingRule"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update Data Masking Rule",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Data Masking Rules"
+                ],
+                "summary": "Update Data Masking Rule",
+                "parameters": [
+                    {
+                        "description": "The request body resource",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/openapi.DataMaskingRuleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.DataMaskingRule"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a Data Masking Rule resource.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Data Masking Rules"
+                ],
+                "summary": "Delete Data Masking Rule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The unique identifier of the resource",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/dbroles/jobs": {
             "get": {
                 "description": "List all db role jobs",
@@ -4476,6 +4694,43 @@ const docTemplate = `{
                 }
             }
         },
+        "openapi.CustomEntityTypesEntry": {
+            "type": "object",
+            "required": [
+                "name",
+                "regex",
+                "score"
+            ],
+            "properties": {
+                "deny_list": {
+                    "description": "List of words to be returned as PII if found.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Mr",
+                        "Mr.",
+                        "Mister"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the custom entity type as uppercase",
+                    "type": "string",
+                    "example": "ZIP_CODE"
+                },
+                "regex": {
+                    "description": "The regex pattern to match (python) the custom entity type",
+                    "type": "string",
+                    "example": "\\b\\d{5}(?:-\\d{4})?\\b"
+                },
+                "score": {
+                    "description": "Detection confidence of this pattern (0.01 if very noisy, 0.6-1.0 if very specific)",
+                    "type": "number",
+                    "example": 0.01
+                }
+            }
+        },
         "openapi.DBRoleJob": {
             "type": "object",
             "properties": {
@@ -4688,6 +4943,108 @@ const docTemplate = `{
                 "value": {
                     "type": "string",
                     "example": "banking"
+                }
+            }
+        },
+        "openapi.DataMaskingRule": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "connection_ids": {
+                    "description": "The connections that this rule applies to",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7",
+                        "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D8"
+                    ]
+                },
+                "custom_entity_types": {
+                    "description": "The custom entity types that this rule applies to",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.CustomEntityTypesEntry"
+                    }
+                },
+                "description": {
+                    "description": "The description of the data masking rule",
+                    "type": "string",
+                    "example": "Mask email addresses in the data"
+                },
+                "id": {
+                    "description": "The unique identifier of the data masking rule",
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7"
+                },
+                "name": {
+                    "description": "The unique name of the data masking rule",
+                    "type": "string",
+                    "example": "mask-email"
+                },
+                "supported_entity_types": {
+                    "description": "The registered entity types that this rule applies to",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.SupportedEntityTypesEntry"
+                    }
+                },
+                "updated_at": {
+                    "description": "UpdatedAt is the timestamp when the resource was last updated",
+                    "type": "string",
+                    "example": "2023-08-15T14:30:45Z"
+                }
+            }
+        },
+        "openapi.DataMaskingRuleRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "connection_ids": {
+                    "description": "The connections that this rule applies to",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7",
+                        "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D8"
+                    ]
+                },
+                "custom_entity_types": {
+                    "description": "The custom entity types that this rule applies to",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.CustomEntityTypesEntry"
+                    }
+                },
+                "description": {
+                    "description": "The description of the data masking rule",
+                    "type": "string",
+                    "example": "Mask email addresses in the data"
+                },
+                "name": {
+                    "description": "The unique name of the data masking rule",
+                    "type": "string",
+                    "example": "mask-email"
+                },
+                "supported_entity_types": {
+                    "description": "The registered entity types that this rule applies to",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.SupportedEntityTypesEntry"
+                    }
+                },
+                "updated_at": {
+                    "description": "UpdatedAt is the timestamp when the resource was last updated",
+                    "type": "string",
+                    "example": "2023-08-15T14:30:45Z"
                 }
             }
         },
@@ -6453,6 +6810,22 @@ const docTemplate = `{
                 "StatusReviewing",
                 "StatusInvited"
             ]
+        },
+        "openapi.SupportedEntityTypesEntry": {
+            "type": "object",
+            "properties": {
+                "entity_types": {
+                    "description": "The registered entity types in the redact provider",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "description": "The name of the entity type as uppercase",
+                    "type": "string"
+                }
+            }
         },
         "openapi.TablesResponse": {
             "type": "object",

--- a/gateway/api/openapi/docs/Core.md
+++ b/gateway/api/openapi/docs/Core.md
@@ -1,1 +1,0 @@
-Core resources

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1457,3 +1457,42 @@ type TablesResponse struct {
 type ColumnsResponse struct {
 	Columns []ConnectionColumn `json:"columns"` // The columns of a table
 }
+
+type DataMaskingRule struct {
+	// The unique identifier of the data masking rule
+	ID                     string `json:"id" format:"uuid" example:"15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7"`
+	DataMaskingRuleRequest `json:",inline"`
+}
+
+type DataMaskingRuleRequest struct {
+	// The unique name of the data masking rule
+	Name string `json:"name" binding:"required" example:"mask-email"`
+	// The description of the data masking rule
+	Description string `json:"description" example:"Mask email addresses in the data"`
+	// The connections that this rule applies to
+	ConnectionIDs []string `json:"connection_ids" example:"15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7,15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D8"`
+	// The registered entity types that this rule applies to
+	SupportedEntityTypes []SupportedEntityTypesEntry `json:"supported_entity_types"`
+	// The custom entity types that this rule applies to
+	CustomEntityTypesEntrys []CustomEntityTypesEntry `json:"custom_entity_types"`
+	// UpdatedAt is the timestamp when the resource was last updated
+	UpdatedAt time.Time `json:"updated_at" example:"2023-08-15T14:30:45Z"`
+}
+
+type SupportedEntityTypesEntry struct {
+	// The name of the entity type as uppercase
+	Name string `json:"name"`
+	// The registered entity types in the redact provider
+	EntityTypes []string `json:"entity_types"`
+}
+
+type CustomEntityTypesEntry struct {
+	// The name of the custom entity type as uppercase
+	Name string `json:"name" binding:"required" example:"ZIP_CODE"`
+	// The regex pattern to match (python) the custom entity type
+	Regex string `json:"regex" binding:"required" example:"\\b\\d{5}(?:-\\d{4})?\\b"`
+	// List of words to be returned as PII if found.
+	DenyList []string `json:"deny_list" example:"Mr,Mr.,Mister"`
+	// Detection confidence of this pattern (0.01 if very noisy, 0.6-1.0 if very specific)
+	Score float64 `json:"score" binding:"required" example:"0.01"`
+}

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1465,7 +1465,7 @@ type DataMaskingRule struct {
 }
 
 type DataMaskingRuleRequest struct {
-	// The unique name of the data masking rule
+	// The unique name of the data masking rule, it's immutable after creation
 	Name string `json:"name" binding:"required" example:"mask-email"`
 	// The description of the data masking rule
 	Description string `json:"description" example:"Mask email addresses in the data"`
@@ -1475,23 +1475,25 @@ type DataMaskingRuleRequest struct {
 	SupportedEntityTypes []SupportedEntityTypesEntry `json:"supported_entity_types"`
 	// The custom entity types that this rule applies to
 	CustomEntityTypesEntrys []CustomEntityTypesEntry `json:"custom_entity_types"`
-	// UpdatedAt is the timestamp when the resource was last updated
-	UpdatedAt time.Time `json:"updated_at" example:"2023-08-15T14:30:45Z"`
+	// The timestamp when the rule was updated
+	UpdatedAt time.Time `json:"updated_at" readonly:"true" example:"2023-08-15T14:30:45Z"`
 }
 
 type SupportedEntityTypesEntry struct {
-	// The name of the entity type as uppercase
-	Name string `json:"name"`
+	// An identifier for this structure, it's used as an identifier of a collection of entities.
+	Name string `json:"name" example:"PII"`
 	// The registered entity types in the redact provider
-	EntityTypes []string `json:"entity_types"`
+	EntityTypes []string `json:"entity_types" example:"EMAIL_ADDRESS,PERSON,PHONE_NUMBER,IP_ADDRESS"`
 }
 
 type CustomEntityTypesEntry struct {
 	// The name of the custom entity type as uppercase
 	Name string `json:"name" binding:"required" example:"ZIP_CODE"`
-	// The regex pattern to match (python) the custom entity type
-	Regex string `json:"regex" binding:"required" example:"\\b\\d{5}(?:-\\d{4})?\\b"`
+	// The regex pattern to match (python) the custom entity type.
+	// Either this or the deny_list is required
+	Regex string `json:"regex" example:"\\b\\d{5}(?:-\\d{4})?\\b"`
 	// List of words to be returned as PII if found.
+	// Either this or the regex is required
 	DenyList []string `json:"deny_list" example:"Mr,Mr.,Mister"`
 	// Detection confidence of this pattern (0.01 if very noisy, 0.6-1.0 if very specific)
 	Score float64 `json:"score" binding:"required" example:"0.01"`

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -69,9 +69,6 @@ type Api struct {
 //	@tag.name	Authentication
 //	@tag.description.markdown
 
-//	@tag.name	Core
-//	@tag.description.markdown
-
 //	@tag.name	User Management
 //	@tag.description.markdown
 

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -19,6 +19,7 @@ import (
 	apiagents "github.com/hoophq/hoop/gateway/api/agents"
 	"github.com/hoophq/hoop/gateway/api/apiroutes"
 	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
+	apidatamasking "github.com/hoophq/hoop/gateway/api/datamasking"
 	apifeatures "github.com/hoophq/hoop/gateway/api/features"
 	apiguardrails "github.com/hoophq/hoop/gateway/api/guardrails"
 	apihealthz "github.com/hoophq/hoop/gateway/api/healthz"
@@ -647,4 +648,25 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		api.TrackRequest(analytics.EventDeleteGuardRailRules),
 		apiguardrails.Delete)
+
+	r.POST("/datamasking-rules",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		apidatamasking.Post)
+	r.PUT("/datamasking-rules/:id",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		apidatamasking.Put)
+	r.GET("/datamasking-rules",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		apidatamasking.List)
+	r.GET("/datamasking-rules/:id",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		apidatamasking.Get)
+	r.DELETE("/datamasking-rules/:id",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		apidatamasking.Delete)
 }

--- a/gateway/api/session/run-exec.go
+++ b/gateway/api/session/run-exec.go
@@ -32,7 +32,7 @@ func getAccessToken(c *gin.Context) string {
 //
 //	@Summary		Reviewed Exec
 //	@Description	Run an execution in a reviewed session
-//	@Tags			Core
+//	@Tags			Session
 //	@Accept			json
 //	@Produce		json
 //	@Param			session_id		path		string					true	"The id of the resource"

--- a/gateway/models/datamasking.go
+++ b/gateway/models/datamasking.go
@@ -1,0 +1,220 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+type SupportedEntityTypesList []SupportedEntityTypesEntry
+type CustomEntityTypesList []CustomEntityTypesEntry
+
+type DataMaskingRule struct {
+	ID                   string                   `gorm:"column:id"`
+	OrgID                string                   `gorm:"column:org_id"`
+	Name                 string                   `gorm:"column:name"`
+	Description          string                   `gorm:"column:description"`
+	SupportedEntityTypes SupportedEntityTypesList `gorm:"column:supported_entity_types;serializer:json"`
+	CustomEntityTypes    CustomEntityTypesList    `gorm:"column:custom_entity_types;serializer:json"`
+	ConnectionIDs        pq.StringArray           `gorm:"column:connection_ids;type:text[];->"`
+	UpdatedAt            time.Time                `gorm:"column:updated_at"`
+}
+
+type SupportedEntityTypesEntry struct {
+	Name        string   `json:"name"`
+	EntityTypes []string `json:"entity_types"`
+}
+
+type CustomEntityTypesEntry struct {
+	Name     string   `json:"name"`
+	Regex    string   `json:"regex"`
+	DenyList []string `json:"deny_list"`
+	Score    float64  `json:"score"`
+}
+
+func (r *SupportedEntityTypesList) Scan(value any) error {
+	if value == nil {
+		return nil
+	}
+
+	var data []byte
+	switch v := value.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return fmt.Errorf("unsupported data type: %T", value)
+	}
+	return json.Unmarshal(data, r)
+}
+
+func CreateDataMaskingRule(rule *DataMaskingRule) (*DataMaskingRule, error) {
+	return rule, DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Table("private.datamasking_rules").Create(rule).Error; err != nil {
+			if err == gorm.ErrDuplicatedKey {
+				return ErrAlreadyExists
+			}
+			return err
+		}
+
+		for _, connID := range rule.ConnectionIDs {
+			err := tx.Exec(`
+			INSERT INTO private.datamasking_rules_connections (org_id, rule_id, connection_id)
+			VALUES (?, ?, ?)
+			`, rule.OrgID, rule.ID, connID).
+				Error
+			if err == gorm.ErrForeignKeyViolated {
+				return ErrNotFound
+			}
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func UpdateDataMaskingRule(rule *DataMaskingRule) (*DataMaskingRule, error) {
+	return rule, DB.Transaction(func(tx *gorm.DB) error {
+		res := tx.Debug().Table("private.datamasking_rules").
+			Where("org_id = ? AND id = ?", rule.OrgID, rule.ID).
+			Select("description", "supported_entity_types", "custom_entity_types", "updated_at").
+			Updates(DataMaskingRule{
+				Description:          rule.Description,
+				SupportedEntityTypes: rule.SupportedEntityTypes,
+				CustomEntityTypes:    rule.CustomEntityTypes,
+				UpdatedAt:            rule.UpdatedAt,
+			})
+		if res.Error != nil {
+			return fmt.Errorf("failed updating data masking rule: %v", res.Error)
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+
+		err := tx.Table("private.datamasking_rules_connections").
+			Where("org_id = ? AND rule_id = ?", rule.OrgID, rule.ID).
+			Delete(&DataMaskingRule{}).
+			Error
+		if err != nil {
+			return fmt.Errorf("failed removing data masking associations: %v", err)
+		}
+
+		for _, connID := range rule.ConnectionIDs {
+			err := tx.Exec(`
+			INSERT INTO private.datamasking_rules_connections (org_id, rule_id, connection_id)
+			VALUES (?, ?, ?)
+			`, rule.OrgID, rule.ID, connID).
+				Error
+			if err != nil {
+				return fmt.Errorf("failed creating data masking association %s: %v", connID, err)
+			}
+		}
+		return nil
+	})
+}
+
+func ListDataMaskingRules(orgID string) ([]DataMaskingRule, error) {
+	var rules []DataMaskingRule
+	return rules, DB.Raw(`
+	SELECT
+		r.id, r.org_id, r.name, r.description, r.supported_entity_types, r.custom_entity_types,
+		(
+			SELECT ARRAY_AGG(connection_id) FROM private.datamasking_rules_connections
+			WHERE org_id = ? AND rule_id = r.id AND status = 'active'
+		) AS connection_ids, r.updated_at
+	FROM private.datamasking_rules r
+	WHERE org_id = ?
+	`, orgID, orgID).
+		Find(&rules).
+		Error
+}
+
+func GetDataMaskingRuleByID(orgID, ruleID string) (*DataMaskingRule, error) {
+	var rule DataMaskingRule
+	err := DB.Raw(`
+	SELECT
+		r.id, r.org_id, r.name, r.description, r.supported_entity_types, r.custom_entity_types,
+		(
+			SELECT ARRAY_AGG(connection_id) FROM private.datamasking_rules_connections
+			WHERE org_id = ? AND rule_id = r.id AND status = 'active'
+		) AS connection_ids, r.updated_at
+	FROM private.datamasking_rules r
+	WHERE org_id = ? AND r.id = ?
+	`, orgID, orgID, ruleID).
+		First(&rule).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, ErrNotFound
+	}
+	return &rule, err
+}
+
+func GetDataMaskingEntityTypes(orgID, connID string) (json.RawMessage, error) {
+	var jsonStr string
+	err := DB.Raw(`
+		SELECT COALESCE(json_agg(
+			json_build_object(
+				'id', r.id,
+				'name', r.name,
+				'supported_entity_types', r.supported_entity_types,
+				'custom_entity_types', r.custom_entity_types
+			)), '[]'::json)
+		FROM private.datamasking_rules r
+		INNER JOIN private.datamasking_rules_connections c ON r.id = c.rule_id
+		WHERE c.org_id = ? AND c.connection_id = ? AND c.status = 'active'`, orgID, connID).
+		Row().
+		Scan(&jsonStr)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(jsonStr), nil
+}
+
+// TODO: add migration function to convert plugin connections to data masking rules
+// func MigratePluginConnectionToDataMaskingRules(orgID string) error {
+// 	return DB.Transaction(func(tx *gorm.DB) error {
+// 		err := tx.Exec(`
+// 		INSERT INTO datamasking_rules (org_id, name, description, field_types, created_at, updated_at)
+// 		SELECT
+// 			pc.org_id,
+// 			'dm_' || c.name as name,  -- Make unique names per connection
+// 			pc.config as field_types,
+// 			pc.created_at,
+// 			pc.updated_at
+// 		FROM plugin_connections pc
+// 		INNER JOIN connections c ON pc.connection_id = c.id
+// 		INNER JOIN plugins p ON pc.plugin_id = p.id
+// 		WHERE p.name = 'dlp' AND pc.enabled = TRUE AND p.org_id = ?`, orgID).
+// 			Error
+// 		if err != nil {
+// 			return fmt.Errorf("failed migrating plugin connections to data masking rules: %v", err)
+// 		}
+// 		return tx.Exec(`
+// 		INSERT INTO datamasking_rules_connections (org_id, rule_id, connection_id, status, created_at)
+// 		SELECT
+// 			pc.org_id,
+// 			dr.id as rule_id,
+// 			pc.connection_id,
+// 			CASE
+// 				WHEN pc.enabled = TRUE THEN 'active'::enum_datamasking_assoc_status
+// 				ELSE 'inactive'::enum_datamasking_assoc_status
+// 			END as status,
+// 			pc.created_at
+// 		FROM plugin_connections pc
+// 		JOIN plugins p ON pc.plugin_id = p.id
+// 		JOIN datamasking_rules dr ON dr.name = p.name || '_' || pc.id::text AND dr.org_id = pc.org_id
+// 		WHERE p.name = 'dlp';`, orgID).Error
+// 	})
+// }
+
+func DeleteDataMaskingRule(orgID, ruleID string) error {
+	return DB.Table("private.datamasking_rules").
+		Where("org_id = ? AND id = ?", orgID, ruleID).
+		Delete(&DataMaskingRule{}).
+		Error
+}

--- a/gateway/models/guadrails.go
+++ b/gateway/models/guadrails.go
@@ -119,7 +119,6 @@ func UpdateGuardRailRules(r *GuardRailRules) error {
 		Model(r).
 		Clauses(clause.Returning{}).
 		Updates(GuardRailRules{
-			Name:        r.Name,
 			Description: r.Description,
 			Input:       r.Input,
 			Output:      r.Output,

--- a/rootfs/app/migrations/000038_data_masking.down.sql
+++ b/rootfs/app/migrations/000038_data_masking.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+SET search_path TO private;
+
+DROP TABLE IF EXISTS datamasking_connection_associations;
+DROP TABLE IF EXISTS datamasking;
+DROP TYPE enum_datamasking_assoc_status;
+
+COMMIT;

--- a/rootfs/app/migrations/000038_data_masking.up.sql
+++ b/rootfs/app/migrations/000038_data_masking.up.sql
@@ -1,0 +1,35 @@
+BEGIN;
+
+SET search_path TO private;
+
+CREATE TABLE datamasking_rules(
+    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    org_id UUID NOT NULL REFERENCES orgs (id),
+
+    name VARCHAR(128) NOT NULL,
+    description VARCHAR(512) NULL,
+    supported_entity_types JSONB NULL,
+    custom_entity_types JSONB NULL,
+
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+
+    UNIQUE(org_id, name)
+);
+
+CREATE TYPE enum_datamasking_assoc_status AS ENUM ('active', 'inactive');
+
+CREATE TABLE datamasking_rules_connections(
+    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    org_id UUID NULL REFERENCES orgs (id),
+
+    rule_id UUID NOT NULL REFERENCES datamasking_rules (id) ON DELETE CASCADE,
+    connection_id UUID NOT NULL REFERENCES connections (id) ON DELETE CASCADE,
+    status enum_datamasking_assoc_status DEFAULT 'active',
+
+    created_at TIMESTAMP DEFAULT NOW(),
+
+    UNIQUE(rule_id, connection_id)
+);
+
+COMMIT;


### PR DESCRIPTION
- Add table to handle data masking rules configuration deprecating plugin connections
- Add attribute to enable or disable the data masking rule for a single connection
- Add adhoc recognizers to support regex and deny word list
- Add attribute to load data masking from a different data source

## TODO

- [ ] Add plugin migrations to data masking new resource table
- [ ] Implement frontend