### PR TITLE
fix: add complement component to JIT review toggle

### DIFF
--- a/webapp/src/webapp/connections/views/setup/metadata_driven.cljs
+++ b/webapp/src/webapp/connections/views/setup/metadata_driven.cljs
@@ -70,7 +70,7 @@
     (if configs
       [:> Box {:class "space-y-5"}
        [:> Heading {:as "h3" :size "4" :weight "bold"}
-        "Environment credentialssss"]
+        "Environment credentials"]
 
        [:> Grid {:columns "1" :gap "4"}
         (for [field configs]

--- a/webapp/src/webapp/resources/configure_role/native_access_tab.cljs
+++ b/webapp/src/webapp/resources/configure_role/native_access_tab.cljs
@@ -15,6 +15,7 @@
            checked
            disabled?
            on-change
+           complement-component
            upgrade-plan-component
            learning-component]}]
   [:> Flex {:align "center" :gap "5"}
@@ -25,6 +26,9 @@
    [:> Box
     [:> Heading {:as "h4" :size "3" :weight "medium" :class "text-[--gray-12]"} title]
     [:> Text {:as "p" :size "2" :class "text-[--gray-11]"} description]
+
+    (when complement-component
+      complement-component)
 
     (when upgrade-plan-component
       upgrade-plan-component)


### PR DESCRIPTION
## 📝 Description

This pull request fixes the issue that is not allowing to select the groups for JIT Reviews.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

* Added support for an optional `complement-component` prop in the `native_access_tab.cljs` configuration tab, allowing additional UI elements to be rendered when provided.

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: MacOs

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots

<img width="966" height="695" alt="image" src="https://github.com/user-attachments/assets/35a48d6e-3f03-4ca6-9cce-a706dee5ba19" />


## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

