### PR TITLE
Add score threshold input for data masking configuration

### DIFF
--- a/webapp/src/webapp/ai_data_masking/basic_info.cljs
+++ b/webapp/src/webapp/ai_data_masking/basic_info.cljs
@@ -5,8 +5,10 @@
 
 (defn main [{:keys [name
                     description
+                    score_threshold
                     on-name-change
-                    on-description-change]}]
+                    on-description-change
+                    on-score-threshold-change]}]
   [:> Grid {:columns "7" :gap "7"}
    [:> Box {:grid-column "span 2 / span 2"}
     [:> Flex {:align "center" :gap "2"}
@@ -32,4 +34,20 @@
        :value @description
        :on-change #(on-description-change (-> % .-target .-value))
        :placeholder "Describe how this is used in your connections"
-       :rows 3}]]]])
+       :rows 3}]]
+
+    [:> Box
+     [forms/input
+      {:label "Analyzer confidence threshold"
+       :label-suffix "(Optional)"
+       :name "score_threshold"
+       :type "number"
+       :min 1
+       :max 100
+       :maxlength 3
+       :value @score_threshold
+       :on-change #(let [value (-> % .-target .-value)]
+                     (on-score-threshold-change (if (empty? value) nil (js/parseInt value))))
+       :placeholder "85"}]
+     [:> Text {:size "2" :class "text-[--gray-11] mt-1"}
+      "Minimum confidence level required to detect and mask sensitive data. Default 85% works well for most use cases."]]]])

--- a/webapp/src/webapp/ai_data_masking/create_update_form.cljs
+++ b/webapp/src/webapp/ai_data_masking/create_update_form.cljs
@@ -34,15 +34,15 @@
          [basic-info/main
           {:name (:name state)
            :description (:description state)
+           :score_threshold (:score_threshold state)
            :on-name-change #(reset! (:name state) %)
-           :on-description-change #(reset! (:description state) %)}]
+           :on-description-change #(reset! (:description state) %)
+           :on-score-threshold-change #(reset! (:score_threshold state) %)}]
 
          ;; Connections section
          [connections-section/main
           {:connection-ids (:connection_ids state)
            :on-connections-change (:on-connections-change handlers)}]
-
-
 
          ;; Output rules section
          [:> Flex {:direction "column" :gap "5"}


### PR DESCRIPTION
## 📝 Description

Added the "Analyzer confidence threshold" field to the AI Data Masking rule creation/edit form. This optional field allows users to set the minimum confidence level (percentage) required to detect and mask sensitive data, with automatic conversion between percentage display and float API format.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `score_threshold` field to AI Data Masking form state management in `helpers.cljs`
- Implemented bidirectional conversion between percentage (UI) and float (API) formats
- Added "Analyzer confidence threshold" input field in `basic_info.cljs` with validation (1-100, max 3 digits)
- Updated form component to handle the new field in `create_update_form.cljs`
- Enhanced payload preparation to conditionally include `score_threshold` only when user provides a value
- Added proper handling for empty/null values to avoid sending unnecessary API fields

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome, Firefox, Safari
- **OS**: macOS, Windows, Linux

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

### Manual Testing Scenarios:
1. Create new AI Data Masking rule with empty threshold field
2. Create new AI Data Masking rule with threshold value (e.g., 75%)
3. Edit existing rule and modify threshold value
4. Edit existing rule and clear threshold value
5. Verify API payload contains correct float values (0.75 for 75%)
6. Verify form loads existing threshold values correctly from API

## 📸 Screenshots (if applicable)

Screenshots showing the new "Analyzer confidence threshold" field in both create and edit forms would be helpful to demonstrate the UI changes.

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings

## 📄 Additional Notes

The field implementation follows these design decisions:
- **Optional field**: Users can leave it empty, and it won't be included in the API payload
- **Percentage display**: UI shows values as percentages (1-100) for better UX
- **Float API format**: Automatically converts to float (0.01-1.00) for API compatibility
- **Input validation**: Limited to 3 digits maximum with min/max constraints
- **Backward compatibility**: Existing rules without this field continue to work normally

The helper text suggests 85% as a good default while allowing full user control over the value.

---