### PR TITLE
[bugfix] Fix nil pointer when runbook file does not exists

### DIFF
--- a/gateway/api/runbooks/runbooks.go
+++ b/gateway/api/runbooks/runbooks.go
@@ -173,6 +173,11 @@ func RunExec(c *gin.Context) {
 		return
 	}
 
+	if runbook == nil {
+		c.JSON(http.StatusNotFound, gin.H{"message": fmt.Sprintf("runbook file %v not found on git repo", req.FileName)})
+		return
+	}
+
 	for key, val := range req.EnvVars {
 		// don't replace environment variables from runbook
 		if _, ok := runbook.EnvVars[key]; ok {


### PR DESCRIPTION
It prevents nil pointer exception when a runbook file doesn't exists when fetching from the git repository.