### PR TITLE
[FIX]: sync connection details dispatch to prevent stale data persistence

### DIFF
--- a/webapp/src/webapp/connections/views/setup/connection_update_form.cljs
+++ b/webapp/src/webapp/connections/views/setup/connection_update_form.cljs
@@ -60,7 +60,7 @@
                                 (when form
                                   (.reportValidity form)
                                   (reset! credentials-valid? (.checkValidity form))))))
-     _ (rf/dispatch [:connections->get-connection-details connection-name])
+     _ (rf/dispatch-sync [:connections->get-connection-details connection-name])
      _ (rf/dispatch [:guardrails->get-all])
      _ (rf/dispatch [:jira-templates->get-all])]
 


### PR DESCRIPTION
## 📝 Description

Fixed connection details state synchronization issue where updating connection details in terminal and then configuring a different connection would retain data from the previously selected terminal connection. Changed the dispatch call to synchronous to ensure proper state synchronization.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- Changed `rf/dispatch` to `rf/dispatch-sync` for `[:connections->get-connection-details connection-name]` in connection update form
- Ensures connection details are loaded synchronously before proceeding with form initialization
- Prevents stale connection data from persisting when switching between different connections

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome, Firefox, Safari
- **OS**: macOS, Linux, Windows

### Tests performed:
- [x] Manual testing completed
- [x] Verified connection switching works correctly
- [x] Confirmed no data persistence issues between different connections

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings