### PR TITLE
fix: migration 52 returning error when database contains legacy user_groups views

### DIFF
--- a/rootfs/app/migrations/000052_user_groups_name_size.up.sql
+++ b/rootfs/app/migrations/000052_user_groups_name_size.up.sql
@@ -1,1 +1,8 @@
+-- very old legacy views cleanup - versions before 1.35.22
+-- the migration will fail if those view exists
+DROP VIEW IF EXISTS public.user_groups CASCADE;
+DROP VIEW IF EXISTS public_a.user_groups CASCADE;
+DROP VIEW IF EXISTS public_b.user_groups CASCADE;
+
+-- modify column size
 ALTER TABLE private.user_groups ALTER COLUMN name TYPE VARCHAR(180);


### PR DESCRIPTION
## 📝 Description

Fix migration 52 returning error when database contains legacy user_groups views

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

