### PR TITLE
feat: nightly release process & sandbox auto-deploy

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,797 @@
+name: Dev Release
+
+on:
+  push:
+    branches:
+      - dev
+
+run-name: |-
+  Dev Release (${{ github.sha }})
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ">=1.24.0"
+      - name: Setup Rust for WASM
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - name: Test
+        run: make test
+
+  build-rust-binaries-darwin:
+    runs-on: macos-latest
+    name: Build Darwin Rust Binaries
+    environment: production
+    needs: [test]
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
+
+      - name: Add Darwin Rust targets
+        run: |
+          rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build Darwin Rust Binaries
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: make build-rust-darwin-all
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  build-rust-binary-linux-amd64:
+    runs-on: ubuntu-latest
+    name: Build Linux Rust Binaries Amd64
+    environment: production
+    needs: [test]
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
+
+      - name: Add Linux Rust targets
+        run: |
+          rustup target add x86_64-unknown-linux-gnu
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build Linux Rust Binaries
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: GOOS=linux GOARCH=amd64 make build-rust-single
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  build-rust-binary-linux-arm64:
+    runs-on: ubuntu-24.04-arm
+    name: Build Linux Rust Binaries Arm64
+    environment: production
+    needs: [test]
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
+
+      - name: Add Linux Rust targets
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build Linux Rust Binaries
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: GOOS=linux GOARCH=arm64 make build-rust-single
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  darwin-amd64:
+    runs-on: ubuntu-latest
+    name: Build Darwin Amd64
+    environment: production
+    needs: [test]
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.24.0"
+          cache-dependency-path: "**/go.sum"
+
+      - name: Setup Rust for WASM
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Generate WASM
+        run: make generate-wasm
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: amd64
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: GOOS=darwin GOARCH=amd64 make build-go
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  darwin-arm64:
+    runs-on: ubuntu-latest
+    name: Build Darwin Arm64
+    environment: production
+    needs: [test]
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.24.0"
+          cache-dependency-path: "**/go.sum"
+
+      - name: Setup Rust for WASM
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Generate WASM
+        run: make generate-wasm
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: GOOS=darwin GOARCH=arm64 make build-go
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  windows-amd64:
+    runs-on: ubuntu-latest
+    name: Build Windows Amd64
+    environment: production
+    needs: [test]
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.24.0"
+          cache-dependency-path: "**/go.sum"
+
+      - name: Setup Rust for WASM
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Generate WASM
+        run: make generate-wasm
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: GOOS=windows GOARCH=amd64 make build-go
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  windows-arm64:
+    runs-on: ubuntu-latest
+    name: Build Windows Arm64
+    environment: production
+    needs: [test]
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.24.0"
+          cache-dependency-path: "**/go.sum"
+
+      - name: Setup Rust for WASM
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Generate WASM
+        run: make generate-wasm
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: GOOS=windows GOARCH=arm64 make build-go
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  linux-amd64:
+    runs-on: ubuntu-latest
+    name: Build Linux Amd64
+    environment: production
+    needs: [test]
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.24.0"
+          cache-dependency-path: "**/go.sum"
+
+      - name: Setup Rust for WASM
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Generate WASM
+        run: make generate-wasm
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SEGMENT_API_KEY: ${{ secrets.SEGMENT_API_KEY }}
+          INTERCOM_HMAC_KEY: ${{ secrets.INTERCOM_HMAC_KEY }}
+        run: GOOS=linux GOARCH=amd64 make build-go
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  linux-arm64:
+    runs-on: ubuntu-latest
+    name: Build Linux Arm64
+    environment: production
+    needs: [test]
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.24.0"
+          cache-dependency-path: "**/go.sum"
+
+      - name: Setup Rust for WASM
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Generate WASM
+        run: make generate-wasm
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SEGMENT_API_KEY: ${{ secrets.SEGMENT_API_KEY }}
+          INTERCOM_HMAC_KEY: ${{ secrets.INTERCOM_HMAC_KEY }}
+        run: GOOS=linux GOARCH=arm64 make build-go
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  build-webapp:
+    runs-on: ubuntu-latest
+    name: Build Webapp
+    environment: production
+    needs: [test]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "21"
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          cli: 1.12.0.1479 # releases: https://clojure.org/releases/tools
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: webapp/package-lock.json
+      - name: Build
+        run: make build-webapp
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  build-tar-files:
+    runs-on: ubuntu-latest
+    name: Build Tar Files
+    environment: production
+    needs:
+      - build-webapp
+      - darwin-amd64
+      - darwin-arm64
+      - windows-amd64
+      - windows-arm64
+      - linux-amd64
+      - linux-arm64
+      - build-rust-binaries-darwin
+      - build-rust-binary-linux-amd64
+      - build-rust-binary-linux-arm64
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-artifacts-*
+          merge-archive: true
+          path: dist/
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Merge Artifacts into dist/
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: make merge-artifacts
+
+      - name: Build Tar Files for All Architectures
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: |
+          GOOS=darwin GOARCH=amd64 make build-tar-files
+          GOOS=darwin GOARCH=arm64 make build-tar-files
+          GOOS=windows GOARCH=amd64 make build-tar-files
+          GOOS=windows GOARCH=arm64 make build-tar-files
+          GOOS=linux GOARCH=amd64 make build-tar-files
+          GOOS=linux GOARCH=arm64 make build-tar-files
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts-${{ github.job }}
+          path: dist/
+
+  docker-publish-hoopgateway-arm64:
+    runs-on: GitHub-Linux-Arm-Runner
+    name: Dck Publish Gateway (arm64)
+    environment: production
+    needs:
+      - build-tar-files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoop
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-artifacts-*
+          merge-multiple: true
+          path: dist/
+      - name: Extract Webapp
+        run: make extract-webapp
+      - name: Build and Push
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile
+          context: '.'
+          platforms: linux/arm64
+          provenance: false
+          sbom: false
+          push: true
+          tags: |
+            hoophq/hoop:${{ github.sha }}-arm64
+
+  docker-publish-hoopgateway-amd64:
+    runs-on: ubuntu-latest
+    name: Dck Publish Gateway (amd64)
+    environment: production
+    needs:
+      - build-tar-files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoop
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-artifacts-*
+          merge-multiple: true
+          path: dist/
+      - name: Extract Webapp
+        run: make extract-webapp
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile
+          context: '.'
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          push: true
+          tags: |
+            hoophq/hoop:${{ github.sha }}-amd64
+
+  docker-publish-hoopgateway-multiarch:
+    runs-on: ubuntu-latest
+    name: Publish Gateway Image
+    environment: production
+    needs:
+      - docker-publish-hoopgateway-amd64
+      - docker-publish-hoopgateway-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoop
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Create SHA manifest and push
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: |
+          docker manifest create hoophq/hoop:${{ env.GIT_TAG }} \
+            --amend hoophq/hoop:${{ github.sha }}-amd64 \
+            --amend hoophq/hoop:${{ github.sha }}-arm64
+          docker manifest push hoophq/hoop:${{ env.GIT_TAG }}
+
+  docker-publish-hoopagent-arm64:
+    runs-on: GitHub-Linux-Arm-Runner
+    name: Dck Publish Agent (arm64)
+    environment: production
+    needs:
+      - build-tar-files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoopdev
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-artifacts-*
+          merge-multiple: true
+          path: dist/
+      - name: Build and Push
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.dev
+          context: '.'
+          platforms: linux/arm64
+          provenance: false
+          sbom: false
+          push: true
+          tags: |
+            hoophq/hoopdev:${{ github.sha }}-arm64
+
+  docker-publish-hoopagent-amd64:
+    runs-on: ubuntu-latest
+    name: Dck Publish Agent (amd64)
+    environment: production
+    needs:
+      - build-tar-files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoopdev
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-artifacts-*
+          merge-multiple: true
+          path: dist/
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.dev
+          context: '.'
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          push: true
+          tags: |
+            hoophq/hoopdev:${{ github.sha }}-amd64
+
+  docker-publish-hoopagent-multiarch:
+    runs-on: ubuntu-latest
+    name: Publish Hoopagent Image
+    environment: production
+    needs:
+      - docker-publish-hoopagent-amd64
+      - docker-publish-hoopagent-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoopdev
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Create SHA manifest and push
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: |
+          docker manifest create hoophq/hoopdev:${{ env.GIT_TAG }} \
+            --amend hoophq/hoopdev:${{ github.sha }}-amd64 \
+            --amend hoophq/hoopdev:${{ github.sha }}-arm64
+          docker manifest push hoophq/hoopdev:${{ env.GIT_TAG }}
+
+  publish-release:
+    runs-on: ubuntu-latest
+    name: Publish Release
+    environment: production
+    needs:
+      - docker-publish-hoopgateway-multiarch
+      - docker-publish-hoopagent-multiarch
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v4
+        id: download
+        with:
+          pattern: dist-artifacts-*
+          merge-multiple: true
+          path: dist/
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build Gateway Bundle (amd64)
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+          GOARCH: amd64
+        run: make build-gateway-bundle
+
+      - name: Build Gateway Bundle (arm64)
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+          GOARCH: arm64
+        run: make build-gateway-bundle
+
+      - name: Build Helm Chart
+        env:
+          GIT_TAG: "${{ env.GIT_TAG }}"
+          GITHUB_CONTAINER_REGISTRY_TOKEN: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
+          GITHUB_USERNAME: ${{ github.actor }}
+        run: make build-helm-chart
+
+      - name: Publish Release to S3
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          AWS_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: make release-s3
+
+  deploy-sandbox:
+    runs-on: ubuntu-latest
+    name: Deploy to Sandbox
+    environment: production
+    needs:
+      - publish-release
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      - name: Set Git Tag
+        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Trigger Sandbox Deploy
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: |-
+          gh workflow run deploy-by-app.yml \
+            --repo hoophq/infra \
+            -f version="${GIT_TAG}" \
+            -f app=sandbox
+          echo "Triggered sandbox deploy with version ${GIT_TAG}"

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -59,7 +59,7 @@ jobs:
           rustup target add aarch64-apple-darwin
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build Darwin Rust Binaries
         env:
