### PR TITLE
[FIX] Correct hostname retrieval in API URL configuration

### DIFF
--- a/webapp/.env.sample
+++ b/webapp/.env.sample
@@ -5,11 +5,10 @@
 # API_URL - OPTIONAL: Custom API endpoint
 # 
 # If not set, the webapp will automatically determine the API URL:
-# - For localhost (development): https://localhost:8009/api  
-# - For production/staging: uses the current domain + /api
+# - uses the current domain + /api
 #
 # Only set this if you need to use a custom API endpoint:
-# API_URL=https://api.custom-domain.com
+# export API_URL=https://api.custom-domain.com
 
 ###################
 # instrumentation #

--- a/webapp/shadow-cljs.edn
+++ b/webapp/shadow-cljs.edn
@@ -34,7 +34,7 @@
                              webapp.env/sentry-sample-rate #shadow/env ["SENTRY_SAMPLE_RATE" "1.0"]
                              webapp.env/sentry-dsn #shadow/env ["SENTRY_DSN"
                                                                 "https://38e03773be6b0d77219d6678a90ed6a5@o4504559799566336.ingest.us.sentry.io/4508377639092224"]
-                             webapp.env/api-url #shadow/env ["API_URL"]}}}
+                             webapp.env/api-url #shadow/env ["API_URL" ""]}}}
    :release {:compiler-options {:output-to "resources/public/js"
                                 :output-dir "resources/public/js"
                                 :source-maps "resources/public/js/app.js.map"
@@ -49,7 +49,7 @@
                                  webapp.env/sentry-sample-rate #shadow/env ["SENTRY_SAMPLE_RATE" "1.0"]
                                  webapp.env/sentry-dsn #shadow/env ["SENTRY_DSN"
                                                                     "https://b2bf390e5cd94bfc83c0005312d796fd@o919346.ingest.sentry.io/6707471"]
-                                 webapp.env/api-url #shadow/env ["API_URL"]}}
+                                 webapp.env/api-url #shadow/env ["API_URL" ""]}}
              :build-options {}}}
   ;; end :hoop-ui
 

--- a/webapp/src/webapp/config.cljs
+++ b/webapp/src/webapp/config.cljs
@@ -13,12 +13,9 @@
 
 (defn get-api-url []
   (if (cs/blank? env/api-url)
-    (let [hostname (.-hostname js/location)
-          host (.-host js/location)
+    (let [host (.-host js/location)
           protocol (.-protocol js/location)]
-      (if (or (= hostname "localhost") (= hostname "127.0.0.1"))
-        (str protocol "//" hostname ":8009/api")
-        (str protocol "//" host "/api")))
+      (str protocol "//" host "/api"))
 
     env/api-url))
 


### PR DESCRIPTION
## 📝 Description

This fixes the issue where requests were not being sent to the correct API when running on localhost. The host value includes the port, which caused the condition to always evaluate to false.
Since we are establishing that the default behavior is to always use the same URL, we should rely on the .env files to define

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

### Tests performed:
- [x] Manual testing completed

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
