### PR TITLE
fix: improve kubectl wrapper to only set flags when HEADER_AUTHORIZATION is set

### DIFF
--- a/rootfs/opt/hoop/bin/kubectl
+++ b/rootfs/opt/hoop/bin/kubectl
@@ -1,5 +1,11 @@
 #!/bin/bash
-INSECURE=${INSECURE:=false}
 [[ "$CONNECTION_DEBUG" == "1" ]] && set -x
+INSECURE=${INSECURE:=false}
 
-/usr/local/bin/kubectl --token=$HEADER_AUTHORIZATION --insecure-skip-tls-verify=$INSECURE --server=$REMOTE_URL $@
+if [[ -z "$HEADER_AUTHORIZATION" ]]; then
+    /usr/local/bin/kubectl $@
+    exit $?
+fi
+
+HEADER_AUTHORIZATION=$(sed 's|Bearer ||g' <<< $HEADER_AUTHORIZATION)
+/usr/local/bin/kubectl --server="$REMOTE_URL" --insecure-skip-tls-verify=$INSECURE --token="$HEADER_AUTHORIZATION" $@


### PR DESCRIPTION
## 📝 Description

- It uses the global flags only when the env `HEADER_AUTHORIZATION`
- Fix HEADER_AUTHORIZATION to remove the "Bearer " to only add the token

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 🧪 Testing


### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
