### PR TITLE
feat: implement user token management with database storage

### DIFF
--- a/gateway/api/login/local/login.go
+++ b/gateway/api/login/local/login.go
@@ -76,9 +76,14 @@ func generateNewAccessToken(subject, email string) (string, error) {
 	}
 
 	token, err := localVerifier.NewAccessToken(subject, email, defaultTokenExpiration)
-	if err == nil {
-		idp.UserTokens.Store(subject, token)
+	if err != nil {
+		return "", err
 	}
 
-	return token, err
+	err = models.UpsertUserToken(models.DB, subject, token)
+	if err != nil {
+		return "", fmt.Errorf("failed upserting user token: %v", err)
+	}
+
+	return token, nil
 }

--- a/gateway/api/login/oidc/login.go
+++ b/gateway/api/login/oidc/login.go
@@ -193,7 +193,14 @@ func (h *handler) LoginCallback(c *gin.Context) {
 		return
 	}
 
-	idp.UserTokens.Store(subject, token.AccessToken)
+	err = models.UpsertUserToken(models.DB, subject, token.AccessToken)
+	if err != nil {
+		login.Outcome = fmt.Sprintf("failed upserting user token subject=%s, email=%s, reason=%v", uinfo.Subject, uinfo.Email, err)
+		log.Error(login.Outcome)
+		sentry.CaptureException(err)
+		c.Redirect(http.StatusTemporaryRedirect, redirectErrorURL)
+		return
+	}
 
 	redirectSuccessURL := login.Redirect + "?token=" + token.AccessToken
 

--- a/gateway/api/login/saml/login.go
+++ b/gateway/api/login/saml/login.go
@@ -285,7 +285,12 @@ func (h *handler) SamlLoginCallback(c *gin.Context) {
 		return
 	}
 
-	idp.UserTokens.Store(uinfo.Subject, sessionToken)
+	err = models.UpsertUserToken(models.DB, uinfo.Subject, sessionToken)
+	if err != nil {
+		log.Errorf("failed upserting user token, reason=%v", err)
+		redirectToErrURL(c, login.Redirect, "unable to store user token")
+		return
+	}
 
 	redirectSuccessURL := fmt.Sprintf("%s?token=%v", login.Redirect, sessionToken)
 	url, _ := url.Parse(login.Redirect)

--- a/gateway/idp/core.go
+++ b/gateway/idp/core.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/aws/smithy-go/ptr"
@@ -22,8 +21,6 @@ import (
 )
 
 var ErrUnknownIdpProvider = fmt.Errorf("unknown idp provider")
-
-var UserTokens = sync.Map{}
 
 type TokenVerifier interface {
 	VerifyAccessToken(accessToken string) (subject string, err error)

--- a/gateway/models/user_tokens.go
+++ b/gateway/models/user_tokens.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type UserToken struct {
+	UserID string `gorm:"column:user_id"`
+	Token  string `gorm:"column:token"`
+}
+
+func GetUserToken(db *gorm.DB, userID string) (*UserToken, error) {
+	var userToken UserToken
+
+	err := db.Table("private.user_tokens").Where("user_id = ?", userID).First(&userToken).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return &userToken, nil
+}
+
+func UpsertUserToken(db *gorm.DB, userID string, token string) error {
+	userToken := UserToken{
+		UserID: userID,
+		Token:  token,
+	}
+
+	tx := db.Table("private.user_tokens").Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"token"}),
+	}).Create(userToken)
+
+	return tx.Error
+}

--- a/rootfs/app/migrations/000050_add_user_tokens.down.sql
+++ b/rootfs/app/migrations/000050_add_user_tokens.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path TO private;
+
+DROP TABLE user_tokens;
+
+COMMIT;

--- a/rootfs/app/migrations/000050_add_user_tokens.up.sql
+++ b/rootfs/app/migrations/000050_add_user_tokens.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+SET search_path TO private;
+
+CREATE TABLE user_tokens (
+  user_id TEXT PRIMARY KEY REFERENCES users(subject) ON DELETE CASCADE,
+  token TEXT NOT NULL
+);
+
+COMMIT;


### PR DESCRIPTION
## 📝 Description

This PR implements database-backed user token management, replacing the in-memory `sync.Map` storage with persistent PostgreSQL storage. User tokens are now stored in a dedicated table and managed through upsert operations during login flows.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- Added `user_tokens` table in `private` schema with migration files (up/down)
- Created `UserToken` model with `GetUserToken` and `UpsertUserToken` functions in `gateway/models/user_tokens.go`
- Replaced `idp.UserTokens` sync.Map with database calls in login flows (local, OIDC, SAML)
- Updated `CheckUserToken` and `PollingUserToken` in `gateway/transport/auth.go` to fetch tokens from database
- Removed `UserTokens` sync.Map from `gateway/idp/core.go`
- Added proper error handling for database operations during token storage and retrieval

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes
<!-- Thank you for contributing to our project! 🙏 --> 