### PR TITLE
add: CLI agent-friendly UX enhancements (exec, login, connect)

### DIFF
--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -145,11 +145,13 @@ func runConnect(args []string, clientEnvVars map[string]string, durationFlagChan
 		case pbclient.SessionOpenWaitingApproval:
 			if jsonMode {
 				reviewURL := string(pkt.Payload)
+				sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
 				emitJSONEvent(os.Stdout, JSONEvent{
 					Status:  "waiting_approval",
-					Message: "poll status with: hoop admin get reviews " + string(pkt.Spec[pb.SpecGatewaySessionID]) + " -o json",
+					Message: "poll status with: hoop admin get sessions " + sessionID + " -o json | check review.status field",
 					Data: map[string]string{
-						"review_url": reviewURL,
+						"review_url":  reviewURL,
+						"session_id":  sessionID,
 					},
 				})
 				os.Exit(0)

--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -147,11 +147,12 @@ func runConnect(args []string, clientEnvVars map[string]string, durationFlagChan
 				reviewURL := string(pkt.Payload)
 				emitJSONEvent(os.Stdout, JSONEvent{
 					Status:  "waiting_approval",
-					Message: "waiting task to be approved",
+					Message: "waiting task to be approved, poll GET /api/reviews/{session_id} for status",
 					Data: map[string]string{
 						"review_url": reviewURL,
 					},
 				})
+				os.Exit(0)
 			} else {
 				loader.Color("yellow")
 				if !loader.Active() {

--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -83,6 +83,7 @@ func init() {
 	connectCmd.Flags().StringSliceVarP(&inputEnvVars, "env", "e", nil, "Input environment variables to send")
 	connectCmd.Flags().StringVarP(&connectFlags.duration, "duration", "d", "30m", "The amount of time that the session will last. Valid time units are 's', 'm', 'h'")
 	connectCmd.Flags().BoolVarP(&silentMode, "silent", "s", false, "Silent mode")
+	connectCmd.Flags().StringVarP(&outputFlag, "output", "o", "", "Output format. One of: (json)")
 	rootCmd.AddCommand(connectCmd)
 }
 
@@ -96,10 +97,13 @@ type connect struct {
 }
 
 func runConnect(args []string, clientEnvVars map[string]string) {
+	jsonMode := outputFlag == "json"
 	config := clientconfig.GetClientConfigOrDie()
 	loader := spinner.New(spinner.CharSets[11], 70*time.Millisecond)
 	loader.Color("green")
-	loader.Start()
+	if !jsonMode {
+		loader.Start()
+	}
 	defer func() { loader.Stop() }()
 	ossig := &osInterrupt{shutdownFn: func() { loader.Stop() }}
 	ossig.handleOsInterrupt()
@@ -128,12 +132,23 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 		}
 		switch pb.PacketType(pkt.Type) {
 		case pbclient.SessionOpenWaitingApproval:
-			loader.Color("yellow")
-			if !loader.Active() {
-				loader.Start()
+			if jsonMode {
+				reviewURL := string(pkt.Payload)
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status:  "waiting_approval",
+					Message: "waiting task to be approved",
+					Data: map[string]string{
+						"review_url": reviewURL,
+					},
+				})
+			} else {
+				loader.Color("yellow")
+				if !loader.Active() {
+					loader.Start()
+				}
+				loader.Suffix = " waiting task to be approved at " +
+					styles.Keyword(fmt.Sprintf(" %v ", string(pkt.Payload)))
 			}
-			loader.Suffix = " waiting task to be approved at " +
-				styles.Keyword(fmt.Sprintf(" %v ", string(pkt.Payload)))
 		case pbclient.SessionOpenOK:
 			sessionID, ok := pkt.Spec[pb.SpecGatewaySessionID]
 			if !ok || sessionID == nil {
@@ -141,6 +156,16 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 			}
 
 			connectionType := pb.ConnectionType(pkt.Spec[pb.SpecConnectionType])
+			if jsonMode {
+				sid := string(sessionID)
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status: "connected",
+					Data: map[string]string{
+						"session_id":      sid,
+						"connection_type": connectionType.String(),
+					},
+				})
+			}
 			switch connectionType {
 			case pb.ConnectionTypePostgres:
 				srv := proxy.NewPGServer(c.proxyPort, c.client)
@@ -156,6 +181,17 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 				fmt.Printf("      host=%s port=%s user=noop password=noop\n", srv.Host().Host, srv.Host().Port)
 				fmt.Println("------------------------------------------------------------")
 				fmt.Println("ready to accept connections!")
+				if jsonMode {
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:  "ready",
+						Message: "ready to accept connections",
+						Data: map[string]string{
+							"host": srv.Host().Host,
+							"port": srv.Host().Port,
+							"user": "noop",
+						},
+					})
+				}
 			case pb.ConnectionTypeMySQL:
 				srv := proxy.NewMySQLServer(c.proxyPort, c.client)
 				if err := srv.Serve(string(sessionID)); err != nil {
@@ -170,6 +206,17 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 				fmt.Printf("      host=%s port=%s user=noop password=noop\n", srv.Host().Host, srv.Host().Port)
 				fmt.Println("------------------------------------------------------------")
 				fmt.Println("ready to accept connections!")
+				if jsonMode {
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:  "ready",
+						Message: "ready to accept connections",
+						Data: map[string]string{
+							"host": srv.Host().Host,
+							"port": srv.Host().Port,
+							"user": "noop",
+						},
+					})
+				}
 			case pb.ConnectionTypeMSSQL:
 				srv := proxy.NewMSSQLServer(c.proxyPort, c.client)
 				if err := srv.Serve(string(sessionID)); err != nil {
@@ -184,6 +231,17 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 				fmt.Printf("      host=%s port=%s user=noop password=noop\n", srv.Host().Host, srv.Host().Port)
 				fmt.Println("------------------------------------------------------------")
 				fmt.Println("ready to accept connections!")
+				if jsonMode {
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:  "ready",
+						Message: "ready to accept connections",
+						Data: map[string]string{
+							"host": srv.Host().Host,
+							"port": srv.Host().Port,
+							"user": "noop",
+						},
+					})
+				}
 			case pb.ConnectionTypeMongoDB:
 				srv := proxy.NewMongoDBServer(c.proxyPort, c.client)
 				if err := srv.Serve(string(sessionID)); err != nil {
@@ -198,6 +256,17 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 				fmt.Printf(" mongodb://noop:noop@%s:%s/?directConnection=true\n", srv.Host().Host, srv.Host().Port)
 				fmt.Println("------------------------------------------------------------")
 				fmt.Println("ready to accept connections!")
+				if jsonMode {
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:  "ready",
+						Message: "ready to accept connections",
+						Data: map[string]string{
+							"host": srv.Host().Host,
+							"port": srv.Host().Port,
+							"uri":  fmt.Sprintf("mongodb://noop:noop@%s:%s/?directConnection=true", srv.Host().Host, srv.Host().Port),
+						},
+					})
+				}
 			case pb.ConnectionTypeTCP:
 				tcp := proxy.NewTCPServer(c.proxyPort, c.client, pbagent.TCPConnectionWrite)
 				if err := tcp.Serve(string(sessionID)); err != nil {
@@ -212,6 +281,16 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 				fmt.Printf("               host=%s port=%s\n", tcp.Host().Host, tcp.Host().Port)
 				fmt.Println("------------------------------------------------------")
 				fmt.Println("ready to accept connections!")
+				if jsonMode {
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:  "ready",
+						Message: "ready to accept connections",
+						Data: map[string]string{
+							"host": tcp.Host().Host,
+							"port": tcp.Host().Port,
+						},
+					})
+				}
 			case pb.ConnectionTypeSSH:
 				c.loader.Stop()
 				var sshHostKeySigner ssh.Signer
