### PR TITLE
fix: Change hostname -> host to fix non standard ports for gateway

### DIFF
--- a/webapp/src/webapp/config.cljs
+++ b/webapp/src/webapp/config.cljs
@@ -13,7 +13,7 @@
 
 (defn get-api-url []
   (if (cs/blank? env/api-url)
-    (let [hostname (.-hostname js/location)
+    (let [hostname (.-host js/location)
           protocol (.-protocol js/location)]
       (if (or (= hostname "localhost") (= hostname "127.0.0.1"))
         (str protocol "//" hostname ":8009/api")


### PR DESCRIPTION
## 📝 Description

This changes the "auto discovery" of API by using `window.location.host` instead `window.location.hostname`. The `host` contains the hostname + port when is specified. 

## 🔗 Related Issue

* Might fix #1106 
* Fix #1039

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

<!-- Thank you for contributing to our project! 🙏 --> 
