### PR TITLE
feat: add test connection endpoint

### DIFF
--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -825,7 +825,7 @@ func TestConnection(c *gin.Context) {
 		return
 	}
 	if conn == nil {
-		c.JSON(http.StatusNotFound, gin.H{"message": "not found"})
+		c.JSON(http.StatusNotFound, gin.H{"message": "connection not found"})
 		return
 	}
 

--- a/gateway/api/connections/helpers.go
+++ b/gateway/api/connections/helpers.go
@@ -53,7 +53,7 @@ func GetConnectionDefaults(connType, connSubType string, useMongoConnStr bool) (
 			"sqlcmd", "--exit-on-error", "--trim-spaces", "-s\t", "-r",
 			"-S$HOST:$PORT", "-U$USER", "-d$DB", "-i/dev/stdin"}
 	case pb.ConnectionTypeOracleDB:
-		envs["envvar:LD_LIBRARY_PATH"] = base64.StdEncoding.EncodeToString([]byte(`/opt/oracle/instantclient_19_24`))
+		envs["envvar:LD_LIBRARY_PATH"] = base64.StdEncoding.EncodeToString([]byte(`/opt/oracle/instantclient_23_9`))
 		cmd = []string{"sqlplus", "-s", "$USER/$PASS@$HOST:$PORT/$SID"}
 	case pb.ConnectionTypeMongoDB:
 		envs["envvar:OPTIONS"] = base64.StdEncoding.EncodeToString([]byte(`tls=true`))

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -774,6 +774,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/connections/{nameOrID}/test": {
+            "get": {
+                "description": "Test resource by name or id (only for database connections, it will attempt a simple ping).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Test Connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name or UUID of the connection",
+                        "name": "nameOrID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.ConnectionTestResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{name}": {
             "delete": {
                 "description": "Delete a connection resource.",
@@ -5526,6 +5567,16 @@ const docTemplate = `{
                 }
             }
         },
+        "openapi.ConnectionTestResponse": {
+            "type": "object",
+            "properties": {
+                "success": {
+                    "description": "Indicates if the connection test was successful",
+                    "type": "boolean",
+                    "example": true
+                }
+            }
+        },
         "openapi.CreateDBRoleJob": {
             "type": "object",
             "required": [
@@ -7374,12 +7425,14 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "connections": {
+                    "description": "Connections found in the search",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/openapi.ConnectionSearch"
                     }
                 },
                 "runbooks": {
+                    "description": "Runbooks found in the search",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1707,6 +1707,13 @@ type ConnectionSearch struct {
 }
 
 type SearchResponse struct {
+	// Connections found in the search
 	Connections []ConnectionSearch `json:"connections"`
-	Runbooks    []string           `json:"runbooks" example:"myrunbooks/run-backup.runbook.sql,myrunbooks/run-update.runbook.sql"`
+	// Runbooks found in the search
+	Runbooks []string `json:"runbooks" example:"myrunbooks/run-backup.runbook.sql,myrunbooks/run-update.runbook.sql"`
+}
+
+type ConnectionTestResponse struct {
+	// Indicates if the connection test was successful
+	Success bool `json:"success" example:"true"`
 }

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -288,6 +288,9 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		apiconnections.UpdateDataMaskingRuleConnection)
 
+	r.GET("/connections/:nameOrID/test",
+		r.AuthMiddleware,
+		apiconnections.TestConnection)
 	r.POST("/connections/:nameOrID/credentials",
 		r.AuthMiddleware,
 		apiconnections.CreateConnectionCredentials,


### PR DESCRIPTION
## 📝 Description

Added a new Test Connection endpoint that allows users to validate database connections by performing a simple ping test. This feature helps users verify their connection configuration before using it in production environments.
Furthermore, fixes the OracleDB library path to version 23.9 to match the docker file.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- Added `TestConnection` endpoint at `/connections/{nameOrID}/test` that validates database connections
- Implemented connection testing logic for multiple database types (PostgreSQL, MySQL, MSSQL, OracleDB, MongoDB, DynamoDB, CloudWatch)
- Added `ConnectionTestResponse` type to OpenAPI schema with proper documentation
- Updated OracleDB library path from version 19.24 to 23.9 in connection defaults
- Added proper error handling and logging for connection test failures
- Integrated the new endpoint into the API router with authentication middleware

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: N/A (API endpoint)
- **OS**: macOS

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
  - Tested connection validation for different database types
  - Verified proper error responses for invalid connections
  - Confirmed successful responses for valid connections

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

<!-- Add any additional notes, concerns, or discussion points here -->
<!-- Is there anything specific you'd like reviewers to focus on? -->

The connection test functionality supports the following database types:
- **PostgreSQL, MySQL, MSSQL, OracleDB**: Uses `SELECT 1` query
- **MongoDB**: Uses `db.runCommand({ping:1})` with proper verbosity handling
- **DynamoDB**: Uses `aws dynamodb list-tables` command
- **CloudWatch**: Uses `aws logs describe-log-groups` command

Special handling was added for OracleDB connections since they return exit code 0 even when commands fail, so we check for "error" prefix in the output.

The endpoint requires authentication and will return appropriate HTTP status codes (200 for success, 400 for test failure, 404 for connection not found, 500 for server errors).