@@ -259,6 +338,16 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 				fmt.Printf("               host=%s port=%s\n", srv.Host().Host, srv.Host().Port)
 				fmt.Println("------------------------------------------------------")
 				fmt.Println("ready to accept connections!")
+				if jsonMode {
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:  "ready",
+						Message: "ready to accept connections",
+						Data: map[string]string{
+							"host": srv.Host().Host,
+							"port": srv.Host().Port,
+						},
+					})
+				}
 			case pb.ConnectionTypeKubernetes:
 				srv := proxy.NewHttpProxy(c.proxyPort, c.client, pbagent.HttpProxyConnectionWrite)
 				if err := srv.Serve(string(sessionID)); err != nil {
@@ -279,6 +368,16 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 
 					fmt.Println("\nissue the command below to interact with the cluster via kubectl")
 					fmt.Printf("export KUBECONFIG=%s\n", kubeconfigFilePath)
+				}
+				if jsonMode {
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:  "ready",
+						Message: "ready to accept connections",
+						Data: map[string]string{
+							"host": srv.Host().Host,
+							"port": srv.Host().Port,
+						},
+					})
 				}
 			case pb.ConnectionTypeCommandLine:
 				c.loader.Stop()
@@ -303,15 +402,41 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 				c.processGracefulExit(errMsg)
 			}
 		case pbclient.SessionOpenApproveOK:
