### PR TITLE
agent: make debug level to log aws response instead of printing the body response

### DIFF
--- a/agent/secretsmanager/aws.go
+++ b/agent/secretsmanager/aws.go
@@ -26,7 +26,7 @@ func newAwsProvider() (*awsProvider, error) {
 	}
 	svc := secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
 		if log.IsDebugLevel {
-			o.ClientLogMode = aws.LogSigning | aws.LogRequest | aws.LogResponseWithBody
+			o.ClientLogMode = aws.LogResponse
 		}
 		// TODO: add zap as logger
 		o.Logger = logging.NewStandardLogger(os.Stdout)


### PR DESCRIPTION
Improve logging to not leak sensitive AWS resource information when secrets manager is enabled.