### PR TITLE
fix: show Jira required-fields modal before runbook execution

### DIFF
--- a/webapp/src/webapp/features/runbooks/runner/main.cljs
+++ b/webapp/src/webapp/features/runbooks/runner/main.cljs
@@ -156,6 +156,7 @@
 
     (rf/dispatch [:editor-plugin->clear-script])
     (rf/dispatch [:runbooks/load-persisted-connection])
+    (rf/dispatch [:jira-integration->get])
 
     (fn []
       (when (and (seq @search-term)

--- a/webapp/src/webapp/features/runbooks/runner/views/form.cljs
+++ b/webapp/src/webapp/features/runbooks/runner/views/form.cljs
@@ -124,7 +124,7 @@
                                 (when (or (nil? @form-ref) (.reportValidity @form-ref))
                                   (let [connection selected-connection
                                         has-jira-template? (and connection
-                                                                (seq (:jira_issue_template_id connection)))
+                                                                (not (cs/blank? (:jira_issue_template_id connection))))
                                         jira-integration-enabled? (= (-> @(rf/subscribe [:jira-integration->details])
                                                                          :data
                                                                          :status)


### PR DESCRIPTION
## 📝 Description

This PR fixes a runbook execution issue where the Jira required-fields modal was not shown before execution.

The root cause was that runbooks UI was checking `:jira-integration->details `in the form submit flow, but that state was not being loaded in this context.
By dispatching `[:jira-integration->get]` when the runbooks runner loads, the `jira-integration-enabled? `condition in the form becomes accurate, so the Jira modal is shown when needed.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Dispatch `[:jira-integration->get]` when loading the runbooks runner to ensure Jira integration status is available in this flow.
- Fix Jira-template detection in runbook submit logic by using `cs/blank?` for `:jira_issue_template_id` string validation.
- Restore expected behavior where the Jira required-fields modal is shown before runbook execution, preventing ticket creation failures due to missing required fields.

## 🧪 Testing

- Open runbooks runner with a connection that has a Jira issue template configured.
- Submit a runbook that requires Jira fields.
- Confirm the Jira modal is shown before execution.
- Fill required fields and confirm runbook + ticket creation succeeds.
- Repeat with Jira integration disabled and confirm no Jira modal is shown.

### Test Configuration:
- **Browser(s)**:  Chrome
- **OS**: MacOs

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
