### PR TITLE
Improve handling of environment variables in connection setup

### DIFF
--- a/webapp/src/webapp/connections/views/setup/events/db_events.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/db_events.cljs
@@ -136,7 +136,10 @@
               (not (empty? current-value)))
        (-> db
            (update-in [:connection-setup :credentials :environment-variables]
-                      #(conj (or % []) {:key current-key :value current-value}))
+                      (fn [value]
+                        (if (seq value)
+                          (conj value {:key current-key :value current-value})
+                          [{:key current-key :value current-value}])))
            (assoc-in [:connection-setup :credentials :current-key] "")
            (assoc-in [:connection-setup :credentials :current-value] ""))
        db))))

--- a/webapp/src/webapp/connections/views/setup/events/process_form.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/process_form.cljs
@@ -318,13 +318,16 @@
                                  (= (:subtype connection) "httpproxy"))
                         (let [headers (process-connection-envvars (:secret connection) "envvar")
                               remote-url? #(= (:key %) "REMOTE_URL")
+                              insecure? #(= (:key %) "INSECURE")
                               header? #(str/starts-with? % "HEADER_")
-                              processed-headers (map (fn [{:keys [key value]}]
-                                                       {:key (if (header? key)
-                                                               (str/replace key "HEADER_" "")
-                                                               key)
-                                                        :value value})
-                                                     (remove remote-url? headers))]
+                              processed-headers (mapv (fn [{:keys [key value]}]
+                                                        {:key (if (header? key)
+                                                                (str/replace key "HEADER_" "")
+                                                                key)
+                                                         :value value})
+                                                      (->> headers
+                                                           (remove remote-url?)
+                                                           (remove insecure?)))]
                           processed-headers))
 
         connection-type (:type connection)


### PR DESCRIPTION
## 📝 Description

Fixed a critical bug in the HTTP proxy form handling where environment variables and headers couldn't be accessed by index due to improper data structure usage. The issue occurred when using `map` function which returns a lazy sequence instead of a vector, preventing index-based access operations.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Fixed environment variables handling in `db_events.cljs` to properly initialize empty vectors
- Changed `map` to `mapv` in `process_form.cljs` to ensure vector return type for index access
- Added proper filtering for `INSECURE` variable in HTTP proxy headers processing
- Improved error handling when environment-variables collection is nil or empty