-			loader.Color("green")
-			loader.Suffix = " command approved, running ... "
+			if jsonMode {
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status:  "approved",
+					Message: "command approved, running",
+				})
+			} else {
+				loader.Color("green")
+				loader.Suffix = " command approved, running ... "
+			}
 			sendOpenSessionPktFn()
 		case pbclient.SessionOpenAgentOffline:
 			if agentOfflineRetryCounter > 60 {
+				if jsonMode {
+					exitCode := 1
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:   "error",
+						Message:  "agent is offline, max retry reached",
+						ExitCode: &exitCode,
+					})
+					os.Exit(1)
+				}
 				c.processGracefulExit(errors.New("agent is offline, max retry reached"))
 			}
-			loader.Color("red")
-			loader.Suffix = fmt.Sprintf(" agent is offline, retrying in 30s (%v/60) ... ", agentOfflineRetryCounter)
+			if jsonMode {
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status:  "agent_offline",
+					Message: fmt.Sprintf("agent is offline, retrying in 30s (%v/60)", agentOfflineRetryCounter),
+					Data: map[string]string{
+						"retry": fmt.Sprintf("%v/60", agentOfflineRetryCounter),
+					},
+				})
+			} else {
+				loader.Color("red")
+				loader.Suffix = fmt.Sprintf(" agent is offline, retrying in 30s (%v/60) ... ", agentOfflineRetryCounter)
+			}
 			time.Sleep(time.Second * 30)
 			agentOfflineRetryCounter++
 			sendOpenSessionPktFn()
@@ -416,19 +541,31 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 				srv.CloseTCPConnection(string(pkt.Spec[pb.SpecClientConnectionID]))
 			}
 		case pbclient.SessionClose:
-			// close terminal
 			loader.Stop()
 			sessionID := pkt.Spec[pb.SpecGatewaySessionID]
 			if srv, ok := c.connStore.Get(string(sessionID)).(proxy.Closer); ok {
 				srv.Close()
 			}
-			if len(pkt.Payload) > 0 {
-				os.Stderr.Write([]byte(styles.ClientError(string(pkt.Payload)) + "\n"))
-			}
 			exitCodeStr := string(pkt.Spec[pb.SpecClientExitCodeKey])
 			exitCode, err := strconv.Atoi(exitCodeStr)
 			if err != nil {
 				exitCode = 1
+			}
+			if jsonMode {
+				data := map[string]string{}
+				if len(pkt.Payload) > 0 {
+					data["error"] = string(pkt.Payload)
+				}
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status:   "disconnected",
+					Message:  "session closed",
+					ExitCode: &exitCode,
+					Data:     data,
+				})
+				os.Exit(exitCode)
+			}
+			if len(pkt.Payload) > 0 {
+				os.Stderr.Write([]byte(styles.ClientError(string(pkt.Payload)) + "\n"))
 			}
 			os.Exit(exitCode)
 		}

--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -147,7 +147,7 @@ func runConnect(args []string, clientEnvVars map[string]string, durationFlagChan
 				reviewURL := string(pkt.Payload)
 				emitJSONEvent(os.Stdout, JSONEvent{
 					Status:  "waiting_approval",
-					Message: "waiting task to be approved, poll GET /api/reviews/{session_id} for status",
+					Message: "poll status with: hoop admin get reviews " + string(pkt.Spec[pb.SpecGatewaySessionID]) + " -o json",
 					Data: map[string]string{
 						"review_url": reviewURL,
 					},

--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -73,7 +73,7 @@ var (
 				fmt.Println(err)
 				os.Exit(1)
 			}
-			runConnect(args, clientEnvVars)
+			runConnect(args, clientEnvVars, cmd.Flags().Changed("duration"))
 		},
 	}
 )
@@ -96,7 +96,7 @@ type connect struct {
 	loader         *spinner.Spinner
 }
 
