### PR TITLE
Add kubectl command to work with kubernetes bearer token new resource

### DIFF
--- a/rootfs/opt/hoop/bin/kubectl
+++ b/rootfs/opt/hoop/bin/kubectl
@@ -1,0 +1,5 @@
+#!/bin/bash
+INSECURE=${INSECURE:=false}
+[[ "$CONNECTION_DEBUG" == "1" ]] && set -x
+
+/usr/local/bin/kubectl --token=$HEADER_AUTHORIZATION --insecure-skip-tls-verify=$INSECURE --server=$REMOTE_URL $@

--- a/webapp/src/webapp/resources/setup/roles_step.cljs
+++ b/webapp/src/webapp/resources/setup/roles_step.cljs
@@ -91,7 +91,7 @@
     [:> Box {:class "space-y-4"}
      ;; Cluster URL
      [forms/input {:label "Cluster URL"
-                   :placeholder "e.g. https://example.com:51434"
+                   :placeholder "e.g. https://kubernetes.default.svc.cluster.local:443"
                    :value (get credentials "remote_url" "")
                    :required true
                    :type "text"


### PR DESCRIPTION
## 📝 Description

Add kubectl custom command to work with the Kubernetes Bearer token type in the Web Console

## 🔗 Related Issue

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 🧪 Testing

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
