### PR TITLE
feat: implement time window configuration for review sessions

### DIFF
--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -502,7 +502,7 @@ const docTemplate = `{
                 }
             },
             "put": {
-                "description": "Update a connection resource.",
+                "description": "Update a connection resource",
                 "consumes": [
                     "application/json"
                 ],
@@ -8397,6 +8397,15 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "time_window": {
+                    "description": "The time window configuration that can execute the session",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.ReviewSessionTimeWindow"
+                        }
+                    ],
+                    "readOnly": true
+                },
                 "type": {
                     "description": "The type of the review\n* onetime - Represents a one time execution\n* jit - Represents a time based review",
                     "enum": [
@@ -8498,6 +8507,9 @@ const docTemplate = `{
                         }
                     ],
                     "example": "APPROVED"
+                },
+                "time_window": {
+                    "$ref": "#/definitions/openapi.ReviewSessionTimeWindow"
                 }
             }
         },
@@ -8513,6 +8525,35 @@ const docTemplate = `{
                 "ReviewStatusRequestRejectedType",
                 "ReviewStatusRequestRevokedType"
             ]
+        },
+        "openapi.ReviewSessionTimeWindow": {
+            "type": "object",
+            "required": [
+                "configuration",
+                "type"
+            ],
+            "properties": {
+                "configuration": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "example": {
+                        "end_time": "18:00",
+                        "start_time": "09:00"
+                    }
+                },
+                "type": {
+                    "enum": [
+                        "time_range"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.ReviewTimeWindowType"
+                        }
+                    ]
+                }
+            }
         },
         "openapi.ReviewStatusType": {
             "type": "string",
@@ -8533,6 +8574,15 @@ const docTemplate = `{
                 "ReviewStatusProcessing",
                 "ReviewStatusExecuted",
                 "ReviewStatusUnknown"
+            ]
+        },
+        "openapi.ReviewTimeWindowType": {
+            "type": "string",
+            "enum": [
+                "time_range"
+            ],
+            "x-enum-varnames": [
+                "ReviewTimeWindowTypeTimeRange"
             ]
         },
         "openapi.ReviewType": {
@@ -9838,6 +9888,15 @@ const docTemplate = `{
                             "$ref": "#/definitions/openapi.ReviewStatusType"
                         }
                     ]
+                },
+                "time_window": {
+                    "description": "The time window configuration that can execute the session",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openapi.ReviewSessionTimeWindow"
+                        }
+                    ],
+                    "readOnly": true
                 },
                 "type": {
                     "description": "The type of the review\n* onetime - Represents a one time execution\n* jit - Represents a time based review",

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -645,6 +645,7 @@ type (
 	ReviewStatusType        string
 	ReviewRequestStatusType string
 	ReviewType              string
+	ReviewTimeWindowType    string
 )
 
 const (
@@ -662,6 +663,8 @@ const (
 
 	ReviewTypeJit     ReviewType = "jit"
 	ReviewTypeOneTime ReviewType = "onetime"
+
+	ReviewTimeWindowTypeTimeRange ReviewTimeWindowType = "time_range"
 )
 
 type ReviewRequest struct {
@@ -669,7 +672,8 @@ type ReviewRequest struct {
 	// * APPROVED - Approve the review resource
 	// * REJECTED - Reject the review resource
 	// * REVOKED - Revoke an approved review
-	Status ReviewRequestStatusType `json:"status" binding:"required" example:"APPROVED"`
+	Status     ReviewRequestStatusType  `json:"status" binding:"required" example:"APPROVED"`
+	TimeWindow *ReviewSessionTimeWindow `json:"time_window"`
 }
 
 type SessionReview struct {
@@ -696,6 +700,13 @@ type SessionReview struct {
 	CreatedAt time.Time `json:"created_at" readonly:"true" example:"2024-07-25T15:56:35.317601Z"`
 	// Contains the groups that requires to approve this review
 	ReviewGroupsData []ReviewGroup `json:"review_groups_data" readonly:"true"`
+	// The time window configuration that can execute the session
+	TimeWindow *ReviewSessionTimeWindow `json:"time_window" readonly:"true"`
+}
+
+type ReviewSessionTimeWindow struct {
+	Type          ReviewTimeWindowType `json:"type" binding:"required" enums:"time_range"`
+	Configuration map[string]string    `json:"configuration" binding:"required" example:"start_time:09:00,end_time:18:00"`
 }
 
 type Review struct {
@@ -724,6 +735,8 @@ type Review struct {
 	CreatedAt time.Time `json:"created_at" readonly:"true" example:"2024-07-25T15:56:35.317601Z"`
 	// Contains the groups that requires to approve this review
 	ReviewGroupsData []ReviewGroup `json:"review_groups_data" readonly:"true"`
+	// The time window configuration that can execute the session
+	TimeWindow *ReviewSessionTimeWindow `json:"time_window" readonly:"true"`
 }
 
 type ReviewOwner struct {

--- a/gateway/api/session/parser.go
+++ b/gateway/api/session/parser.go
@@ -100,6 +100,13 @@ func topOpenApiReview(r *models.SessionReview) *openapi.SessionReview {
 			ReviewDate: rg.ReviewedAt,
 		})
 	}
+	var timeWindow *openapi.ReviewSessionTimeWindow
+	if r.TimeWindow != nil {
+		timeWindow = &openapi.ReviewSessionTimeWindow{
+			Type:          openapi.ReviewTimeWindowType(r.TimeWindow.Type),
+			Configuration: r.TimeWindow.Configuration,
+		}
+	}
 	return &openapi.SessionReview{
 		ID:   r.ID,
 		Type: openapi.ReviewType(r.Type),
@@ -110,6 +117,7 @@ func topOpenApiReview(r *models.SessionReview) *openapi.SessionReview {
 		CreatedAt:        r.CreatedAt,
 		RevokeAt:         r.RevokedAt,
 		ReviewGroupsData: itemGroups,
+		TimeWindow:       timeWindow,
 	}
 }
 

--- a/gateway/models/reviews.go
+++ b/gateway/models/reviews.go
@@ -50,6 +50,12 @@ type Review struct {
 	ReviewGroups      []ReviewGroups    `gorm:"column:review_groups;serializer:json;->"`
 	CreatedAt         time.Time         `gorm:"column:created_at"`
 	RevokedAt         *time.Time        `gorm:"column:revoked_at"`
+	TimeWindow        *ReviewTimeWindow `gorm:"column:time_window;serializer:json;"`
+}
+
+type ReviewTimeWindow struct {
+	Type          string            `json:"type"`
+	Configuration map[string]string `json:"configuration"`
 }
 
 type ReviewGroups struct {
@@ -110,7 +116,7 @@ func GetReviewByIdOrSid(orgID, id string) (*Review, error) {
 	err := DB.Raw(`
 	SELECT
 		id, org_id, session_id, connection_name, type, access_duration_sec, status,
-		blob_input_id, input_env_vars, input_client_args,
+		blob_input_id, input_env_vars, input_client_args, time_window,
 		owner_id, owner_email, owner_name, owner_slack_id,
 		( SELECT jsonb_agg(
 				jsonb_build_object(

--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -121,14 +121,15 @@ type Blob struct {
 	BlobFormat *string         `gorm:"column:format"`
 }
 type SessionReview struct {
-	ID                string         `json:"id"`
-	SessionID         string         `json:"session_id"`
-	Type              string         `json:"type"`
-	Status            string         `json:"status"`
-	CreatedAt         time.Time      `json:"created_at"`
-	RevokedAt         *time.Time     `json:"revoked_at"`
-	AccessDurationSec int64          `json:"access_duration_sec"`
-	ReviewGroups      []ReviewGroups `json:"review_groups" gorm:"review_groups;serializer:json"`
+	ID                string            `json:"id"`
+	SessionID         string            `json:"session_id"`
+	Type              string            `json:"type"`
+	Status            string            `json:"status"`
+	CreatedAt         time.Time         `json:"created_at"`
+	RevokedAt         *time.Time        `json:"revoked_at"`
+	AccessDurationSec int64             `json:"access_duration_sec"`
+	ReviewGroups      []ReviewGroups    `json:"review_groups" gorm:"review_groups;serializer:json"`
+	TimeWindow        *ReviewTimeWindow `json:"time_window" gorm:"time_window;serializer:json;"`
 }
 
 func (r *SessionReview) Scan(value any) error {
@@ -207,6 +208,7 @@ func GetSessionByID(orgID, sid string) (*Session, error) {
 				'type', rv.type,
 				'access_duration_sec', rv.access_duration_sec,
 				'status', rv.status,
+				'time_window', rv.time_window,
 				'created_at', to_char(rv.created_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
 				'revoked_at', to_char(rv.revoked_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
 				'review_groups', (

--- a/gateway/transport/plugins/slack/events.go
+++ b/gateway/transport/plugins/slack/events.go
@@ -81,7 +81,7 @@ func (p *slackPlugin) processEventResponse(ev *event) {
 }
 
 func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status models.ReviewStatusType) {
-	rev, err := reviewapi.DoReview(ctx, ev.msg.ID, status)
+	rev, err := reviewapi.DoReview(ctx, ev.msg.ID, status, nil)
 	var msg string
 	switch err {
 	case reviewapi.ErrNotFound:

--- a/rootfs/app/migrations/000053_add_timewindow_review.down.sql
+++ b/rootfs/app/migrations/000053_add_timewindow_review.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path TO private;
+
+ALTER TABLE reviews DROP COLUMN time_window;
+
+COMMIT;

--- a/rootfs/app/migrations/000053_add_timewindow_review.up.sql
+++ b/rootfs/app/migrations/000053_add_timewindow_review.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path TO private;
+
+ALTER TABLE reviews ADD time_window jsonb NULL;
+
+COMMIT;


### PR DESCRIPTION
## 📝 Description

This PR implements time window configuration for review sessions, allowing administrators to restrict when approved sessions can be executed. The feature adds support for defining time ranges (e.g., 09:00-18:00 UTC) during which reviewed sessions can run, enhancing security and compliance controls.

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `time_window` field to `Review` and `SessionReview` models with JSONB storage
- Implemented `ReviewSessionTimeWindow` and `ReviewTimeWindowType` OpenAPI types
- Created `parseTimeWindow` function to validate time window configurations (HH:MM format)
- Added `canExecReviewedSession` validation function with time range enforcement
- Updated review approval flow to accept and store time window configurations
- Implemented support for overnight time windows (e.g., 22:00-06:00)
- All time validations use UTC timezone for consistency

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (Backend feature)
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**Time Window Configuration Format:**
```json
{
  "status": "APPROVED",
  "time_window": {
    "type": "time_range",
    "configuration": {
      "start_time": "09:00",
      "end_time": "18:00"
    }
  }
}