### PR TITLE
hotfix: assume protocol in base URL for claude code resource type

### DIFF
--- a/webapp/src/webapp/connections/native_client_access/custom_credential_views.cljs
+++ b/webapp/src/webapp/connections/native_client_access/custom_credential_views.cljs
@@ -20,11 +20,11 @@
 (defn claude-code-credentials-fields
   "Claude Code specific credentials fields"
   [{:keys [connection_credentials]}]
-  (println "connection_credentials" connection_credentials)
   (let [hostname (:hostname connection_credentials)
         port (:port connection_credentials)
         proxy-token (:proxy_token connection_credentials)
-        base-url (str "http://" hostname ":" port)
+        protocol (-> js/window .-location .-protocol)
+        base-url (str protocol "//" hostname ":" port)
         custom-headers (str "Authorization: " proxy-token)
         build-json-content (fn [base-url custom-headers]
                              {:env {:ANTHROPIC_BASE_URL base-url


### PR DESCRIPTION
## 📝 Description

This PR fixes the assumption in the code that would build Claude Code instructions with `http` only. It uses the window.location to determine which protocol is being used for hoop webapp <-> gateway and uses that protocol to build the configuration instructions.

## 🔗 Related Issue

Fixes ENG-262

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore


## 🧪 Testing

- Create a new Claude Code resource type
- Try to connect to it under http and https
- For each of those cases, the configuration should reflect the right protocol

### Test Configuration:
- **Browser(s)**: 
- **OS**:

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
<!-- You can drag and drop images directly into this text area -->

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
