### PR TITLE
hotfix: update ResourceName field in session model to use GORM struct tag for read-only access

### DIFF
--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -65,7 +65,7 @@ type Session struct {
 	ID                   string            `gorm:"column:id"`
 	OrgID                string            `gorm:"column:org_id"`
 	Connection           string            `gorm:"column:connection"`
-	ResourceName         string            `gorm:"column:resource_name"`
+	ResourceName         string            `gorm:"column:resource_name;->"`
 	ConnectionType       string            `gorm:"column:connection_type"`
 	ConnectionSubtype    string            `gorm:"column:connection_subtype"`
 	ConnectionTags       map[string]string `gorm:"column:connection_tags;serializer:json"`


### PR DESCRIPTION
## 📝 Description

This PR fixes a transport layer error that occurred when creating sessions via `hoop connect`. The error was caused by the `ResourceName` field being added to the `Session` struct but not properly configured as read-only in GORM, causing "invalid field" errors during session persistence.

## 🔗 Related Issue

Fixes #1288 

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `->` (read-only) GORM tag to `ResourceName` field in `Session` struct

## 🧪 Testing

### Test Configuration:
- **OS**: macOS/Linux

### Tests performed:
- [x] Manual testing completed
- [x] Verified `hoop connect` works without errors
- [x] Confirmed GET endpoints return `resource_name` correctly
- [x] Validated session creation no longer fails with "invalid field" error

## 🔍 Technical Details

### Problem
When adding `resource_name` and `role_name` fields to session responses, the `ResourceName` field was added to the `Session` model struct with a standard GORM column tag. This caused GORM to attempt writing this field during INSERT/UPDATE operations, resulting in an "invalid field" error since no physical column exists in the `sessions` table.

Error encountered:
```
failed persisting session to store, reason=invalid field
```

### Root Cause
The `ResourceName` field in the `Session` struct was mapped to a column that doesn't exist in the database. The field is only meant to be populated via LEFT JOIN with the `connections` table during SELECT queries.

### Solution
Added the `->` GORM tag to mark `ResourceName` as read-only:

```go
ResourceName string `gorm:"column:resource_name;->"`
```

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings