### PR TITLE
Fix: Correct user group access path in session details view

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.47.6",
+  "version": "1.47.7",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -246,7 +246,7 @@
                                review-groups)
                          (some (fn [review-group]
                                  (some #(= (:group review-group) %)
-                                       (-> user :data :groups)))
+                                       (-> user :groups)))
                                review-groups))
             is-session-owner? (= session-user-id current-user-id)
             add-review-cb (fn [status]


### PR DESCRIPTION
## 📝 Description

Fixed a bug in the session details view where user group access checking was using an incorrect data path. The code was trying to access user groups via `(-> user :data :groups)` when it should be accessing them directly via `(-> user :groups)`. This fix ensures that session review permissions are properly validated based on the user's group membership.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Fixed user group access path in session details view from `(-> user :data :groups)` to `(-> user :groups)`
- Updated package.json version to 1.47.7
- Corrected session review permission validation logic

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome, Firefox
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed
- [x] Verified session review permissions work correctly for users in review groups

## 📸 Screenshots (if applicable)

No UI changes - this is a backend logic fix.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

This fix addresses an issue where users who should have been able to review sessions based on their group membership were unable to do so due to the incorrect data access path. The fix ensures that the review permission logic correctly evaluates user group membership against the configured review groups.