### PR TITLE
Resolve terminal database error and CodeMirror keymaps issue

### DIFF
--- a/webapp/src/webapp/connections/views/connection_list.cljs
+++ b/webapp/src/webapp/connections/views/connection_list.cljs
@@ -253,6 +253,7 @@
                                          [:> DropdownMenu.Item {:on-click
                                                                 (fn []
                                                                   (js/localStorage.setItem "selected-connection" connection)
+                                                                  (rf/dispatch [:database-schema->clear-schema])
                                                                   (rf/dispatch [:navigate :editor-plugin-panel]))}
                                           "Open in Web Terminal"])
 


### PR DESCRIPTION
## 📝 Description

This PR fixes two critical bugs in the Web Terminal functionality that were affecting user experience when navigating from the connection list.

## 🔗 Related Issue

Fixes #1088

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Fixed "database not found" error when navigating to Terminal from connection list by clearing cached database schema
- Fixed CodeMirror keyboard shortcuts not working in custom/command-line connection types by removing extension caching logic
- Refactored `create-codemirror-extensions` function to ensure keymap is properly initialized for all connection types

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome, Safari
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

**Manual Testing Steps:**
1. Navigate to connection list
2. Click "Open in Web Terminal" for a database connection
3. Verify no "database not found" error appears
4. Test keyboard shortcuts (Ctrl+Enter, etc.) in custom/command-line connections
5. Verify shortcuts work correctly after page refresh

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
---