### PR TITLE
Implement Postgres Server Proxy on gateway

### DIFF
--- a/common/keys/keys.go
+++ b/common/keys/keys.go
@@ -33,7 +33,7 @@ func GenerateSecureRandomKey(prefixKey string, size uint16) (secretKey, secretKe
 		prefixKey = defaultPrefixKey
 	}
 	secretKey = prefixKey + "-" + secretKey
-	secretKeyHash, err = hash256Key(secretKey)
+	secretKeyHash, err = Hash256Key(secretKey)
 	if err != nil {
 		return "", "", fmt.Errorf("failed generating secret hash, err=%v", err)
 	}
@@ -115,7 +115,7 @@ func Base64DecodeEd25519PublicKey(encodedKey string) (ed25519.PublicKey, error) 
 	return ed25519.PublicKey(pubKeyBytes), nil
 }
 
-func hash256Key(secretKey string) (secret256Hash string, err error) {
+func Hash256Key(secretKey string) (secret256Hash string, err error) {
 	h := sha256.New()
 	if _, err := h.Write([]byte(secretKey)); err != nil {
 		return "", fmt.Errorf("failed hashing secret key, err=%v", err)

--- a/common/pgtypes/const.go
+++ b/common/pgtypes/const.go
@@ -15,20 +15,38 @@ func (t PacketType) String() string {
 // client
 // http://www.postgresql.org/docs/9.4/static/protocol-message-formats.html
 const (
-	ClientBind           PacketType = 'B'
-	ClientClose          PacketType = 'C'
-	ClientCopyData       PacketType = 'd'
-	ClientCopyDone       PacketType = 'c'
-	ClientCopyFail       PacketType = 'f'
-	ClientDescribe       PacketType = 'D'
-	ClientExecute        PacketType = 'E'
-	ClientFlush          PacketType = 'H'
-	ClientParse          PacketType = 'P'
-	ClientPassword       PacketType = 'p'
-	ClientSimpleQuery    PacketType = 'Q'
-	ClientSync           PacketType = 'S'
-	ClientTerminate      PacketType = 'X'
-	ServerBackendKeyData PacketType = 'K'
+	ClientBind        PacketType = 'B'
+	ClientClose       PacketType = 'C'
+	ClientCopyData    PacketType = 'd'
+	ClientCopyDone    PacketType = 'c'
+	ClientCopyFail    PacketType = 'f'
+	ClientDescribe    PacketType = 'D'
+	ClientExecute     PacketType = 'E'
+	ClientFlush       PacketType = 'H'
+	ClientParse       PacketType = 'P'
+	ClientPassword    PacketType = 'p'
+	ClientSimpleQuery PacketType = 'Q'
+	ClientSync        PacketType = 'S'
+	ClientTerminate   PacketType = 'X'
+
+	ServerAuth                 PacketType = 'R'
+	ServerBindComplete         PacketType = '2'
+	ServerCommandComplete      PacketType = 'C'
+	ServerCloseComplete        PacketType = '3'
+	ServerCopyInResponse       PacketType = 'G'
+	ServerDataRow              PacketType = 'D'
+	ServerEmptyQuery           PacketType = 'I'
+	ServerErrorResponse        PacketType = 'E'
+	ServerNoticeResponse       PacketType = 'N'
+	ServerNoData               PacketType = 'n'
+	ServerParameterDescription PacketType = 't'
+	ServerParameterStatus      PacketType = 'S'
+	ServerParseComplete        PacketType = '1'
+	ServerPortalSuspended      PacketType = 's'
+	ServerBackendKeyData       PacketType = 'K'
+	ServerReadyForQuery        PacketType = 'Z'
+	ServerRowDescription       PacketType = 'T'
+	ServerSSLNotSupported      PacketType = 'N'
 )
 
 const ClientCancelRequestMessage uint32 = 80877102
@@ -49,7 +67,39 @@ var clientPacketType = map[PacketType]string{
 	ClientTerminate:   "ClientTerminate",
 }
 
+const (
+	ClientSSLRequestMessage    uint32 = 80877103
+	ClientGSSENCRequestMessage uint32 = 80877104
+)
+
 func isClientType(packetType byte) (isClient bool) {
 	_, isClient = clientPacketType[PacketType(packetType)]
 	return
 }
+
+// server
+type (
+	Severity string
+	Code     string
+)
+
+const (
+	LevelError   Severity = "ERROR"
+	LevelFatal   Severity = "FATAL"
+	LevelPanic   Severity = "PANIC"
+	LevelWarning Severity = "WARNING"
+	LevelNotice  Severity = "NOTICE"
+	LevelDebug   Severity = "DEBUG"
+	LevelInfo    Severity = "INFO"
+	LevelLog     Severity = "LOG"
+)
+
+const (
+	// Class 08 - Connection Exception
+	ConnectionFailure Code = "08006"
+	// Class 0A — Feature Not Supported
+	FeatureNotSupported Code = "0A000"
+	// Class 28 — Invalid Authorization Specification
+	InvalidPassword                   Code = "28P01"
+	InvalidAuthorizationSpecification Code = "28000"
+)

--- a/common/proto/transport_grpc.pb.go
+++ b/common/proto/transport_grpc.pb.go
@@ -8,6 +8,7 @@ package proto
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/gateway/api/dbaccess/dbaccess.go
+++ b/gateway/api/dbaccess/dbaccess.go
@@ -1,0 +1,128 @@
+package apidbaccess
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/keys"
+	"github.com/hoophq/hoop/common/proto"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/appconfig"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2"
+)
+
+// CreateConnectionDbAccess
+//
+//	@Summary		Create Database Access
+//	@Description	Create Database Access
+//	@Tags			Connections
+//	@Accept			json
+//	@Produce		json
+//	@Param			nameOrID	path		string								true	"Name or UUID of the connection"
+//	@Param			request		body		openapi.ConnectionDbAccessRequest	true	"The request body resource"
+//	@Success		201			{object}	openapi.ConnectionDbAccess
+//	@Failure		400,404,500	{object}	openapi.HTTPError
+//	@Router			/connections/{nameOrID}/dbaccess [post]
+func CreateConnectionDbAccess(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	var req openapi.ConnectionDbAccessRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(400, gin.H{"message": err.Error()})
+		return
+	}
+
+	serverConfig, err := models.GetServerMiscConfig()
+	if err != nil && err != models.ErrNotFound {
+		c.AbortWithStatusJSON(500, gin.H{"message": fmt.Sprintf("failed to retrieve server config, err=%v", err)})
+		return
+	}
+
+	var pgServerListenAddr string
+	if serverConfig != nil && serverConfig.PostgresServerConfig != nil {
+		pgServerListenAddr = serverConfig.PostgresServerConfig.ListenAddress
+	}
+
+	_, listenPort, _ := strings.Cut(pgServerListenAddr, ":")
+	if listenPort == "" {
+		c.AbortWithStatusJSON(400, gin.H{"message": "postgres server proxy is not configured"})
+		return
+	}
+
+	connNameOrID := c.Param("nameOrID")
+	conn, err := models.GetConnectionByNameOrID(ctx, connNameOrID)
+	if err != nil {
+		c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})
+		return
+	}
+	if conn == nil {
+		c.AbortWithStatusJSON(404, gin.H{"message": fmt.Sprintf("connection %s not found", connNameOrID)})
+		return
+	}
+
+	if conn.SubType.String != string(proto.ConnectionTypePostgres) {
+		c.AbortWithStatusJSON(400, gin.H{"message": "unsupported connection type"})
+		return
+	}
+
+	if conn.AccessModeConnect != "enabled" {
+		c.AbortWithStatusJSON(400, gin.H{"message": "access mode connect is not enabled for this connection"})
+		return
+	}
+
+	dbHostname := appconfig.Get().ApiHostname()
+	if dbHostname == "localhost" {
+		dbHostname = "127.0.0.1"
+	}
+
+	defaultDB := "postgres"
+	defaultDBEnc := conn.Envs["envvar:DB"]
+	if defaultDBEnc != "" {
+		defaultDBBytes, _ := base64.RawStdEncoding.DecodeString(defaultDBEnc)
+		defaultDB = string(defaultDBBytes)
+	}
+	secretKey, secretKeyHash, err := keys.GenerateSecureRandomKey("pgaccess", 32)
+	if err != nil {
+		c.AbortWithStatusJSON(500, gin.H{"message": "failed to generate secret key"})
+		return
+	}
+	expireAt := time.Now().UTC().Add(time.Duration(req.AccessDurationSec) * time.Second)
+	if expireAt.After(time.Now().UTC().Add(48 * time.Hour)) {
+		c.AbortWithStatusJSON(400, gin.H{"message": "access duration cannot exceed 48 hours"})
+		return
+	}
+	db, err := models.CreateConnectionDbAccess(&models.DbAccess{
+		ID:             uuid.NewString(),
+		OrgID:          ctx.OrgID,
+		UserSubject:    ctx.UserID,
+		ConnectionName: conn.Name,
+		SecretKeyHash:  secretKeyHash,
+		CreatedAt:      time.Now().UTC(),
+		ExpireAt:       expireAt,
+	})
+	if err != nil {
+		c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})
+		return
+	}
+
+	dbPassword, dbPort := "noop", listenPort
+	connectionString := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		secretKey, dbPassword, dbHostname, dbPort, defaultDB)
+	c.JSON(201,
+		openapi.ConnectionDbAccess{
+			ID:               db.ID,
+			DatabaseName:     defaultDB,
+			Hostname:         dbHostname,
+			Username:         secretKey,
+			Password:         dbPassword,
+			Port:             dbPort,
+			ConnectionString: connectionString,
+			CreatedAt:        db.CreatedAt,
+			ExpireAt:         db.ExpireAt,
+		},
+	)
+}

--- a/gateway/api/login/local/register.go
+++ b/gateway/api/login/local/register.go
@@ -23,7 +23,7 @@ import (
 //	@Tags			Authentication
 //	@Accept			json
 //	@Produce		json
-//	@Param			Token				header		string				false	"The access token generated after successful registration"
+//	@Param			Token				header		string						false	"The access token generated after successful registration"
 //	@Param			request				body		openapi.LocalUserRequest	true	"The request body resource"
 //	@Success		201					{object}	openapi.HTTPError
 //	@Failure		400,401,403,409,500	{object}	openapi.HTTPError

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -597,6 +597,65 @@ const docTemplate = `{
                 }
             }
         },
+        "/connections/{nameOrID}/dbaccess": {
+            "post": {
+                "description": "Create Database Access",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Create Database Access",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name or UUID of the connection",
+                        "name": "nameOrID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "The request body resource",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/openapi.ConnectionDbAccessRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.ConnectionDbAccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{nameOrID}/tables": {
             "get": {
                 "description": "List tables from a database without column details",
@@ -5200,6 +5259,66 @@ const docTemplate = `{
                 }
             }
         },
+        "openapi.ConnectionDbAccess": {
+            "type": "object",
+            "properties": {
+                "connection_string": {
+                    "description": "The connection string to access the database instance",
+                    "type": "string",
+                    "example": "postgres://noop:noop@db.example.com:5432/mydb?sslmode=disable"
+                },
+                "created_at": {
+                    "description": "When the resource was created",
+                    "type": "string",
+                    "example": "2025-08-25T12:00:00Z"
+                },
+                "database_name": {
+                    "description": "The default database name of the connection",
+                    "type": "string",
+                    "example": "mydb"
+                },
+                "expire_at": {
+                    "description": "When the database access connection expires",
+                    "type": "string",
+                    "example": "2025-08-25T13:00:00Z"
+                },
+                "hostname": {
+                    "description": "The hostname to access the database instance",
+                    "type": "string",
+                    "example": "db.example.com"
+                },
+                "id": {
+                    "description": "The unique identifier of the connection database access",
+                    "type": "string",
+                    "format": "uuid",
+                    "readOnly": true,
+                    "example": "15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7"
+                },
+                "password": {
+                    "description": "The password of the database instance",
+                    "type": "string",
+                    "example": "noop"
+                },
+                "port": {
+                    "description": "The port of the database instance",
+                    "type": "string",
+                    "example": "5432"
+                },
+                "username": {
+                    "description": "The username of the database instance",
+                    "type": "string",
+                    "example": "noop"
+                }
+            }
+        },
+        "openapi.ConnectionDbAccessRequest": {
+            "type": "object",
+            "properties": {
+                "access_duration_seconds": {
+                    "type": "integer"
+                }
+            }
+        },
         "openapi.ConnectionTag": {
             "type": "object",
             "properties": {
@@ -6539,6 +6658,19 @@ const docTemplate = `{
                 }
             }
         },
+        "openapi.PostgresServerConfig": {
+            "type": "object",
+            "required": [
+                "listen_address"
+            ],
+            "properties": {
+                "listen_address": {
+                    "description": "The listen address to run the PostgreSQL server proxy",
+                    "type": "string",
+                    "example": "0.0.0.0:15432"
+                }
+            }
+        },
         "openapi.ProviderType": {
             "type": "string",
             "enum": [
@@ -7304,6 +7436,14 @@ const docTemplate = `{
                     "description": "The gRPC server URL used to advertise the gRPC server to clients",
                     "type": "string",
                     "default": "grpc://127.0.0.1:8010"
+                },
+                "postgres_server_config": {
+                    "description": "The PostgreSQL server proxy configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.PostgresServerConfig"
+                        }
+                    ]
                 },
                 "product_analytics": {
                     "description": "Either to enable or disable the product analytics tracking",

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1542,6 +1542,13 @@ type ServerMiscConfig struct {
 	ProductAnalytics string `json:"product_analytics" enum:"active,inactive" example:"active"`
 	// The gRPC server URL used to advertise the gRPC server to clients
 	GrpcServerURL string `json:"grpc_server_url" default:"grpc://127.0.0.1:8010"`
+	// The PostgreSQL server proxy configuration
+	PostgresServerConfig *PostgresServerConfig `json:"postgres_server_config"`
+}
+
+type PostgresServerConfig struct {
+	// The listen address to run the PostgreSQL server proxy
+	ListenAddress string `json:"listen_address" example:"0.0.0.0:15432" binding:"required"`
 }
 
 type ServerAuthOidcConfig struct {
@@ -1605,4 +1612,29 @@ type LocalUserRequest struct {
 	Email    string `json:"email" binding:"required"`
 	Password string `json:"password" binding:"required"`
 	Name     string `json:"name"`
+}
+
+type ConnectionDbAccessRequest struct {
+	AccessDurationSec int `json:"access_duration_seconds"`
+}
+
+type ConnectionDbAccess struct {
+	// The unique identifier of the connection database access
+	ID string `json:"id" format:"uuid" readonly:"true" example:"15B5A2FD-0706-4A47-B1CF-B93CCFC5B3D7"`
+	// The default database name of the connection
+	DatabaseName string `json:"database_name" example:"mydb"`
+	// The hostname to access the database instance
+	Hostname string `json:"hostname" example:"db.example.com"`
+	// The username of the database instance
+	Username string `json:"username" example:"noop"`
+	// The password of the database instance
+	Password string `json:"password" example:"noop"`
+	// The port of the database instance
+	Port string `json:"port" example:"5432"`
+	// The connection string to access the database instance
+	ConnectionString string `json:"connection_string" example:"postgres://noop:noop@db.example.com:5432/mydb?sslmode=disable"`
+	// When the resource was created
+	CreatedAt time.Time `json:"created_at" example:"2025-08-25T12:00:00Z"`
+	// When the database access connection expires
+	ExpireAt time.Time `json:"expire_at" example:"2025-08-25T13:00:00Z"`
 }

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hoophq/hoop/gateway/api/apiroutes"
 	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
 	apidatamasking "github.com/hoophq/hoop/gateway/api/datamasking"
+	apidbaccess "github.com/hoophq/hoop/gateway/api/dbaccess"
 	apifeatures "github.com/hoophq/hoop/gateway/api/features"
 	apiguardrails "github.com/hoophq/hoop/gateway/api/guardrails"
 	apihealthz "github.com/hoophq/hoop/gateway/api/healthz"
@@ -259,12 +260,6 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		api.TrackRequest(analytics.EventUpdateConnection),
 		apiconnections.Put)
-	// DEPRECATED in flavor of POST /sessions
-	r.POST("/connections/:name/exec",
-		r.AuthMiddleware,
-		api.TrackRequest(analytics.EventApiExecConnection),
-		sessionapi.Post,
-	)
 	r.GET("/connections",
 		r.AuthMiddleware,
 		apiconnections.List)
@@ -288,6 +283,12 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		apiroutes.ReadOnlyAccessRole,
 		r.AuthMiddleware,
 		apiconnections.GetTableColumns)
