### PR TITLE
feat: Add insecure header to HTTP proxy connection parameters

### DIFF
--- a/agent/controller/httpproxy.go
+++ b/agent/controller/httpproxy.go
@@ -48,6 +48,7 @@ func (a *Agent) processHttpProxyWriteServer(pkt *pb.Packet) {
 	connenv.httpProxyHeaders["remote_url"] = connenv.httpProxyRemoteURL
 	connenv.httpProxyHeaders["connection_id"] = clientConnectionID
 	connenv.httpProxyHeaders["sid"] = sessionID
+	connenv.httpProxyHeaders["insecure"] = fmt.Sprintf("%v", connenv.insecure)
 	httpProxy, err := libhoop.NewHttpProxy(context.Background(), httpStreamClient, connenv.httpProxyHeaders)
 	if err != nil {
 		log.Infof("failed connecting to %v, err=%v", sessionID, connenv.host, err)


### PR DESCRIPTION
## 📝 Description

This PR adds support for passing the `insecure` connection parameter to HTTP proxy connections. The insecure flag, which controls SSL/TLS certificate verification.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- Added `insecure` header to HTTP proxy connection parameters in `agent/controller/httpproxy.go`

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
