### PR TITLE
Exclude 'rdsadmin' from the list of database endpoint when it is a PostgreSQL connection

### DIFF
--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -353,6 +353,7 @@ SELECT datname as database_name
 FROM pg_database
 WHERE datistemplate = false
   AND datname != 'postgres'
+	AND datname != 'rdsadmin'
 ORDER BY datname;`
 
 	case pb.ConnectionTypeMongoDB:


### PR DESCRIPTION
## 📝 Description

Exclude 'rdsadmin' from the list of database endpoint when it is a PostgreSQL connection

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Code refactor

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
