### PR TITLE
Move libhoop tagging to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,31 +6,10 @@ on:
       - "*.*.*"
 
 jobs:
-  tag-libhoop:
-    name: Tag libhoop
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - name: Checkout libhoop
-        uses: actions/checkout@v3
-        with:
-          repository: hoophq/libhoop
-          path: "./libhoop"
-          token: ${{ secrets.GH_TOKEN }}
-          ref: main
-      - name: Tag libhoop with release tag
-        working-directory: ./libhoop
-        env:
-          GIT_TAG: ${{ github.ref_name }}
-        run: |
-          git tag "$GIT_TAG" 2>/dev/null || true
-          git push origin "$GIT_TAG"
-
   test:
     name: Test
     runs-on: ubuntu-latest
     environment: production
-    needs: [tag-libhoop]
 
     steps:
       - name: Checkout Hoop
@@ -42,7 +21,6 @@ jobs:
           repository: hoophq/libhoop
           path: "./libhoop"
           token: ${{ secrets.GH_TOKEN }}
-          ref: ${{ github.ref_name }}
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -174,7 +152,6 @@ jobs:
           repository: hoophq/libhoop
           path: "./libhoop"
           token: ${{ secrets.GH_TOKEN }}
-          ref: ${{ github.ref_name }}
 
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -220,7 +197,6 @@ jobs:
           repository: hoophq/libhoop
           path: "./libhoop"
           token: ${{ secrets.GH_TOKEN }}
-          ref: ${{ github.ref_name }}
 
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -266,7 +242,6 @@ jobs:
           repository: hoophq/libhoop
           path: "./libhoop"
           token: ${{ secrets.GH_TOKEN }}
-          ref: ${{ github.ref_name }}
 
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -312,7 +287,6 @@ jobs:
           repository: hoophq/libhoop
           path: "./libhoop"
           token: ${{ secrets.GH_TOKEN }}
-          ref: ${{ github.ref_name }}
 
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -358,7 +332,6 @@ jobs:
           repository: hoophq/libhoop
           path: "./libhoop"
           token: ${{ secrets.GH_TOKEN }}
-          ref: ${{ github.ref_name }}
 
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -408,7 +381,6 @@ jobs:
           repository: hoophq/libhoop
           path: "./libhoop"
           token: ${{ secrets.GH_TOKEN }}
-          ref: ${{ github.ref_name }}
 
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -822,3 +794,17 @@ jobs:
         run: make publish-sentry-sourcemaps
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Tag libhoop with release tag
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Push tag
+        working-directory: ./libhoop
+        env:
+          GIT_TAG: ${{ github.ref_name }}
+        run: |
+          git tag "$GIT_TAG" 2>/dev/null || true
+          git push origin "$GIT_TAG"


### PR DESCRIPTION
## Summary

- Moves libhoop tagging from the local `publish-release.sh` script to the release pipeline (`release.yml`)
- Tags libhoop at the **end** of the pipeline (after all builds, tests, docker publishes, and uploads succeed) instead of at the start
- All libhoop checkouts now use the default branch instead of the tag ref

This eliminates user error — if anything fails mid-pipeline, libhoop won't get tagged.

**Note:** Verify that `GH_TOKEN` has **write** access to `hoophq/libhoop`.

## Test plan

- [ ] Verify `GH_TOKEN` has write access to `hoophq/libhoop`
- [ ] Trigger a release and confirm the pipeline tags libhoop only after everything passes