### PR TITLE
[fix] fix brew tap as it returns invalid tap name on mac

### DIFF
--- a/webapp/src/webapp/connections/views/hoop_cli_modal.cljs
+++ b/webapp/src/webapp/connections/views/hoop_cli_modal.cljs
@@ -7,7 +7,7 @@
    [webapp.config :as config]))
 
 (defn cli-commands [api-url]
-  {:macos {:install ["brew tap hoophq/hoopcli https://github.com/hoophq/hoopcli"
+  {:macos {:install ["brew tap hoophq/brew https://github.com/hoophq/brew"
                      "brew install hoop"]
            :configure (str "hoop config create --api-url " api-url)
            :login "hoop login"

--- a/webapp/src/webapp/connections/views/hoop_cli_modal.cljs
+++ b/webapp/src/webapp/connections/views/hoop_cli_modal.cljs
@@ -7,7 +7,7 @@
    [webapp.config :as config]))
 
 (defn cli-commands [api-url]
-  {:macos {:install ["brew tap brew https://github.com/hoophq/brew"
+  {:macos {:install ["brew tap hoophq/hoopcli https://github.com/hoophq/hoopcli"
                      "brew install hoop"]
            :configure (str "hoop config create --api-url " api-url)
            :login "hoop login"


### PR DESCRIPTION
## 📝 Description

brew tap brew doesn't work
```
brew tap brew https://github.com/hoophq/brew
Error: Invalid tap name: 'brew'
```

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when this PR is merged -->

Fixes #

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [X ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- 
- 
- 

## 🧪 Testing

Tested on Mac 15.5

### Test Configuration:
- **Browser(s)**: 
- **OS**:

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
<!-- You can drag and drop images directly into this text area -->

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings

## 📄 Additional Notes

<!-- Add any additional notes, concerns, or discussion points here -->
<!-- Is there anything specific you'd like reviewers to focus on? -->

---

<!-- Thank you for contributing to our project! 🙏 --> 
