### PR TITLE
fix: update cookie handling in IDP login callbacks for safari

### DIFF
--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -130,11 +130,20 @@
    [webapp.webclient.events.multiple-connection-execution]
    [webapp.webclient.events.search]
    [webapp.webclient.events.metadata]
-   [webapp.webclient.panel :as webclient]
-   [webapp.utilities :as utilities]))
+   [webapp.webclient.panel :as webclient]))
 
 ;; Tracking initialization is now handled by :tracking->initialize-if-allowed
 ;; which is dispatched after gateway info is loaded and checks do_not_track
+(defn- get-cookie-value
+  "Helper function to extract cookie value by name"
+  [cookie-name]
+  (when-let [cookie-string (.-cookie js/document)]
+    (let [cookies (cs/split cookie-string #"; ")
+          target-cookie (some #(when (cs/starts-with? % (str cookie-name "="))
+                                 %) cookies)]
+      (when target-cookie
+        (subs target-cookie (+ (count cookie-name) 1))))))
+
 (defn- clear-cookie
   "Helper function to clear a cookie by setting it to empty with past expiration"
   [cookie-name]
@@ -145,7 +154,7 @@
   []
   (let [search-string (.. js/window -location -search)
         url-params (new js/URLSearchParams search-string)
-        token (utilities/get-cookie-value "hoop_access_token")
+        token (get-cookie-value "hoop_access_token")
         error (.get url-params "error")
         redirect-after-auth (.getItem js/localStorage "redirect-after-auth")]
 
@@ -153,7 +162,8 @@
     (when error (.setItem js/localStorage "login_error" error))
 
     (when token
-      (.setItem js/localStorage "jwt-token" token))
+      (.setItem js/localStorage "jwt-token" token)
+      (clear-cookie "hoop_access_token"))
 
     (if error
       (rf/dispatch [:navigate :login-hoop])
@@ -180,7 +190,7 @@
   []
   (let [search-string (.. js/window -location -search)
         url-params (new js/URLSearchParams search-string)
-        token (utilities/get-cookie-value "hoop_access_token")
+        token (get-cookie-value "hoop_access_token")
         error (.get url-params "error")
         destiny (if error :login-hoop :signup-hoop)]
     (.removeItem js/localStorage "login_error")

--- a/webapp/src/webapp/http/api.cljs
+++ b/webapp/src/webapp/http/api.cljs
@@ -1,8 +1,7 @@
 (ns webapp.http.api
   (:require
    [webapp.http.request :as request]
-   [webapp.config :as config]
-   [webapp.utilities :as utilities]))
+   [webapp.config :as config]))
 
 (defn request
   "request abstraction for calling Hoop API
@@ -17,9 +16,7 @@
 
   it returns a promise with the response in a clojure map and executes a on-sucess callback"
   [{:keys [method uri query-params body on-success on-failure headers]}]
-  (let [local-storage-token (.getItem js/localStorage "jwt-token")
-        cookie-token (utilities/get-cookie-value "hoop_access_token")
-        token (or cookie-token local-storage-token)
+  (let [token (.getItem js/localStorage "jwt-token")
         common-headers {:headers {:accept "application/json"
                                   "Content-Type" "application/json"
                                   "Authorization" (str "Bearer " token)

--- a/webapp/src/webapp/utilities.cljs
+++ b/webapp/src/webapp/utilities.cljs
@@ -32,14 +32,3 @@
         (string/replace (js/decodeURIComponent (js/escape decoded)) #"∞" "\t")
         (catch js/Error _ decoded)))
     (catch js/Error _ "")))
-
-
-(defn get-cookie-value
-  "Helper function to extract cookie value by name"
-  [cookie-name]
-  (when-let [cookie-string (.-cookie js/document)]
-    (let [cookies (string/split cookie-string #"; ")
-          target-cookie (some #(when (string/starts-with? % (str cookie-name "="))
-                                 %) cookies)]
-      (when target-cookie
-        (subs target-cookie (+ (count cookie-name) 1))))))


### PR DESCRIPTION
## 📝 Description

Fixes infinite login loop in Safari caused by Intelligent Tracking Prevention (ITP) blocking authentication cookies. The issue occurred when users authenticated via OIDC or SAML - authentication would succeed but Safari would block/clear cookies, causing immediate logout and redirect loops.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- Updated OIDC and SAML login handlers to set cookies with `SameSite=Lax` attribute for Safari ITP compatibility
- Made cookie `Secure` flag conditional based on HTTPS detection (supports reverse proxies)

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: Safari (normal and private browsing), Chrome
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

**Manual Testing Steps:**
1. Tested OIDC login flow in Safari - verified no infinite loop
2. Tested SAML login flow in Safari - verified successful authentication
3. Tested token persistence across page refreshes

## 📸 Screenshots

**Login with IDP on Safari**
![Screen Recording 2026-01-06 at 19 09 52](https://github.com/user-attachments/assets/1e8f3019-04db-4573-8056-adf70307a89b)

**Login with IDP on Chrome**
![Screen Recording 2026-01-06 at 19 11 26](https://github.com/user-attachments/assets/04b37c3b-e4e6-4762-9924-715fba9dc3d2)

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- ⚠️ Safari 26.0 with "Prevent cross-site tracking" enabled may cause immediate logout due to `localStorage` being cleared. This is already fixed in Safari 26.x+, so we're not addressing it in this PR.

**Security Considerations:**
- Cookies maintain `Secure` flag when served over HTTPS
- `HttpOnly=false` is necessary for frontend token extraction but tokens remain protected by HTTPS
- Existing security measures (HTTPS enforcement, token validation) remain unchanged

**Browser Compatibility:**
- Safari: Fixed infinite login loop with proper `SameSite` cookie attributes
- Chrome: No changes to existing behavior

---

<!-- Thank you for contributing to our project! 🙏 -->