### PR TITLE
fix: add apt-archive to postgres client 15.

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -100,7 +100,7 @@ RUN curl -sL "https://dl.k8s.io/release/v1.22.1/bin/linux/amd64/kubectl" -o kube
     dpkg -i session-manager-plugin.deb && \
     rm -rf /tmp/* session-manager-plugin.deb
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
+RUN echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
     echo "deb [arch=amd64,arm64] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list && \
     echo "deb https://cli-assets.heroku.com/apt ./" > /etc/apt/sources.list.d/heroku.list && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/scripts/dev/Dockerfile
+++ b/scripts/dev/Dockerfile
@@ -91,7 +91,7 @@ RUN echo 'root:1a2b3c4d' | chpasswd && \
   mkdir -p /root/.ssh && \
   ssh-keygen -A
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
+RUN echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
   echo "deb [arch=amd64,arm64] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list && \
   echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
   curl -sL https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
@@ -106,7 +106,7 @@ RUN apt-get update -y && \
   default-mysql-client \
   postgresql-client-15 \
   mongodb-mongosh mongodb-org-tools mongodb-org-shell mongocli \
-  google-cloud-cli \
+  google-cloud-cli=488.0.0-0 \
   sqlcmd unixodbc-dev
 
 # Download and install Oracle Instant Client and SQL*Plus


### PR DESCRIPTION
## Description

The apt repository for Postgres changed to apt-archive for Ubuntu Focal distribution. 

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [x] 🔧 Build configuration change
- [ ] 🧹 Chore