### PR TITLE
fix: improve error handling during runbook migration

### DIFF
--- a/gateway/models/bootstrap/migrations/RunbooksV2.go
+++ b/gateway/models/bootstrap/migrations/RunbooksV2.go
@@ -103,7 +103,9 @@ func migrateOrganizationRunbooks(db *gorm.DB, orgID string) error {
 
 	commonConfig, err := models.BuildCommonConfig(&modelConfig)
 	if err != nil {
-		return fmt.Errorf("failed to build common config, err=%v", err)
+		log.Warnf("Failed to build common config for org %s, err=%v", orgID, err)
+		log.Warnf("Skipping runbook migration for org %s, only removing plugin", orgID)
+		return models.DeletePlugin(db, obj)
 	}
 
 	repositoryName := commonConfig.GetNormalizedGitURL()


### PR DESCRIPTION
## 📝 Description

Improves error handling during runbook migration by gracefully handling failures when building common config. Instead of failing the entire migration, the system now logs a warning and skips the runbook migration while still removing the plugin for affected organizations.

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when this PR is merged -->


## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- Modified `migrateOrganizationRunbooks` function in [RunbooksV2.go](gateway/models/bootstrap/migrations/RunbooksV2.go) to handle `BuildCommonConfig` errors gracefully
- Added warning logs when common config building fails for an organization
- Changed behavior to skip runbook migration and only remove plugin when config building fails, preventing migration failure
- Improved error messages to include organization ID for better debugging

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
<!-- You can drag and drop images directly into this text area -->

N/A - Backend change only

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

<!-- Add any additional notes, concerns, or discussion points here -->
<!-- Is there anything specific you'd like reviewers to focus on? -->

This change prevents the runbook migration from completely failing when an organization has invalid configuration. The migration will now continue for other organizations while properly cleaning up the affected organization by removing the plugin.

---

<!-- Thank you for contributing to our project! 🙏 -->