### PR TITLE
Propagate idp provider name from configuration to serverinfo endpoint

### DIFF
--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -6365,6 +6365,25 @@ const docTemplate = `{
                 }
             }
         },
+        "openapi.IdpProviderNameType": {
+            "type": "string",
+            "enum": [
+                "microsoft-entra-id",
+                "okta",
+                "google",
+                "aws-cognito",
+                "jumpcloud",
+                "unknown"
+            ],
+            "x-enum-varnames": [
+                "IdpProviderMicrosoftEntraID",
+                "IdpProviderOkta",
+                "IdpProviderGoogle",
+                "IdpProviderAwsCognito",
+                "IdpProviderJumpCloud",
+                "IdpProviderUnknown"
+            ]
+        },
         "openapi.JiraAssetObjectValue": {
             "type": "object",
             "properties": {
@@ -7604,8 +7623,21 @@ const docTemplate = `{
                     "description": "Report if WEBHOOK_APPKEY is set",
                     "type": "boolean"
                 },
+                "idp_provider_name": {
+                    "description": "The provider name identified based on the configured identity provider credentials",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.IdpProviderNameType"
+                        }
+                    ]
+                },
                 "license_info": {
-                    "$ref": "#/definitions/openapi.ServerLicenseInfo"
+                    "description": "License information",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.ServerLicenseInfo"
+                        }
+                    ]
                 },
                 "log_level": {
                     "description": "Log level of the server",

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -885,6 +885,17 @@ type PublicServerInfo struct {
 	AuthMethod string `json:"auth_method" enums:"local,oidc,saml" example:"local"`
 }
 
+type IdpProviderNameType string
+
+const (
+	IdpProviderMicrosoftEntraID IdpProviderNameType = "microsoft-entra-id"
+	IdpProviderOkta             IdpProviderNameType = "okta"
+	IdpProviderGoogle           IdpProviderNameType = "google"
+	IdpProviderAwsCognito       IdpProviderNameType = "aws-cognito"
+	IdpProviderJumpCloud        IdpProviderNameType = "jumpcloud"
+	IdpProviderUnknown          IdpProviderNameType = "unknown"
+)
+
 type ServerInfo struct {
 	// Version of the server
 	Version string `json:"version" example:"1.35.0"`
@@ -915,8 +926,11 @@ type ServerInfo struct {
 	// The GRPC_URL advertise to clients
 	GrpcURL string `json:"grpc_url" example:"127.0.0.1:8009"`
 	// The tenancy type
-	TenancyType string             `json:"tenancy_type" enums:"selfhosted,multitenant"`
+	TenancyType string `json:"tenancy_type" enums:"selfhosted,multitenant"`
+	// License information
 	LicenseInfo *ServerLicenseInfo `json:"license_info"`
+	// The provider name identified based on the configured identity provider credentials
+	IdpProviderName IdpProviderNameType `json:"idp_provider_name"`
 	// Indicates if session download functionality is disabled
 	// * true - Session download is disabled and not available to users
 	// * false - Session download is enabled and available to users

--- a/gateway/api/search/search.go
+++ b/gateway/api/search/search.go
@@ -20,9 +20,9 @@ import (
 //	@Description	Performs a search for connections and runbooks based on the provided criteria.
 //	@Tags			Search
 //	@Produce		json
-//	@Param			term	query	string	true	"Search term"
-//	@Success		200 {object} openapi.SearchResponse
-//	@Failure		400,422,500	{object} openapi.HTTPError
+//	@Param			term		query		string	true	"Search term"
+//	@Success		200			{object}	openapi.SearchResponse
+//	@Failure		400,422,500	{object}	openapi.HTTPError
 //	@Router			/search [get]
 func Get(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)


### PR DESCRIPTION
## 📝 Description

Propagate IDP Provider Name to allow the WebApp apply a distinct logic to prevent fully signing out users of SSO.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