@@ -93,7 +93,7 @@ jobs:
           rustup target add x86_64-unknown-linux-gnu
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build Linux Rust Binaries
         env:
@@ -127,7 +127,7 @@ jobs:
           rustup target add aarch64-unknown-linux-gnu
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build Linux Rust Binaries
         env:
@@ -172,7 +172,7 @@ jobs:
         run: make generate-wasm
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: amd64
         env:
@@ -217,7 +217,7 @@ jobs:
         run: make generate-wasm
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build
         env:
@@ -262,7 +262,7 @@ jobs:
         run: make generate-wasm
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build
         env:
@@ -307,7 +307,7 @@ jobs:
         run: make generate-wasm
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build
         env:
@@ -352,7 +352,7 @@ jobs:
         run: make generate-wasm
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build
         env:
@@ -401,7 +401,7 @@ jobs:
         run: make generate-wasm
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build
         env:
@@ -476,7 +476,7 @@ jobs:
           path: dist/
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Merge Artifacts into dist/
         env:
@@ -602,7 +602,7 @@ jobs:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Create SHA manifest and push
         env:
           GIT_TAG: ${{ env.GIT_TAG }}
@@ -711,7 +711,7 @@ jobs:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Create SHA manifest and push
         env:
           GIT_TAG: ${{ env.GIT_TAG }}
