### PR TITLE
Add patch to fix panic when handling packets

### DIFF
--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -119,12 +119,17 @@ func (s *Server) listenClientMessages(stream *streamclient.ProxyStream) error {
 	recvCh := grpc.NewStreamRecv(stream.Context(), stream)
 	for {
 		var dstream *grpc.DataStream
+		var ok bool
 		select {
 		case <-stream.Context().Done():
 			return stream.ContextCauseError()
 		case <-pctx.Context.Done():
 			return status.Error(codes.Aborted, "session ended, reached connection duration")
-		case dstream = <-recvCh:
+		case dstream, ok = <-recvCh:
+			if !ok {
+				// Channel was closed, stream ended
+				return io.EOF
+			}
 		}
 
 		// receive data from stream channel


### PR DESCRIPTION
## 📝 Description

Patch to fix 1.44.2 version with upstream fix from 1.47.0.
It fixes panic when handling packets. Ensure to only proceed if the dstream is set.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

