### PR TITLE
Update base images with Ubuntu 24.04 LTS (Noble Numbat)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,9 +282,140 @@ jobs:
           name: dist-artifacts-${{ github.job }}
           path: dist/
 
-  docker-publish:
+  # docker-publish:
+  #   runs-on: ubuntu-latest
+  #   name: Docker Publish
+  #   environment: production
+  #   needs:
+  #     - darwin-amd64
+  #     - darwin-arm64
+  #     - windows-amd64
+  #     - windows-arm64
+  #     - linux-amd64
+  #     - linux-arm64
+  #     - build-webapp
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #     - name: Docker meta
+  #       id: meta
+  #       uses: docker/metadata-action@v4
+  #       with:
+  #         images: hoophq/hoop
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKER_LOGIN }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: dist-artifacts-*
+  #         merge-multiple: true
+  #         path: dist/
+  #     - name: Extract Webapp
+  #       run: make extract-webapp
+  #     - name: Build and push
+  #       uses: docker/build-push-action@v4
+  #       with:
+  #         context: .
+  #         platforms: linux/amd64
+  #         push: true
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         labels: ${{ steps.meta.outputs.labels }}
+
+  # docker-publish-agent:
+  #   runs-on: ubuntu-latest
+  #   name: Docker Publish Agent
+  #   environment: production
+  #   needs:
+  #     - darwin-amd64
+  #     - darwin-arm64
+  #     - windows-amd64
+  #     - windows-arm64
+  #     - linux-amd64
+  #     - linux-arm64
+  #     - build-webapp
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #     - name: Docker meta
+  #       id: meta
+  #       uses: docker/metadata-action@v4
+  #       with:
+  #         images: hoophq/hoopdev
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKER_LOGIN }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: dist-artifacts-*
+  #         merge-multiple: true
+  #         path: dist/
+  #     - name: Build and Push
+  #       uses: docker/build-push-action@v4
+  #       with:
+  #         file: ./Dockerfile.dev
+  #         context: .
+  #         platforms: linux/amd64
+  #         push: true
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         labels: ${{ steps.meta.outputs.labels }}
+
+  docker-publish-hoopgateway-arm64:
+    runs-on: GitHub-Linux-Arm-Runner
+    name: Dck Publish Gateway (arm64)
+    environment: production
+    needs:
+      - darwin-amd64
+      - darwin-arm64
+      - windows-amd64
+      - windows-arm64
+      - linux-amd64
+      - linux-arm64
+      - build-webapp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoop
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-artifacts-*
+          merge-multiple: true
+          path: dist/
+      - name: Extract Webapp
+        run: make extract-webapp
+      - name: Build and Push
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile
+          context: '.'
+          platforms: linux/arm64
+          provenance: false
+          sbom: false
+          push: true
+          tags: |
+            hoophq/hoop:${{ github.sha }}-arm64
+
+  docker-publish-hoopgateway-amd64:
     runs-on: ubuntu-latest
-    name: Docker Publish
+    name: Dck Publish Agent (amd64)
     environment: production
     needs:
       - darwin-amd64
@@ -319,15 +450,56 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
-          context: .
+          file: ./Dockerfile
+          context: '.'
           platforms: linux/amd64
+          provenance: false
+          sbom: false
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            hoophq/hoop:${{ github.sha }}-amd64
 
-  docker-publish-agent:
+  docker-publish-hoopgateway-multiarch:
     runs-on: ubuntu-latest
-    name: Docker Publish Agent
+    name: Publish Gateway Image
+    environment: production
+    needs:
+      - docker-publish-hoopgateway-amd64
+      - docker-publish-hoopgateway-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoop
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set Git Tag
+        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Create SHA manifest and push
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: |
+          docker manifest create hoophq/hoop:${{ env.GIT_TAG }} \
+            --amend hoophq/hoop:${{ github.sha }}-amd64 \
+            --amend hoophq/hoop:${{ github.sha }}-arm64
+          docker manifest create hoophq/hoop:latest \
+            --amend hoophq/hoop:${{ github.sha }}-amd64 \
+            --amend hoophq/hoop:${{ github.sha }}-arm64
+          docker manifest push hoophq/hoop:${{ env.GIT_TAG }}
+          docker manifest push hoophq/hoop:latest
+
+
+  docker-publish-hoopagent-arm64:
+    runs-on: GitHub-Linux-Arm-Runner
+    name: Dck Publish Agent (arm64)
     environment: production
     needs:
       - darwin-amd64
