### PR TITLE
Add License Expiration Warning for Admin Users

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.47.1",
+  "version": "1.47.2",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/events/gateway_info.cljs
+++ b/webapp/src/webapp/events/gateway_info.cljs
@@ -50,3 +50,21 @@
    (or
     (get-in db [:gateway->info :data :auth_method])
     "local")))
+
+(rf/reg-sub
+ :gateway->should-show-license-expiration-warning
+ (fn [db _]
+   (let [gateway-info (get-in db [:gateway->info :data])
+         user-info (get-in db [:users->current-user :data])
+         license-info (:license_info gateway-info)
+         expire-at (:expire_at license-info)
+         is-admin? (:admin? user-info)
+         is-enterprise? (= (:type license-info) "enterprise")
+         is-valid? (:is_valid license-info)]
+
+     (when (and is-admin? is-enterprise? is-valid? expire-at)
+       (let [now (js/Date.now)
+             expire-date (* expire-at 1000) ; convert to milliseconds
+             three-months-ms (* 90 24 60 60 1000) ; 90 days in milliseconds
+             warning-date (- expire-date three-months-ms)]
+         (>= now warning-date))))))

--- a/webapp/src/webapp/settings/license/panel.cljs
+++ b/webapp/src/webapp/settings/license/panel.cljs
@@ -3,7 +3,8 @@
    [clojure.string :as strings]
    [re-frame.core :as rf]
    [reagent.core :as r]
-   ["@radix-ui/themes" :refer [Table Flex Box Text Heading Button]]
+   ["@radix-ui/themes" :refer [Table Flex Box Text Heading Button Callout]]
+   ["lucide-react" :refer [AlertCircle]]
    [webapp.components.headings :as h]
    [webapp.components.forms :as forms]))
 
@@ -92,6 +93,17 @@
                           :placeholder "Enter your license key"
                           :type "password"}]]]]]]])))
 
+(defn license-expiration-warning []
+  (let [should-show-warning (rf/subscribe [:gateway->should-show-license-expiration-warning])]
+    (fn []
+      (when @should-show-warning
+        [:> Box {:class "mb-6"}
+         [:> Callout.Root {:color "yellow" :role "alert" :size "1"}
+          [:> Callout.Icon
+           [:> AlertCircle {:size 16 :class "text-warning-12"}]]
+          [:> Callout.Text {:class "text-warning-12"}
+           "Your organization's license is expiring soon. Please contact us to avoid interruption."]]]))))
+
 (defn main []
   (let [gateway-info (rf/subscribe [:gateway->info])
         ;; used here for the input because the action
@@ -115,6 +127,9 @@
                                      (strings/blank? @license-value))
                        :on-click #(rf/dispatch [:license->update-license-key @license-value])}
             "Save license"]]]
+
+         [license-expiration-warning]
+
          [:> Flex {:direction :column
                    :gap "8"}
           [information-table license-info]

--- a/webapp/src/webapp/shared_ui/sidebar/components/profile.cljs
+++ b/webapp/src/webapp/shared_ui/sidebar/components/profile.cljs
@@ -30,7 +30,7 @@
                                     :class "mt-1 px-2"}
         [:li
          [:a {:target "_blank"
-              :href "https://hoop.canny.io/"
+              :href "https://github.com/hoophq/hoop/issues"
               :class "group -mx-2 flex items-center gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-300 hover:bg-white/5 hover:text-white"}
           [:> MessageSquarePlus {:size 24
                                  :aria-hidden "true"}]

--- a/webapp/src/webapp/webclient/components/database_schema.cljs
+++ b/webapp/src/webapp/webclient/components/database_schema.cljs
@@ -374,8 +374,8 @@
                    (not= @local-schema-state new-schema)))))
 
       :reagent-render
-      (fn [{:keys [connection-name]}]
-        (let [current-schema (get-in @database-schema [:data connection-name])]
+      (fn [connection]
+        (let [current-schema (get-in @database-schema [:data (:connection-name connection)])]
           (when (and (= (:status current-schema) :success)
                      (not= @local-schema-state current-schema))
             (reset! local-schema-state current-schema))

--- a/webapp/src/webapp/webclient/panel.cljs
+++ b/webapp/src/webapp/webclient/panel.cljs
@@ -199,6 +199,8 @@
     [:> Tooltip {:content (str "Your script streams to " (cs/join " " command) " via stdin")}
      [:> Info {:class "shrink-0 text-gray-11"}]]]])
 
+
+
 (defn editor []
   (let [user (rf/subscribe [:users->current-user])
         gateway-info (rf/subscribe [:gateway->info])
@@ -373,7 +375,7 @@
              [:> Allotment {:defaultSizes vertical-pane-sizes
                             :onDragEnd #(.setItem js/localStorage "editor-vertical-pane-sizes" (str %))}
               [:> (.-Pane Allotment) {:minSize 270}
-               [:aside {:class "h-full flex flex-col gap-8 border-r-2 border-[--gray-3] overflow-auto pb-16"}
+               [:aside {:class "h-full flex flex-col gap-8 border-r-2 border-[--gray-3] overflow-auto"}
                 (if @multi-run-panel?
                   [connections-panel/main dark-mode? (some? (:data @selected-template))]
                   [connections-list/main dark-mode? (show-tree? current-connection)])]]


### PR DESCRIPTION
This PR implements a license expiration warning system that displays alerts to admin users when their enterprise license is approaching expiration (3 months or less remaining).

## Changes Made

### Core Logic
- **Added subscription** `gateway->should-show-license-expiration-warning` in `gateway_info.cljs`
  - Checks if user is admin
  - Validates enterprise license status
  - Calculates if expiration is within 3 months (90 days)

### UI Components
- **License Management Page** (`settings/license/panel.cljs`)
  - Added yellow warning callout above license information table
  - Uses `AlertCircle` icon with warning text

- **Terminal Sidebar** (`webclient/components/connections_list.cljs`)
  - Added fixed warning banner at bottom of connections sidebar
  - Includes "Go to license page" navigation link
  - Implemented proper layout with `flex-1 overflow-auto` for scrollable connections list
  - Warning remains fixed at bottom without interfering with connection scrolling

### User Experience
- Warnings only display for admin users
- Only shows for valid enterprise licenses
- Automatic detection based on license expiration timestamp
- Responsive design that doesn't interfere with existing UI components

## Screenshots
![Screenshot 2025-06-11 at 18 38 27](https://github.com/user-attachments/assets/b4c2d83e-fff5-47cf-ad98-bb0d252ef5be)
![Screenshot 2025-06-11 at 18 38 07](https://github.com/user-attachments/assets/0db5de20-d135-44e5-847b-503ba1c70ca5)


## Testing Notes
- Tested with admin and non-admin users
- Verified warning appears only when conditions are met
- Confirmed sidebar scrolling works independently of warning banner
- UI remains consistent with existing design system