### PR TITLE
fix: Use right attribute to filter properly reviewed sessions

### DIFF
--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -298,7 +298,7 @@ func ListSessions(orgID string, userId string, isAuditorOrAdmin bool, opt Sessio
 			return fmt.Errorf("unable to obtain total count of sessions, reason=%v", err)
 		}
 
-		err = tx.Debug().Raw(`
+		err = tx.Raw(`
 		SELECT
 			s.id, s.org_id, s.connection, s.connection_type, s.connection_subtype, s.connection_tags, s.verb, s.labels, s.exit_code,
 			s.user_id, s.user_name, s.user_email, s.status, s.metadata, s.integrations_metadata, s.metrics,


### PR DESCRIPTION
Users that are approvers are not able to list sessions in which they are assigned to. This change fix this issue to filter the properly attribute since `@user_id` is the subject not the email address.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore
