### PR TITLE
Add Resource Subtype Override for Custom Connections

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.47.15",
+  "version": "1.47.16",
   "scripts": {
     "ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
     "genversion": "npx genversion src/webapp/version.js",

--- a/webapp/src/webapp/connections/views/setup/connection_update_form.cljs
+++ b/webapp/src/webapp/connections/views/setup/connection_update_form.cljs
@@ -180,7 +180,7 @@
                       "database" [database/credentials-step
                                   (:subtype (:data @connection))
                                   :update]
-                      "custom" [server/credentials-step]
+                      "custom" [server/credentials-step :update]
                       "application" (if (= (:subtype (:data @connection)) "ssh")
                                       [server/ssh-credentials]
                                       [network/credentials-form

--- a/webapp/src/webapp/connections/views/setup/events/db_events.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/db_events.cljs
@@ -145,6 +145,12 @@
  (fn [db [_ index field value]]
    (assoc-in db [:connection-setup :credentials :environment-variables index field] value)))
 
+;; Resource Subtype Override events
+(rf/reg-event-db
+ :connection-setup/set-resource-subtype-override
+ (fn [db [_ value]]
+   (assoc-in db [:connection-setup :resource-subtype-override] value)))
+
 ;; Configuration Files events
 (rf/reg-event-db
  :connection-setup/update-config-file-name

--- a/webapp/src/webapp/connections/views/setup/events/subs.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/subs.cljs
@@ -222,3 +222,9 @@
  :connection-setup/ssh-credentials
  (fn [db]
    (get-in db [:connection-setup :ssh-credentials] {})))
+
+;; Resource Subtype Override subscription
+(rf/reg-sub
+ :connection-setup/resource-subtype-override
+ (fn [db]
+   (get-in db [:connection-setup :resource-subtype-override])))

--- a/webapp/src/webapp/connections/views/setup/server.cljs
+++ b/webapp/src/webapp/connections/views/setup/server.cljs
@@ -1,7 +1,7 @@
 ;; server.cljs
 (ns webapp.connections.views.setup.server
   (:require
-   ["@radix-ui/themes" :refer [Avatar Box Card Flex Grid Heading RadioGroup Text]]
+   ["@radix-ui/themes" :refer [Avatar Box Badge Card Flex Grid Heading RadioGroup Text]]
    ["lucide-react" :refer [Blocks SquareTerminal]]
    [re-frame.core :as rf]
    [reagent.core :as r]
@@ -28,7 +28,29 @@
               :title "Console"
               :subtitle "For Ruby on Rails, Python, Node JS and more."}})
 
-(defn credentials-step []
+(defn resource-subtype-override-section []
+  (let [resource-subtype-override @(rf/subscribe [:connection-setup/resource-subtype-override])]
+    [:> Box {:class "space-y-4"}
+     [:> Flex {:align "center" :gap "2"}
+      [:> Heading {:size "3"} "Resource Subtype Override"]
+      [:> Badge {:variant "solid" :color "green" :size "1"} "Beta"]]
+
+     [:> Text {:size "2" :color "gray"}
+      "Configure your connection for specific resource types. Select a subtype only if it matches your actual resource, applying the optimal settings for that resource type."]
+     [:> Text {:size "2" :color "gray"}
+      "This feature is currently in Beta to streamline connections to most common resource types."]
+
+     [:> Box
+      [forms/select
+       {:options [{:text "DynamoDB" :value "dynamodb"}
+                  {:text "CloudWatch" :value "cloudwatch"}]
+        :selected (or resource-subtype-override "")
+        :placeholder "Select one"
+        :on-change #(rf/dispatch [:connection-setup/set-resource-subtype-override %])
+        :full-width? true
+        :not-margin-bottom? true}]]]))
+
+(defn credentials-step [& [mode]]
   [:form
    {:id "credentials-form"
     :on-submit (fn [e]
@@ -59,6 +81,10 @@
         :name "command-args"}]
       [:> Text {:size "2" :color "gray" :mt "2"}
        "Example: 'python', '-m', 'http.server', '8000'"]]]
+
+    ;; Resource Subtype Override Section (only in update mode)
+    (when (= mode :update)
+      [resource-subtype-override-section])
 
     ;; Agent Section
     [agent-selector/main]]])


### PR DESCRIPTION
## 📝 Description

This PR adds a Resource Subtype Override feature that allows custom connections to specify their actual resource type (DynamoDB or CloudWatch) while maintaining the flexibility of custom connection configuration. This enables users to get optimal settings and features for specific resource types while still using the custom connection workflow.

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added Resource Subtype Override select component for custom connections in edit mode
- Implemented event handlers and subscriptions for managing subtype override state
- Updated form processing logic to use override value as actual subtype when specified
- Added proper loading/saving logic to detect and preserve existing override configurations
- Integrated with existing forms component system for consistent UI styling
- Added Beta badge to indicate the feature is in beta phase

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome, Firefox, Safari
- **OS**: macOS, Windows, Linux

### Tests performed:
- [x] Manual testing completed

#### Manual Testing Scenarios:
- Creating new custom connections (override select not visible)
- Editing existing custom connections (override select visible)
- Selecting DynamoDB override and verifying subtype is saved correctly
- Selecting CloudWatch override and verifying subtype is saved correctly
- Loading connections with existing overrides and verifying UI shows correct selection
- Clearing override selection and verifying connection reverts to custom subtype

## 📸 Screenshots

<img width="1504" height="993" alt="Screenshot 2025-08-08 at 17 14 41" src="https://github.com/user-attachments/assets/88676feb-52b7-41a6-bfa0-607a193135b3" />

The Resource Subtype Override section appears in the custom connection edit form with:
- Clear heading with Beta badge
- Explanatory text about the feature
- Dropdown with DynamoDB and CloudWatch options
- Full-width layout consistent with other form elements

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings