### PR TITLE
Fix how to expand positional arguments to prevent handling parameters incorrectly

### DIFF
--- a/rootfs/opt/hoop/bin/mongo
+++ b/rootfs/opt/hoop/bin/mongo
@@ -18,4 +18,4 @@ if [ "$HOOP_EXEC_MONGOSH_RUNTIME" == "1" ]; then
     MONGO_BIN=/usr/bin/mongosh
 fi
 
-$MONGO_BIN $@
+$MONGO_BIN "$@"


### PR DESCRIPTION
## 📝 Description

A expanded environment variable with space was expanded incorrectly when using the mongo wrapper.

When issuing the underline command of a connection the command was expanding connection environment variables incorrectly:

**Before:**
```sh
mongo --quiet 'mongodb+srv://user:<pwd>@mongo-host/?appName=My' App Name
```

**After:**
```sh
mongo --quiet 'mongodb+srv://user:<pwd>@mongo-host/?appName=My App Name'
```

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore