### PR TITLE
fix: Increase user groups size to allow 180 characters

### DIFF
--- a/rootfs/app/migrations/000052_user_groups_name_size.down.sql
+++ b/rootfs/app/migrations/000052_user_groups_name_size.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE private.user_groups ALTER COLUMN name TYPE VARCHAR(100);

--- a/rootfs/app/migrations/000052_user_groups_name_size.up.sql
+++ b/rootfs/app/migrations/000052_user_groups_name_size.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE private.user_groups ALTER COLUMN name TYPE VARCHAR(180);


### PR DESCRIPTION
## 📝 Description

Increase user groups size to allow 180 characters.
Some customers are receiving this error when creating groups with more than 100 chars.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore