### PR TITLE
fix: OracleDB connection issues because LD_LIBRARY_PATH

### DIFF
--- a/gateway/api/connections/helpers.go
+++ b/gateway/api/connections/helpers.go
@@ -53,7 +53,6 @@ func GetConnectionDefaults(connType, connSubType string, useMongoConnStr bool) (
 			"sqlcmd", "--exit-on-error", "--trim-spaces", "-s\t", "-r",
 			"-S$HOST:$PORT", "-U$USER", "-d$DB", "-i/dev/stdin"}
 	case pb.ConnectionTypeOracleDB:
-		envs["envvar:LD_LIBRARY_PATH"] = base64.StdEncoding.EncodeToString([]byte(`/opt/oracle/instantclient_23_9`))
 		cmd = []string{"sqlplus", "-s", "$USER/$PASS@$HOST:$PORT/$SID"}
 	case pb.ConnectionTypeMongoDB:
 		envs["envvar:OPTIONS"] = base64.StdEncoding.EncodeToString([]byte(`tls=true`))

--- a/rootfs/app/migrations/000046_remove_oracle_ld.up.sql
+++ b/rootfs/app/migrations/000046_remove_oracle_ld.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+UPDATE private.env_vars ev
+SET envs = ev.envs::jsonb - 'envvar:LD_LIBRARY_PATH'
+WHERE ev.id IN (
+  SELECT c.id
+  FROM private.connections c
+  WHERE c.subtype = 'oracledb'
+);
+
+COMMIT;

--- a/rootfs/app/migrations/000046_remove_oracle_ld.up.sql
+++ b/rootfs/app/migrations/000046_remove_oracle_ld.up.sql
@@ -5,7 +5,7 @@ SET envs = ev.envs::jsonb - 'envvar:LD_LIBRARY_PATH'
 WHERE ev.id IN (
   SELECT c.id
   FROM private.connections c
-  WHERE c.subtype = 'oracledb'
+  WHERE c.type = 'database' AND c.subtype = 'oracledb'
 );
 
 COMMIT;


### PR DESCRIPTION
## 📝 Description

Refactored OracleDB connection logic by removing the `LD_LIBRARY_PATH` environment variable from the connection setup.
There were some changes made on `libhoop` to use the `LD_LIBRARY_PATH` from user environment.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Removed LD_LIBRARY_PATH from OracleDB connection in `gateway/api/connections/helpers.go`
- Ensured OracleDB connection uses only required environment variables and command arguments

## 🧪 Testing

### Test Configuration:
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual OracleDB 19c and 23ai connection verified

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