+
+	// DB Access routes
+	r.POST("/connections/:nameOrID/dbaccess",
+		r.AuthMiddleware,
+		apidbaccess.CreateConnectionDbAccess,
+	)
 
 	r.GET("/connection-tags",
 		apiroutes.ReadOnlyAccessRole,

--- a/gateway/api/serverconfig/misc.go
+++ b/gateway/api/serverconfig/misc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/proxyproto"
 )
 
 const defaultGrpcServerURL = "grpc://127.0.0.1:8010"
@@ -54,9 +55,17 @@ func GetServerMisc(c *gin.Context) {
 		grpcURL = *config.GrpcServerURL
 	}
 
+	var pgServerConfig *openapi.PostgresServerConfig
+	if config.PostgresServerConfig != nil {
+		pgServerConfig = &openapi.PostgresServerConfig{
+			ListenAddress: config.PostgresServerConfig.ListenAddress,
+		}
+	}
+
 	c.JSON(http.StatusOK, openapi.ServerMiscConfig{
-		ProductAnalytics: productAnalytics,
-		GrpcServerURL:    grpcURL,
+		ProductAnalytics:     productAnalytics,
+		GrpcServerURL:        grpcURL,
+		PostgresServerConfig: pgServerConfig,
 	})
 }
 
@@ -82,9 +91,38 @@ func UpdateServerMisc(c *gin.Context) {
 		return
 	}
 
