### PR TITLE
fix: update RDP hostname retrieval in native client access

### DIFF
--- a/webapp/src/webapp/connections/native_client_access/main.cljs
+++ b/webapp/src/webapp/connections/native_client_access/main.cljs
@@ -149,7 +149,7 @@
     [logs/new-container
      {:status :success
       :id "hostname"
-      :logs (:hostname native-client-access-data)}]]
+      :logs (.-hostname js/location)}]]
 
    ;; Username
    [:> Box {:class "space-y-2"}
@@ -259,10 +259,8 @@
 (defn- connection-established-view
   "Step 2: Connection established - show credentials"
   [native-client-access-data minimize-fn disconnect-fn]
-  (let [active-tab (r/atom "credentials")
-        has-connection-uri? (some? (get (:connection_credentials native-client-access-data) :connection_string))
+  (let [active-tab (r/atom "credentials") 
         has-command? (some? (get (:connection_credentials native-client-access-data) :command))]
-
 
     (fn []
       [:> Flex {:direction "column" :class "h-full"}

--- a/webapp/src/webapp/resources/setup/events/process_form.cljs
+++ b/webapp/src/webapp/resources/setup/events/process_form.cljs
@@ -60,8 +60,6 @@
         ;; command-args is stored as array of {"value": "...", "label": "..."}
         ;; Extract just the values
 
-        _ (println "role" role)
-
         command-args (:command-args role [])
         command (if (and (= type "custom")
                          (= subtype "linux-vm"))


### PR DESCRIPTION
## 📝 Description

This pull request fixes the RDP hostname displayed in the native client access.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

* Changed the source of the hostname log to use `js/location.hostname` instead of reading from `native-client-access-data`, ensuring the displayed hostname accurately reflects the current browser location.
* Removed the unused `has-connection-uri?` variable, simplifying the credentials step logic.

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**:  Chrome
- **OS**: MacOs

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed


## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

