### PR TITLE
Fix CodeMirror vertical scroll in webclient editor

### DIFF
--- a/webapp/src/webapp/webclient/panel.cljs
+++ b/webapp/src/webapp/webclient/panel.cljs
@@ -377,7 +377,8 @@
                   [:div {:class "h-full flex flex-col"}
                    (when (= "custom" (:type current-connection))
                      [connection-state-indicator @dark-mode? (:command current-connection)])
-                   [:> Box {:aria-label "Script editor. Press Escape to exit editor"
+                   [:> Box {:class "flex-1 min-h-0 overflow-hidden"
+                            :aria-label "Script editor. Press Escape to exit editor"
                             :aria-describedby "editor-instructions"
                             :tabIndex "0"
                             :on-focus (fn [e]


### PR DESCRIPTION
## Description

Fixes the CodeMirror editor in the webclient so it shows a vertical scrollbar when the content exceeds the visible area.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `flex-1 min-h-0 overflow-hidden` to the CodeMirror editor container in `panel.cljs`
- `flex-1` lets the container use the remaining space in the flex layout
- `min-h-0` allows the flex item to shrink so its height is constrained
- `overflow-hidden` keeps the content within the container so CodeMirror’s internal scroller can show the vertical scrollbar

## Testing

### Test Configuration
- **Browser(s)**: Chrome
- **OS**: macOS

### Tests performed
- [x] Manual testing completed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings