### PR TITLE
feat: Add `hoop list` and `hoop describe` commands for connection management

### DIFF
--- a/client/cmd/describe.go
+++ b/client/cmd/describe.go
@@ -1,0 +1,376 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	clientconfig "github.com/hoophq/hoop/client/config"
+	"github.com/hoophq/hoop/common/httpclient"
+	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/common/version"
+	"github.com/spf13/cobra"
+)
+
+var describeExampleDesc = `hoop describe db-read
+hoop describe my-postgres-connection
+hoop describe -o json redis-cache`
+
+var describeCmd = &cobra.Command{
+	Use:     "describe CONNECTION",
+	Short:   "Show detailed information about a connection",
+	Long:    "Display detailed information about a specific connection including command, plugins, and configuration",
+	Example: describeExampleDesc,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		runDescribe(args[0])
+	},
+}
+
+func init() {
+	describeCmd.Flags().StringVarP(&outputFlag, "output", "o", "", "Output format. One of: (json)")
+	rootCmd.AddCommand(describeCmd)
+}
+
+func runDescribe(connectionName string) {
+	config := clientconfig.GetClientConfigOrDie()
+
+	connection, err := fetchConnection(config, connectionName)
+	if err != nil {
+		printErrorAndExit("Failed to fetch connection '%s': %v", connectionName, err)
+	}
+
+	if outputFlag == "json" {
+		jsonData, err := json.MarshalIndent(connection, "", "  ")
+		if err != nil {
+			printErrorAndExit("Failed to encode JSON: %v", err)
+		}
+		fmt.Print(string(jsonData))
+		return
+	}
+
+	displayConnectionDetails(config, connection)
+}
+
+func fetchConnection(config *clientconfig.Config, name string) (map[string]any, error) {
+	url := fmt.Sprintf("%s/api/connections/%s", config.ApiURL, name)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", config.Token))
+	if config.IsApiKey() {
+		req.Header.Set("Api-Key", config.Token)
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+
+	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed performing request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	log.Debugf("http response %v", resp.StatusCode)
+
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("connection '%s' not found", name)
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to fetch connection, status=%v", resp.StatusCode)
+	}
+
+	var connection map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&connection); err != nil {
+		return nil, fmt.Errorf("failed decoding response: %v", err)
+	}
+
+	return connection, nil
+}
+
+func displayConnectionDetails(config *clientconfig.Config, conn map[string]any) {
+	name := toStr(conn["name"])
+	connType := toStr(conn["type"])
+	subType := toStr(conn["subtype"])
+	status := toStr(conn["status"])
+	agentID := toStr(conn["agent_id"])
+
+	// Fetch agent information (use same approach as list)
+	allAgentInfo := fetchAllAgentInfo(config)
+	agentName := getAgentNameFromAllInfo(allAgentInfo, agentID)
+
+	// Fetch plugins for this connection
+	plugins := fetchConnectionPlugins(config, name)
+
+	fmt.Printf("name: %s\n", name)
+
+	if subType != "-" && subType != connType {
+		fmt.Printf("type: %s (%s)\n", connType, subType)
+	} else {
+		fmt.Printf("type: %s\n", connType)
+	}
+
+	fmt.Printf("status: %s\n", strings.ToLower(status))
+	fmt.Printf("agent: %s\n", agentName)
+
+	// Full command
+	cmdList, _ := conn["command"].([]any)
+	command := joinFullCommand(cmdList)
+	fmt.Printf("command: %s\n", command)
+
+	// Plugins
+	fmt.Printf("plugins: %s\n", formatPlugins(plugins))
+
+	// Secrets
+	secrets, _ := conn["secret"].(map[string]any)
+	if secrets == nil {
+		secrets, _ = conn["secrets"].(map[string]any)
+	}
+	if len(secrets) > 0 {
+		fmt.Printf("secrets: %d configured\n", len(secrets))
+	} else {
+		fmt.Printf("secrets: -\n")
+	}
+
+	// Tags (if they exist)
+	if tags := conn["connection_tags"]; tags != nil {
+		if tagStr := formatTags(tags); tagStr != "-" {
+			fmt.Printf("tags: %s\n", tagStr)
+		}
+	}
+
+	// Environment variables (if they exist)
+	if envs := conn["envs"]; envs != nil {
+		if envMap, ok := envs.(map[string]any); ok && len(envMap) > 0 {
+			fmt.Printf("environment: %d variables configured\n", len(envMap))
+		}
+	}
+}
+
+func fetchAllAgentInfo(config *clientconfig.Config) map[string]map[string]any {
+	url := config.ApiURL + "/api/agents"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Debugf("failed creating agents request: %v", err)
+		return nil
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", config.Token))
+	if config.IsApiKey() {
+		req.Header.Set("Api-Key", config.Token)
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+
+	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
+	if err != nil {
+		log.Debugf("failed performing agents request: %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Debugf("failed to fetch agents, status=%v", resp.StatusCode)
+		return nil
+	}
+
+	var agents []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&agents); err != nil {
+		log.Debugf("failed decoding agents response: %v", err)
+		return nil
+	}
+
+	// Create map of ID -> agent info
+	agentMap := make(map[string]map[string]any)
+	for _, agent := range agents {
+		if id, ok := agent["id"].(string); ok {
+			agentMap[id] = agent
+		}
+	}
+
+	return agentMap
+}
+
+func getAgentNameFromAllInfo(agentInfo map[string]map[string]any, agentID string) string {
+	if agentInfo == nil {
+		return "-"
+	}
+
+	if agent, exists := agentInfo[agentID]; exists {
+		if name := toStr(agent["name"]); name != "-" {
+			return name
+		}
+	}
+
+	return "-"
+}
+
+func fetchConnectionPlugins(config *clientconfig.Config, connectionName string) []string {
+	url := fmt.Sprintf("%s/api/plugins", config.ApiURL)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Debugf("failed creating plugins request: %v", err)
+		return []string{}
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", config.Token))
+	if config.IsApiKey() {
+		req.Header.Set("Api-Key", config.Token)
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+
+	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
+	if err != nil {
+		log.Debugf("failed performing plugins request: %v", err)
+		return []string{}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Debugf("failed to fetch plugins, status=%v", resp.StatusCode)
+		return []string{}
+	}
+
+	var plugins []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&plugins); err != nil {
+		log.Debugf("failed decoding plugins response: %v", err)
+		return []string{}
+	}
+
+	// Filter plugins that apply to this connection
+	var connectionPlugins []string
+	for _, plugin := range plugins {
+		pluginName := toStr(plugin["name"])
+		if pluginName == "-" {
+			continue
+		}
+
+		connections, ok := plugin["connections"].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, connObj := range connections {
+			if connMap, ok := connObj.(map[string]any); ok {
+				if toStr(connMap["name"]) == connectionName {
+					connectionPlugins = append(connectionPlugins, pluginName)
+					break
+				}
+			}
+		}
+	}
+
+	sort.Strings(connectionPlugins)
+	return connectionPlugins
+}
+
+func joinFullCommand(cmdList []any) string {
+	if len(cmdList) == 0 {
+		return "-"
+	}
+
+	var list []string
+	for _, c := range cmdList {
+		list = append(list, fmt.Sprintf("%q", c))
+	}
+	cmd := strings.Join(list, " ")
+
+	// In describe we show the full command without truncating
+	return fmt.Sprintf("[ %s ]", cmd)
+}
+
+func formatPlugins(plugins []string) string {
+	if len(plugins) == 0 {
+		return "-"
+	}
+
+	return strings.Join(plugins, ", ")
+}
+
+func formatTags(tags any) string {
+	switch v := tags.(type) {
+	case map[string]any:
+		if len(v) == 0 {
+			return "-"
+		}
+		var tagPairs []string
+		for key, val := range v {
+			formattedTag := formatSingleTag(key, toStr(val))
+			if formattedTag != "" {
+				tagPairs = append(tagPairs, formattedTag)
+			}
+		}
+		if len(tagPairs) == 0 {
+			return "-"
+		}
+		sort.Strings(tagPairs)
+		return strings.Join(tagPairs, ", ")
+	case []any:
+		if len(v) == 0 {
+			return "-"
+		}
+		var tagList []string
+		for _, tag := range v {
+			if tagStr := toStr(tag); tagStr != "-" {
+				// For arrays, we assume they are already in key=value format
+				formattedTag := formatTagString(tagStr)
+				if formattedTag != "" {
+					tagList = append(tagList, formattedTag)
+				}
+			}
+		}
+		if len(tagList) == 0 {
+			return "-"
+		}
+		sort.Strings(tagList)
+		return strings.Join(tagList, ", ")
+	default:
+		return "-"
+	}
+}
+
+// formatSingleTag formats an individual tag based on separate key and value
+func formatSingleTag(key, value string) string {
+	if value == "-" || value == "" {
+		return ""
+	}
+
+	// If it's an internal Hoop tag: hoop.dev/group.key
+	if strings.HasPrefix(key, "hoop.dev/") {
+		// Remove the "hoop.dev/" prefix
+		remaining := strings.TrimPrefix(key, "hoop.dev/")
+
+		// Find the last dot that separates the group from the key
+		lastDotIndex := strings.LastIndex(remaining, ".")
+		if lastDotIndex != -1 && lastDotIndex < len(remaining)-1 {
+			// Extract only the key (after the last dot)
+			userKey := remaining[lastDotIndex+1:]
+			return fmt.Sprintf("%s=%s", userKey, value)
+		}
+	}
+
+	// For custom tags, keep as is
+	return fmt.Sprintf("%s=%s", key, value)
+}
+
+// formatTagString formats a tag string that is already in "key=value" format
+func formatTagString(tagStr string) string {
+	// If it already contains =, split and process
+	if strings.Contains(tagStr, "=") {
+		parts := strings.SplitN(tagStr, "=", 2)
+		if len(parts) == 2 {
+			return formatSingleTag(parts[0], parts[1])
+		}
+	}
+
+	// If it doesn't contain =, assume it's a simple custom tag
+	return tagStr
+}

--- a/client/cmd/describe.go
+++ b/client/cmd/describe.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hoophq/hoop/client/cmd/styles"
 	clientconfig "github.com/hoophq/hoop/client/config"
 	"github.com/hoophq/hoop/common/httpclient"
 	"github.com/hoophq/hoop/common/log"
@@ -39,13 +40,13 @@ func runDescribe(connectionName string) {
 
 	connection, err := fetchConnection(config, connectionName)
 	if err != nil {
-		printErrorAndExit("Failed to fetch connection '%s': %v", connectionName, err)
+		styles.PrintErrorAndExit("Failed to fetch connection '%s': %v", connectionName, err)
 	}
 
 	if outputFlag == "json" {
 		jsonData, err := json.MarshalIndent(connection, "", "  ")
 		if err != nil {
-			printErrorAndExit("Failed to encode JSON: %v", err)
+			styles.PrintErrorAndExit("Failed to encode JSON: %v", err)
 		}
 		fmt.Print(string(jsonData))
 		return
@@ -67,7 +68,7 @@ func fetchConnection(config *clientconfig.Config, name string) (map[string]any, 
 	if config.IsApiKey() {
 		req.Header.Set("Api-Key", config.Token)
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%v", version.Get().Version))
 
 	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
 	if err != nil {
@@ -166,7 +167,7 @@ func fetchAllAgentInfo(config *clientconfig.Config) map[string]map[string]any {
 	if config.IsApiKey() {
 		req.Header.Set("Api-Key", config.Token)
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%v", version.Get().Version))
 
 	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
 	if err != nil {
@@ -225,7 +226,7 @@ func fetchConnectionPlugins(config *clientconfig.Config, connectionName string) 
 	if config.IsApiKey() {
 		req.Header.Set("Api-Key", config.Token)
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%v", version.Get().Version))
 
 	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
 	if err != nil {

--- a/client/cmd/list.go
+++ b/client/cmd/list.go
@@ -1,0 +1,290 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	clientconfig "github.com/hoophq/hoop/client/config"
+	"github.com/hoophq/hoop/common/httpclient"
+	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/common/version"
+	"github.com/spf13/cobra"
+)
+
+var (
+	verboseFlag bool
+	outputFlag  string
+)
+
+var listExampleDesc = `hoop list
+hoop ls
+hoop list --verbose
+hoop list -o json`
+
+var listCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List available connections",
+	Long:    "Display connections that you have access to connect",
+	Example: listExampleDesc,
+	Run: func(cmd *cobra.Command, args []string) {
+		runList()
+	},
+}
+
+func init() {
+	listCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Show additional information including command")
+	listCmd.Flags().StringVarP(&outputFlag, "output", "o", "", "Output format. One of: (json)")
+	rootCmd.AddCommand(listCmd)
+}
+
+func runList() {
+	config := clientconfig.GetClientConfigOrDie()
+
+	connections, err := fetchConnections(config)
+	if err != nil {
+		printErrorAndExit("Failed to fetch connections: %v", err)
+	}
+
+	if outputFlag == "json" {
+		jsonData, err := json.MarshalIndent(connections, "", "  ")
+		if err != nil {
+			printErrorAndExit("Failed to encode JSON: %v", err)
+		}
+		fmt.Print(string(jsonData))
+		return
+	}
+
+	displayConnections(connections)
+}
+
+func fetchConnections(config *clientconfig.Config) ([]map[string]any, error) {
+	url := config.ApiURL + "/api/connections"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", config.Token))
+	if config.IsApiKey() {
+		req.Header.Set("Api-Key", config.Token)
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+
+	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed performing request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	log.Debugf("http response %v", resp.StatusCode)
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to fetch connections, status=%v", resp.StatusCode)
+	}
+
+	var connections []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&connections); err != nil {
+		return nil, fmt.Errorf("failed decoding response: %v", err)
+	}
+
+	return connections, nil
+}
+
+func displayConnections(connections []map[string]any) {
+	if len(connections) == 0 {
+		fmt.Println("No connections available")
+		return
+	}
+
+	// Fetch agent information
+	config := clientconfig.GetClientConfigOrDie()
+	agentInfo := fetchAgentInfo(config)
+
+	w := tabwriter.NewWriter(os.Stdout, 6, 4, 3, ' ', tabwriter.TabIndent)
+	defer w.Flush()
+
+	if verboseFlag {
+		fmt.Fprintln(w, "NAME\tCOMMAND\tTYPE\tAGENT\tSTATUS\tTAGS\t")
+	} else {
+		fmt.Fprintln(w, "NAME\tTYPE\tAGENT\tSTATUS\t")
+	}
+
+	// Sort connections by name
+	sortConnections(connections)
+
+	for _, conn := range connections {
+		name := toStr(conn["name"])
+		connType := toStr(conn["type"])
+		status := toStr(conn["status"])
+		agentID := toStr(conn["agent_id"])
+
+		// Get agent name
+		agentName := getAgentName(agentInfo, agentID)
+
+		if verboseFlag {
+			cmdList, _ := conn["command"].([]any)
+			command := joinCommand(cmdList)
+			tags := formatConnectionTags(conn["connection_tags"])
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t",
+				name, command, connType, agentName, status, tags)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t",
+				name, connType, agentName, status)
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+func fetchAgentInfo(config *clientconfig.Config) map[string]map[string]any {
+	url := config.ApiURL + "/api/agents"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Debugf("failed creating agents request: %v", err)
+		return nil
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", config.Token))
+	if config.IsApiKey() {
+		req.Header.Set("Api-Key", config.Token)
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+
+	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
+	if err != nil {
+		log.Debugf("failed performing agents request: %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Debugf("failed to fetch agents, status=%v", resp.StatusCode)
+		return nil
+	}
+
+	var agents []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&agents); err != nil {
+		log.Debugf("failed decoding agents response: %v", err)
+		return nil
+	}
+
+	// Create map of ID -> agent info
+	agentMap := make(map[string]map[string]any)
+	for _, agent := range agents {
+		if id, ok := agent["id"].(string); ok {
+			agentMap[id] = agent
+		}
+	}
+
+	return agentMap
+}
+
+func getAgentName(agentInfo map[string]map[string]any, agentID string) string {
+	if agentInfo == nil {
+		return "-"
+	}
+
+	if agent, exists := agentInfo[agentID]; exists {
+		if name := toStr(agent["name"]); name != "-" {
+			return name
+		}
+	}
+
+	return "-"
+}
+
+func sortConnections(connections []map[string]any) {
+	sort.Slice(connections, func(i, j int) bool {
+		nameI := toStr(connections[i]["name"])
+		nameJ := toStr(connections[j]["name"])
+		return strings.ToLower(nameI) < strings.ToLower(nameJ)
+	})
+}
+
+func joinCommand(cmdList []any) string {
+	if len(cmdList) == 0 {
+		return "-"
+	}
+
+	var list []string
+	for _, c := range cmdList {
+		list = append(list, fmt.Sprintf("%q", c))
+	}
+	cmd := strings.Join(list, " ")
+
+	// Truncate to keep the table readable (more aggressive than admin)
+	if len(cmd) > 25 {
+		cmd = cmd[:22] + "..."
+	}
+
+	return fmt.Sprintf("[ %s ]", cmd)
+}
+
+func toStr(v any) string {
+	s := fmt.Sprintf("%v", v)
+	if s == "" || s == "<nil>" || v == nil {
+		return "-"
+	}
+	return s
+}
+
+func formatConnectionTags(tags any) string {
+	switch v := tags.(type) {
+	case map[string]any:
+		if len(v) == 0 {
+			return "-"
+		}
+		var tagPairs []string
+		for key, val := range v {
+			formattedTag := formatSingleTagForList(key, toStr(val))
+			if formattedTag != "" {
+				tagPairs = append(tagPairs, formattedTag)
+			}
+		}
+		if len(tagPairs) == 0 {
+			return "-"
+		}
+		sort.Strings(tagPairs)
+		tags := strings.Join(tagPairs, ", ")
+		// Truncate long tags to keep the table readable
+		if len(tags) > 30 {
+			tags = tags[:27] + "..."
+		}
+		return tags
+	default:
+		return "-"
+	}
+}
+
+// formatSingleTagForList formats an individual tag for the list command
+func formatSingleTagForList(key, value string) string {
+	if value == "-" || value == "" {
+		return ""
+	}
+
+	// If it's an internal Hoop tag: hoop.dev/group.key
+	if strings.HasPrefix(key, "hoop.dev/") {
+		// Remove the "hoop.dev/" prefix
+		remaining := strings.TrimPrefix(key, "hoop.dev/")
+
+		// Find the last dot that separates the group from the key
+		lastDotIndex := strings.LastIndex(remaining, ".")
+		if lastDotIndex != -1 && lastDotIndex < len(remaining)-1 {
+			// Extract only the key (after the last dot)
+			userKey := remaining[lastDotIndex+1:]
+			return fmt.Sprintf("%s=%s", userKey, value)
+		}
+	}
+
+	// For custom tags, keep as is
+	return fmt.Sprintf("%s=%s", key, value)
+}

--- a/client/cmd/list.go
+++ b/client/cmd/list.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/hoophq/hoop/client/cmd/styles"
 	clientconfig "github.com/hoophq/hoop/client/config"
 	"github.com/hoophq/hoop/common/httpclient"
 	"github.com/hoophq/hoop/common/log"
@@ -48,13 +49,13 @@ func runList() {
 
 	connections, err := fetchConnections(config)
 	if err != nil {
-		printErrorAndExit("Failed to fetch connections: %v", err)
+		styles.PrintErrorAndExit("Failed to fetch connections: %v", err)
 	}
 
 	if outputFlag == "json" {
 		jsonData, err := json.MarshalIndent(connections, "", "  ")
 		if err != nil {
-			printErrorAndExit("Failed to encode JSON: %v", err)
+			styles.PrintErrorAndExit("Failed to encode JSON: %v", err)
 		}
 		fmt.Print(string(jsonData))
 		return
@@ -76,7 +77,7 @@ func fetchConnections(config *clientconfig.Config) ([]map[string]any, error) {
 	if config.IsApiKey() {
 		req.Header.Set("Api-Key", config.Token)
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%v", version.Get().Version))
 
 	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
 	if err != nil {
@@ -157,7 +158,7 @@ func fetchAgentInfo(config *clientconfig.Config) map[string]map[string]any {
 	if config.IsApiKey() {
 		req.Header.Set("Api-Key", config.Token)
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%s", version.Get().Version))
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%v", version.Get().Version))
 
 	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
 	if err != nil {


### PR DESCRIPTION
## 📝 Description

This PR introduces two new CLI commands to improve user experience when working with connections:

- **`hoop list` / `hoop ls`**: Lists available connections in a tabular format with optional verbose mode
- **`hoop describe <connection>`**: Shows detailed information about a specific connection

These commands provide a user-friendly interface for non-admin users to discover and inspect connections without requiring administrative privileges.

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

- **Added `hoop list` command** with tabular output showing Name, Type, Agent, and Status
- **Added `hoop ls` alias** for the list command
- **Added `--verbose` flag** to list command showing Command and Tags columns
- **Added `hoop describe` command** for detailed connection information including:
  - Full command with proper formatting (following admin pattern)
  - Plugin information
  - Secret count (without exposing credentials)
  - User-friendly tag formatting (strips `hoop.dev/group.` prefix)
  - Environment variable count
- **Implemented JSON output support** with `-o json` flag for both commands
- **Added intelligent tag formatting** that extracts user-relevant parts from internal Hoop tags
- **Consistent error handling** using `styles.PrintErrorAndExit`
- **Standardized HTTP client patterns** following existing codebase conventions
- **Command formatting** following admin pattern with quoted arguments and brackets

## 🧪 Testing

### Test Configuration:
- **OS**: macOS, Linux
- **Go Version**: 1.23.8+

### Tests performed:
- [x] Manual testing completed
- [x] Command help text validation
- [x] JSON output validation
- [x] Tag formatting verification
- [x] Error handling testing (invalid connections, network errors)
- [x] Integration with existing auth flow
- [x] Verbose mode functionality
- [x] Agent name resolution
- [x] Plugin listing accuracy

### Example Usage:

```bash
# Basic listing
$ hoop list
NAME            TYPE        AGENT           STATUS
postgres-prod   postgres    prod-agent-01   active
mysql-dev       mysql       dev-agent-02    active

# Verbose listing with commands and tags
$ hoop list --verbose
NAME            COMMAND                 TYPE        AGENT           STATUS    TAGS
postgres-prod   [ "psql" "-v" "..." ]   postgres    prod-agent-01   active    cloud=gcp, env=prod
mysql-dev       [ "mysql" "-h" "..." ]  mysql       dev-agent-02    active    team=backend

# Detailed connection information
$ hoop describe postgres-prod
name: postgres-prod
type: database (postgres)
status: active
agent: prod-agent-01
command: [ "psql" "-v" "ON_ERROR_STOP=1" "-h" "$PGHOST" "-U" "$PGUSER" "-d" "$PGDATABASE" ]
plugins: access_control, audit, dlp, review
secrets: 3 configured
tags: cloud=gcp, env=prod, team=backend

# JSON output for scripting
$ hoop list -o json
$ hoop describe db-prod -o json
```

## 📸 Screenshots

![Screenshot 2025-06-30 at 16 10 34](https://github.com/user-attachments/assets/62fef57d-5cf5-40d1-b8c9-4ed08c26b0b2)
![Screenshot 2025-06-30 at 16 10 21](https://github.com/user-attachments/assets/37d7ca5f-e3a8-4b18-a759-1a25741ab958)
![Screenshot 2025-06-30 at 16 10 52](https://github.com/user-attachments/assets/6bbaa1f4-6e40-47f3-bc5c-2b601dc848ff)
![Screenshot 2025-06-30 at 16 11 04](https://github.com/user-attachments/assets/ba2ee8ac-7dc2-4966-afb7-e9d712f01bbf)


## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

### Key Features:

1. **User-Friendly Tag Display**: Converts internal tags like `hoop.dev/infrastructure.cloud=gcp` to `cloud=gcp` for better readability
2. **Consistent Command Formatting**: Follows the same pattern as `admin get connections` with quoted arguments and brackets
3. **Smart Truncation**: Commands and tags are intelligently truncated in list view to maintain table readability
4. **Plugin Integration**: Shows which plugins are active for each connection
5. **Security Conscious**: Shows secret count without exposing sensitive information

### Technical Implementation:

- Reuses existing HTTP client patterns and authentication flow
- Implements proper error handling and logging
- Follows established import organization and naming conventions
- Uses same configuration loading mechanism as other commands
- Maintains consistency with existing CLI patterns

This enhancement significantly improves the developer experience by providing easy-to-use commands for connection discovery and inspection, bridging the gap between admin-level connection management and user-level connection usage.