### PR TITLE
feat: Add runbooks extension info to empty state list view

### DIFF
--- a/webapp/src/webapp/features/runbooks/runner/views/list.cljs
+++ b/webapp/src/webapp/features/runbooks/runner/views/list.cljs
@@ -184,6 +184,7 @@
       [:> Text {:weight "medium"} ".runbooks"]
       " on the extension."]
      [:> Link {:href (get-in config/docs-url [:features :runbooks])
+               :target "_blank"
                :class "text-info-12 font-medium"}
       "Go to Runbooks configuration docs ↗"]]]])
 


### PR DESCRIPTION
## 📝 Description

This pull request enhances the user experience in the Runbooks runner list view by providing clearer guidance for users who may be missing Runbooks due to file extension issues. The main improvement is the addition of a contextual callout that informs users about the required `.runbooks` file extension and links directly to the relevant documentation.

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

* Added a new `runbooks-extension-callout` component that displays a blue informational callout, reminding users to ensure their files have the `.runbooks` extension and providing a direct link to the Runbooks configuration documentation.
* Updated the `no-integration-templates-view` to include the new callout at the bottom, improving visibility and support for users who may not see their Runbooks listed.

## 🧪 Testing

* Open Runbooks runner with no runbooks or wrong file extension.

### Test Configuration:
- **Browser(s)**:  Chrome
- **OS**: MacOs

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots

<img width="1733" height="952" alt="image" src="https://github.com/user-attachments/assets/98031c29-8fca-45fa-8439-6050d861fb91" />


## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