-func runConnect(args []string, clientEnvVars map[string]string) {
+func runConnect(args []string, clientEnvVars map[string]string, durationFlagChanged bool) {
 	jsonMode := outputFlag == "json"
 	config := clientconfig.GetClientConfigOrDie()
 	loader := spinner.New(spinner.CharSets[11], 70*time.Millisecond)
@@ -112,7 +112,9 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 	c := newClientConnect(config, loader, args, pb.ClientVerbConnect)
 	sendOpenSessionPktFn := func() {
 		spec := newClientArgsSpec(c.clientArgs, clientEnvVars)
-		spec[pb.SpecJitTimeout] = []byte(connectFlags.duration)
+		if durationFlagChanged {
+			spec[pb.SpecJitTimeout] = []byte(connectFlags.duration)
+		}
 		if err := c.client.Send(&pb.Packet{
 			Type: pbagent.SessionOpen,
 			Spec: spec,
@@ -126,6 +128,15 @@ func runConnect(args []string, clientEnvVars map[string]string) {
 	agentOfflineRetryCounter := 1
 	for {
 		pkt, err := c.client.Recv()
+		if err != nil && jsonMode {
+			exitCode := 1
+			emitJSONEvent(os.Stdout, JSONEvent{
+				Status:   "error",
+				Message:  err.Error(),
+				ExitCode: &exitCode,
+			})
+			os.Exit(1)
+		}
 		c.processGracefulExit(err)
 		if pkt == nil {
 			continue

--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -194,7 +194,7 @@ func runExec(args []string, clientEnvVars map[string]string) {
 				sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
 				emitJSONEvent(os.Stdout, JSONEvent{
 					Status:  "waiting_approval",
-					Message: "waiting command to be approved, poll GET /api/reviews/{session_id} for status, then POST /api/sessions/{session_id}/exec to run",
+					Message: "poll status with: hoop admin get reviews " + sessionID + " -o json",
 					Data: map[string]string{
 						"review_url": reviewURL,
 						"session_id": sessionID,

--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -208,7 +208,7 @@ func runExec(args []string, clientEnvVars map[string]string) {
 				sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
 				emitJSONEvent(os.Stdout, JSONEvent{
 					Status:  "waiting_approval",
-					Message: "poll status with: hoop admin get reviews " + sessionID + " -o json",
+					Message: "poll status with: hoop admin get sessions " + sessionID + " -o json | check review.status field, then run: hoop exec --session " + sessionID + " --output json",
 					Data: map[string]string{
 						"review_url": reviewURL,
 						"session_id": sessionID,

--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -16,9 +18,11 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/hoophq/hoop/client/cmd/styles"
 	clientconfig "github.com/hoophq/hoop/client/config"
+	"github.com/hoophq/hoop/common/httpclient"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbagent "github.com/hoophq/hoop/common/proto/agent"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
+	"github.com/hoophq/hoop/common/version"
 	"github.com/spf13/cobra"
 )
 
@@ -26,10 +30,12 @@ var inputFilepath string
 var inputStdin string
 var autoExec bool
 var silentMode bool
+var execSessionID string
 
 var execExampleDesc = `hoop exec bash -i 'env'
 hoop exec bash -e MYENV=val --input 'env' -- --verbose
 hoop exec bash <<< 'env'
+hoop exec --session <session_id> --output json
 `
 
 // execCmd represents the exec command
@@ -38,12 +44,19 @@ var execCmd = &cobra.Command{
 	Short:   "Execute a given input in a remote resource",
 	Example: execExampleDesc,
 	PreRun: func(cmd *cobra.Command, args []string) {
+		if execSessionID != "" {
+			return
+		}
 		if len(args) < 1 {
 			cmd.Usage()
 			os.Exit(1)
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		if execSessionID != "" {
+			runExecSession(execSessionID)
+			return
+		}
 		clientEnvVars, err := parseClientEnvVars()
 		if err != nil {
 			fmt.Println(err)
@@ -60,6 +73,7 @@ func init() {
 	execCmd.Flags().BoolVar(&autoExec, "auto-approve", false, "Automatically run after a command is approved")
 	execCmd.Flags().BoolVarP(&silentMode, "silent", "s", false, "Silent mode")
 	execCmd.Flags().StringVarP(&outputFlag, "output", "o", "", "Output format. One of: (json)")
+	execCmd.Flags().StringVar(&execSessionID, "session", "", "Execute an approved reviewed session by its ID")
 	rootCmd.AddCommand(execCmd)
 }
 
@@ -345,4 +359,90 @@ func runExec(args []string, clientEnvVars map[string]string) {
 			os.Exit(exitCode)
 		}
 	}
+}
+
+// runExecSession executes an already-approved reviewed session via the API.
+// Used by agents to trigger execution after polling for approval.
+func runExecSession(sessionID string) {
+	jsonMode := outputFlag == "json"
+	config := clientconfig.GetClientConfigOrDie()
+
+	url := fmt.Sprintf("%s/api/sessions/%s/exec", config.ApiURL, sessionID)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		if jsonMode {
+			exitCode := 1
+			emitJSONEvent(os.Stdout, JSONEvent{Status: "error", Message: err.Error(), ExitCode: &exitCode})
+			os.Exit(1)
+		}
+		styles.PrintErrorAndExit(err.Error())
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", config.Token))
+	if config.IsApiKey() {
+		req.Header.Set("Api-Key", config.Token)
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%v", version.Get().Version))
+
+	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
+	if err != nil {
+		if jsonMode {
+			exitCode := 1
+			emitJSONEvent(os.Stdout, JSONEvent{Status: "error", Message: err.Error(), ExitCode: &exitCode})
+			os.Exit(1)
+		}
+		styles.PrintErrorAndExit(err.Error())
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode >= 400 {
+		if jsonMode {
+			exitCode := 1
+			msg := string(body)
+			emitJSONEvent(os.Stdout, JSONEvent{Status: "error", Message: msg, ExitCode: &exitCode})
+			os.Exit(1)
+		}
+		styles.PrintErrorAndExit("failed executing session: %s", string(body))
+	}
+
+	if jsonMode {
+		// Parse the API response and emit as a JSONEvent
+		var apiResp map[string]any
+		if err := json.Unmarshal(body, &apiResp); err != nil {
+			exitCode := 1
+			emitJSONEvent(os.Stdout, JSONEvent{Status: "error", Message: err.Error(), ExitCode: &exitCode})
+			os.Exit(1)
+		}
+
+		exitCode := 0
+		if ec, ok := apiResp["exit_code"].(float64); ok {
+			exitCode = int(ec)
+		}
+
+		data := map[string]string{
+			"session_id": sessionID,
+		}
+		if output, ok := apiResp["output"].(string); ok && output != "" {
+			data["stdout"] = output
+		}
+		if outputStatus, ok := apiResp["output_status"].(string); ok {
+			data["output_status"] = outputStatus
+		}
+
+		status := "completed"
+		if resp.StatusCode == http.StatusAccepted {
+			status = "running"
+		}
+
+		emitJSONEvent(os.Stdout, JSONEvent{
+			Status:   status,
+			ExitCode: &exitCode,
+			Data:     data,
+		})
+		os.Exit(exitCode)
+	}
+
+	// Non-JSON mode: print output directly
+	fmt.Print(string(body))
 }

--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -59,6 +59,7 @@ func init() {
 	execCmd.Flags().StringSliceVarP(&inputEnvVars, "env", "e", nil, "Input environment variables to send")
 	execCmd.Flags().BoolVar(&autoExec, "auto-approve", false, "Automatically run after a command is approved")
 	execCmd.Flags().BoolVarP(&silentMode, "silent", "s", false, "Silent mode")
+	execCmd.Flags().StringVarP(&outputFlag, "output", "o", "", "Output format. One of: (json)")
 	rootCmd.AddCommand(execCmd)
 }
 
@@ -114,19 +115,26 @@ func parseExecInput(c *connect) (bool, []byte) {
 }
 
 func runExec(args []string, clientEnvVars map[string]string) {
+	jsonMode := outputFlag == "json"
+	if jsonMode {
+		autoExec = true
+	}
+
 	config := clientconfig.GetClientConfigOrDie()
 	loader := spinner.New(spinner.CharSets[11], 70*time.Millisecond,
 		spinner.WithWriter(os.Stderr), spinner.WithHiddenCursor(true))
 	loader.Color("green")
 	loader.Suffix = " running ..."
-	loader.Start()
+	if !jsonMode {
+		loader.Start()
+	}
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		for {
 			switch <-done {
 			case syscall.SIGTERM, syscall.SIGINT:
-				loader.Stop() // this fixes terminal restore
+				loader.Stop()
 				os.Exit(143)
 			}
 		}
@@ -143,13 +151,33 @@ func runExec(args []string, clientEnvVars map[string]string) {
 			Payload: execInputPayload,
 		}); err != nil {
 			_, _ = c.client.Close()
+			if jsonMode {
+				exitCode := 1
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status:   "error",
+					Message:  fmt.Sprintf("failed opening session with gateway, err=%v", err),
+					ExitCode: &exitCode,
+				})
+				os.Exit(1)
+			}
 			c.printErrorAndExit("failed opening session with gateway, err=%v", err)
 		}
 	}
 	sendOpenSessionPktFn()
+
+	var stdoutBuf, stderrBuf bytes.Buffer
 	agentOfflineRetryCounter := 1
 	for {
 		pkt, err := c.client.Recv()
+		if err != nil && jsonMode {
+			exitCode := 1
+			emitJSONEvent(os.Stdout, JSONEvent{
+				Status:   "error",
+				Message:  err.Error(),
+				ExitCode: &exitCode,
+			})
+			os.Exit(1)
+		}
 		c.processGracefulExit(err)
 		if pkt == nil {
 			continue
@@ -161,12 +189,25 @@ func runExec(args []string, clientEnvVars map[string]string) {
 				msg := "require use of --auto-approve option. It's a review command with an invalid device to prompt for execution"
 				c.processGracefulExit(errors.New(msg))
 			}
-			loader.Color("yellow")
-			if !loader.Active() {
-				loader.Start()
+			if jsonMode {
+				reviewURL := string(pkt.Payload)
+				sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status:  "waiting_approval",
+					Message: "waiting command to be approved",
+					Data: map[string]string{
+						"review_url": reviewURL,
+						"session_id": sessionID,
+					},
+				})
+			} else {
+				loader.Color("yellow")
+				if !loader.Active() {
+					loader.Start()
+				}
+				loader.Suffix = " waiting command to be approved at " +
+					styles.Keyword(fmt.Sprintf(" %v ", string(pkt.Payload)))
 			}
-			loader.Suffix = " waiting command to be approved at " +
-				styles.Keyword(fmt.Sprintf(" %v ", string(pkt.Payload)))
 		case pbclient.SessionOpenApproveOK:
 			if !autoExec {
 				loader.Stop()
@@ -177,15 +218,41 @@ func runExec(args []string, clientEnvVars map[string]string) {
 				}
 				loader.Start()
 			}
-			loader.Color("green")
-			loader.Suffix = " command approved, running ... "
+			if jsonMode {
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status:  "approved",
+					Message: "command approved, running",
+				})
+			} else {
+				loader.Color("green")
+				loader.Suffix = " command approved, running ... "
+			}
 			sendOpenSessionPktFn()
 		case pbclient.SessionOpenAgentOffline:
 			if agentOfflineRetryCounter > 60 {
+				if jsonMode {
+					exitCode := 1
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:   "error",
+						Message:  "agent is offline, max retry reached",
+						ExitCode: &exitCode,
+					})
+					os.Exit(1)
+				}
 				c.processGracefulExit(errors.New("agent is offline, max retry reached"))
 			}
-			loader.Color("red")
-			loader.Suffix = fmt.Sprintf(" agent is offline, retrying in 30s (%v/60) ... ", agentOfflineRetryCounter)
+			if jsonMode {
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status:  "agent_offline",
+					Message: fmt.Sprintf("agent is offline, retrying in 30s (%v/60)", agentOfflineRetryCounter),
+					Data: map[string]string{
+						"retry": fmt.Sprintf("%v/60", agentOfflineRetryCounter),
+					},
+				})
+			} else {
+				loader.Color("red")
+				loader.Suffix = fmt.Sprintf(" agent is offline, retrying in 30s (%v/60) ... ", agentOfflineRetryCounter)
+			}
 			time.Sleep(time.Second * 30)
 			agentOfflineRetryCounter++
 			sendOpenSessionPktFn()
@@ -196,7 +263,17 @@ func runExec(args []string, clientEnvVars map[string]string) {
 				Payload: execInputPayload,
 				Spec:    execSpec,
 			}
-			if !silentMode {
+			if jsonMode {
+				sid := string(pkt.Spec[pb.SpecGatewaySessionID])
+				cmd := string(pkt.Spec[pb.SpecClientExecCommandKey])
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status: "running",
+					Data: map[string]string{
+						"session_id": sid,
+						"command":    cmd,
+					},
+				})
+			} else if !silentMode {
 				c.loader.Stop()
 				cmd := string(pkt.Spec[pb.SpecClientExecCommandKey])
 				sid := string(pkt.Spec[pb.SpecGatewaySessionID])
@@ -204,7 +281,6 @@ func runExec(args []string, clientEnvVars map[string]string) {
 				if debugFlag {
 					out = styles.Fainted("<stdin-input> | %s (the input is piped to this command) | session: %s", cmd, sid)
 				}
-				// if it is not set, fallback to previous version
 				if cmd == "" {
 					out = styles.Fainted("session: %s", sid)
 				}
@@ -212,22 +288,58 @@ func runExec(args []string, clientEnvVars map[string]string) {
 				c.loader.Start()
 			}
 			if err := c.client.Send(stdinPkt); err != nil {
+				if jsonMode {
+					exitCode := 1
+					emitJSONEvent(os.Stdout, JSONEvent{
+						Status:   "error",
+						Message:  fmt.Sprintf("failed executing command, err=%v", err),
+						ExitCode: &exitCode,
+					})
+					os.Exit(1)
+				}
 				c.printErrorAndExit("failed executing command, err=%v", err)
 			}
 		case pbclient.WriteStdout:
 			loader.Stop()
-			os.Stdout.Write(pkt.Payload)
+			if jsonMode {
+				stdoutBuf.Write(pkt.Payload)
+			} else {
+				os.Stdout.Write(pkt.Payload)
+			}
 		case pbclient.WriteStderr:
 			loader.Stop()
-			os.Stderr.Write(pkt.Payload)
+			if jsonMode {
+				stderrBuf.Write(pkt.Payload)
+			} else {
+				os.Stderr.Write(pkt.Payload)
+			}
 		case pbclient.SessionClose:
 			loader.Stop()
-			if len(pkt.Payload) > 0 {
-				_, _ = os.Stderr.Write([]byte(styles.ClientError(string(pkt.Payload)) + "\n"))
-			}
 			exitCode, err := strconv.Atoi(string(pkt.Spec[pb.SpecClientExitCodeKey]))
 			if err != nil {
-				os.Exit(254)
+				exitCode = 254
+			}
+			if jsonMode {
+				data := map[string]string{}
+				if stdoutBuf.Len() > 0 {
+					data["stdout"] = stdoutBuf.String()
+				}
+				if stderrBuf.Len() > 0 {
+					data["stderr"] = stderrBuf.String()
+				}
+				if len(pkt.Payload) > 0 {
+					data["error"] = string(pkt.Payload)
+				}
+				emitJSONEvent(os.Stdout, JSONEvent{
+					Status:   "completed",
+					Message:  "session closed",
+					ExitCode: &exitCode,
+					Data:     data,
+				})
+				os.Exit(exitCode)
+			}
+			if len(pkt.Payload) > 0 {
+				_, _ = os.Stderr.Write([]byte(styles.ClientError(string(pkt.Payload)) + "\n"))
 			}
 			os.Exit(exitCode)
 		}

--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -194,12 +194,13 @@ func runExec(args []string, clientEnvVars map[string]string) {
 				sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
 				emitJSONEvent(os.Stdout, JSONEvent{
 					Status:  "waiting_approval",
-					Message: "waiting command to be approved",
+					Message: "waiting command to be approved, poll GET /api/reviews/{session_id} for status, then POST /api/sessions/{session_id}/exec to run",
 					Data: map[string]string{
 						"review_url": reviewURL,
 						"session_id": sessionID,
 					},
 				})
+				os.Exit(0)
 			} else {
 				loader.Color("yellow")
 				if !loader.Active() {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -27,6 +27,7 @@ import (
 )
 
 var noBrowser bool
+var loginToken string
 
 type serverInfo struct {
 	GrpcURL string `json:"grpc_url"`
@@ -42,6 +43,41 @@ var loginCmd = &cobra.Command{
 	Short: "Authenticate at Hoop",
 	Long:  `Login to gain access to hoop usage.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Non-interactive login with --token flag
+		if loginToken != "" {
+			if err := validateLoginToken(loginToken); err != nil {
+				printErrorAndExit(err.Error())
+			}
+			conf, err := proxyconfig.Load()
+			switch err {
+			case proxyconfig.ErrEmpty:
+				configureHostsPrompt(conf)
+			case nil:
+				if !conf.IsValid() {
+					configureHostsPrompt(conf)
+				}
+			default:
+				printErrorAndExit(err.Error())
+			}
+			conf.Token = loginToken
+			if conf.GrpcURL == "" {
+				si, err := fetchServerInfo(conf.ApiURL, conf.Token, conf.TlsCA())
+				if err != nil {
+					printErrorAndExit(err.Error())
+				}
+				conf.GrpcURL = si.GrpcURL
+			}
+			saved, err := conf.Save()
+			if err != nil {
+				printErrorAndExit(err.Error())
+			}
+			if saved {
+				fmt.Println("Login succeeded")
+			} else {
+				fmt.Println(conf.Token)
+			}
+			return
+		}
 		conf, err := proxyconfig.Load()
 		switch err {
 		case proxyconfig.ErrEmpty:
@@ -89,6 +125,7 @@ var loginCmd = &cobra.Command{
 
 func init() {
 	loginCmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the login url to stdout instead of opening the browser")
+	loginCmd.Flags().StringVar(&loginToken, "token", "", "Provide a pre-existing API key or access token (skips interactive login)")
 	rootCmd.AddCommand(loginCmd)
 }
 
@@ -330,4 +367,11 @@ func openBrowser(url string) (err error) {
 func isValidURL(addr string) bool {
 	u, err := url.Parse(addr)
 	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+func validateLoginToken(token string) error {
+	if token == "" {
+		return fmt.Errorf("token cannot be empty")
+	}
+	return nil
 }

--- a/client/cmd/login_test.go
+++ b/client/cmd/login_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestLoginTokenFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		wantErr bool
+	}{
+		{"empty token", "", true},
+		{"valid token", "xapi-abc123", false},
+		{"valid jwt-like token", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLoginToken(tt.token)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateLoginToken(%q) error = %v, wantErr %v", tt.token, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/client/cmd/output.go
+++ b/client/cmd/output.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// JSONEvent is the structured output format for agent-friendly CLI usage.
+// Each state transition emits one JSON object per line to the output writer.
+type JSONEvent struct {
+	Status   string            `json:"status"`
+	Message  string            `json:"message,omitempty"`
+	Data     map[string]string `json:"data,omitempty"`
+	ExitCode *int              `json:"exit_code,omitempty"`
+}
+
+// emitJSONEvent writes a single JSON event as one line to the given writer.
+func emitJSONEvent(w io.Writer, event JSONEvent) {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.Encode(event)
+}

--- a/client/cmd/output_test.go
+++ b/client/cmd/output_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestEmitJSONEvent(t *testing.T) {
+	var buf bytes.Buffer
+	emitJSONEvent(&buf, JSONEvent{
+		Status:  "waiting_approval",
+		Message: "waiting command to be approved",
+		Data: map[string]string{
+			"review_url": "https://app.hoop.dev/reviews/abc-123",
+			"session_id": "sid-456",
+		},
+	})
+
+	var got JSONEvent
+	if err := json.NewDecoder(&buf).Decode(&got); err != nil {
+		t.Fatalf("failed to decode JSON event: %v", err)
+	}
+	if got.Status != "waiting_approval" {
+		t.Errorf("expected status 'waiting_approval', got %q", got.Status)
+	}
+	if got.Data["review_url"] != "https://app.hoop.dev/reviews/abc-123" {
+		t.Errorf("expected review_url in data, got %v", got.Data)
+	}
+	if got.Data["session_id"] != "sid-456" {
+		t.Errorf("expected session_id in data, got %v", got.Data)
+	}
+}
+
+func TestEmitJSONEventExitCode(t *testing.T) {
+	var buf bytes.Buffer
+	exitCode := 1
+	emitJSONEvent(&buf, JSONEvent{
+		Status:   "completed",
+		Message:  "session closed",
+		ExitCode: &exitCode,
+	})
+
+	var got JSONEvent
+	if err := json.NewDecoder(&buf).Decode(&got); err != nil {
+		t.Fatalf("failed to decode JSON event: %v", err)
+	}
+	if got.ExitCode == nil || *got.ExitCode != 1 {
+		t.Errorf("expected exit_code 1, got %v", got.ExitCode)
+	}
+}


### PR DESCRIPTION
## Summary
- **`exec --output json`**: Emits structured NDJSON events for each state transition (`waiting_approval`, `approved`, `running`, `completed`). Implies `--auto-approve`. On review-required connections, returns immediately with `session_id` and `review_url` instead of blocking.
- **`exec --session <id>`**: Executes a previously approved reviewed session via API. Enables the full non-blocking agent workflow: submit → poll → execute.
- **`login --token <key>`**: Non-interactive authentication for agents using API keys or pre-existing tokens.
- **`connect --output json`**: Structured JSON events for approval wait and proxy connection info (host/port).
- **`connect --duration` fix**: Only sends JIT timeout when `--duration` is explicitly set, fixing "exceeds max duration" errors on connections with lower limits.

## Agent workflow (exec with review)
```bash
# 1. Submit — returns immediately
hoop exec db-write -i 'SELECT 1' --output json
# {"status":"waiting_approval","data":{"review_url":"...","session_id":"abc-123"}}

# 2. Poll — check review.status
hoop admin get sessions abc-123 -o json

# 3. Execute approved session
hoop exec --session abc-123 --output json
# {"status":"completed","exit_code":0,"data":{"stdout":"..."}}
```

## Test plan
- [x] `go test ./client/cmd/ -v` — all 12 tests pass
- [x] `go build ./client/...` — compiles clean
- [x] `exec --help` shows `--output` and `--session` flags
- [x] `login --help` shows `--token` flag
- [x] `connect --help` shows `--output` flag
- [x] Tested exec JSON flow end-to-end: submit → poll PENDING → approve → poll APPROVED → exec --session
- [x] Tested connect without --duration no longer fails with max duration error