### PR TITLE
feat(client): add batch connection creation via YAML file

### DIFF
--- a/client/cmd/admin/create-conn-batch.go
+++ b/client/cmd/admin/create-conn-batch.go
@@ -1,0 +1,343 @@
+package admin
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hoophq/hoop/client/cmd/styles"
+	clientconfig "github.com/hoophq/hoop/client/config"
+	"github.com/hoophq/hoop/common/log"
+	pb "github.com/hoophq/hoop/common/proto"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// BatchConnectionFile represents the YAML file format for batch connection creation.
+//
+// Example file:
+//
+//	agent: default
+//	type: database/postgres
+//	overwrite: false
+//	tags:
+//	  env: production
+//	  team: platform
+//	access_modes:
+//	  - connect
+//	  - exec
+//	  - runbooks
+//	connections:
+//	  - name: users-db
+//	    env:
+//	      HOST: 10.0.1.10
+//	      USER: admin
+//	      PASS: file:///secrets/users-db.txt
+//	      PORT: "5432"
+//	  - name: orders-db
+//	    env:
+//	      HOST: 10.0.1.11
+//	      USER: admin
+//	      PASS: base64://c2VjcmV0
+//	      PORT: "5432"
+type BatchConnectionFile struct {
+	Agent       string            `yaml:"agent"`
+	Type        string            `yaml:"type"`
+	Overwrite   bool              `yaml:"overwrite"`
+	Tags        map[string]string `yaml:"tags"`
+	AccessModes []string          `yaml:"access_modes"`
+	Schema      string            `yaml:"schema"`
+	Connections []BatchConnection `yaml:"connections"`
+}
+
+// BatchConnection represents a single connection entry in the batch file.
+// Each entry can override the top-level agent, type, tags, and access_modes.
+type BatchConnection struct {
+	Name        string            `yaml:"name"`
+	Agent       string            `yaml:"agent"`
+	Type        string            `yaml:"type"`
+	Env         map[string]string `yaml:"env"`
+	Command     []string          `yaml:"command"`
+	Tags        map[string]string `yaml:"tags"`
+	AccessModes []string          `yaml:"access_modes"`
+	Schema      string            `yaml:"schema"`
+	Overwrite   *bool             `yaml:"overwrite"`
+}
+
+var fromFileFlag string
+
+func init() {
+	createConnectionBatchCmd.Flags().StringVar(&fromFileFlag, "from-file", "", "Path to a YAML file defining multiple connections")
+	createConnectionBatchCmd.MarkFlagRequired("from-file")
+}
+
+var createConnectionBatchExamplesDesc = `
+  # Create multiple postgres connections from a YAML file
+  hoop admin create connections --from-file connections.yaml
+
+  # Example YAML file (connections.yaml):
+  #
+  # agent: default
+  # type: database/postgres
+  # connections:
+  #   - name: users-db
+  #     env:
+  #       HOST: 10.0.1.10
+  #       USER: admin
+  #       PASS: secret
+  #       PORT: "5432"
+  #   - name: orders-db
+  #     env:
+  #       HOST: 10.0.1.11
+  #       USER: admin
+  #       PASS: file:///secrets/orders-db.txt
+  #       PORT: "5432"
+`
+
+var createConnectionBatchCmd = &cobra.Command{
+	Use:     "connections --from-file FILE",
+	Aliases: []string{"conns"},
+	Example: createConnectionBatchExamplesDesc,
+	Short:   "Create multiple connection resources from a YAML file.",
+	Run: func(cmd *cobra.Command, args []string) {
+		config := clientconfig.GetClientConfigOrDie()
+		batchFile, err := parseBatchFile(fromFileFlag)
+		if err != nil {
+			styles.PrintErrorAndExit("failed to parse file %q: %v", fromFileFlag, err)
+		}
+
+		if len(batchFile.Connections) == 0 {
+			styles.PrintErrorAndExit("no connections defined in %q", fromFileFlag)
+		}
+
+		fmt.Printf("creating %d connection(s) from %s\n\n", len(batchFile.Connections), fromFileFlag)
+
+		var succeeded, failed int
+		var errors []string
+
+		for i, conn := range batchFile.Connections {
+			if conn.Name == "" {
+				errMsg := fmt.Sprintf("[%d/%d] skipped: missing connection name", i+1, len(batchFile.Connections))
+				fmt.Println(styles.ClientErrorSimple(errMsg))
+				errors = append(errors, errMsg)
+				failed++
+				continue
+			}
+
+			connName := NormalizeResourceName(conn.Name)
+			result := createSingleConnection(config, batchFile, conn, connName, i+1, len(batchFile.Connections))
+			if result != nil {
+				errMsg := fmt.Sprintf("[%d/%d] %s: %v", i+1, len(batchFile.Connections), connName, result)
+				fmt.Println(styles.ClientErrorSimple(errMsg))
+				errors = append(errors, errMsg)
+				failed++
+			} else {
+				succeeded++
+			}
+		}
+
+		// Print summary
+		fmt.Printf("\ndone: %d succeeded, %d failed out of %d total\n", succeeded, failed, len(batchFile.Connections))
+		if len(errors) > 0 {
+			fmt.Println("\nfailed connections:")
+			for _, e := range errors {
+				fmt.Printf("  - %s\n", e)
+			}
+			os.Exit(1)
+		}
+	},
+}
+
+func createSingleConnection(config *clientconfig.Config, batch *BatchConnectionFile, conn BatchConnection, connName string, index, total int) error {
+	// Resolve effective values (connection-level overrides top-level)
+	agentName := batch.Agent
+	if conn.Agent != "" {
+		agentName = conn.Agent
+	}
+	if agentName == "" {
+		return fmt.Errorf("no agent specified (set at top-level or per-connection)")
+	}
+
+	connTypeStr := batch.Type
+	if conn.Type != "" {
+		connTypeStr = conn.Type
+	}
+	if connTypeStr == "" {
+		connTypeStr = "custom"
+	}
+
+	overwrite := batch.Overwrite
+	if conn.Overwrite != nil {
+		overwrite = *conn.Overwrite
+	}
+
+	accessModes := batch.AccessModes
+	if len(conn.AccessModes) > 0 {
+		accessModes = conn.AccessModes
+	}
+	if len(accessModes) == 0 {
+		accessModes = defaultAccessModes
+	}
+
+	schema := batch.Schema
+	if conn.Schema != "" {
+		schema = conn.Schema
+	}
+
+	tags := map[string]string{}
+	for k, v := range batch.Tags {
+		tags[k] = v
+	}
+	for k, v := range conn.Tags {
+		tags[k] = v
+	}
+
+	// Determine method
+	method := "POST"
+	actionName := "created"
+	if overwrite {
+		exists, err := getConnection(config, connName)
+		if err != nil {
+			return fmt.Errorf("failed checking existence: %v", err)
+		}
+		if exists {
+			method = "PUT"
+			actionName = "updated"
+		}
+	}
+
+	// Parse environment variables
+	envVar, err := parseBatchEnvVars(conn.Env)
+	if err != nil {
+		return fmt.Errorf("invalid env vars: %v", err)
+	}
+
+	// Parse and validate connection type
+	connType, subType, _ := strings.Cut(connTypeStr, "/")
+	protocolConnectionType := pb.ToConnectionType(connType, subType)
+
+	if !skipStrictValidation {
+		if err := validateConnectionType(protocolConnectionType, envVar, conn.Command); err != nil {
+			return err
+		}
+	}
+
+	// Resolve agent ID
+	agentID, err := getAgentIDByName(config, agentName)
+	if err != nil {
+		return fmt.Errorf("failed resolving agent %q: %v", agentName, err)
+	}
+	if agentID == "" && !skipStrictValidation {
+		return fmt.Errorf("agent %q not found", agentName)
+	}
+
+	// Build API resource
+	apir := &apiResource{
+		resourceType:   "connection",
+		name:           connName,
+		method:         method,
+		conf:           config,
+		resourceCreate: true,
+		resourceUpdate: true,
+		decodeTo:       "object",
+	}
+	if method == "POST" {
+		apir.suffixEndpoint = "/api/connections"
+	} else {
+		apir.suffixEndpoint = fmt.Sprintf("/api/connections/%s", connName)
+	}
+	if outputFlag == "json" {
+		apir.decodeTo = "raw"
+	}
+
+	connectionBody := map[string]any{
+		"name":                 connName,
+		"type":                 connType,
+		"subtype":              subType,
+		"command":              conn.Command,
+		"secret":               envVar,
+		"agent_id":             agentID,
+		"redact_enabled":       true,
+		"connection_tags":      tags,
+		"access_mode_runbooks": batchAccessModeStatus(accessModes, "runbooks"),
+		"access_mode_exec":     batchAccessModeStatus(accessModes, "exec"),
+		"access_mode_connect":  batchAccessModeStatus(accessModes, "connect"),
+		"access_schema":        verifySchemaStatus(schema, connType),
+	}
+
+	log.Debugf("creating connection %v (%d/%d)", connName, index, total)
+	_, err = httpBodyRequest(apir, method, connectionBody)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("[%d/%d] connection %s %s\n", index, total, connName, actionName)
+	return nil
+}
+
+func parseBatchFile(filePath string) (*BatchConnectionFile, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %v", err)
+	}
+
+	var batch BatchConnectionFile
+	if err := yaml.Unmarshal(data, &batch); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %v", err)
+	}
+
+	return &batch, nil
+}
+
+func parseBatchEnvVars(envMap map[string]string) (map[string]string, error) {
+	result := map[string]string{}
+	for key, val := range envMap {
+		// Support the same value formats as the single create command:
+		// raw values, base64://<content>, file:///path
+		resolvedVal, err := getEnvValue(val)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve value for %q: %v", key, err)
+		}
+		envKey := fmt.Sprintf("envvar:%s", key)
+		result[envKey] = base64.StdEncoding.EncodeToString([]byte(resolvedVal))
+	}
+	return result, nil
+}
+
+func validateConnectionType(protocolType pb.ConnectionType, envVar map[string]string, cmdList []string) error {
+	switch protocolType {
+	case pb.ConnectionTypeCommandLine:
+		if len(cmdList) == 0 {
+			return fmt.Errorf("command-line type must have at least one command")
+		}
+	case pb.ConnectionTypeTCP:
+		return validateTcpEnvs(envVar)
+	case pb.ConnectionTypePostgres, pb.ConnectionTypeMySQL, pb.ConnectionTypeMSSQL:
+		return validateNativeDbEnvs(envVar)
+	case pb.ConnectionTypeMongoDB:
+		if envVar["envvar:CONNECTION_STRING"] == "" {
+			return fmt.Errorf("missing required CONNECTION_STRING env for %v", pb.ConnectionTypeMongoDB)
+		}
+	case pb.ConnectionTypeHttpProxy:
+		if envVar["envvar:REMOTE_URL"] == "" {
+			return fmt.Errorf("missing required REMOTE_URL env for %v", pb.ConnectionTypeHttpProxy)
+		}
+	case pb.ConnectionTypeKubernetes:
+		// no validation needed
+	case pb.ConnectionTypeSSH:
+		return validateSSHEnvs(envVar)
+	default:
+		return fmt.Errorf("invalid connection type %q", protocolType)
+	}
+	return nil
+}
+
+func batchAccessModeStatus(modes []string, mode string) string {
+	for _, m := range modes {
+		if m == mode {
+			return "enabled"
+		}
+	}
+	return "disabled"
+}

--- a/client/cmd/admin/create-conn-batch.go
+++ b/client/cmd/admin/create-conn-batch.go
@@ -164,7 +164,7 @@ func createSingleConnection(config *clientconfig.Config, batch *BatchConnectionF
 		connTypeStr = conn.Type
 	}
 	if connTypeStr == "" {
-		connTypeStr = "custom"
+		return fmt.Errorf("no connection type specified (set at top-level or per-connection)")
 	}
 
 	overwrite := batch.Overwrite

--- a/client/cmd/admin/create-conn-batch_test.go
+++ b/client/cmd/admin/create-conn-batch_test.go
@@ -165,6 +165,28 @@ func TestValidateConnectionType(t *testing.T) {
 	}
 }
 
+func TestParseBatchFileMissingType(t *testing.T) {
+	yamlContent := `
+agent: default
+connections:
+  - name: users-db
+    env:
+      HOST: 10.0.1.10
+      USER: admin
+      PASS: secret
+`
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "no-type.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(yamlContent), 0644))
+
+	batch, err := parseBatchFile(filePath)
+	require.NoError(t, err)
+
+	// Type should be empty — not defaulted to "custom"
+	assert.Equal(t, "", batch.Type)
+	assert.Equal(t, "", batch.Connections[0].Type)
+}
+
 func TestBatchAccessModeStatus(t *testing.T) {
 	modes := []string{"connect", "exec"}
 

--- a/client/cmd/admin/create-conn-batch_test.go
+++ b/client/cmd/admin/create-conn-batch_test.go
@@ -1,0 +1,174 @@
+package admin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBatchFile(t *testing.T) {
+	yamlContent := `
+agent: default
+type: database/postgres
+overwrite: true
+tags:
+  env: production
+  team: platform
+access_modes:
+  - connect
+  - exec
+connections:
+  - name: users-db
+    env:
+      HOST: 10.0.1.10
+      USER: admin
+      PASS: secret
+      PORT: "5432"
+  - name: orders-db
+    env:
+      HOST: 10.0.1.11
+      USER: admin
+      PASS: secret
+      PORT: "5432"
+    tags:
+      env: staging
+`
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "connections.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(yamlContent), 0644))
+
+	batch, err := parseBatchFile(filePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "default", batch.Agent)
+	assert.Equal(t, "database/postgres", batch.Type)
+	assert.True(t, batch.Overwrite)
+	assert.Equal(t, map[string]string{"env": "production", "team": "platform"}, batch.Tags)
+	assert.Equal(t, []string{"connect", "exec"}, batch.AccessModes)
+	assert.Len(t, batch.Connections, 2)
+
+	assert.Equal(t, "users-db", batch.Connections[0].Name)
+	assert.Equal(t, "10.0.1.10", batch.Connections[0].Env["HOST"])
+	assert.Equal(t, "admin", batch.Connections[0].Env["USER"])
+
+	assert.Equal(t, "orders-db", batch.Connections[1].Name)
+	// Connection-level tags override top-level
+	assert.Equal(t, "staging", batch.Connections[1].Tags["env"])
+}
+
+func TestParseBatchFileWithOverrides(t *testing.T) {
+	yamlContent := `
+agent: default
+type: database/postgres
+connections:
+  - name: special-db
+    agent: custom-agent
+    type: database/mysql
+    env:
+      HOST: 10.0.1.50
+      USER: root
+      PASS: secret
+`
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "connections.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(yamlContent), 0644))
+
+	batch, err := parseBatchFile(filePath)
+	require.NoError(t, err)
+
+	assert.Len(t, batch.Connections, 1)
+	assert.Equal(t, "custom-agent", batch.Connections[0].Agent)
+	assert.Equal(t, "database/mysql", batch.Connections[0].Type)
+}
+
+func TestParseBatchEnvVars(t *testing.T) {
+	envMap := map[string]string{
+		"HOST": "localhost",
+		"PORT": "5432",
+		"USER": "admin",
+	}
+
+	result, err := parseBatchEnvVars(envMap)
+	require.NoError(t, err)
+
+	assert.Len(t, result, 3)
+	// Keys should be prefixed with "envvar:"
+	assert.NotEmpty(t, result["envvar:HOST"])
+	assert.NotEmpty(t, result["envvar:PORT"])
+	assert.NotEmpty(t, result["envvar:USER"])
+}
+
+func TestParseBatchEnvVarsWithFileRef(t *testing.T) {
+	tmpDir := t.TempDir()
+	secretFile := filepath.Join(tmpDir, "secret.txt")
+	require.NoError(t, os.WriteFile(secretFile, []byte("my-secret-password"), 0644))
+
+	envMap := map[string]string{
+		"HOST": "localhost",
+		"PASS": "file://" + secretFile,
+	}
+
+	result, err := parseBatchEnvVars(envMap)
+	require.NoError(t, err)
+
+	assert.Len(t, result, 2)
+	assert.NotEmpty(t, result["envvar:HOST"])
+	assert.NotEmpty(t, result["envvar:PASS"])
+}
+
+func TestParseBatchFileEmpty(t *testing.T) {
+	yamlContent := `
+agent: default
+type: database/postgres
+connections: []
+`
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "empty.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(yamlContent), 0644))
+
+	batch, err := parseBatchFile(filePath)
+	require.NoError(t, err)
+
+	assert.Empty(t, batch.Connections)
+}
+
+func TestValidateConnectionType(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "valid postgres envs",
+			envVars: map[string]string{"envvar:HOST": "val", "envvar:USER": "val", "envvar:PASS": "val"},
+			wantErr: false,
+		},
+		{
+			name:    "missing postgres envs",
+			envVars: map[string]string{"envvar:HOST": "val"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConnectionType("postgres", tt.envVars, nil)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBatchAccessModeStatus(t *testing.T) {
+	modes := []string{"connect", "exec"}
+
+	assert.Equal(t, "enabled", batchAccessModeStatus(modes, "connect"))
+	assert.Equal(t, "enabled", batchAccessModeStatus(modes, "exec"))
+	assert.Equal(t, "disabled", batchAccessModeStatus(modes, "runbooks"))
+}

--- a/client/cmd/admin/create.go
+++ b/client/cmd/admin/create.go
@@ -8,6 +8,7 @@ func init() {
 	createCmd.AddCommand(createAgentCmd)
 	createCmd.AddCommand(createOrgKeyCmd)
 	createCmd.AddCommand(createConnectionCmd)
+	createCmd.AddCommand(createConnectionBatchCmd)
 	createCmd.AddCommand(createPluginCmd)
 	createCmd.AddCommand(createUserCmd)
 	createCmd.AddCommand(createSvcAccountCmd)

--- a/client/cmd/admin/examples/batch-connections.yaml
+++ b/client/cmd/admin/examples/batch-connections.yaml
@@ -1,0 +1,73 @@
+# Example: Batch connection creation for hoop CLI
+# Usage: hoop admin create connections --from-file batch-connections.yaml
+
+# Top-level defaults (applied to all connections unless overridden)
+agent: default
+type: database/postgres
+overwrite: false
+
+# Optional: shared tags applied to all connections
+tags:
+  env: production
+  team: platform
+
+# Optional: shared access modes (default: connect, exec, runbooks)
+access_modes:
+  - connect
+  - exec
+  - runbooks
+
+# List of connections to create
+connections:
+  - name: users-db
+    env:
+      HOST: 10.0.1.10
+      USER: admin
+      PASS: file:///etc/hoop/secrets/users-db-pass.txt
+      PORT: "5432"
+      DB: users
+
+  - name: orders-db
+    env:
+      HOST: 10.0.1.11
+      USER: admin
+      PASS: base64://c2VjcmV0cGFzc3dvcmQ=
+      PORT: "5432"
+      DB: orders
+
+  - name: analytics-db
+    env:
+      HOST: 10.0.1.12
+      USER: readonly
+      PASS: analytics-readonly-pass
+      PORT: "5432"
+      DB: analytics
+    # Per-connection tag override
+    tags:
+      env: production
+      team: data
+    # Restrict access modes for this connection only
+    access_modes:
+      - connect
+
+  # Override type for a specific connection
+  - name: redis-cache
+    type: application/tcp
+    env:
+      HOST: 10.0.1.20
+      PORT: "6379"
+    tags:
+      env: production
+      team: infra
+
+  # Override agent for a specific connection
+  - name: staging-db
+    agent: staging-agent
+    env:
+      HOST: 10.0.2.10
+      USER: admin
+      PASS: staging-pass
+      PORT: "5432"
+      DB: app
+    tags:
+      env: staging


### PR DESCRIPTION
## 📝 Description

Add `hoop admin create connections --from-file` command that allows admins to create multiple connections from a single YAML file, reducing friction during environment onboarding.

## 🔗 Related Issue

<!-- Link to Linear design task here -->

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- New `hoop admin create connections --from-file FILE` command (plural `connections`, aliased as `conns`)
- YAML file format with top-level defaults (`agent`, `type`, `tags`, `access_modes`, `overwrite`) and per-connection overrides
- Connection type is required — no silent fallback to `custom`, preventing misconfigured resources
- Supports same env value formats as single create: raw, `base64://`, `file:///`
- Progress output with `[n/total]` prefix and error summary on completion
- Unit tests for YAML parsing, env var resolution, and validation
- Example YAML file at `client/cmd/admin/examples/batch-connections.yaml`
- Registered new command in `create.go` — no gateway/API changes needed

## 🧪 Testing

### Test Configuration:
- **OS**: macOS (darwin/arm64)

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

> **Note**: Go toolchain was not available in the authoring environment. Unit tests are written but need to be compiled and run. Manual testing with a live Hoop instance is pending.

## 📸 Screenshots (if applicable)

### Example YAML file

```yaml
agent: default
type: database/postgres
tags:
  env: production
connections:
  - name: users-db
    env:
      HOST: 10.0.1.10
      USER: admin
      PASS: file:///secrets/users-db.txt
      PORT: "5432"
  - name: orders-db
    env:
      HOST: 10.0.1.11
      USER: admin
      PASS: base64://c2VjcmV0
      PORT: "5432"
```

**Expected output:**
```creating 2 connection(s) from connections.yaml

[1/2] connection users-db created
[2/2] connection orders-db created

done: 2 succeeded, 0 failed out of 2 total
```

## ✅ Checklist

- [ ] I have run `make generate-openapi-docs` to update the OpenAPI docs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

### Scope
This is a **client-side only** change. No gateway or API modifications. The new command iterates over YAML entries and calls the existing `POST /api/connections` endpoint for each one.

### Out of scope (considered for next version)
- **Plugin support** — YAML format does not support a `plugins` field per connection
- **Dry-run mode** — `--dry-run` flag to validate the file without creating resources
- **Parallelism** — creation is sequential; concurrent execution for large batches may be added later
- **Additional flags** — `reviewers`, `guardrail-rules`, `redact-types` are not yet exposed in the YAML format
- **Move to `resources` subcommand** — the `admin` subcommand is experimental and not fully aligned with the webapp experience. A future version should introduce `hoop resources create --from-file` (or similar) to match the webapp's resource model and move away from `admin`
- **Resource Roles support** — the webapp treats Roles as a first-class concept (named, multiple per resource, with different credential methods). The current YAML format maps to flat env vars. A future version should support defining multiple roles per connection, aligning CLI and webapp experiences