+	pgProxyServer := proxyproto.GetPostgresServerInstance()
+	enablePgServerProxy := req.PostgresServerConfig != nil
+	if enablePgServerProxy {
+		currentSrvConfig, err := models.GetServerMiscConfig()
+		if err != nil && err != models.ErrNotFound {
+			log.Errorf("failed to get server config, reason=%v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+			return
+		}
+
+		// Stop the server if the listen address has changed
+		if currentSrvConfig != nil && currentSrvConfig.PostgresServerConfig != nil {
+			if currentSrvConfig.PostgresServerConfig.ListenAddress != req.PostgresServerConfig.ListenAddress {
+				_ = pgProxyServer.Stop()
+			}
+		}
+
+		if err := pgProxyServer.Start(req.PostgresServerConfig.ListenAddress); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+			return
+		}
+	} else {
+		if err := pgProxyServer.Stop(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+			return
+		}
+	}
+
 	updatedConfig, err := models.UpsertServerMiscConfig(&models.ServerMiscConfig{
-		ProductAnalytics: req.ProductAnalytics,
-		GrpcServerURL:    req.GrpcServerURL,
+		ProductAnalytics:     req.ProductAnalytics,
+		GrpcServerURL:        req.GrpcServerURL,
+		PostgresServerConfig: req.PostgresServerConfig,
 	})
 	if err != nil {
 		log.Errorf("failed to update server config, reason=%v", err)
@@ -92,16 +130,23 @@ func UpdateServerMisc(c *gin.Context) {
 		return
 	}
 
+	var pgServerConfig *openapi.PostgresServerConfig
+	if updatedConfig.PostgresServerConfig != nil {
+		pgServerConfig = &openapi.PostgresServerConfig{
+			ListenAddress: updatedConfig.PostgresServerConfig.ListenAddress,
+		}
+	}
+
 	c.JSON(http.StatusOK, openapi.ServerMiscConfig{
-		ProductAnalytics: ptr.ToString(updatedConfig.ProductAnalytics),
-		GrpcServerURL:    ptr.ToString(updatedConfig.GrpcServerURL),
+		ProductAnalytics:     ptr.ToString(updatedConfig.ProductAnalytics),
+		GrpcServerURL:        ptr.ToString(updatedConfig.GrpcServerURL),
+		PostgresServerConfig: pgServerConfig,
 	})
 }
 
 func parseMiscPayload(c *gin.Context) (*models.ServerMiscConfig, error) {
 	var req openapi.ServerMiscConfig
 	if err := c.ShouldBindJSON(&req); err != nil {
-		log.Errorf("failed to bind request, reason=%v", err)
 		return nil, err
 	}
 
@@ -127,9 +172,20 @@ func parseMiscPayload(c *gin.Context) (*models.ServerMiscConfig, error) {
 		return nil, fmt.Errorf("invalid attribute for 'grpc_server_url', it must start with 'grpc://', 'grpcs://', 'http://', or 'https://'")
 	}
 
+	var pgServerConfig *models.PostgresServerConfig
+	if req.PostgresServerConfig != nil {
+		if _, _, found := strings.Cut(req.PostgresServerConfig.ListenAddress, ":"); !found {
+			return nil, fmt.Errorf("invalid attribute for 'listen_address', it must be in the format 'ip:port'")
+		}
+		pgServerConfig = &models.PostgresServerConfig{
+			ListenAddress: req.PostgresServerConfig.ListenAddress,
+		}
+	}
+
 	return &models.ServerMiscConfig{
-		ProductAnalytics: &req.ProductAnalytics,
-		GrpcServerURL:    &req.GrpcServerURL,
+		ProductAnalytics:     &req.ProductAnalytics,
+		GrpcServerURL:        &req.GrpcServerURL,
+		PostgresServerConfig: pgServerConfig,
 	}, nil
 }
 

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -72,11 +72,6 @@ func Post(c *gin.Context) {
 		return
 	}
 
