### PR TITLE
fix: Add JSON parse error handling in license update event

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.47.14",
+  "version": "1.47.15",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/events/license.cljs
+++ b/webapp/src/webapp/events/license.cljs
@@ -10,7 +10,11 @@
               [:fetch {:method "PUT"
                        :uri "/orgs/license"
                        :body license-obj
-                       :on-success #(rf/dispatch [:gateway->get-info %])}]]]})
+                       :on-success (fn [response]
+                                     (rf/dispatch [:gateway->get-info response])
+                                     (rf/dispatch [:show-snackbar
+                                                   {:level :success
+                                                    :text "License updated successfully"}]))}]]]})
      (catch js/Error e
        {:fx [[:dispatch
               [:show-snackbar {:level :error

--- a/webapp/src/webapp/events/license.cljs
+++ b/webapp/src/webapp/events/license.cljs
@@ -2,11 +2,17 @@
   (:require [re-frame.core :as rf]))
 
 (rf/reg-event-fx
-  :license->update-license-key
-  (fn [_ [_ license-info]]
-    (let [license-obj (.parse js/JSON license-info)]
-    {:fx [[:dispatch
-           [:fetch {:method "PUT"
-                    :uri "/orgs/license"
-                    :body license-obj
-                    :on-success #(rf/dispatch [:gateway->get-info %])}]]]})))
+ :license->update-license-key
+ (fn [_ [_ license-info]]
+   (try
+     (let [license-obj (.parse js/JSON license-info)]
+       {:fx [[:dispatch
+              [:fetch {:method "PUT"
+                       :uri "/orgs/license"
+                       :body license-obj
+                       :on-success #(rf/dispatch [:gateway->get-info %])}]]]})
+     (catch js/Error e
+       {:fx [[:dispatch
+              [:show-snackbar {:level :error
+                               :text "Error processing license: invalid JSON format"
+                               :details {:error (.-message e)}}]]]}))))


### PR DESCRIPTION
## 📝 Description

Added error handling for JSON parsing in the license update event to provide better user feedback when invalid JSON is submitted.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- Added try-catch block around JSON.parse in `:license->update-license-key` event
- Implemented error snackbar notification when JSON parsing fails
- Provided user-friendly error message with technical details for debugging

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome, Firefox, Safari
- **OS**: macOS, Windows, Linux

### Tests performed:
- [x] Manual testing completed

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings