### PR TITLE
feat: enhance event tracking with additional properties including org-id

### DIFF
--- a/gateway/analytics/segment.go
+++ b/gateway/analytics/segment.go
@@ -3,6 +3,7 @@ package analytics
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"net/url"
 
 	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/storagev2/types"
@@ -87,6 +88,19 @@ func (s *Segment) Track(userID, eventName string, properties map[string]any) {
 	}
 	if properties == nil {
 		properties = map[string]any{}
+	}
+
+	if apiUrl, exists := properties["api-hostname"]; (!exists || apiUrl == "") && appconfig.Get().ApiURL() != "" {
+		url, err := url.Parse(appconfig.Get().ApiURL())
+		if err == nil {
+			properties["api-hostname"] = url.Hostname()
+		}
+	}
+
+	if orgID, exists := properties["org-id"]; exists && orgID != "" {
+		properties["$groups"] = map[string]any{
+			"org-id": orgID,
+		}
 	}
 
 	hashedUserID := getUserIDHash(userID)

--- a/gateway/api/login/local/register.go
+++ b/gateway/api/login/local/register.go
@@ -110,7 +110,10 @@ func Register(c *gin.Context) {
 		UserID:          userSubject,
 		UserAnonSubject: org.ID,
 	})
-	trackClient.Track(userSubject, analytics.EventSingleTenantFirstUserCreated, nil)
+	trackClient.Track(userSubject, analytics.EventSingleTenantFirstUserCreated, map[string]any{
+		"org-id":       org.ID,
+		"api-hostname": c.Request.Host,
+	})
 
 	err = models.InsertUserGroups([]models.UserGroup{adminUserGroup})
 	if err != nil {

--- a/gateway/api/middleware.go
+++ b/gateway/api/middleware.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/hoophq/hoop/common/apiutils"
-	"github.com/hoophq/hoop/common/license"
 	"github.com/hoophq/hoop/common/version"
 	"github.com/hoophq/hoop/gateway/analytics"
 	"github.com/hoophq/hoop/gateway/appconfig"
@@ -23,21 +22,13 @@ func (a *Api) TrackRequest(eventName string) func(c *gin.Context) {
 			return
 		}
 
-		licenseType := license.OSSType
-		if ctx.OrgLicenseData != nil && len(*ctx.OrgLicenseData) > 0 {
-			var l license.License
-			err := json.Unmarshal(*ctx.OrgLicenseData, &l)
-			if err == nil {
-				licenseType = l.Payload.Type
-			}
-		}
-
 		properties := map[string]any{
 			"org-id":         ctx.OrgID,
 			"auth-method":    appconfig.Get().AuthMethod(),
-			"license-type":   licenseType,
+			"license-type":   ctx.GetLicenseType(),
 			"content-length": c.Request.ContentLength,
 			"user-agent":     apiutils.NormalizeUserAgent(c.Request.Header.Values),
+			"api-hostname":   c.Request.Host,
 		}
 		switch eventName {
 		case analytics.EventCreateAgent:

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -136,7 +136,10 @@ func Create(c *gin.Context) {
 		// wait some time until the identify call get times to reach to intercom
 		time.Sleep(time.Second * 10)
 		properties := map[string]any{
-			"user-agent": apiutils.NormalizeUserAgent(c.Request.Header.Values),
+			"user-agent":   apiutils.NormalizeUserAgent(c.Request.Header.Values),
+			"org-id":       ctx.OrgID,
+			"license-type": ctx.GetLicenseType(),
+			"api-hostname": c.Request.Host,
 		}
 		ctx.Analytics().Track(userSubject, analytics.EventSignup, properties)
 		ctx.Analytics().Track(userSubject, analytics.EventCreateInvitedUser, properties)

--- a/gateway/models/user_context.go
+++ b/gateway/models/user_context.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"slices"
 
+	"github.com/hoophq/hoop/common/license"
 	"github.com/hoophq/hoop/gateway/storagev2/types"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
@@ -48,6 +49,17 @@ func (c *Context) GetUserID() string       { return c.UserID }
 func (c *Context) GetUserGroups() []string { return c.UserGroups }
 func (c *Context) IsAdmin() bool           { return slices.Contains(c.UserGroups, types.GroupAdmin) }
 func (c *Context) IsAuditor() bool         { return slices.Contains(c.UserGroups, types.GroupAuditor) }
+func (c *Context) GetLicenseType() string {
+	licenseType := license.OSSType
+	if len(c.OrgLicenseData) > 0 {
+		var l license.License
+		err := json.Unmarshal(c.OrgLicenseData, &l)
+		if err == nil {
+			licenseType = l.Payload.Type
+		}
+	}
+	return licenseType
+}
 
 // GetUserContext retrieves user context data based on the subject claim or OIDC information.
 //

--- a/gateway/storagev2/core.go
+++ b/gateway/storagev2/core.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/common/license"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/gateway/analytics"
 	idptypes "github.com/hoophq/hoop/gateway/idp/types"
@@ -127,4 +128,16 @@ func (c *Context) GroupRoleName() string {
 		}
 	}
 	return "regular"
+}
+func (c *Context) GetLicenseType() string {
+	licenseType := license.OSSType
+	if c.OrgLicenseData != nil && len(*c.OrgLicenseData) > 0 {
+		var l license.License
+		err := json.Unmarshal(*c.OrgLicenseData, &l)
+		if err == nil {
+			licenseType = l.Payload.Type
+		}
+	}
+
+	return licenseType
 }

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -109,6 +109,7 @@ func (s *Server) subscribeClient(stream *streamclient.ProxyStream) (err error) {
 	})
 	analytics.New().Track(pctx.UserID, eventName, map[string]any{
 		"org-id":                pctx.OrgID,
+		"license-type":          pctx.OrgLicenseType,
 		"connection-name":       pctx.ConnectionName,
 		"connection-type":       pctx.ConnectionType,
 		"connection-subtype":    pctx.ConnectionSubType,

--- a/gateway/transport/proxymanager.go
+++ b/gateway/transport/proxymanager.go
@@ -200,6 +200,8 @@ func (s *Server) proccessConnectOKAck(stream *streamclient.ProxyStream) error {
 			"connection-name":    req.RequestConnectionName,
 			"connection-type":    conn.Type,
 			"connection-subtype": conn.SubType,
+			"org-id":             pctx.OrgID,
+			"license-type":       pctx.OrgLicenseType,
 			"client-version":     stream.GetMeta("version"),
 			"platform":           stream.GetMeta("platform"),
 			"user-agent":         userAgent,


### PR DESCRIPTION
## 📝 Description

Enhanced event tracking across the platform by adding consistent tracking properties including `org-id`, `api-hostname`, and `license-type` to all Segment analytics events. This improvement ensures better organization-level analytics and enables PostHog group tracking functionality.

## 🔗 Related Issue

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added automatic `api-hostname` property extraction and injection in Segment tracking events
- Implemented PostHog group tracking support via `$groups` property when `org-id` is present
- Created `GetLicenseType()` helper method in both `gateway/models/user_context.go` and `gateway/storagev2/core.go` to reduce code duplication
- Enhanced tracking properties in signup, login, user creation, and connection events to include `org-id`, `api-hostname`, and `license-type`
- Updated middleware to include `api-hostname` in all tracked API requests
- Refactored license type extraction logic to use centralized helper methods

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (backend changes)
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed (verified tracking events are fired with correct properties)

## 📸 Screenshots (if applicable)

N/A - Backend analytics enhancement

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

---

<!-- Thank you for contributing to our project! 🙏 -->