-	// Accept request body and url params as connection name
-	// Maintained for compatibility with legacy endpoint /api/connections/:name/exec
-	if req.Connection == "" {
-		req.Connection = c.Param("name")
-	}
 	if err := CoerceMetadataFields(req.Metadata); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
 		return

--- a/gateway/models/connection_dbaccess.go
+++ b/gateway/models/connection_dbaccess.go
@@ -1,0 +1,56 @@
+package models
+
+import (
+	"time"
+
+	"github.com/hoophq/hoop/common/memory"
+	"gorm.io/gorm"
+)
+
+var dbaccessStore = memory.New()
+
+type DbAccess struct {
+	ID             string    `gorm:"column:id"`
+	OrgID          string    `gorm:"column:org_id"`
+	UserSubject    string    `gorm:"column:user_subject"`
+	ConnectionName string    `gorm:"column:connection_name"`
+	SecretKeyHash  string    `gorm:"column:secret_key_hash"`
+	CreatedAt      time.Time `gorm:"column:created_at"`
+	ExpireAt       time.Time `gorm:"column:expire_at"`
+}
+
+func CreateConnectionDbAccess(db *DbAccess) (*DbAccess, error) {
+	return db, DB.Table("private.connection_dbaccess").Create(db).Error
+}
+
+// func CreateConnectionDbAccess(db *DbAccess) (*DbAccess, error) {
+// 	if dbaccessStore.Has(db.ID) {
+// 		return nil, ErrAlreadyExists
+// 	}
+// 	dbaccessStore.Set(db.ID, db)
+// 	return db, nil
+// }
+
+func GetConnectionDbAccessByID(orgID, id string) (*DbAccess, error) {
+	var resp DbAccess
+	err := DB.Table("private.connection_dbaccess").
+		Where("org_id = ? AND id = ?", orgID, id).
+		First(&resp).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, ErrNotFound
+	}
+	return &resp, err
+}
+
+func GetValidDbAccessBySecretKey(secretKeyHash string) (*DbAccess, error) {
+	var resp DbAccess
+	err := DB.Table("private.connection_dbaccess").
+		Where("secret_key_hash = ?", secretKeyHash).
+		First(&resp).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, ErrNotFound
+	}
+	return &resp, err
+}

