### PR TITLE
fix: remove httpproxy check to allow kubectl to work in the Web Console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,6 @@ EXPOSE 8010
 EXPOSE 15432
 
 ENV PATH="/app:${PATH}"
-ENV PATH="${PATH}:/opt/hoop/bin"
+ENV PATH="/opt/hoop/bin:${PATH}"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN tar -xf /tmp/hoop_*_$(uname -s)_$(uname -m).tar.gz -C /app/ && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
-ENV PATH="${PATH}:/opt/hoop/bin"
+ENV PATH="/opt/hoop/bin:${PATH}"
 
 ENTRYPOINT ["tini", "--"]
 CMD ["hoop", "start", "agent"]

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -460,7 +460,7 @@ func validateConnectionType(clientVerb string, pctx plugintypes.Context) error {
 	if clientVerb == pb.ClientVerbExec {
 		connType := pb.ToConnectionType(pctx.ConnectionType, pctx.ConnectionSubType)
 		switch connType {
-		case pb.ConnectionTypeTCP, pb.ConnectionTypeHttpProxy, pb.ConnectionTypeSSH:
+		case pb.ConnectionTypeTCP, pb.ConnectionTypeSSH:
 			return status.Errorf(codes.InvalidArgument,
 				fmt.Sprintf("exec is not allowed for %v type connections. Use 'hoop connect %s' instead", connType, pctx.ConnectionName))
 		}

--- a/scripts/dev/Dockerfile
+++ b/scripts/dev/Dockerfile
@@ -24,6 +24,6 @@ RUN curl -Lo ec2-metadata-mock "https://github.com/aws/amazon-ec2-metadata-mock/
 COPY rootfs/usr/local/bin /usr/local/bin/
 COPY rootfs/opt/hoop/bin /opt/hoop/bin/
 
-ENV PATH="${PATH}:/opt/hoop/bin"
+ENV PATH="/opt/hoop/bin:${PATH}"
 
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
## 📝 Description

- Add `/opt/hoop/bin` as main binary path to docker images
- Remove check to allow kubectl to work for the kubernetes bearer token resource

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: 
- **OS**:

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

