### PR TITLE
add volume mounts and init container

### DIFF
--- a/deploy/helm-chart/chart/agent/templates/deployment.yaml
+++ b/deploy/helm-chart/chart/agent/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: hoopagent
       {{- end }}
+      {{- with .Values.additionalInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: '{{ .Values.image.repository |default "hoophq/hoopdev" }}:{{ .Values.image.tag |default "latest" }}'
         name: agent
@@ -44,6 +48,10 @@ spec:
         - secretRef:
             name: extra-agent-config
         {{- end}}
+        {{- with .Values.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -54,5 +62,9 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm-chart/chart/agent/values.yaml
+++ b/deploy/helm-chart/chart/agent/values.yaml
@@ -57,3 +57,21 @@ serviceAccount:
   create: false
   # Annotations to add to the service account
   annotations: {}
+
+# -- Additional init containers to run before the agent container
+additionalInitContainers: []
+# - name: init-myservice
+#   image: busybox
+#   command: ['sh', '-c', 'echo init']
+
+# -- Volume mounts for the agent container
+volumeMounts: []
+# - name: my-configmap-volume
+#   mountPath: /etc/config/myfile.conf
+#   subPath: myfile.conf
+
+# -- Volumes to mount into the pod
+volumes: []
+# - name: my-configmap-volume
+#   configMap:
+#     name: my-configmap


### PR DESCRIPTION
## 📝 Description

Add support for optional `volumeMounts`, `volumes`, and `additionalInitContainers` in the Hoop agent Helm chart. This allows admins to mount files from ConfigMaps (or other volume sources) directly into the agent container.

A key benefit of this feature is enabling admins to inject custom scripts or binaries into the agent. Since Hoop executes commands through the agent, any script or binary mounted into the container becomes immediately available for use in Hoop connections and runbooks — without requiring a custom agent image.

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when this PR is merged -->

Fixes #

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- Added `volumeMounts` value to mount volumes into the agent container
- Added `volumes` value to define pod-level volumes (e.g. from a ConfigMap)
- Added `additionalInitContainers` value to run init containers before the agent starts. Users may apply this init containers to download the binary files and install on the agent.

## 🧪 Testing

Deploy the agent chart with a separate ConfigMap containing a custom script, then verify the script is accessible inside the agent container and executable via a Hoop connection.

### Test Configuration:
- **Browser(s)**: 
- **OS**:

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-configmap
  namespace: hoop
data:
  hello.sh: |
    #!/bin/sh
    echo "Hello World"
```

```yaml
# -- Volume mounts for the agent container
volumeMounts:
- name: my-configmap-volume
  mountPath: /opt/scripts

# -- Volumes to mount into the pod
volumes:
- name: my-configmap-volume
  configMap:
    name: my-configmap
    defaultMode: 0755
```


## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [ ] I have run `make generate-openapi-docs` to update the OpenAPI docs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

All three new fields default to empty ([]), so this change is fully backwards-compatible. No existing deployments are affected unless the new values are explicitly set.

---

<!-- Thank you for contributing to our project! 🙏 --> 