@@ -741,7 +741,7 @@ jobs:
           path: dist/
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build Gateway Bundle (amd64)
         env:
@@ -783,7 +783,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set Git Tag
-        run: echo "GIT_TAG=0.0.0-dev-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_TAG=0.0.0-nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Trigger Sandbox Deploy
         env:
@@ -795,3 +795,9 @@ jobs:
             -f version="${GIT_TAG}" \
             -f app=sandbox
           echo "Triggered sandbox deploy with version ${GIT_TAG}"
+
+      - name: Publish Nightly Brew Recipe
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: gh workflow run release.yml -f version=$GIT_TAG --repo hoophq/brew-nightly

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -1,0 +1,105 @@
+name: Migration Safety Check
+
+on:
+  pull_request:
+    paths:
+      - 'rootfs/app/migrations/**'
+
+jobs:
+  analyze-migrations:
+    name: Analyze Migration Safety
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Detect Migration Changes
+        id: detect
+        run: |-
+          BASE_REF="${{ github.base_ref }}"
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- 'rootfs/app/migrations/' || true)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No migration files changed"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+          MIGRATION_CONTENT=""
+          for file in $CHANGED_FILES; do
+            if [ -f "$file" ]; then
+              MIGRATION_CONTENT="${MIGRATION_CONTENT}
+          --- FILE: ${file} ---
+          $(cat "$file")
+          --- END FILE ---
+          "
+            fi
+          done
+          echo "$MIGRATION_CONTENT" > /tmp/migration_content.txt
+          echo "$CHANGED_FILES" > /tmp/changed_files.txt
+          echo "Changed migration files:"
+          echo "$CHANGED_FILES"
+
+      - name: Analyze with Claude
+        if: steps.detect.outputs.has_changes == 'true'
+        id: analyze
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |-
+          chmod +x ./scripts/check-migration-safety.sh
+          if ./scripts/check-migration-safety.sh; then
+            echo "analysis_failed=false" >> $GITHUB_OUTPUT
+          else
+            echo "analysis_failed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post PR Comment
+        if: steps.detect.outputs.has_changes == 'true' && steps.analyze.outputs.analysis_failed == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |-
+          ANALYSIS=$(cat /tmp/analysis.txt)
+          COMMENT_BODY="<!-- migration-check-bot -->
+          ${ANALYSIS}
+
+          ---
+          *Automated analysis by Migration Safety Check. Review carefully -- LLM analysis may miss edge cases.*"
+          EXISTING_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("<!-- migration-check-bot -->")) | .id' \
+            | head -1)
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" -f body="$COMMENT_BODY"
+            echo "Updated existing comment ${EXISTING_COMMENT_ID}"
+          else
+            gh pr comment "${PR_NUMBER}" --body "$COMMENT_BODY"
+            echo "Posted new comment"
+          fi
+
+      - name: Post Fallback Comment
+        if: steps.detect.outputs.has_changes == 'true' && steps.analyze.outputs.analysis_failed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |-
+          CHANGED_FILES=$(cat /tmp/changed_files.txt)
+          COMMENT="<!-- migration-check-bot -->
+          ## Migration Safety Analysis
+
+          :warning: **Automated analysis unavailable** -- the LLM API call failed. Please review these migration files manually:
+
+          \`\`\`
+          ${CHANGED_FILES}
+          \`\`\`
+
+          Check for:
+          - Destructive operations (DROP TABLE, DROP COLUMN, TRUNCATE)
+          - Missing or noop .down.sql files
+          - Rollback safety for sandbox deployments
+          ---
+          *Automated analysis by Migration Safety Check.*"
+          gh pr comment "${PR_NUMBER}" --body "$COMMENT"

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -2,8 +2,6 @@ name: Migration Safety Check
 
 on:
   pull_request:
-    paths:
-      - 'rootfs/app/migrations/**'
 
 jobs:
   analyze-migrations:
@@ -103,3 +101,25 @@ jobs:
           ---
           *Automated analysis by Migration Safety Check.*"
           gh pr comment "${PR_NUMBER}" --body "$COMMENT"
+
+      - name: Post No Migrations Comment
+        if: steps.detect.outputs.has_changes == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |-
+          COMMENT_BODY="<!-- migration-check-bot -->
+          ## Migration Safety Analysis
+
+          No database migrations were changed in this PR. Safe to deploy to sandbox."
+          EXISTING_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("<!-- migration-check-bot -->")) | .id' \
+            | head -1)
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" -f body="$COMMENT_BODY"
+            echo "Updated existing comment ${EXISTING_COMMENT_ID}"
+          else
+            gh pr comment "${PR_NUMBER}" --body "$COMMENT_BODY"
+            echo "Posted new comment"
+          fi

--- a/scripts/check-migration-safety.sh
+++ b/scripts/check-migration-safety.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Migration Safety Check - Analyzes migration files using Claude API
+# Usage: ./scripts/check-migration-safety.sh
+#
+# Required environment variables:
+#   ANTHROPIC_API_KEY - API key for Claude (or proxy auth token)
+#
+# Optional environment variables:
+#   ANTHROPIC_BASE_URL  - Base URL including /v1 path (default: https://api.anthropic.com/v1)
+#   ANTHROPIC_AUTH_HEADER - If set, sends an "Authorization" header with this value
+#                           (useful for proxied API access through hoop)
+#
+# Expected input files:
+#   /tmp/migration_content.txt - Contents of changed migration files
+#   /tmp/changed_files.txt     - List of changed file paths
+#
+# Output:
+#   /tmp/analysis.txt          - The LLM analysis in Markdown
+#   Exit code 0 = success, 1 = API failure
+
+set -euo pipefail
+
+# Strip trailing slash from base URL, default to standard Anthropic API
+BASE_URL="${ANTHROPIC_BASE_URL:-https://api.anthropic.com/v1}"
+BASE_URL="${BASE_URL%/}"
+
+MIGRATION_CONTENT=$(cat /tmp/migration_content.txt)
+CHANGED_FILES=$(cat /tmp/changed_files.txt)
+
+SYSTEM_PROMPT='You are a database migration safety analyzer for a Go application that uses golang-migrate (v4) with PostgreSQL.
+
+Context about this project'\''s migration system:
+- SQL migrations live in rootfs/app/migrations/ with sequential numbering (000001, 000002, etc.)
+- Each migration MUST have both a .up.sql and .down.sql file
+- The gateway runs migrations automatically on startup via golang-migrate'\''s m.Up()
+- Production builds only ship .up.sql files (down migrations are dev-only)
+- The gateway can tolerate running against a DB with a newer schema version (it logs a warning but does not crash)
+- If a migration fails mid-execution, the DB enters a "dirty" state requiring manual intervention
+- There are also Go-coded migrations that run after SQL migrations -- these are forward-only with no rollback path
+
+Your job is to analyze new or modified migration files and produce a safety report. Focus on:
+
+1. **Rollback Safety**: Can this migration be safely rolled back using the .down.sql? Is the down migration a noop?
+2. **Destructive Operations**: Does the .up.sql contain DROP TABLE, DROP COLUMN, TRUNCATE, DELETE, or ALTER TYPE that could lose data?
+3. **Down Migration Quality**: Does the .down.sql actually reverse what the .up.sql does? Are there mismatches?
+4. **Sandbox Deploy Risk**: If this migration is applied to the sandbox environment, what is the risk level for iterative development? Can we roll back the gateway binary to a previous version without issues?
+5. **Missing Pairs**: Are there .up.sql files without corresponding .down.sql files or vice versa?
+6. **Best Practices**: Any other concerns (e.g., missing IF EXISTS guards, large table locks, missing indexes on foreign keys, etc.)
+
+Output your analysis as a GitHub-flavored Markdown comment. Use this structure:
+
+## Migration Safety Analysis
+
+### Summary
+[One-line overall risk assessment: LOW / MEDIUM / HIGH]
+
+### Files Analyzed
+[List of files]
+
+### Findings
+[Detailed findings organized by category, using checkboxes:]
+- [ ] or [x] for each check
+
+### Recommendations
+[Actionable recommendations if any issues found]
+
+Keep it concise but thorough. If everything looks safe, say so clearly.'
+
+USER_PROMPT="Please analyze the following migration files for safety:
+
+Changed files:
+${CHANGED_FILES}
+
+File contents:
+${MIGRATION_CONTENT}"
+
+# Build curl headers
+CURL_HEADERS=(
+  -H "content-type: application/json"
+  -H "x-api-key: ${ANTHROPIC_API_KEY}"
+  -H "anthropic-version: 2023-06-01"
+)
+
+# Add Authorization header if provided (for proxied access through hoop)
+if [ -n "${ANTHROPIC_AUTH_HEADER:-}" ]; then
+  CURL_HEADERS+=(-H "Authorization: ${ANTHROPIC_AUTH_HEADER}")
+fi
+
+# Call Claude API using jq to safely build the JSON payload
+RESPONSE=$(curl -s --max-time 120 -w "\n%{http_code}" "${BASE_URL}/messages" \
+  "${CURL_HEADERS[@]}" \
+  -d "$(jq -n \
+    --arg system "$SYSTEM_PROMPT" \
+    --arg user "$USER_PROMPT" \
+    '{
+      model: "claude-haiku-4-5",
+      max_tokens: 4096,
+      system: $system,
+      messages: [{role: "user", content: $user}]
+    }')")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "Claude API returned HTTP ${HTTP_CODE}"
+  echo "$BODY"
+  exit 1
+fi
+
+# Extract the text content from Claude's response
+ANALYSIS=$(echo "$BODY" | jq -r '.content[0].text')
+
+echo "$ANALYSIS" > /tmp/analysis.txt
+echo "Migration analysis complete"


### PR DESCRIPTION
## Summary

- Adds a `dev-release.yml` workflow that triggers a full build pipeline on pushes to the `dev` branch, producing `0.0.0-nightly-{SHA}` versioned artifacts (Docker images, Helm chart, S3) and auto-deploying to sandbox via infra's `deploy-by-app.yml`
- Adds a `migration-check.yml` workflow that runs on all PRs, using Claude (Haiku 4.5) to analyze migration safety and post a PR comment with findings
- Adds `scripts/check-migration-safety.sh` supporting both direct Anthropic API and proxied access through hoop
- Creates [`hoophq/brew-nightly`](https://github.com/hoophq/brew-nightly) tap for nightly CLI installs

## Dev Branch Workflow

1. Developers merge feature PRs into `dev` for sandbox testing
2. Every push to `dev` triggers: full build (all OS/arch) -> Docker images -> Helm chart -> S3 -> auto-deploy to sandbox
3. Version format: `0.0.0-nightly-{SHORT_SHA}` (valid semver, clearly distinguishable from releases)
4. No `latest` tag overwrite, no Sentry/CF template updates
5. Publishes nightly Homebrew recipe to `hoophq/brew-nightly`

### Nightly CLI Install

```sh
brew tap hoophq/brew-nightly https://github.com/hoophq/brew-nightly.git
brew install hoop
```

## Migration Safety Check

- Runs on **every PR** (not just ones touching migrations)
- When migrations change: calls Claude API to analyze rollback safety, destructive operations, down migration quality, and sandbox deploy risk
- When no migrations change: posts "No database migrations changed, safe to deploy"
- Updates existing bot comment instead of creating duplicates

## Setup Required

- [x] Add `ANTHROPIC_API_KEY` secret to GitHub repo settings
- [x] Verify `GH_TOKEN` has permissions to trigger workflows in `hoophq/infra`