### PR TITLE
[fix] infinite scroll at resources page

### DIFF
--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -378,10 +378,9 @@
     [users/main]]])
 
 (defmethod routes/panels :resources-panel []
-  [layout :application-hoop [:> Box {:class "flex flex-col bg-gray-1 px-4 py-10 sm:px-6 lg:p-10 h-full space-y-radix-7"}
-                             [:> Heading {:as "h1" :size "8" :weight "bold" :class "text-gray-12"}
-                              "Resources"]
-                             [resources-main/panel]]])
+  [layout :application-hoop
+   [:> Box {:class "bg-gray-1 min-h-full h-screen"}
+    [resources-main/panel]]])
 
 (defmethod routes/panels :configure-resource-panel []
   (let [pathname (.. js/window -location -pathname)

--- a/webapp/src/webapp/resources/main.cljs
+++ b/webapp/src/webapp/resources/main.cljs
@@ -285,7 +285,6 @@
             resources-loading? (= :loading (:loading resources-state))
             connections-loading? (= :loading (:loading connections-state))
             ;; Conditional logic based on active tab
-            current-state (if (= @active-tab "resources") resources-state connections-state)
             current-loading? (if (= @active-tab "resources") resources-loading? connections-loading?)
             has-filters? (or (seq @selected-tags) @selected-resource)
             current-count (if (= @active-tab "resources")
@@ -307,48 +306,39 @@
                                (rf/dispatch [:resources/get-resources-paginated request])
                                (rf/dispatch [:connections/get-connections-paginated request]))))]
 
-        [infinite-scroll
-         {:on-load-more (fn []
-                          (when-not current-loading?
-                            (if (= @active-tab "resources")
+        [:> Box {:class "flex flex-col px-10 pb-10"}
+         [:> Tabs.Root
+          {:value @active-tab
+           :onValueChange (fn [new-tab]
+                            (reset! active-tab new-tab)
+                            (reset! search-name "")
+                            (reset! selected-tags {})
+                            (reset! selected-resource nil)
+                            (when @search-debounce-timer
+                              (js/clearTimeout @search-debounce-timer))
+                            (reset! search-debounce-timer nil)
+                            ;; Reset pagination state for the new tab
+                            (if (= new-tab "resources")
                               (rf/dispatch [:resources/get-resources-paginated
-                                            {:page (inc (:current-page resources-state 1))
-                                             :force-refresh? false}])
+                                            {:page 1 :force-refresh? true :filters {}}])
                               (rf/dispatch [:connections/get-connections-paginated
-                                            {:page (inc (:current-page connections-state 1))
-                                             :force-refresh? false}]))))
-          :has-more? (:has-more? current-state)
-          :loading? current-loading?}
+                                            {:page 1 :force-refresh? true :filters {}}])))}
 
-         ^{:key "infinite-scroll-children"}
-         [:> Box {:height "100%"}
-          ;; Add button (admin only)
+          ;; Sticky Header with Title, Tabs and Filters
+          [:> Box {:class "sticky top-0 z-10 bg-gray-1 pt-10 pb-4 space-y-4"}
+           ;; Title and Add button row
+           [:> Flex {:justify "between" :align "center"}
+            [:> Heading {:as "h1" :size "8" :weight "bold" :class "text-gray-12"}
+             "Resources"]
 
-          (when-not (empty? resources-data)
-            [:> Box {:class "absolute top-10 right-4 sm:right-6 lg:top-12 lg:right-10"}
-             [:> Button {:on-click #(rf/dispatch [:navigate :resource-catalog])}
-              (if (-> @user :data :admin?)
-                "Setup new Resource"
-                "Explore Resource Catalog")]])
+            (when-not (empty? resources-data)
+              [:> Button {:on-click #(rf/dispatch [:navigate :resource-catalog])}
+               (if (-> @user :data :admin?)
+                 "Setup new Resource"
+                 "Explore Resource Catalog")])]
 
-          [:> Tabs.Root
-           {:value @active-tab
-            :onValueChange (fn [new-tab]
-                             (reset! active-tab new-tab)
-                             (reset! search-name "")
-                             (reset! selected-tags {})
-                             (reset! selected-resource nil)
-                             (when @search-debounce-timer
-                               (js/clearTimeout @search-debounce-timer))
-                             (reset! search-debounce-timer nil)
-                             ;; Reset pagination state for the new tab
-                             (if (= new-tab "resources")
-                               (rf/dispatch [:resources/get-resources-paginated
-                                             {:page 1 :force-refresh? true :filters {}}])
-                               (rf/dispatch [:connections/get-connections-paginated
-                                             {:page 1 :force-refresh? true :filters {}}])))}
-
-           [:> Flex {:justify "between" :align "center" :class "mb-4"}
+           ;; Tabs and Filters row
+           [:> Flex {:justify "between" :align "center"}
             [custom-tab-header]
 
             [:> Flex {:gap "2"}
@@ -447,40 +437,60 @@
                     @active-tab
                     " found"
                     (when has-filters?
-                      " with active filters")))]]
+                      " with active filters")))]]]
 
