### PR TITLE
feat: make grpc message size configurable

### DIFF
--- a/common/grpc/client.go
+++ b/common/grpc/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -54,11 +55,23 @@ type (
 const (
 	OptionConnectionName OptionKey = "connection-name"
 	LocalhostAddr                  = "127.0.0.1:8010"
-
-	// MaxRecvMsgSize defines the maximum message size in bytes that can be received.
-	// Set to allow protocols to transmit larger data chunks in a single packet.
-	MaxRecvMsgSize int = 1024 * 1024 * 17 // 17 MiB
 )
+
+var (
+	defaultMaxRecvMsgSize = 1024 * 1024 * 17 // 17 MiB
+	// MaxRecvMsgSize defines the maximum message size in bytes that can be received.
+	// It can be overridden via HOOP_GRPC_MESSAGE_SIZE_BYTES to accommodate larger payloads.
+	MaxRecvMsgSize = initMaxRecvMsgSize()
+)
+
+func initMaxRecvMsgSize() int {
+	if envVal := os.Getenv("HOOP_GRPC_MESSAGE_SIZE_BYTES"); envVal != "" {
+		if parsedVal, err := strconv.Atoi(envVal); err == nil && parsedVal > 0 {
+			return parsedVal
+		}
+	}
+	return defaultMaxRecvMsgSize
+}
 
 func WithOption(optKey OptionKey, val string) *ClientOptions {
 	return &ClientOptions{optionKey: optKey, optionVal: val}


### PR DESCRIPTION
## 📝 Description

In order to handle bigger payloads (e.g. for large postgres db listings) it is necessary to increase the grpc message size when needed.


In current state it is not possible to list larger databases due to the current hard coded limit: 

<img width="594" height="198" alt="Screenshot 2025-12-05 at 09 51 18" src="https://github.com/user-attachments/assets/99e7ef6f-7152-47f8-8710-9b6460fc75f8" />


## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [x] 🧹 Chore

## 📋 Changes Made

- Added the option to set the message size in bytes for grpc by environment variable

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings


