### PR TITLE
Fix database schema loading on connection switching + UI improvements

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/webclient/components/connections_list.cljs
+++ b/webapp/src/webapp/webclient/components/connections_list.cljs
@@ -1,6 +1,6 @@
 (ns webapp.webclient.components.connections-list
   (:require
-   ["@radix-ui/themes" :refer [Box Button Flex Heading IconButton Text]]
+   ["@radix-ui/themes" :refer [Box Button Flex Heading Tooltip IconButton Text]]
    ["lucide-react" :refer [FolderTree Settings2 EllipsisVertical X]]
    [clojure.string :as cs]
    [re-frame.core :as rf]
@@ -40,9 +40,9 @@
        [:> EllipsisVertical {:size 16}]])]])
 
 (defn selected-connection []
-  (let [show-schema? (r/atom false)
+  (let [show-schema? (r/atom true)
         ;; State to avoid premature loading of the heavy component
-        schema-loaded? (r/atom false)]
+        schema-loaded? (r/atom true)]
     (fn [connection dark-mode? admin? show-tree?]
       [:> Box {:class "bg-primary-11 light"}
        [:> Flex {:justify "between" :align "center" :class "px-2 pt-2 pb-1"}
@@ -58,17 +58,19 @@
                 :admin? admin?)]
         [:> Flex {:align "center" :gap "2"}
          (when show-tree?
-           [:> IconButton {:onClick #(do
-                                       (swap! show-schema? not)
-                                       ;; Load the schema only when needed
-                                       (when (and @show-schema? (not @schema-loaded?))
-                                         (reset! schema-loaded? true)))
-                           :class (if @show-schema? "bg-[--gray-a4]" "")}
-            [:> FolderTree {:size 16}]])
+           [:> Tooltip {:content "Database Schema"}
+            [:> IconButton {:onClick #(do
+                                        (swap! show-schema? not)
+                                        ;; Load the schema only when needed
+                                        (when (and @show-schema? (not @schema-loaded?))
+                                          (reset! schema-loaded? true)))
+                            :class (if @show-schema? "bg-[--gray-a4]" "")}
+             [:> FolderTree {:size 16}]]])
          (when admin?
-           [:> IconButton
-            {:onClick #(rf/dispatch [:navigate :edit-connection {} :connection-name (:name connection)])}
-            [:> Settings2 {:size 16}]])]]
+           [:> Tooltip {:content "Configure"}
+            [:> IconButton
+             {:onClick #(rf/dispatch [:navigate :edit-connection {} :connection-name (:name connection)])}
+             [:> Settings2 {:size 16}]]])]]
 
        ;; Tree view of database schema with lazy loading
        (when (and @show-schema?


### PR DESCRIPTION
This PR fixes a critical bug in the database schema component where the schema would fail to load when switching between already selected connections, and includes several UI and code quality improvements.

### **Problem Fixed**

**Issue:** When switching between database connections without removing the current selection first, the database schema would fail to load on the third connection switch, requiring users to manually close and reopen the schema panel.

**Root Cause:** Race condition in the component lifecycle management where the `loading-started` flag wasn't properly reset when the global schema was cleared via `:database-schema->clear-schema` event.

### **Changes Made**

#### **1. Database Schema Loading Fix**
- Fixed race condition in `component-did-update` lifecycle method
- Added detection for global schema clearing when switching connections
- Implemented automatic reinitialization when schema is cleared but connection remains the same
- Moved initialization logic from render body to `component-did-mount` to prevent execution on every render

#### **2. Code Quality Improvements**
- Translated all comments from Portuguese to English for better maintainability
- Removed unused parameter `connection-type` from `reagent-render` function
- Improved import formatting for better readability
- Enhanced component lifecycle management with better state tracking

#### **3. UI/UX Enhancements**
- Added tooltips to database schema and configuration buttons for better user experience
- Improved visual feedback during schema loading states

### **Flow Correction**

**Before (Broken):**
```
Connection A selected → Schema loads ✓
Connection B selected → Schema loads ✓  
Connection C selected → Schema fails to load ✗ (user must manually toggle)
```

**After (Fixed):**
```
Connection A selected → Schema loads ✓
Connection B selected → Schema loads ✓
Connection C selected → Schema loads automatically ✓
```

### **Testing**

**Test Scenario:**
1. Select any database connection → Schema should load automatically
2. Select another connection (without removing first) → Schema should load automatically  
3. Continue switching connections → Each switch should load schema automatically

### **Benefits**

- Fixes critical UX bug affecting database schema navigation
- Improves performance by eliminating unnecessary re-renders
- Better code maintainability with English comments
- Enhanced user experience with tooltips and smoother interactions
- More robust state management with better lifecycle handling