-           [:> Tabs.Content {:value "resources"}
-            (cond
-              ;; Loading state when no data
-              (and resources-loading? (empty? resources-data))
-              [:> Box {:class "flex-1 h-full"}
-               [loading-list-view]]
+          [:> Tabs.Content {:value "resources"}
+           (cond
+             ;; Loading state when no data
+             (and resources-loading? (empty? resources-data))
+             [:> Box {:class "flex-1 min-h-96"}
+              [loading-list-view]]
 
-              ;; Empty state
-              (and (empty? resources-data) (not resources-loading?))
-              [:> Box {:class "flex flex-col h-full"}
-               [empty-list-view (-> @user :data :admin?)]]
+             ;; Empty state
+             (and (empty? resources-data) (not resources-loading?))
+             [:> Box {:class "flex flex-col min-h-96"}
+              [empty-list-view (-> @user :data :admin?)]]
 
-              ;; Content
-              :else
-              [:> Box {:class "flex-1 h-full"}
-               [resources-list-content resources-data @user resource-names]])]
+             ;; Content
+             :else
+             [:> Box {:class "flex-1"}
+              [resources-list-content resources-data @user resource-names]
+              (when (:has-more? resources-state)
+                [infinite-scroll
+                 {:on-load-more (fn []
+                                  (when-not resources-loading?
+                                    (rf/dispatch [:resources/get-resources-paginated
+                                                  {:page (inc (:current-page resources-state 1))
+                                                   :force-refresh? false}])))
+                  :has-more? (:has-more? resources-state)
+                  :loading? resources-loading?}
+                 [:div]])])]
 
-           [:> Tabs.Content {:value "roles"}
-            [test-connection-modal/test-connection-modal
-             (get-in @test-connection-state [:connection-name])]
-            (cond
-              ;; Loading state when no data
-              (and connections-loading? (empty? connections-data))
-              [:> Box {:class "flex-1 h-full"}
-               [loading-list-view]]
+          [:> Tabs.Content {:value "roles"}
+           [test-connection-modal/test-connection-modal
+            (get-in @test-connection-state [:connection-name])]
+           (cond
+             ;; Loading state when no data
+             (and connections-loading? (empty? connections-data))
+             [:> Box {:class "flex-1 min-h-96"}
+              [loading-list-view]]
 
-              ;; Empty state
-              (and (empty? connections-data) (not connections-loading?))
-              [:> Box {:class "flex flex-col h-full"}
-               [empty-list-view (-> @user :data :admin?)]]
+             ;; Empty state
+             (and (empty? connections-data) (not connections-loading?))
+             [:> Box {:class "flex flex-col min-h-96"}
+              [empty-list-view (-> @user :data :admin?)]]
 
-              ;; Content
-              :else
-              [:> Box {:class "flex-1 h-full"}
-               [roles-list-content connections-data @user @test-connection-state resource-names]])]]]]))))
+             ;; Content
+             :else
+             [:> Box {:class "flex-1"}
+              [roles-list-content connections-data @user @test-connection-state resource-names]
+              (when (:has-more? connections-state)
+                [infinite-scroll
+                 {:on-load-more (fn []
+                                  (when-not connections-loading?
+                                    (rf/dispatch [:connections/get-connections-paginated
+                                                  {:page (inc (:current-page connections-state 1))
+                                                   :force-refresh? false}])))
+                  :has-more? (:has-more? connections-state)
+                  :loading? connections-loading?}
+                 [:div]])])]]]))))


### PR DESCRIPTION
## 📝 Description

This PR refactors the layout and accessibility of the Resources panel in the webapp. The main structural change moves the page title ("Resources") and the action button ("Setup new Resource" / "Explore Resource Catalog") inside the panel component itself, introduces a sticky header for improved UX during scrolling, and replaces the shared `infinite-scroll` wrapper with per-tab lazy loading.

## 🔗 Related Issue

Fixes ENG-276

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- **`webapp/src/webapp/app.cljs`**: Simplified the `:resources-panel` route definition — removed the outer padding/heading wrapper and delegated layout ownership to `resources-main/panel`. The outer `Box` now only provides `bg-gray-1 min-h-full h-screen`.
- **`webapp/src/webapp/resources/main.cljs`**: Added a sticky header (`sticky top-0 z-10 bg-gray-1`) that contains the "Resources" heading, the action button, the tab switcher, and the search/filter controls, keeping them visible during scroll.
- **`webapp/src/webapp/resources/main.cljs`**: Replaced the single shared `infinite-scroll` wrapping the entire component with individual `infinite-scroll` instances placed at the bottom of each tab's content block (`resources` and `roles`), so lazy loading is scoped per tab.
- **`webapp/src/webapp/resources/main.cljs`**: Removed the unused `current-state` local binding and replaced `h-full` with `min-h-96` on loading/empty state containers for more predictable rendering.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome / Firefox
- **OS**: Linux / macOS

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

> Verify that the sticky header remains fixed when scrolling through a long list of resources or roles. Confirm that infinite scroll triggers correctly and independently for each tab. Confirm the action button and title are visible and correctly positioned.

## 📸 Screenshots

![Screen Recording 2026-03-06 at 10 40 27](https://github.com/user-attachments/assets/ccb40c30-7df2-4a4a-9844-8be3dd0444cb)


## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings