### PR TITLE
fix: Allow scrolling in runbook list and run with cmd+enter key

### DIFF
--- a/webapp/src/webapp/components/keyboard_shortcuts.cljs
+++ b/webapp/src/webapp/components/keyboard_shortcuts.cljs
@@ -5,7 +5,7 @@
    [clojure.string :as cs]
    [re-frame.core :as rf]))
 
-(defn- detect-os []
+(defn detect-os []
   (let [user-agent (.. js/window -navigator -userAgent)]
     (cond
       (re-find #"Mac" user-agent) :mac

--- a/webapp/src/webapp/features/runbooks/runner/main.cljs
+++ b/webapp/src/webapp/features/runbooks/runner/main.cljs
@@ -9,6 +9,7 @@
    [clojure.string :as cs]
    [webapp.components.notification-badge :refer [notification-badge]]
    [webapp.webclient.components.search :as search]
+   [webapp.components.keyboard-shortcuts :refer [detect-os]]
    [webapp.webclient.components.panels.metadata :as metadata-panel]
    [webapp.webclient.log-area.main :as log-area]
    [webapp.webclient.panel :refer [discover-connection-type]]
@@ -48,7 +49,8 @@
                                   (seq @metadata-key)
                                   (seq @metadata-value))
                 disable-run-button? (run-disabled?)
-                runbook-loading? (= (:status @script-response) :loading)]
+                runbook-loading? (= (:status @script-response) :loading)
+                os (detect-os)]
             [:> Box {:class "h-16 border-b-2 border-gray-3 bg-gray-1"}
              [:> Flex {:class "h-full px-4 items-center justify-between"}
               [:> Flex {:class "items-end gap-2"}
@@ -90,7 +92,7 @@
                   :has-notification? has-metadata?
                   :disabled? false}]]
 
-               [:> Tooltip {:content "cmd + Enter"}
+               [:> Tooltip {:content (if (= os :mac) "cmd + Enter" "ctrl + Enter")}
                 [:> Button
                  {:disabled disable-run-button?
                   :loading runbook-loading?

--- a/webapp/src/webapp/webclient/components/header.cljs
+++ b/webapp/src/webapp/webclient/components/header.cljs
@@ -4,7 +4,8 @@
    ["lucide-react" :refer [CircleHelp FastForward PackagePlus
                            Play Sun Moon ChevronDown Search]]
    [re-frame.core :as rf]
-   [webapp.components.notification-badge :refer [notification-badge]]))
+   [webapp.components.notification-badge :refer [notification-badge]]
+   [webapp.components.keyboard-shortcuts :refer [detect-os]]))
 
 
 (defn main []
@@ -25,7 +26,8 @@
             exec-enabled? (= "enabled" (:access_mode_exec @primary-connection))
             disable-run-button? (or (not exec-enabled?)
                                     no-connection-selected?)
-            script-loading? (= (:status @script-response) :loading)]
+            script-loading? (= (:status @script-response) :loading)
+            os (detect-os)]
         [:> Box {:class "h-16 border-b-2 border-gray-3 bg-gray-1"}
          [:> Flex {:align "center"
                    :justify "between"
@@ -104,7 +106,7 @@
                :has-notification? has-multirun?
                :disabled? false}]]]
 
-           [:> Tooltip {:content "cmd + Enter"}
+          [:> Tooltip {:content (if (= os :mac) "cmd + Enter" "ctrl + Enter")}
             [:> Button
              {:disabled disable-run-button?
               :loading script-loading?


### PR DESCRIPTION
## 📝 Description

This pull request fixes the scrolling issue in the runbooks library panel and adds support for running a runbook with the cmd+Enter key.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- Modified the runbooks library panel to use a calculated height and enable vertical scrolling, improving usability when displaying long lists.
- Added support for running a runbook with the cmd+Enter key, enhancing keyboard accessibility and user experience.

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**:  Chrome
- **OS**: MacOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

![Screen Recording 2025-10-20 at 13 36 45](https://github.com/user-attachments/assets/f2952c97-f8ec-47de-8f54-43d88370d944)

<img width="534" height="176" alt="image" src="https://github.com/user-attachments/assets/58dfb5b2-501e-4573-94a6-1ddd327bcde7" />

<img width="468" height="194" alt="image" src="https://github.com/user-attachments/assets/ec60bffb-e6e4-4416-ba07-7d98766c8fee" />


## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
