### PR TITLE
Fix SSH protocol for scp over large files

### DIFF
--- a/agent/controller/agent.go
+++ b/agent/controller/agent.go
@@ -43,6 +43,7 @@ type (
 		// Using sync.Map is more complex here due untyped nature, so we use a mutex + typed map
 		connMtx         map[string]*sync.Mutex
 		connMtxStoreMtx sync.Mutex
+		closedSessions  sync.Map
 	}
 	connEnv struct {
 		scheme             string
@@ -229,8 +230,16 @@ func (a *Agent) Run() error {
 		default:
 		}
 
-		// We don't need to wait here for the result, so we just spawn a goroutine to process it.
-		go a.processPacket(pkt)
+		// SSH data packets are processed synchronously so that gRPC flow
+		// control propagates backpressure from the destination SSH server
+		// all the way back to the SCP/SSH client. Without this, Recv()
+		// keeps draining packets into goroutines that pile up in memory
+		// while blocked on the SSH channel's flow control window.
+		if pkt.Type == pbagent.SSHConnectionWrite {
+			a.processPacket(pkt)
+		} else {
+			go a.processPacket(pkt)
+		}
 	}
 }
 
@@ -337,6 +346,7 @@ func (a *Agent) processSessionClose(pkt *pb.Packet) {
 
 func (a *Agent) sessionCleanup(sessionID string) {
 	log.With("sid", sessionID).Infof("cleaning up session")
+	a.closedSessions.Store(sessionID, true)
 	filterFn := func(k string) bool { return strings.Contains(k, sessionID) }
 	for key, obj := range a.connStore.Filter(filterFn) {
 		if p, ok := obj.(libhoop.Proxy); ok {
@@ -352,8 +362,8 @@ func (a *Agent) sessionCleanup(sessionID string) {
 					log.With("sid", sessionID).Warnf("failed closing connection, err=%v", err)
 				}
 			}()
-			a.connStore.Del(key)
 		}
+		a.connStore.Del(key)
 	}
 }
 

