### PR TITLE
Fix wrong tagging if libhoop isnt up to date.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,31 @@ on:
       - "*.*.*"
 
 jobs:
+  tag-libhoop:
+    name: Tag libhoop
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+          ref: main
+      - name: Tag libhoop with release tag
+        working-directory: ./libhoop
+        env:
+          GIT_TAG: ${{ github.ref_name }}
+        run: |
+          git tag "$GIT_TAG" 2>/dev/null || true
+          git push origin "$GIT_TAG"
+
   test:
     name: Test
     runs-on: ubuntu-latest
     environment: production
+    needs: [tag-libhoop]
 
     steps:
       - name: Checkout Hoop

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -64,44 +64,7 @@ $(cat $NOTE_FILE)
 
 EOF
 
-tagLibhoop(){
-  # Resolve libhoop path (it may be a symlink)
-  LIBHOOP_PATH="libhoop"
-  if [ -L "$LIBHOOP_PATH" ]; then
-    LIBHOOP_PATH=$(readlink -f "$LIBHOOP_PATH")
-  fi
-
-  if [ ! -d "$LIBHOOP_PATH/.git" ]; then
-    echo "WARNING: libhoop directory not found or not a git repository at $LIBHOOP_PATH"
-    echo "Skipping libhoop tagging"
-    return
-  fi
-
-  echo "=> Fetching latest state of libhoop from remote..."
-  (cd "$LIBHOOP_PATH" && git fetch origin)
-
-  LIBHOOP_BRANCH=$(cd "$LIBHOOP_PATH" && git rev-parse --abbrev-ref HEAD)
-  if [ "$LIBHOOP_BRANCH" != "main" ]; then
-    echo "ERROR: libhoop is on branch '${LIBHOOP_BRANCH}', but must be on 'main' before tagging."
-    echo "Please switch to main: cd ${LIBHOOP_PATH} && git checkout main"
-    exit 1
-  fi
-
-  LOCAL_SHA=$(cd "$LIBHOOP_PATH" && git rev-parse HEAD)
-  REMOTE_SHA=$(cd "$LIBHOOP_PATH" && git rev-parse origin/main)
-  if [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
-    echo "ERROR: libhoop/main is not up to date with origin/main."
-    echo "Please pull the latest changes: cd ${LIBHOOP_PATH} && git pull origin main"
-    exit 1
-  fi
-
-  echo "=> Tagging libhoop with ${GIT_TAG}..."
-  (cd "$LIBHOOP_PATH" && git tag "$GIT_TAG" 2>/dev/null || true && git push origin "$GIT_TAG")
-  echo "=> libhoop tagged successfully"
-}
-
 ghRelease(){
-  tagLibhoop
   gh release create $GIT_TAG -F $NOTE_FILE --title $GIT_TAG
 }
 


### PR DESCRIPTION
## 📝 Description

Moves libhoop tagging from the local `publish-release.sh` script to the release pipeline (`release.yml`).

Previously, the release script validated that libhoop was up-to-date locally and required the user to tag it manually. This was error-prone — if a developer forgot to pull the latest libhoop changes, the tag would point to the wrong commit.

Now, a new `tag-libhoop` job in the release workflow automatically checks out `libhoop/main` and tags it with the release tag before any build jobs run. This eliminates user error entirely.

**Note:** Verify that `GH_TOKEN` has **write** access to `hoophq/libhoop` (Contents: Read and write for fine-grained PATs, or `repo` scope for classic PATs).

## 🔗 Related Issue

ENG-233

## 🚀 Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- Added `tag-libhoop` job to `.github/workflows/release.yml` that tags libhoop/main with the release tag before builds run
- Made `test` job depend on `tag-libhoop` so all downstream jobs find the tag
- Removed `tagLibhoop()` function from `scripts/publish-release.sh`

## 🧪 Testing

- [ ] Verify `GH_TOKEN` has write access to `hoophq/libhoop`
- [ ] Trigger a release and confirm the `tag-libhoop` job tags libhoop correctly
- [ ] Confirm downstream build jobs checkout libhoop at the correct tag