@@ -361,11 +533,95 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: ./Dockerfile.dev
-          context: .
-          platforms: linux/amd64
+          context: '.'
+          platforms: linux/arm64
+          provenance: false
+          sbom: false
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            hoophq/hoopdev:${{ github.sha }}-arm64
+
+  docker-publish-hoopagent-amd64:
+    runs-on: ubuntu-latest
+    name: Dck Publish Agent (amd64)
+    environment: production
+    needs:
+      - darwin-amd64
+      - darwin-arm64
+      - windows-amd64
+      - windows-arm64
+      - linux-amd64
+      - linux-arm64
+      - build-webapp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoopdev
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-artifacts-*
+          merge-multiple: true
+          path: dist/
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: Dockerfile.dev
+          context: '.'
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          push: true
+          tags: |
+            hoophq/hoopdev:${{ github.sha }}-amd64
+
+  docker-publish-hoopagent-multiarch:
+    runs-on: ubuntu-latest
+    name: Publish Hoopagent Image
+    environment: production
+    needs:
+      - docker-publish-hoopagent-amd64
+      - docker-publish-hoopagent-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoopdev
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set Git Tag
+        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Create SHA manifest and push
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: |
+          docker manifest create hoophq/hoopdev:${{ env.GIT_TAG }} \
+            --amend hoophq/hoopdev:${{ github.sha }}-amd64 \
+            --amend hoophq/hoopdev:${{ github.sha }}-arm64
+          docker manifest create hoophq/hoopdev:latest \
+            --amend hoophq/hoopdev:${{ github.sha }}-amd64 \
+            --amend hoophq/hoopdev:${{ github.sha }}-arm64
+          docker manifest push hoophq/hoopdev:${{ env.GIT_TAG }}
+          docker manifest push hoophq/hoopdev:latest
+
 
   docker-publish-hooplabs-arm64:
     runs-on: GitHub-Linux-Arm-Runner
@@ -515,9 +771,9 @@ jobs:
     name: Publish Release
     environment: production
     needs:
-      - docker-publish
-      - docker-publish-agent
       - docker-publish-multiarch
+      - docker-publish-hoopgateway-multiarch
+      - docker-publish-hoopagent-multiarch
 
     steps:
       - name: Checkout Hoop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,7 +415,7 @@ jobs:
 
   docker-publish-hoopgateway-amd64:
     runs-on: ubuntu-latest
-    name: Dck Publish Agent (amd64)
+    name: Dck Publish Gateway (amd64)
     environment: production
     needs:
       - darwin-amd64
@@ -576,7 +576,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
-          file: Dockerfile.dev
+          file: ./Dockerfile.dev
           context: '.'
           platforms: linux/amd64
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal-20250404
+FROM ubuntu:noble-20250714
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV ACCEPT_EULA=y
@@ -32,6 +32,7 @@ RUN tar -xf /tmp/hoop_*_$(uname -s)_$(uname -m).tar.gz -C /app/ && \
 
 EXPOSE 8009
 EXPOSE 8010
+EXPOSE 15432
 
 ENV PATH="/app:${PATH}"
 ENV PATH="${PATH}:/opt/hoop/bin"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,5 @@
 # Dockerfile.tools
-FROM hoophq/agent-tools:0.0.10
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM hoophq/agent-tools:noble-20250812
 
 COPY rootfs /
 COPY dist/binaries/ /tmp/
