### PR TITLE
Remove plugin dispatch in editor plugin panel

### DIFF
--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -410,7 +410,6 @@
 
 (defmethod routes/panels :editor-plugin-panel []
   (rf/dispatch [:destroy-page-loader])
-  (rf/dispatch [:plugins->get-plugin-by-name "editor"])
   [layout :application-hoop [:div {:class "h-full"}
                              [webclient/main]]])
 


### PR DESCRIPTION
## 📝 Description

Some users are experiencing a login loop caused by the deprecated request to plugins for getting the editor info.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
