### PR TITLE
Add httpproxy port on helm

### DIFF
--- a/deploy/helm-chart/chart/gateway/templates/service.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/service.yaml
@@ -26,6 +26,9 @@ spec:
       name: ssh
       protocol: TCP
       targetPort: 12222
+    - port: 18888
+      name: httpproxy
+      protocol: TCP
 {{- with .Values.mainService.httpBackendConfig }}
 ---
 apiVersion: cloud.google.com/v1

--- a/webapp/src/webapp/settings/infrastructure/main.cljs
+++ b/webapp/src/webapp/settings/infrastructure/main.cljs
@@ -139,7 +139,7 @@
                [:> Heading {:as "h4" :size "3" :weight "medium" :class "text-[--gray-12] mb-1"}
                 "Http Proxy Port"]
                [forms/input
-                {:placeholder "e.g. 13389"
+                {:placeholder "e.g. 18888"
                  :value (:http-proxy-port data)
                  :on-change #(rf/dispatch [:infrastructure->update-field
                                            :http-proxy-port (-> % .-target .-value)])}]]]]]])))))


### PR DESCRIPTION
- Add http proxy port (18888) on helm
- Change placeholder with default port number for httpproxy

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