@@ -11,7 +9,6 @@ RUN tar -xf /tmp/hoop_*_$(uname -s)_$(uname -m).tar.gz -C /app/ && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
-ENV PATH="/app:${PATH}"
 ENV PATH="${PATH}:/opt/hoop/bin"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,21 +1,19 @@
-FROM ubuntu:focal-20250404
+FROM ubuntu:noble-20250714
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV ACCEPT_EULA=y
-ARG CLOJURE_VERSION=1.10.3.1040
-ARG AWS_CLI_VERSION=2.9.6
-ARG AWS_SM_VERSION=1.2.398.0
-ARG GCLOUD_VERSION=488.0.0-0
+ARG AWS_CLI_VERSION=2.28.6
+ARG GCLOUD_VERSION=533.0.0-0
 ARG GCLOUD_GKE_AUTHN_PLUGIN_VERSION=467.0.0-0
-ARG NODE_VERSION=20.17.0
+ARG NODE_VERSION=22.18.0
 
 # Common
 RUN mkdir -p /app && \
-    apt-get update -y && \
-    apt-get install -y \
+    apt update -y && \
+    apt install -y \
     python3-dev \
     python3-pip \
-    python3.9 \
+    python3.12 \
     locales \
     tini \
     apt-utils \
@@ -23,7 +21,7 @@ RUN mkdir -p /app && \
     gnupg \
     gnupg2 \
     net-tools \
-    netcat \
+    netcat-openbsd \
     groff \
     jq \
     openssh-client \
@@ -33,14 +31,15 @@ RUN mkdir -p /app && \
     gettext-base \
     lsb-release \
     alien \
-    libaio1 \
+    libaio1t64 \
     elfutils \
     libelf-dev \
     bc \
     wget \
-    && \
+    redis-tools && \
     ln -s /usr/bin/python3 /usr/bin/python
 
+# https://github.com/nodejs/release-keys
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
     amd64) ARCH='x64';; \
@@ -54,6 +53,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && export GNUPGHOME="$(mktemp -d)" \
     && set -ex \
     && for key in \
+    5BE8A3F6C8A5C01D106C0AD820B1A390B168D356 \
     4ED778F539E3634C779C87C6D7062848A1AB005C \
     141F07595B7B3FFE74309A937405533BE57C7D57 \
     74F12602B6F1C4E913FAA37AD3A89613643B6201 \
@@ -82,89 +82,108 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && node --version \
     && npm --version
 
