### PR TITLE
refactor: simplify runbook configuration after fail during migration

### DIFF
--- a/gateway/models/bootstrap/migrations/RunbooksV2.go
+++ b/gateway/models/bootstrap/migrations/RunbooksV2.go
@@ -104,8 +104,15 @@ func migrateOrganizationRunbooks(db *gorm.DB, orgID string) error {
 	commonConfig, err := models.BuildCommonConfig(&modelConfig)
 	if err != nil {
 		log.Warnf("Failed to build common config for org %s, err=%v", orgID, err)
-		log.Warnf("Skipping runbook migration for org %s, only removing plugin", orgID)
-		return models.DeletePlugin(db, obj)
+		log.Warnf("Using a simplified runbook configuration")
+
+		commonConfig, err = models.BuildCommonConfig(&models.RunbookRepositoryConfig{
+			GitUrl: string(gitUrl),
+		})
+		if err != nil {
+			log.Warnf("Skipping runbook migration for org %s, only removing plugin", orgID)
+			return models.DeletePlugin(db, obj)
+		}
 	}
 
 	repositoryName := commonConfig.GetNormalizedGitURL()


### PR DESCRIPTION
## 📝 Description

Improve runbook configuration resilience by implementing a fallback strategy when the full configuration build fails. Instead of immediately skipping migration and deleting the plugin, the system now attempts to build a simplified configuration using only the Git URL. This allows more runbooks to be successfully migrated even when the complete configuration build encounters errors.

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when this PR is merged -->

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- Modified `migrateOrganizationRunbooks` function in `gateway/models/bootstrap/migrations/RunbooksV2.go`
- Added fallback logic to build simplified runbook configuration when full configuration build fails
- Simplified configuration uses only `GitUrl` from the original repository config
- Only deletes plugin and skips migration if even the simplified configuration fails to build
- Improved logging to indicate fallback strategy usage

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: 
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
<!-- You can drag and drop images directly into this text area -->

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

This refactor improves the migration robustness by providing a graceful degradation path. When the full runbook configuration cannot be built, the system attempts to use a minimal viable configuration rather than immediately failing. This approach helps ensure that runbooks are migrated successfully in more scenarios, while still protecting against complete failure by falling back to plugin deletion if necessary.

---

<!-- Thank you for contributing to our project! 🙏 -->