### PR TITLE
fix: restore inline tabular results view in runbooks

### DIFF
--- a/webapp/src/webapp/features/runbooks/runner/main.cljs
+++ b/webapp/src/webapp/features/runbooks/runner/main.cljs
@@ -140,6 +140,7 @@
         selected-template (rf/subscribe [:runbooks->selected-runbooks])
         search-term (rf/subscribe [:search/term])
         runbooks-connection (rf/subscribe [:runbooks/selected-connection])
+        parallel-mode-active? (rf/subscribe [:parallel-mode/is-active?])
         parallel-mode-promotion-seen (rf/subscribe [:parallel-mode/promotion-seen])
         collapsed? (r/atom false)
         metadata-open? (r/atom false)
@@ -193,7 +194,7 @@
              [:> Flex {:direction "column" :justify "between" :class "h-full border-t border-gray-3"}
               [log-area/main
                (discover-connection-type @runbooks-connection)
-               true
+               @parallel-mode-active?
                @dark-mode?]]]]]
           (when @metadata-open?
             [:> (.-Pane Allotment) {:minSize 250 :maxSize 370}


### PR DESCRIPTION
## 📝 Description

This PR restore the inline tabular results in the runbooks page.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

  * The `log-area/main` component now receives the actual state of `parallel-mode-active?` from the application store, ensuring its behavior matches the current parallel mode status.
  * Subscribed to the `:parallel-mode/is-active?` state in the runner component to support this change.

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**:  Chrome
- **OS**: MacOs

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