-# kubectl / aws-cli / aws-session-manager
-RUN curl -sL "https://dl.k8s.io/release/v1.22.1/bin/linux/amd64/kubectl" -o kubectl && \
-    echo '78178a8337fc6c76780f60541fca7199f0f1a2e9c41806bded280a4a5ef665c9  kubectl' | sha256sum -c --ignore-missing --strict - && \
-    chmod 755 kubectl && \
-    mv kubectl /usr/local/bin/kubectl && \
-    curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-$AWS_CLI_VERSION.zip" -o awscli-exe-linux-x86_64-$AWS_CLI_VERSION.zip && \
-    echo '8f1de286d2c66cc0d0d26f205fdb17d5ed073f1e97f305c522e2d1fd89d5c854  awscli-exe-linux-x86_64-2.9.6.zip' | sha256sum \
-    -c --ignore-missing --strict - && \
-    unzip -q awscli-exe-linux-x86_64-$AWS_CLI_VERSION.zip && \
-    aws/install && \
-    aws --version && \
-    rm -rf aws && \
-    curl -sL "https://s3.amazonaws.com/session-manager-downloads/plugin/$AWS_SM_VERSION/ubuntu_64bit/session-manager-plugin.deb" -o session-manager-plugin.deb && \
-    echo 'aae58e58fcfbba465231086766d236ce8d032ae73b9335690e1faba704af2f9a  session-manager-plugin.deb' | sha256sum \
-    -c --ignore-missing --strict - && \
-    dpkg -i session-manager-plugin.deb && \
-    rm -rf /tmp/* session-manager-plugin.deb
+RUN curl -sL "https://dl.k8s.io/release/v1.29.15/bin/linux/$(dpkg --print-architecture)/kubectl" -o kubectl && \
+  chmod 755 kubectl && \
+  mv kubectl /usr/local/bin/kubectl
 
-RUN echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
-    echo "deb [arch=amd64,arm64] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list && \
-    echo "deb https://cli-assets.heroku.com/apt ./" > /etc/apt/sources.list.d/heroku.list && \
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+  amd64) ARCH='x86_64';; \
+  arm64) ARCH='aarch64';; \
+  *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH.zip" -o awscli-exe-linux.zip && \
+    unzip -q awscli-exe-linux.zip && \
+    aws/install && \
+    aws --version
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+  amd64) ARCH='ubuntu_64bit';; \
+  arm64) ARCH='ubuntu_arm64';; \
+  *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -sL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/$ARCH/session-manager-plugin.deb" -o session-manager-plugin.deb && \
+    dpkg -i session-manager-plugin.deb
+
+RUN LIBSSL_1_1_REPO= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+  amd64) LIBSSL_1_1_REPO='deb http://security.ubuntu.com/ubuntu focal-security main';; \
+  arm64) LIBSSL_1_1_REPO='deb http://ports.ubuntu.com/ubuntu-ports focal-security main';; \
+  *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && echo $LIBSSL_1_1_REPO | tee /etc/apt/sources.list.d/focal-security.list && \
+    wget -qO- https://www.mongodb.org/static/pgp/server-8.0.asc | tee /etc/apt/trusted.gpg.d/server-8.0.asc && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl -sL https://cli-assets.heroku.com/apt/release.key | apt-key add - && \
-    curl -sL https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
-    curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    curl -sL https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - && \
+    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list && \
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl -sL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
-RUN apt-get update -y && \
-    apt-get install -y \
-    mongodb-mongosh mongodb-org-tools mongodb-org-shell \
-    openjdk-11-jre \
-    heroku \
-    default-mysql-client \
-    postgresql-client-15 \
-    sqlcmd \
-    unixodbc-dev \
+# legacy mongo client
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+  amd64) ARCH='x86_64';; \
+  arm64) ARCH='aarch64';; \
+  *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -fsSLO --compressed https://fastdl.mongodb.org/linux/mongodb-linux-$ARCH-ubuntu2004-5.0.31.tgz && \
+  apt update -y && apt install libssl1.1 -y && \
+    tar -xzf mongodb-linux-$ARCH-ubuntu2004-5.0.31.tgz && \
+    mv mongodb-linux-$ARCH-ubuntu2004-5.0.31/bin/mongo /usr/local/bin/mongo && \
+    rm mongodb-linux-$ARCH-ubuntu2004-5.0.31.tgz && \
+    mongo --version
+
+RUN apt update -y && apt install -y \
+    mongodb-mongosh=2.5.6 \
+    mongodb-org-tools=8.0.12 \
+    default-mysql-client=1.1.0build1 \
+    unixodbc-dev=2.3.12-1ubuntu0.24.04.1 \
+    postgresql-client-16=16.9-0ubuntu0.24.04.1 \
     google-cloud-cli=$GCLOUD_VERSION \
     google-cloud-sdk-gke-gcloud-auth-plugin=$GCLOUD_GKE_AUTHN_PLUGIN_VERSION && \
-    rm -rf /var/lib/apt/lists/*
+        curl -fsSLO --compressed https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/s/sqlcmd/sqlcmd_1.5.0-1_jammy_all.deb && \
+        dpkg -i sqlcmd_1.5.0-1_jammy_all.deb && \
+        rm sqlcmd_1.5.0-1_jammy_all.deb && \
+        rm -rf /var/lib/apt/lists/*
+
+# configure libaio symlink for oracle client
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+    amd64) ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1;; \
+    arm64) ln -s /usr/lib/aarch64-linux-gnu/libaio.so.1t64 /usr/lib/aarch64-linux-gnu/libaio.so.1;; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+    esac
 
 # Download and install Oracle Instant Client and SQL*Plus
 RUN URL_ORACLE_BASIC= && URL_ORACLE_SQLPLUS= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
-    amd64) URL_ORACLE_BASIC='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-basic-linux.x64-19.24.0.0.0dbru.zip';; \
+    amd64) URL_ORACLE_BASIC='https://download.oracle.com/otn_software/linux/instantclient/2390000/instantclient-basic-linux.x64-23.9.0.25.07.zip';; \
     arm64) URL_ORACLE_BASIC='https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linux-arm64.zip';; \
-    i386) URL_ORACLE_BASIC='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-basic-linux-19.24.0.0.0dbru.zip';; \
     *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && case "${dpkgArch##*-}" in \
-    amd64) URL_ORACLE_SQLPLUS='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-sqlplus-linux.x64-19.24.0.0.0dbru.zip';; \
+    amd64) URL_ORACLE_SQLPLUS='https://download.oracle.com/otn_software/linux/instantclient/2390000/instantclient-sqlplus-linux.x64-23.9.0.25.07.zip';; \
     arm64) URL_ORACLE_SQLPLUS='https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linux-arm64.zip';; \
-    i386) URL_ORACLE_SQLPLUS='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-sqlplus-linux-19.24.0.0.0dbru.zip';; \
     *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && mkdir -p /opt/oracle && \
     cd /opt/oracle && \
     wget -O instantclient-basic-linux.zip $URL_ORACLE_BASIC && \
     wget -O instantclient-sqlplus-linux.zip $URL_ORACLE_SQLPLUS && \
-    unzip instantclient-basic-linux.zip && \
-    rm -rf META-INF && \
-    unzip instantclient-sqlplus-linux.zip && \
-    rm instantclient-basic-linux.zip && \
-    rm instantclient-sqlplus-linux.zip && \
-    echo 'set markup csv on delimiter "\t" quote off\nset heading on echo off termout off\nset feedback off trimspool on' >> instantclient_19_24/glogin.sql && \
+    unzip instantclient-basic-linux.zip && rm -rf META-INF && \
+    unzip instantclient-sqlplus-linux.zip && rm instantclient-basic-linux.zip && rm instantclient-sqlplus-linux.zip && \
+    echo 'set markup csv on delimiter "\t" quote off\nset heading on echo off termout off\nset feedback off trimspool on' >> /opt/oracle/instantclient_23_9/glogin.sql && \
+    LD_LIBRARY_PATH=/opt/oracle/instantclient_23_9 /opt/oracle/instantclient_23_9/sqlplus -V && \
     cd /
 
 # Configure environment variables
-ENV PATH="/opt/oracle/instantclient_19_24:$PATH"
-ENV LD_LIBRARY_PATH="/opt/oracle/instantclient_19_24"
-
-# clojure
-RUN curl -sL https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh -o clojure-install.sh && \
-    sha256sum clojure-install.sh && \
-    echo "665e35e8d7dd0996edaba36220fd5048fee95f5155ec0426f628f18770239821 clojure-install.sh" | sha256sum -c - && \
-    bash clojure-install.sh && \
-    rm clojure-install.sh && \
-    clojure -e "(clojure-version)"
+ENV PATH="/opt/oracle/instantclient_23_9:$PATH"
+ENV LD_LIBRARY_PATH="/opt/oracle/instantclient_23_9"
 
 RUN pip3 install -U \
-    boto3==1.37.38 \
-    requests==2.27.1
+    boto3==1.40.6 \
+    requests==2.32.4 \
+    --break-system-packages
 
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
     locale-gen
@@ -176,4 +195,3 @@ ENV NODE_PATH=/usr/local/lib/node_modules/
 ENV PATH="/app:${PATH}"
 
 ENTRYPOINT ["tini", "--"]
-

--- a/scripts/dev/Dockerfile
+++ b/scripts/dev/Dockerfile
@@ -1,89 +1,15 @@
-FROM ubuntu:focal-20250404
+FROM hoophq/agent-tools:noble-20250812
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV ACCEPT_EULA=y
-ENV NODE_VERSION=18.17.0
-
-RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
-  && case "${dpkgArch##*-}" in \
-  amd64) ARCH='x64';; \
-  arm64) ARCH='arm64';; \
-  i386) ARCH='x86';; \
-  *) echo "unsupported architecture"; exit 1 ;; \
-  esac \
-  && set -ex \
-  # libatomic1 for arm
-  && apt-get update && apt-get install -y \
-  ca-certificates \
-  curl \
-  wget \
-  gnupg \
-  dirmngr \
-  xz-utils \
-  libatomic1 \
-  --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && for key in \
-  4ED778F539E3634C779C87C6D7062848A1AB005C \
-  141F07595B7B3FFE74309A937405533BE57C7D57 \
-  74F12602B6F1C4E913FAA37AD3A89613643B6201 \
-  DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
-  61FC681DFB92A079F1685E77973F295594EC4689 \
-  8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-  C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-  890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
-  C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
-  108F52B48DB57BB0CC439B2997B01419BD92F80A \
-  ; do \
-  gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
-  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && apt-mark auto '.*' > /dev/null \
-  && find /usr/local -type f -executable -exec ldd '{}' ';' \
-  | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
-  | sort -u \
-  | xargs -r dpkg-query --search \
-  | cut -d: -f1 \
-  | sort -u \
-  | xargs -r apt-mark manual \
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-  # smoke tests
-  && node --version \
-  && npm --version
-
-RUN mkdir -p /app && \
-  mkdir -p /opt/hoop/sessions && \
+RUN mkdir -p /opt/hoop/sessions && \
   mkdir -p /opt/hoop/bin && \
   apt-get update -y && \
   apt-get install -y \
-  python3-dev \
-  python3-pip \
-  python3.9 \
-  net-tools \
   iproute2 \
   xz-utils \
-  locales \
-  tini \
-  jq \
-  openssh-client \
   openssh-server \
   sudo \
   apt-utils \
-  procps \
-  unzip \
-  curl \
-  gnupg \
-  gettext-base \
-  gnupg2 \
-  libaio1 \
-  wget
+  procps
 
 # # SSH Server configuration for testing
 RUN echo 'root:1a2b3c4d' | chpasswd && \
@@ -91,86 +17,13 @@ RUN echo 'root:1a2b3c4d' | chpasswd && \
   mkdir -p /root/.ssh && \
   ssh-keygen -A
 
-RUN echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
-  echo "deb [arch=amd64,arm64] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list && \
-  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  curl -sL https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
-  curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-  curl -sL https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - && \
-  curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-  curl -sL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-
-RUN apt-get update -y && \
-  apt-get install -y \
-  openjdk-11-jre \
-  default-mysql-client \
-  postgresql-client-15 \
-  mongodb-mongosh mongodb-org-tools mongodb-org-shell mongocli \
-  google-cloud-cli=488.0.0-0 \
-  sqlcmd unixodbc-dev
-
-# Download and install Oracle Instant Client and SQL*Plus
-RUN URL_ORACLE_BASIC= && URL_ORACLE_SQLPLUS= && dpkgArch="$(dpkg --print-architecture)" \
-  && case "${dpkgArch##*-}" in \
-  amd64) URL_ORACLE_BASIC='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-basic-linux.x64-19.24.0.0.0dbru.zip';; \
-  arm64) URL_ORACLE_BASIC='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-basic-linux.arm64-19.24.0.0.0dbru.zip';; \
-  i386) URL_ORACLE_BASIC='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-basic-linux-19.24.0.0.0dbru.zip';; \
-  *) echo "unsupported architecture"; exit 1 ;; \
-  esac \
-  && case "${dpkgArch##*-}" in \
-  amd64) URL_ORACLE_SQLPLUS='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-sqlplus-linux.x64-19.24.0.0.0dbru.zip';; \
-  arm64) URL_ORACLE_SQLPLUS='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-sqlplus-linux.arm64-19.24.0.0.0dbru.zip';; \
-  i386) URL_ORACLE_SQLPLUS='https://download.oracle.com/otn_software/linux/instantclient/1924000/instantclient-sqlplus-linux-19.24.0.0.0dbru.zip';; \
-  *) echo "unsupported architecture"; exit 1 ;; \
-  esac \
-  && mkdir -p /opt/oracle/instantclient_19_24 && \
-  cd /opt/oracle && \
-  wget -O instantclient-basic-linux.zip $URL_ORACLE_BASIC && \
-  wget -O instantclient-sqlplus-linux.zip $URL_ORACLE_SQLPLUS && \
-  unzip instantclient-basic-linux.zip && \
-  rm -rf META-INF && \
-  unzip instantclient-sqlplus-linux.zip && \
-  rm instantclient-basic-linux.zip && \
-  rm instantclient-sqlplus-linux.zip && \
-  echo 'set markup csv on delimiter "\t" quote off\nset heading on echo off termout off\nset feedback off trimspool on' >> instantclient_19_24/glogin.sql && \
-  cd /
-
 RUN curl -Lo ec2-metadata-mock "https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v1.13.0/ec2-metadata-mock-linux-$(dpkg --print-architecture)" && \
   chmod +x ec2-metadata-mock && \
   mv ec2-metadata-mock /usr/local/bin/ec2-metadata-mock
 
-# Configure environment variables
-ENV PATH="/opt/oracle/instantclient_19_24:$PATH"
-ENV LD_LIBRARY_PATH="/opt/oracle/instantclient_19_24"
-
-RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
-  && case "${dpkgArch##*-}" in \
-  amd64) ARCH='amd64';; \
-  arm64) ARCH='aarch64';; \
-  *) echo "unsupported architecture"; exit 1 ;; \
-  esac \
-  && curl -sL "https://dl.k8s.io/release/v1.22.1/bin/linux/amd64/kubectl" -o kubectl && \
-  echo '78178a8337fc6c76780f60541fca7199f0f1a2e9c41806bded280a4a5ef665c9  kubectl' | sha256sum -c --ignore-missing --strict - && \
-  chmod 755 kubectl && \
-  mv kubectl /usr/local/bin/kubectl && \
-  curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH.zip" -o awscli-exe-linux.zip && \
-    unzip -q awscli-exe-linux.zip && \
-    aws/install && \
-    aws --version
-
-RUN pip3 install -U \
-  boto3==1.37.38 \
-  requests==2.27.1
-
 COPY rootfs/usr/local/bin /usr/local/bin/
 COPY rootfs/opt/hoop/bin /opt/hoop/bin/
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
-  locale-gen
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US:en
-ENV LC_ALL=en_US.UTF-8
 
-ENV PATH="/app:${PATH}"
 ENV PATH="${PATH}:/opt/hoop/bin"
 
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
## 📝 Description

- Add multi image architecture (amd64 and arm64)
  - `hoophq/hoop` - Gateway
  - `hoophq/hoopdev`  - Agent

## Agent Package Updates
- Agent: update python3.9 to python3.12
- Agent: update aws cli to 2.28.6
- Agent: update google cli to 533.0.0-0
- Agent: update node to 22.18 (LTS)
- Agent: add redis-cli tool
- Agent: update kubectl cli to 1.29.15
- Agent: add legacy mongo client and update mongosh to 2.5.6
- Agent: update postgres client to 16.9-0ubuntu0.24.04.1 (main ubuntu repo)
- Agent: update default mysql client to 1.1.0build1 (main ubuntu repo)
- Agent: update oracle clients to 23.9
- Agent: update python3 libs boto3 to 1.40.6 and requests to 2.32.4
- Agent: add compatibility with libaio by creating a symlink with newest libaio package (libaio1t64)
- Agent: removed clojure and jre

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [x] 🔧 Build configuration change
- [ ] 🧹 Chore