--- a/agent/controller/ssh.go
+++ b/agent/controller/ssh.go
@@ -13,6 +13,10 @@ import (
 
 func (a *Agent) processSSHProtocol(pkt *pb.Packet) {
 	sid := string(pkt.Spec[pb.SpecGatewaySessionID])
+	if _, closed := a.closedSessions.Load(sid); closed {
+		log.With("sid", sid).Debugf("session already closed, dropping late SSH packet")
+		return
+	}
 	streamClient := pb.NewStreamWriter(a.client, pbclient.SSHConnectionWrite, pkt.Spec)
 	connParams := a.connectionParams(sid)
 	if connParams == nil {
@@ -35,6 +39,16 @@ func (a *Agent) processSSHProtocol(pkt *pb.Packet) {
 			a.sendClientSessionClose(sid, fmt.Sprintf("unable to write packet: %v", err))
 			_ = serverWriter.Close()
 		}
+		return
+	}
+
+	// SessionClose runs on a different mutex and may have already cleaned up
+	// this session. The closedSessions flag is set atomically before cleanup,
+	// so checking it here prevents creating a spurious SSH connection from a
+	// late-arriving packet.
+	if _, closed := a.closedSessions.Load(sid); closed {
+		log.With("sid", sid, "conn", clientConnectionID).
+			Debugf("session already closed, dropping late SSH packet")
 		return
 	}
 

--- a/gateway/proxyproto/sshproxy/sshproxy.go
+++ b/gateway/proxyproto/sshproxy/sshproxy.go
@@ -178,6 +178,7 @@ type sshConnection struct {
 	sshConn             *ssh.ServerConn
 	sshChannels         sync.Map
 	pendingRequests     sync.Map // maps channelID (uint16) to *pendingReplyQueue
+	channelWg           sync.WaitGroup
 }
 
 func newSSHConnection(sid, connID string, conn net.Conn, hostKey ssh.Signer) (*sshConnection, error) {
@@ -325,6 +326,20 @@ func (c *sshConnection) handleConnection() {
 	// wait for the connection to be closed
 	// either by the client, server, or context cancellation
 	<-c.ctx.Done()
+
+	// Wait for all channel data-forwarding goroutines to flush remaining writes
+	// to the gRPC stream. Without this, SessionClose can be sent before trailing
+	// data packets, causing the agent to tear down the session prematurely.
+	flushDone := make(chan struct{})
+	go func() {
+		c.channelWg.Wait()
+		close(flushDone)
+	}()
+	select {
+	case <-flushDone:
+	case <-time.After(5 * time.Second):
+		log.With("sid", c.sid, "conn", c.id).Warnf("timed out waiting for channel goroutines to finish")
+	}
 
 	ctxErr := context.Cause(c.ctx)
 	log.With("sid", c.sid, "conn", c.id).Infof("ssh connection closed, reason=%v", ctxErr)
@@ -547,6 +562,12 @@ func (c *sshConnection) handleServerWrite() {
 		channelID++
 		go c.handleChannel(newCh, channelID)
 	}
+	// The SSH client disconnected (clientNewSshChannel was closed).
+	// Cancel the context so handleConnection proceeds to close the gRPC stream
+	// and the SSH TCP connection. Without this, handleConnection blocks forever
+	// at <-c.ctx.Done() and c.sshConn.Close() is never called, causing the
+	// client-side ProxyCommand to hang waiting for the TCP FIN.
+	c.cancelFn("ssh client disconnected")
 }
 
 func (c *sshConnection) handleChannel(newCh ssh.NewChannel, channelID uint16) {
@@ -580,7 +601,9 @@ func (c *sshConnection) handleChannel(newCh ssh.NewChannel, channelID uint16) {
 	// the client may still be waiting to receive data (e.g., git clone sends a command
 	// then waits for the response). The channel will be closed when we receive
 	// a CloseChannel message from the agent.
+	c.channelWg.Add(1)
 	go func() {
+		defer c.channelWg.Done()
 		buf := make([]byte, 32*1024)
 		for {
 			n, readErr := clientCh.Read(buf)
@@ -613,7 +636,9 @@ func (c *sshConnection) handleChannel(newCh ssh.NewChannel, channelID uint16) {
 	}()
 
 	// handle incoming requests from the client
+	c.channelWg.Add(1)
 	go func() {
+		defer c.channelWg.Done()
 		for req := range clientRequests {
 			log.With("sid", c.sid, "conn", c.id, "ch", channelID, "type", req.Type).Debug("received client ssh request")
 


### PR DESCRIPTION
## 📝 Description

The SSH proxy was closing the gRPC stream before all data had been flushed and before the recv goroutine finished draining the agent's response. This caused two problems: (1) SessionClose could arrive at the agent before trailing data packets, making the agent tear down the SSH connection mid-transfer, and (2) calling c.grpcClient.Close() while the recv goroutine was still in Recv() crashed the gateway process. Additionally, a goroutine leak in handleClientWrite (the startupCh defer blocked forever) meant every session leaked a goroutine holding the entire sshConnection and gRPC client in memory — accumulating over time toward OOM.

on libhoop
The agent-side SSH proxy had two 2-second timeouts that silently dropped data when channels were full. During large SCP transfers, the SSH server's flow control naturally causes momentary backpressure, and the timeouts interpreted that as "give up" — corrupting the byte stream and causing the remote SCP server to abort. On top of that, go a.processPacket(pkt) spawned a new goroutine for every 32KB data packet. When Write() blocked due to backpressure, goroutines piled up unboundedly (each holding 32KB), consuming hundreds of MBs of RAM and preventing gRPC flow control from ever kicking in. The fix was to remove the timeouts (so writes block correctly), process SSH data synchronously (so Recv() blocks and gRPC flow control propagates end-to-end), and add closedSessions guards to prevent late packets from creating spurious SSH connections after cleanup.
https://github.com/hoophq/libhoop/pull/67

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when this PR is merged -->

Fixes #1327 

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- The SSH proxy was closing the gRPC stream before data finished flushing and before the recv goroutine drained, causing mid-transfer aborts and a gateway crash on session teardown.
- Silent 2-second timeouts dropped data under backpressure, and unbounded goroutine-per-packet dispatching defeated gRPC flow control, causing stream corruption and OOM.
- 

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: 
- **OS**:

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
<!-- You can drag and drop images directly into this text area -->

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

<!-- Add any additional notes, concerns, or discussion points here -->
<!-- Is there anything specific you'd like reviewers to focus on? -->
sending 6gb over scp 
<img width="2088" height="1739" alt="image" src="https://github.com/user-attachments/assets/7c3e06db-49eb-4dc4-bbf0-cbdb068d0393" />

---

<!-- Thank you for contributing to our project! 🙏 --> 
