### PR TITLE
feat: add minlength and maxlength support to runbook templates

### DIFF
--- a/common/runbooks/template_funcs.go
+++ b/common/runbooks/template_funcs.go
@@ -43,6 +43,8 @@ func defaultStaticTemplateFuncs() ttemplate.FuncMap {
 			return "", fmt.Errorf("pattern didn't match:%s", p)
 		},
 		"placeholder": func(_, s string) string { return s },
+		"minlength":   func(_, s string) string { return s },
+		"maxlength":   func(_, s string) string { return s },
 		"options": func(v ...string) string {
 			if len(v) == 0 {
 				return ""

--- a/common/runbooks/templates.go
+++ b/common/runbooks/templates.go
@@ -126,7 +126,7 @@ func parseNode(node string) map[string]any {
 			}
 		case "required":
 			specs[fnName] = true
-		case "description", "default", "placeholder":
+		case "description", "default", "placeholder", "minlength", "maxlength":
 			specs[fnName] = fnVal
 		case "options":
 			specs[fnName] = strings.Split(fnVal, " ")

--- a/common/runbooks/templates_test.go
+++ b/common/runbooks/templates_test.go
@@ -121,6 +121,21 @@ func TestTemplateParseAttributes(t *testing.T) {
 			},
 		},
 		{
+			msg: "it should match [minlength, maxlength] attributes",
+			tmpl: `name = {{ .name
+								| minlength "2"
+								| maxlength "50" }}`,
+			wantAttrs: map[string]any{
+				"name": map[string]any{
+					"description": "",
+					"required":    false,
+					"type":        "text",
+					"minlength":   "2",
+					"maxlength":   "50",
+				},
+			},
+		},
+		{
 			msg: "it should match [placeholder, type, options] attributes",
 			tmpl: `SELECT * FROM gender = {{ .gender
 											| placeholder "the gender type"

--- a/webapp/src/webapp/components/forms.cljs
+++ b/webapp/src/webapp/components/forms.cljs
@@ -131,8 +131,8 @@
            on-blur
            rows
            autoFocus
-           minLength
-           maxLength
+           minlength
+           maxlength
            not-margin-bottom? ;; TODO: Remove this prop when remove margin-bottom from all inputs
            disabled]}]
   [:div {:class (when-not not-margin-bottom? "mb-regular")}
@@ -158,8 +158,8 @@
       :defaultValue defaultValue
       :autoFocus autoFocus
       :placeholder placeholder
-      :minLength minLength
-      :maxLength maxLength
+      :minLength minlength
+      :maxLength maxlength
       :on-change on-change
       :on-blur on-blur
       :on-keyDown on-keyDown

--- a/webapp/src/webapp/components/forms.cljs
+++ b/webapp/src/webapp/components/forms.cljs
@@ -131,6 +131,8 @@
            on-blur
            rows
            autoFocus
+           minLength
+           maxLength
            not-margin-bottom? ;; TODO: Remove this prop when remove margin-bottom from all inputs
            disabled]}]
   [:div {:class (when-not not-margin-bottom? "mb-regular")}
@@ -156,6 +158,8 @@
       :defaultValue defaultValue
       :autoFocus autoFocus
       :placeholder placeholder
+      :minLength minLength
+      :maxLength maxLength
       :on-change on-change
       :on-blur on-blur
       :on-keyDown on-keyDown

--- a/webapp/src/webapp/features/runbooks/runner/views/form.cljs
+++ b/webapp/src/webapp/features/runbooks/runner/views/form.cljs
@@ -218,7 +218,9 @@
                                                          #(update-state param (-> % .-target .-value)))
                                             :helper-text (:description metadata)
                                             :options (:options metadata)
-                                            :default-value (:default metadata)}]))
+                                            :default-value (:default metadata)
+                                            :minlength (:minlength metadata)
+                                            :maxlength (:maxlength metadata)}]))
 
                 (when-let [err (-> template :data :error)]
                   [error-view err])]]]]))))))

--- a/webapp/src/webapp/features/runbooks/runner/views/form.cljs
+++ b/webapp/src/webapp/features/runbooks/runner/views/form.cljs
@@ -44,8 +44,8 @@
                                     :placeholder (or placeholder (str "Define a value for " label))
                                     :value (or value default-value "")
                                     :on-change on-change
-                                    :minLength minlength
-                                    :maxLength maxlength
+                                    :minlength minlength
+                                    :maxlength maxlength
                                     :helper-text helper-text}
                                    (when (and
                                           (not= required "false")
@@ -64,8 +64,8 @@
                       :pattern pattern
                       :on-change on-change
                       :on-keyDown number-input-keydown
-                      :minLength minlength
-                      :maxLength maxlength
+                      :minlength minlength
+                      :maxlength maxlength
                       :min min
                       :max max
                       :step step
@@ -83,6 +83,11 @@
      "Error found."]
     [:> Box {:class " text-sm mb-large"}
      error]]])
+
+(defn- validate-min-length [el val minlength]
+  (if (and minlength (not= val "") (< (count val) (js/parseInt minlength 10)))
+    (.setCustomValidity el (str "Minimum length is " minlength " characters"))
+    (.setCustomValidity el "")))
 
 (defn- sort-params-by-order [params metadata]
   (sort-by #(or (:order ((keyword %) metadata)) js/Number.MAX_SAFE_INTEGER) params))
@@ -215,7 +220,11 @@
                                             :required (:required metadata)
                                             :on-change (if (contains? #{"select" "file"} (:type metadata))
                                                          #(update-state param %)
-                                                         #(update-state param (-> % .-target .-value)))
+                                                         (fn [e]
+                                                           (let [val (-> e .-target .-value)]
+                                                             (validate-min-length (.-target e) val
+                                                                                  (:minlength metadata))
+                                                             (update-state param val))))
                                             :helper-text (:description metadata)
                                             :options (:options metadata)
                                             :default-value (:default metadata)


### PR DESCRIPTION
📝 Description
                                                                                                                                         
Adds minlength and maxlength as supported parameter functions in runbook templates, wiring them end-to-end from template parsing to the frontend dynamic form.

🔗 Related Issue

Fixes ENG-313

🚀 Type of Change

- ✨ New feature (non-breaking change which adds functionality)
- 🐛 Bug fix (non-breaking change which fixes an issue)

📋 Changes Made

- Added minlength and maxlength functions to the template engine (template_funcs.go)
- Added parsing support for both attributes in parseNode() (templates.go)
- Fixed forms/textarea component to accept and apply minLength/maxLength props (they were previously accepted by dynamic-form but
silently dropped by the base component)
- Passed minlength and maxlength from runbook metadata to the dynamic-form component (form.cljs)
- Added test case for minlength/maxlength attribute parsing

🧪 Testing

Tests performed:
- Unit tests pass
- Integration tests pass
- Manual testing completed

✅ Checklist

- I have run make generate-openapi-docs to update the OpenAPI docs
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- My changes generate no new warnings
- New and existing unit tests pass locally with my changes
- I have checked my code and corrected any misspellings