--- a/gateway/models/server_misc_config.go
+++ b/gateway/models/server_misc_config.go
@@ -7,8 +7,13 @@ import (
 )
 
 type ServerMiscConfig struct {
-	ProductAnalytics *string `gorm:"column:product_analytics"`
-	GrpcServerURL    *string `gorm:"column:grpc_server_url"`
+	ProductAnalytics     *string               `gorm:"column:product_analytics"`
+	GrpcServerURL        *string               `gorm:"column:grpc_server_url"`
+	PostgresServerConfig *PostgresServerConfig `gorm:"column:postgres_server_config;serializer:json"`
+}
+
+type PostgresServerConfig struct {
+	ListenAddress string `json:"listen_address"`
 }
 
 func GetServerMiscConfig() (*ServerMiscConfig, error) {
@@ -31,8 +36,9 @@ func UpsertServerMiscConfig(newObj *ServerMiscConfig) (*ServerMiscConfig, error)
 		res := DB.Table("private.serverconfig").
 			Where("1=1").
 			Updates(map[string]any{
-				"product_analytics": newObj.ProductAnalytics,
-				"grpc_server_url":   newObj.GrpcServerURL,
+				"product_analytics":      newObj.ProductAnalytics,
+				"grpc_server_url":        newObj.GrpcServerURL,
+				"postgres_server_config": newObj.PostgresServerConfig,
 			})
 		if res.Error != nil {
 			return nil, res.Error

--- a/gateway/proxyproto/const.go
+++ b/gateway/proxyproto/const.go
@@ -1,0 +1,30 @@
+package proxyproto
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"log"
+)
+
+// ImpersonateSecretKey is a key to impersonate users in the gateway securely by this package
+var ImpersonateSecretKey string = generateSecureRandomKeyOrDie()
+
+const (
+	ImpersonateAuthKeyHeaderKey     = "impersonate-auth-key"
+	ImpersonateUserSubjectHeaderKey = "impersonate-user-subject"
+)
+
+func generateSecureRandomKeyOrDie() string {
+	secretRandomBytes := make([]byte, 32)
+	if _, err := rand.Read(secretRandomBytes); err != nil {
+		log.Fatalf("failed generating entropy, err=%v", err)
+	}
+	secretKey := base64.RawURLEncoding.EncodeToString(secretRandomBytes)
+	h := sha256.New()
+	if _, err := h.Write([]byte(secretKey)); err != nil {
+		log.Fatalf("failed hashing secret key, err=%v", err)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/gateway/proxyproto/core.go
+++ b/gateway/proxyproto/core.go
@@ -1,0 +1,335 @@
+package proxyproto
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/grpc"
+	"github.com/hoophq/hoop/common/keys"
+	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/common/memory"
+	pgtypes "github.com/hoophq/hoop/common/pgtypes"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+	"github.com/hoophq/hoop/gateway/appconfig"
+	"github.com/hoophq/hoop/gateway/models"
+)
+
+var (
+	instanceStore        = memory.New()
+	instanceKey   string = "pg_server"
+)
+
+type PGServer struct {
+	connectionStore memory.Store
+	listener        net.Listener
+	listenAddr      string
+}
+
+// GetPostgresServerInstance returns the singleton instance of PGServer.
+func GetPostgresServerInstance() *PGServer {
+	if server, ok := instanceStore.Get(instanceKey).(*PGServer); ok {
+		return server
+	}
+	server := &PGServer{}
+	instanceStore.Set(instanceKey, server)
+	return server
+}
+
+func (s *PGServer) Start(listenAddr string) error {
+	if _, ok := instanceStore.Get(instanceKey).(*PGServer); ok && s.listener != nil {
+		return nil
+	}
+
+	log.Infof("starting postgres server proxy at %v", listenAddr)
+
+	// start new instance
+	server, err := runPgProxyServer(listenAddr)
+	if err != nil {
+		return err
+	}
+	instanceStore.Set(instanceKey, server)
+	return nil
+}
+
+func (s *PGServer) Stop() error {
+	if server, ok := instanceStore.Pop(instanceKey).(*PGServer); ok {
+		_ = server.Close()
+		if server.listener != nil {
+			log.Infof("stopping postgres server proxy at %v", server.listener.Addr().String())
+			_ = server.listener.Close()
+		}
+	}
+	return nil
+}
+
+func (s *PGServer) ListenAddr() string { return s.listenAddr }
+
+func runPgProxyServer(listenAddr string) (*PGServer, error) {
+	lis, err := net.Listen("tcp4", listenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed listening to address %v, err=%v", listenAddr, err)
+	}
+	server := &PGServer{connectionStore: memory.New(), listener: lis, listenAddr: listenAddr}
+	go func() {
+		defer lis.Close()
+		connectionID := 0
+		for {
+			connectionID++
+			pgClient, err := lis.Accept()
+			if err != nil {
+				log.Errorf("failed obtaining postgres connection, err=%v", err)
+				break
+			}
+
+			sid := uuid.NewString()
+			conn, err := newPostgresConnection(sid, strconv.Itoa(connectionID), pgClient)
+			if err != nil {
+				log.Warnf("failed creating new postgres connection, err=%v", err)
+				_, _ = pgClient.Write(pgtypes.NewFatalError("failed creating new postgres connection, err=%v", err).Encode())
+				_ = pgClient.Close()
+				continue
+			}
+			server.connectionStore.Set(sid, conn)
+
+			go func() {
+				defer server.connectionStore.Del(sid)
+				conn.handleConnection()
+			}()
+		}
+	}()
+	return server, nil
+}
+
+func (s *PGServer) Close() error {
+	if s.connectionStore == nil {
+		return nil
+	}
+	for _, obj := range s.connectionStore.List() {
+		if pgConn, ok := obj.(*postgresConn); ok {
+			pgConn.cancelFn("server is shutting down")
+		}
+	}
+	return nil
+}
+
+type postgresConn struct {
+	sid           string
+	id            string
+	ctx           context.Context
+	cancelFn      func(msg string, a ...any)
+	streamClient  pb.ClientTransport
+	initialPacket []byte
+	net.Conn
+}
+
+func newPostgresConnection(sid, connID string, conn net.Conn) (*postgresConn, error) {
+	pgpkt, err := pgtypes.Decode(conn)
+	if err != nil {
+		return nil, fmt.Errorf("failed decoding startup packet, err=%v", err)
+	}
+	pgConn := &postgresConn{sid: sid, id: connID, Conn: conn, initialPacket: pgpkt.Encode()}
+	if pgpkt.IsFrontendSSLRequest() {
+		// TODO(san): handle SSL request in the future
+		if _, err = pgConn.Write([]byte{pgtypes.ServerSSLNotSupported.Byte()}); err != nil {
+			return nil, fmt.Errorf("failed writing ssl not supported response, err=%v", err)
+		}
+		return nil, fmt.Errorf("ssl request not supported")
+	}
+	if pgpkt.IsCancelRequest() {
+		// TODO(san): handle cancel request in the future
+		return nil, fmt.Errorf("cancel request not implemented")
+	}
+	startupPkt := pgpkt.Frame()
+
+	var parameters []string
+	var param string
+	for _, p := range startupPkt[4 : len(startupPkt)-1] {
+		if p == 0x00 {
+			parameters = append(parameters, param)
+			param = ""
+			continue
+		}
+		param += string(p)
+	}
+
+	var secretKey string
+	for i, p := range parameters {
+		if p == "user" && len(parameters) >= i+1 {
+			secretKey = parameters[i+1]
+		}
+	}
+
+	if secretKey == "" {
+		return nil, fmt.Errorf("failed obtaining secret key from startup parameters")
+	}
+
+	secretKeyHash, err := keys.Hash256Key(secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed hashing secret key: %v", err)
+	}
+
+	dba, err := models.GetValidDbAccessBySecretKey(secretKeyHash)
+	if err != nil {
+		if err == models.ErrNotFound {
+			return nil, fmt.Errorf("invalid secret access key credentials")
+		}
+		return nil, fmt.Errorf("failed obtaining secret access key, reason=%v", err)
+	}
+	ctxDuration := dba.ExpireAt.Sub(time.Now().UTC())
+	if dba.ExpireAt.Before(time.Now().UTC()) {
+		return nil, fmt.Errorf("invalid secret access key credentials")
+	}
+
+	log.Infof("obtained db access by id, id=%v, subject=%v, connection=%v, expires-at=%v (in %v)",
+		dba.ID, dba.UserSubject, dba.ConnectionName,
+		dba.ExpireAt.Format(time.RFC3339), ctxDuration.Truncate(time.Second).String())
+
+	ctx, cancelFn := context.WithCancelCause(context.Background())
+	ctx, timeoutCancelFn := context.WithTimeoutCause(ctx, ctxDuration, fmt.Errorf("connection access expired (%v)", dba.ExpireAt.Format(time.RFC3339)))
+	pgConn.cancelFn = func(msg string, a ...any) {
+		cancelFn(fmt.Errorf(msg, a...))
+		timeoutCancelFn()
+	}
+	pgConn.ctx = ctx
+	tlsCA := appconfig.Get().GatewayTLSCa()
+	client, err := grpc.Connect(grpc.ClientConfig{
+		ServerAddress: grpc.LocalhostAddr,
+		Token:         "", // it will use impersonate-auth-key as authentication
+		UserAgent:     "postgres/grpc",
+		Insecure:      tlsCA == "",
+		TLSCA:         tlsCA,
+	},
+		grpc.WithOption(grpc.OptionConnectionName, dba.ConnectionName),
+		grpc.WithOption(ImpersonateAuthKeyHeaderKey, ImpersonateSecretKey),
+		grpc.WithOption(ImpersonateUserSubjectHeaderKey, dba.UserSubject),
+		grpc.WithOption("origin", pb.ConnectionOriginClient),
+		grpc.WithOption("verb", pb.ClientVerbConnect),
+		grpc.WithOption("session-id", sid),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed connecting to grpc server, err=%v", err)
+	}
+	pgConn.streamClient = client
+	return pgConn, nil
+}
+
+func (c *postgresConn) handleConnection() {
+	go c.handleClientWrite()
+	go c.handleServerWrite()
+
+	<-c.ctx.Done()
+
+	ctxErr := context.Cause(c.ctx)
+	log.With("sid", c.sid, "conn", c.id).Warnf("postgres connection closed, reason=%v", ctxErr)
+	err := c.streamClient.Send(&pb.Packet{
+		Type: pbagent.SessionClose,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID: []byte(c.sid),
+		},
+	})
+	if err != nil {
+		log.With("conn", c.id).Warnf("failed sending session close packet, err=%v", err)
+	}
+
+	// propagate any errors to the underline client connection
+	if ctxErr != nil {
+		_, _ = c.Write(pgtypes.NewFatalError(ctxErr.Error()).Encode())
+	}
+
+	// wait 2 seconds for cleaning up session gracefully
+	time.Sleep(time.Second * 2)
+	_, _ = c.streamClient.Close()
+	_ = c.Conn.Close()
+}
+
+func (c *postgresConn) handleClientWrite() {
+	openSessionPacket := &pb.Packet{
+		Type: pbagent.SessionOpen,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(c.sid),
+			pb.SpecClientConnectionID: []byte(c.id),
+		},
+	}
+
+	if err := c.streamClient.Send(openSessionPacket); err != nil {
+		c.cancelFn("failed sending open session packet, err=%v", err)
+		return
+	}
+	for {
+		pkt, err := c.streamClient.Recv()
+		if err != nil {
+			c.cancelFn("received error processing stream client, err=%v", err)
+			return
+		}
+		if pkt == nil {
+			c.cancelFn("received nil packet, closing connection")
+			return
+		}
+
+		switch pb.PacketType(pkt.Type) {
+		case pbclient.SessionOpenOK:
+			log.With("sid", c.sid).Infof("session opened successfully")
+			connectionType := pb.ConnectionType(pkt.Spec[pb.SpecConnectionType])
+			if connectionType != pb.ConnectionTypePostgres {
+				c.cancelFn("unsupported connection type, got=%v", connectionType)
+				return
+			}
+			err = c.streamClient.Send(&pb.Packet{
+				Type:    pbagent.PGConnectionWrite,
+				Payload: c.initialPacket,
+				Spec: map[string][]byte{
+					pb.SpecGatewaySessionID:   []byte(c.sid),
+					pb.SpecClientConnectionID: []byte(c.id),
+				},
+			})
+			if err != nil {
+				c.cancelFn("failed sending postgres packet to stream client, err=%v", err)
+				return
+			}
+		case pbclient.PGConnectionWrite:
+			if _, err := c.Write(pkt.Payload); err != nil {
+				c.cancelFn("failed writing postgres packet to client, err=%v", err)
+				return
+			}
+		case pbclient.TCPConnectionClose, pbclient.SessionClose:
+			log.With("sid", c.sid, "conn", c.id).Infof("closing session")
+			c.cancelFn("connection closed by server, payload=%v", string(pkt.Payload))
+			return
+		default:
+			c.cancelFn("received invalid packet type %T", pkt.Type)
+			return
+		}
+	}
+}
+
+func (c *postgresConn) handleServerWrite() {
+	for {
+		pkt, err := pgtypes.Decode(c.Conn)
+		if err != nil {
+			defer c.cancelFn("received error processing server write, err=%v", err)
+			if err == io.EOF {
+				return
+			}
+			return
+		}
+		err = c.streamClient.Send(&pb.Packet{
+			Type:    pbagent.PGConnectionWrite,
+			Payload: pkt.Encode(),
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID:   []byte(c.sid),
+				pb.SpecClientConnectionID: []byte(c.id),
+			},
+		})
+		if err != nil {
+			c.cancelFn("failed sending packet to stream client, err=%v", err)
+			return
+		}
+	}
+}

