### PR TITLE
Add command override to plain exec executions

### DIFF
--- a/common/proto/const.go
+++ b/common/proto/const.go
@@ -11,6 +11,7 @@ const (
 	SpecGatewaySessionID         string = "gateway.session_id"
 	SpecConnectionName           string = "gateway.connection_name"
 	SpecConnectionType           string = "gateway.connection_type"
+	SpecConnectionCommand        string = "gateway.connection_command"
 	SpecHasReviewKey             string = "gateway.has_review"
 	SpecPluginDcmDataKey         string = "plugin.dcm_data"
 	SpecDLPTransformationSummary string = "dlp.transformation_summary" // Deprecated: see spectypes.DataMaskingInfoKey

--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -532,11 +532,12 @@ func ListTables(c *gin.Context) {
 
 	userAgent := apiutils.NormalizeUserAgent(c.Request.Header.Values)
 	client, err := clientexec.New(&clientexec.Options{
-		OrgID:          ctx.GetOrgID(),
-		ConnectionName: conn.Name,
-		BearerToken:    getAccessToken(c),
-		UserAgent:      userAgent,
-		Verb:           pb.ClientVerbPlainExec,
+		OrgID:                     ctx.GetOrgID(),
+		ConnectionName:            conn.Name,
+		ConnectionOverrideCommand: getConnectionCommandOverride(currentConnectionType),
+		BearerToken:               getAccessToken(c),
+		UserAgent:                 userAgent,
+		Verb:                      pb.ClientVerbPlainExec,
 	})
 	if err != nil {
 		log.Error(err)

--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -534,7 +534,7 @@ func ListTables(c *gin.Context) {
 	client, err := clientexec.New(&clientexec.Options{
 		OrgID:                     ctx.GetOrgID(),
 		ConnectionName:            conn.Name,
-		ConnectionOverrideCommand: getConnectionCommandOverride(currentConnectionType),
+		ConnectionCommandOverride: getConnectionCommandOverride(currentConnectionType),
 		BearerToken:               getAccessToken(c),
 		UserAgent:                 userAgent,
 		Verb:                      pb.ClientVerbPlainExec,

--- a/gateway/api/connections/helpers.go
+++ b/gateway/api/connections/helpers.go
@@ -583,3 +583,11 @@ func parseCloudWatchTables(output string) (openapi.TablesResponse, error) {
 
 	return response, nil
 }
+
+func getConnectionCommandOverride(currentConnectionType pb.ConnectionType) []string {
+	switch currentConnectionType {
+	case pb.ConnectionTypeCloudWatch, pb.ConnectionTypeDynamoDB:
+		return []string{"bash"}
+	}
+	return nil
+}

--- a/gateway/clientexec/clientexec.go
+++ b/gateway/clientexec/clientexec.go
@@ -57,7 +57,7 @@ type Options struct {
 	OrgID                     string
 	SessionID                 string
 	ConnectionName            string
-	ConnectionOverrideCommand []string
+	ConnectionCommandOverride []string
 	BearerToken               string
 	Origin                    string
 	Verb                      string
@@ -121,9 +121,9 @@ func New(opts *Options) (*clientExec, error) {
 	}
 
 	var connectionCommandJson []byte
-	if len(opts.ConnectionOverrideCommand) > 0 {
+	if len(opts.ConnectionCommandOverride) > 0 {
 		var err error
-		connectionCommandJson, err = json.Marshal(opts.ConnectionOverrideCommand)
+		connectionCommandJson, err = json.Marshal(opts.ConnectionCommandOverride)
 		if err != nil {
 			return nil, fmt.Errorf("failed encoding connection command, reason=%v", err)
 		}

--- a/gateway/clientexec/clientexec.go
+++ b/gateway/clientexec/clientexec.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,23 +43,25 @@ func NewTimeoutResponse(sessionID string) *Response {
 }
 
 type clientExec struct {
-	folderName string
-	wlog       *wal.Log
-	client     pb.ClientTransport
-	ctx        context.Context
-	cancelFn   context.CancelFunc
-	sessionID  string
-	orgID      string
+	folderName                string
+	wlog                      *wal.Log
+	client                    pb.ClientTransport
+	ctx                       context.Context
+	cancelFn                  context.CancelFunc
+	connectionCommandOverride []byte
+	sessionID                 string
+	orgID                     string
 }
 
 type Options struct {
-	OrgID          string
-	SessionID      string
-	ConnectionName string
-	BearerToken    string
-	Origin         string
-	Verb           string
-	UserAgent      string
+	OrgID                     string
+	SessionID                 string
+	ConnectionName            string
+	ConnectionOverrideCommand []string
+	BearerToken               string
+	Origin                    string
+	Verb                      string
+	UserAgent                 string
 }
 
 type Response struct {
@@ -117,6 +120,15 @@ func New(opts *Options) (*clientExec, error) {
 		opts.Verb = pb.ClientVerbExec
 	}
 
+	var connectionCommandJson []byte
+	if len(opts.ConnectionOverrideCommand) > 0 {
+		var err error
+		connectionCommandJson, err = json.Marshal(opts.ConnectionOverrideCommand)
+		if err != nil {
+			return nil, fmt.Errorf("failed encoding connection command, reason=%v", err)
+		}
+	}
+
 	folderName := fmt.Sprintf(walFolderTmpl, walLogPath, opts.OrgID, opts.SessionID)
 	wlog, err := wal.Open(folderName, wal.DefaultOptions)
 	if err != nil {
@@ -148,13 +160,15 @@ func New(opts *Options) (*clientExec, error) {
 	}
 	ctx, cancelFn := context.WithCancel(context.Background())
 	return &clientExec{
-		folderName: folderName,
-		wlog:       wlog,
-		client:     client,
-		ctx:        ctx,
-		cancelFn:   cancelFn,
-		sessionID:  opts.SessionID,
-		orgID:      opts.OrgID}, nil
+		folderName:                folderName,
+		wlog:                      wlog,
+		client:                    client,
+		ctx:                       ctx,
+		cancelFn:                  cancelFn,
+		sessionID:                 opts.SessionID,
+		orgID:                     opts.OrgID,
+		connectionCommandOverride: connectionCommandJson,
+	}, nil
 }
 
 func (c *clientExec) Run(inputPayload []byte, clientEnvVars map[string]string, clientArgs ...string) *Response {
@@ -173,6 +187,11 @@ func (c *clientExec) Run(inputPayload []byte, clientEnvVars map[string]string, c
 		}
 		openSessionSpec[pb.SpecClientExecArgsKey] = encClientArgs
 	}
+
+	if len(c.connectionCommandOverride) > 0 {
+		openSessionSpec[pb.SpecConnectionCommand] = c.connectionCommandOverride
+	}
+
 	now := time.Now().UTC()
 	resp := c.run(inputPayload, openSessionSpec)
 	resp.ExecutionTimeMili = time.Since(now).Milliseconds()

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -243,6 +243,19 @@ func (s *Server) processClientPacket(stream *streamclient.ProxyStream, pkt *pb.P
 			}
 		}
 
+		// override the entrypoint of the connection command
+		if pctx.ClientVerb == pb.ClientVerbPlainExec {
+			connectionCommandJSON, ok := pkt.Spec[pb.SpecConnectionCommand]
+			if ok {
+				var connectionCommand []string
+				if err := json.Unmarshal(connectionCommandJSON, &connectionCommand); err != nil {
+					log.With("sid", pctx.SID).Errorf("failed decoding connection command override, err=%v", err)
+					return status.Errorf(codes.Internal, "failed decoding connection command override, err=%v", err)
+				}
+				pctx.ConnectionCommand = connectionCommand
+			}
+		}
+
 		clientArgs := clientArgsDecode(pkt.Spec)
 		connParams, err := pb.GobEncode(&pb.AgentConnectionParams{
 			ConnectionName:             pctx.ConnectionName,

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp",
-  "version": "1.47.7",
+  "version": "1.47.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp",
-      "version": "1.47.7",
+      "version": "1.47.8",
       "dependencies": {
         "@codemirror/commands": "^6.3.2",
         "@codemirror/lang-javascript": "^6.2.1",


### PR DESCRIPTION
- Add override to `bash` for cloudwatch and dynamodb connection types