### PR TITLE
fix: Prevent showing scrollbar in video session view

### DIFF
--- a/webapp/src/webapp/audit/views/session_data_video.cljs
+++ b/webapp/src/webapp/audit/views/session_data_video.cljs
@@ -63,7 +63,7 @@
     (rf/dispatch [:audit->get-session-logs-data session-id])
 
     (fn [event-stream]
-      [:div {:class "flex flex-col h-full"}
+      [:div {:class "flex flex-col h-[660px] overflow-y-hidden"}
        [tabs/tabs {:on-change handle-tab-change
                    :tabs ["Logs" "Video"]
                    :default-value "Logs"}]

--- a/webapp/src/webapp/shared_ui/cmdk/command_palette_pages.cljs
+++ b/webapp/src/webapp/shared_ui/cmdk/command_palette_pages.cljs
@@ -32,7 +32,9 @@
    {:key (:id connection)
     :value (:name connection)
     :keywords [(:type connection) (:subtype connection) (:status connection) "connection"]
-    :onSelect #(rf/dispatch [:command-palette->navigate-to-page :connection-actions connection])}
+    :onSelect #(do
+                (rf/dispatch [:database-schema->clear-schema])
+                (rf/dispatch [:command-palette->navigate-to-page :connection-actions connection]))}
    [:div {:class "flex items-center gap-2"}
     [:div {:class "flex flex-col"}
      [:span {:class "text-sm font-medium"} (:name connection)]]]])


### PR DESCRIPTION
## 📝 Description

This PR hides the visible scrollbar in the video session view to prevent unwanted screen shaking.
It also fixes an error that occurred when a database connection was previously selected and the user tried to switch connections using Cmd+K.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made
- Updated the styles from `session_data_video.cljs` component to hide y overflows in the Tab content.
- Clear `selected-database` localStorage when switch connection using cmd+k.

## 🧪 Testing

1. Video session
   - Go to the session page and select one item that has a video;
   - Force one overflow by adding some extra height to the video wrapper;
   - Confirm video playback and layout remain stable.
2. Connection switching
   - Select a database for connection A in the connections page, then switch to connection B using Cmd+K. 
   - Confirm that doesn't shows an error related to the previous selected connection.
     
### Test Configuration:
- **Browser(s)**:  Chrome
- **OS**: MacOs

### Tests performed:
- [x] Manual testing completed

## 📸 Screenshots
Before
![Screen Recording 2025-10-06 at 09 58 25](https://github.com/user-attachments/assets/e94a45d1-51dc-47fe-8843-88f56e49a7b1)

After:
![Screen Recording 2025-10-06 at 09 58 56](https://github.com/user-attachments/assets/6d2e8d2b-ab17-4cd6-bcfc-702381765854)

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