--- a/gateway/transport/interceptors/auth/context.go
+++ b/gateway/transport/interceptors/auth/context.go
@@ -15,9 +15,6 @@ type GatewayContext struct {
 	UserContext models.Context
 	Connection  types.ConnectionInfo
 	Agent       models.Agent
-
-	BearerToken string
-	IsAdminExec bool
 }
 
 func (c *GatewayContext) ValidateConnectionAttrs() error {

--- a/rootfs/app/migrations/000043_connection_db_access.down.sql
+++ b/rootfs/app/migrations/000043_connection_db_access.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP TABLE private.connection_dbaccess;
+ALTER TABLE private.serverconfig DROP COLUMN postgres_server_config;
+
+COMMIT;

--- a/rootfs/app/migrations/000043_connection_db_access.up.sql
+++ b/rootfs/app/migrations/000043_connection_db_access.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+SET search_path TO private;
+
+CREATE TABLE connection_dbaccess(
+    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    org_id UUID NOT NULL REFERENCES orgs (id),
+
+    user_subject VARCHAR(255) NOT NULL,
+    connection_name VARCHAR(128) NOT NULL,
+    secret_key_hash VARCHAR(128) NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    expire_at TIMESTAMP NOT NULL
+);
+
+ALTER TABLE private.serverconfig ADD COLUMN postgres_server_config JSONB NULL;
+
+COMMIT;

--- a/scripts/dev/run.sh
+++ b/scripts/dev/run.sh
@@ -59,6 +59,7 @@ docker run --rm --name hoopdev \
   -p 2225:22 \
   -p 8009:8009 \
   -p 8010:8010 \
+  -p 15432:15432 \
   --env-file=.env \
   --cap-add=NET_ADMIN \
   -v ./dist/dev/bin/:/app/bin/ \


### PR DESCRIPTION
## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Add dbaccess endpoint to generate access to Postgres databases
- Add capability to enable or disable the Postgres Server Proxy via API
- BREAKING CHANGE: Remove deprecated endpoint `POST /api/connections/{name}/exec`