### PR TITLE
Implement rejection reason handling in session reviews

### DIFF
--- a/client/cmd/resources.go
+++ b/client/cmd/resources.go
@@ -262,8 +262,8 @@ func runResourcesCreate(name string) {
 	envVars := parseKeyValuePairs(resourcesCreateFlags.envVars)
 
 	payload := map[string]any{
-		"name":    name,
-		"type":    resourcesCreateFlags.resType,
+		"name":     name,
+		"type":     resourcesCreateFlags.resType,
 		"env_vars": envVars,
 	}
 	if resourcesCreateFlags.subtype != "" {

--- a/client/cmd/sessions.go
+++ b/client/cmd/sessions.go
@@ -529,6 +529,17 @@ func displaySession(s map[string]any) {
 		}
 	}
 
+	// Rejection reason (stored in session metadata after a rejection).
+	if metadata, ok := s["metadata"].(map[string]any); ok {
+		if reason, ok := metadata["rejection_reason"].(string); ok && reason != "" {
+			sep()
+			fmt.Fprintln(w, "  Rejection Reason")
+			for _, line := range strings.Split(reason, "\n") {
+				fmt.Fprintf(w, "    %s\n", line)
+			}
+		}
+	}
+
 	// AI analysis section.
 	if ai, ok := s["ai_analysis"].(map[string]any); ok {
 		sep()

--- a/client/cmd/sessions.go
+++ b/client/cmd/sessions.go
@@ -527,11 +527,8 @@ func displaySession(s map[string]any) {
 				}
 			}
 		}
-	}
 
-	// Rejection reason (stored in session metadata after a rejection).
-	if metadata, ok := s["metadata"].(map[string]any); ok {
-		if reason, ok := metadata["rejection_reason"].(string); ok && reason != "" {
+		if reason := toStr(review["rejection_reason"]); reason != "-" && reason != "" {
 			sep()
 			fmt.Fprintln(w, "  Rejection Reason")
 			for _, line := range strings.Split(reason, "\n") {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -761,9 +761,10 @@ type ReviewRequest struct {
 	// * APPROVED - Approve the review resource
 	// * REJECTED - Reject the review resource
 	// * REVOKED - Revoke an approved review
-	Status      ReviewRequestStatusType  `json:"status" binding:"required" example:"APPROVED"`
-	TimeWindow  *ReviewSessionTimeWindow `json:"time_window"`
-	ForceReview bool                     `json:"force_review" example:"false"`
+	Status          ReviewRequestStatusType  `json:"status" binding:"required" example:"APPROVED"`
+	TimeWindow      *ReviewSessionTimeWindow `json:"time_window"`
+	ForceReview     bool                     `json:"force_review" example:"false"`
+	RejectionReason string                   `json:"rejection_reason" example:"This command is not allowed in production."`
 }
 
 type SessionReview struct {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -764,7 +764,7 @@ type ReviewRequest struct {
 	Status          ReviewRequestStatusType  `json:"status" binding:"required" example:"APPROVED"`
 	TimeWindow      *ReviewSessionTimeWindow `json:"time_window"`
 	ForceReview     bool                     `json:"force_review" example:"false"`
-	RejectionReason string                   `json:"rejection_reason" example:"This command is not allowed in production."`
+	RejectionReason string `json:"rejection_reason" example:"This command is not allowed in production."`
 }
 
 type SessionReview struct {
@@ -799,6 +799,8 @@ type SessionReview struct {
 	MinApprovals *int `json:"min_approvals" readonly:"true" example:"2"`
 	// Groups that can force approve sessions for this review
 	ForceApprovalGroups []string `json:"force_approval_groups" readonly:"true" example:"sre-team"`
+	// The reason provided by the reviewer when rejecting this review
+	RejectionReason *string `json:"rejection_reason,omitempty" readonly:"true" example:"This command is not allowed in production."`
 }
 
 type ReviewSessionTimeWindow struct {
@@ -840,6 +842,8 @@ type Review struct {
 	MinApprovals *int `json:"min_approvals" readonly:"true" example:"2"`
 	// Groups that can force approve sessions for this review
 	ForceApprovalGroups []string `json:"force_approval_groups" readonly:"true" example:"sre-team"`
+	// The reason provided by the reviewer when rejecting this review
+	RejectionReason *string `json:"rejection_reason,omitempty" readonly:"true" example:"This command is not allowed in production."`
 }
 
 type ReviewOwner struct {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -764,7 +764,7 @@ type ReviewRequest struct {
 	Status          ReviewRequestStatusType  `json:"status" binding:"required" example:"APPROVED"`
 	TimeWindow      *ReviewSessionTimeWindow `json:"time_window"`
 	ForceReview     bool                     `json:"force_review" example:"false"`
-	RejectionReason string `json:"rejection_reason" example:"This command is not allowed in production."`
+	RejectionReason string                   `json:"rejection_reason" example:"This command is not allowed in production."`
 }
 
 type SessionReview struct {

--- a/gateway/api/review/review.go
+++ b/gateway/api/review/review.go
@@ -490,6 +490,6 @@ func toOpenApiReview(r *models.Review) *openapi.Review {
 		AccessRequestRuleName: r.AccessRequestRuleName,
 		MinApprovals:          r.MinApprovals,
 		ForceApprovalGroups:   r.ForceApprovalGroups,
-		RejectionReason: r.RejectionReason,
+		RejectionReason:       r.RejectionReason,
 	}
 }

--- a/gateway/api/review/review.go
+++ b/gateway/api/review/review.go
@@ -175,6 +175,11 @@ func (h *handler) ReviewByIdOrSid(c *gin.Context) {
 				rev.Status.Str(),
 			)
 		}
+		if rev.Status == models.ReviewStatusRejected && req.RejectionReason != "" {
+			if setErr := models.SetSessionRejectionReason(rev.OrgID, rev.SessionID, req.RejectionReason); setErr != nil {
+				log.Warnf("failed storing rejection reason, sid=%v, err=%v", rev.SessionID, setErr)
+			}
+		}
 		c.JSON(http.StatusOK, toOpenApiReview(rev))
 	default:
 		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed updating review status: %v", err)

--- a/gateway/api/review/review.go
+++ b/gateway/api/review/review.go
@@ -176,7 +176,7 @@ func (h *handler) ReviewByIdOrSid(c *gin.Context) {
 			)
 		}
 		if rev.Status == models.ReviewStatusRejected && req.RejectionReason != "" {
-			if setErr := models.SetSessionRejectionReason(rev.OrgID, rev.SessionID, req.RejectionReason); setErr != nil {
+			if setErr := models.SetReviewRejectionReason(rev.OrgID, rev.SessionID, req.RejectionReason); setErr != nil {
 				log.Warnf("failed storing rejection reason, sid=%v, err=%v", rev.SessionID, setErr)
 			}
 		}
@@ -490,5 +490,6 @@ func toOpenApiReview(r *models.Review) *openapi.Review {
 		AccessRequestRuleName: r.AccessRequestRuleName,
 		MinApprovals:          r.MinApprovals,
 		ForceApprovalGroups:   r.ForceApprovalGroups,
+		RejectionReason: r.RejectionReason,
 	}
 }

--- a/gateway/api/session/parser.go
+++ b/gateway/api/session/parser.go
@@ -160,7 +160,7 @@ func topOpenApiReview(r *models.SessionReview) *openapi.SessionReview {
 		AccessRequestRuleName: r.AccessRequestRuleName,
 		MinApprovals:          r.MinApprovals,
 		ForceApprovalGroups:   r.ForceApprovalGroups,
-		RejectionReason: r.RejectionReason,
+		RejectionReason:       r.RejectionReason,
 	}
 }
 

--- a/gateway/api/session/parser.go
+++ b/gateway/api/session/parser.go
@@ -160,6 +160,7 @@ func topOpenApiReview(r *models.SessionReview) *openapi.SessionReview {
 		AccessRequestRuleName: r.AccessRequestRuleName,
 		MinApprovals:          r.MinApprovals,
 		ForceApprovalGroups:   r.ForceApprovalGroups,
+		RejectionReason: r.RejectionReason,
 	}
 }
 

--- a/gateway/models/connections.go
+++ b/gateway/models/connections.go
@@ -580,10 +580,10 @@ func getConnectionByNameOrID(ctx UserContext, nameOrID string, tx *gorm.DB) (*Co
 		-- allow if any of the user groups are in the access control list
 		ELSE acc.config && (@user_groups)::text[]
 	END`, map[string]any{
-		"org_id":             ctx.GetOrgID(),
-		"nameOrID":           nameOrID,
+		"org_id":              ctx.GetOrgID(),
+		"nameOrID":            nameOrID,
 		"is_admin_or_auditor": ctx.IsAdmin() || isAuditorContext(ctx),
-		"user_groups":        userGroups,
+		"user_groups":         userGroups,
 	}).
 		First(&conn).
 		Error

--- a/gateway/models/reviews.go
+++ b/gateway/models/reviews.go
@@ -53,9 +53,10 @@ type Review struct {
 	ForceApprovalGroups   pq.StringArray `gorm:"column:force_approval_groups;type:text[]"`
 	MinApprovals          *int           `gorm:"column:min_approvals"`
 
-	CreatedAt  time.Time         `gorm:"column:created_at"`
-	RevokedAt  *time.Time        `gorm:"column:revoked_at"`
-	TimeWindow *ReviewTimeWindow `gorm:"column:time_window;serializer:json;"`
+	CreatedAt       time.Time         `gorm:"column:created_at"`
+	RevokedAt       *time.Time        `gorm:"column:revoked_at"`
+	TimeWindow      *ReviewTimeWindow `gorm:"column:time_window;serializer:json;"`
+	RejectionReason *string `gorm:"column:rejection_reason"`
 }
 
 type ReviewTimeWindow struct {

--- a/gateway/models/reviews.go
+++ b/gateway/models/reviews.go
@@ -56,7 +56,7 @@ type Review struct {
 	CreatedAt       time.Time         `gorm:"column:created_at"`
 	RevokedAt       *time.Time        `gorm:"column:revoked_at"`
 	TimeWindow      *ReviewTimeWindow `gorm:"column:time_window;serializer:json;"`
-	RejectionReason *string `gorm:"column:rejection_reason"`
+	RejectionReason *string           `gorm:"column:rejection_reason"`
 }
 
 type ReviewTimeWindow struct {

--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -152,6 +152,7 @@ type SessionReview struct {
 	AccessRequestRuleName *string           `json:"access_request_rule_name"`
 	ForceApprovalGroups   pq.StringArray    `json:"force_approval_groups" gorm:"force_approval_groups;serializer:json;"`
 	MinApprovals          *int              `json:"min_approvals"`
+	RejectionReason *string `json:"rejection_reason"`
 }
 
 func (r *SessionReview) Scan(value any) error {
@@ -235,6 +236,7 @@ func GetSessionByID(orgID, sid string) (*Session, error) {
 				'access_request_rule_name', rv.access_request_rule_name,
 				'min_approvals', rv.min_approvals,
 				'force_approval_groups', rv.force_approval_groups,
+				'rejection_reason', rv.rejection_reason,
 				'created_at', to_char(rv.created_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
 				'revoked_at', to_char(rv.revoked_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
 				'review_groups', (
@@ -358,6 +360,7 @@ func ListSessions(orgID string, userId string, isAuditorOrAdmin bool, opt Sessio
 					'type', rv.type,
 					'access_duration_sec', rv.access_duration_sec,
 					'status', rv.status,
+					'rejection_reason', rv.rejection_reason,
 					'created_at', to_char(rv.created_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
 					'revoked_at', to_char(rv.revoked_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
 					'review_groups', (
@@ -620,17 +623,11 @@ func UpdateSessionGuardRailsInfo(orgID, sid string, info []byte) error {
 	return res.Error
 }
 
-// SetSessionRejectionReason stores the rejection reason in the session metadata.
-// Unlike UpdateSessionMetadata, this function does not require the session owner's email,
-// allowing reviewers to set the reason after rejecting a request.
-func SetSessionRejectionReason(orgID, sessionID, reason string) error {
-	value, err := json.Marshal(map[string]string{"rejection_reason": reason})
-	if err != nil {
-		return fmt.Errorf("failed to encode rejection reason: %w", err)
-	}
-	res := DB.Table("private.sessions").
-		Where("org_id = ? AND id = ?", orgID, sessionID).
-		Update("metadata", gorm.Expr("COALESCE(metadata, '{}'::jsonb) || ?::jsonb", string(value)))
+// SetReviewRejectionReason stores the rejection reason on the review record for the given session.
+func SetReviewRejectionReason(orgID, sessionID, reason string) error {
+	res := DB.Table("private.reviews").
+		Where("org_id = ? AND session_id = ?", orgID, sessionID).
+		Update("rejection_reason", reason)
 	if res.Error == nil && res.RowsAffected == 0 {
 		return ErrNotFound
 	}

--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -152,7 +152,7 @@ type SessionReview struct {
 	AccessRequestRuleName *string           `json:"access_request_rule_name"`
 	ForceApprovalGroups   pq.StringArray    `json:"force_approval_groups" gorm:"force_approval_groups;serializer:json;"`
 	MinApprovals          *int              `json:"min_approvals"`
-	RejectionReason *string `json:"rejection_reason"`
+	RejectionReason       *string           `json:"rejection_reason"`
 }
 
 func (r *SessionReview) Scan(value any) error {

--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -620,6 +620,23 @@ func UpdateSessionGuardRailsInfo(orgID, sid string, info []byte) error {
 	return res.Error
 }
 
+// SetSessionRejectionReason stores the rejection reason in the session metadata.
+// Unlike UpdateSessionMetadata, this function does not require the session owner's email,
+// allowing reviewers to set the reason after rejecting a request.
+func SetSessionRejectionReason(orgID, sessionID, reason string) error {
+	value, err := json.Marshal(map[string]string{"rejection_reason": reason})
+	if err != nil {
+		return fmt.Errorf("failed to encode rejection reason: %w", err)
+	}
+	res := DB.Table("private.sessions").
+		Where("org_id = ? AND id = ?", orgID, sessionID).
+		Update("metadata", gorm.Expr("COALESCE(metadata, '{}'::jsonb) || ?::jsonb", string(value)))
+	if res.Error == nil && res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return res.Error
+}
+
 func UpdateSessionMetadata(orgID, userEmail, sid string, metadata map[string]any) error {
 	res := DB.Table("private.sessions").
 		Where("org_id = ? AND id = ? AND user_email = ?", orgID, sid, userEmail).

--- a/gateway/slack/events.go
+++ b/gateway/slack/events.go
@@ -18,7 +18,6 @@ type rejectModalMetadata struct {
 	EventKind string `json:"event_kind"`
 	GroupName string `json:"group_name"`
 	SlackID   string `json:"slack_id"`
-	SlackName string `json:"slack_name"`
 }
 
 // ProcessEvents start the websocket connection and process the events
@@ -90,7 +89,6 @@ func (s *SlackService) processInteractive(respCh chan *MessageReviewResponse, ev
 				EventKind: fmt.Sprintf("%v", cb.Message.Metadata.EventType),
 				GroupName: groupName,
 				SlackID:   cb.User.ID,
-				SlackName: cb.User.Name,
 			}
 			metaJSON, err := json.Marshal(meta)
 			// OpenRejectModal must be called before Ack() — TriggerID expires ~3s after interaction.
@@ -135,19 +133,6 @@ func (s *SlackService) processInteractive(respCh chan *MessageReviewResponse, ev
 		if block, ok := cb.View.State.Values["rejection_reason_block"]; ok {
 			if elem, ok := block["rejection_reason"]; ok {
 				reason = elem.Value
-			}
-		}
-		addUsername := false
-		if block, ok := cb.View.State.Values["add_username_block"]; ok {
-			if elem, ok := block["add_username"]; ok && len(elem.SelectedOptions) > 0 {
-				addUsername = true
-			}
-		}
-		if addUsername && meta.SlackName != "" {
-			if reason != "" {
-				reason = reason + "\nRejected by " + meta.SlackName
-			} else {
-				reason = "Rejected by " + meta.SlackName
 			}
 		}
 		// Retrieve the original block-action callback so UpdateMessage has the channel,

--- a/gateway/slack/events.go
+++ b/gateway/slack/events.go
@@ -1,6 +1,7 @@
 package slack
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,16 @@ import (
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/socketmode"
 )
+
+// rejectModalMetadata holds the review context serialized into a Slack modal's private_metadata.
+type rejectModalMetadata struct {
+	ReviewID  string `json:"review_id"`
+	SessionID string `json:"session_id"`
+	EventKind string `json:"event_kind"`
+	GroupName string `json:"group_name"`
+	SlackID   string `json:"slack_id"`
+	SlackName string `json:"slack_name"`
+}
 
 // ProcessEvents start the websocket connection and process the events
 // in a go routine. It's a blocking method
@@ -50,27 +61,58 @@ func (s *SlackService) processInteractive(respCh chan *MessageReviewResponse, ev
 		log.Debugf("ignored %+v\n", ev)
 		return
 	}
-	log.Infof("received interaction, user=%v, domain=%s, metaevent=%s",
-		cb.User.ID, cb.Team.Domain, cb.Message.Metadata.EventType)
+	log.Infof("received interaction, user=%v, domain=%s, type=%s",
+		cb.User.ID, cb.Team.Domain, cb.Type)
 
 	switch cb.Type {
 	case slack.InteractionTypeBlockActions:
 		// See https://api.slack.com/apis/connections/socket-implement#button
+		actionID := cb.ActionCallback.BlockActions[0].ActionID
+
+		// reviewUID:GroupName:IndexNo
+		blockID := cb.ActionCallback.BlockActions[0].BlockID
+		groupName := ""
+		if parts := strings.Split(blockID, ":"); len(parts) == 3 {
+			groupName = parts[1]
+		}
+
+		if actionID == "review-rejected" {
+			// Persist the block-action callback so the view submission handler can use it
+			// as the item — preserving channel, message blocks, responseURL, etc.
+			reviewID := fmt.Sprintf("%v", cb.Message.Metadata.EventPayload[reviewIDMetadataKey])
+			s.pendingRejectMu.Lock()
+			s.pendingRejectItems[reviewID] = cb
+			s.pendingRejectMu.Unlock()
+
+			meta := rejectModalMetadata{
+				ReviewID:  reviewID,
+				SessionID: fmt.Sprintf("%v", cb.Message.Metadata.EventPayload[sessionIDMetadataKey]),
+				EventKind: fmt.Sprintf("%v", cb.Message.Metadata.EventType),
+				GroupName: groupName,
+				SlackID:   cb.User.ID,
+				SlackName: cb.User.Name,
+			}
+			metaJSON, err := json.Marshal(meta)
+			// OpenRejectModal must be called before Ack() — TriggerID expires ~3s after interaction.
+			if err != nil {
+				log.Warnf("failed to serialize reject modal metadata: %v", err)
+			} else if err := s.OpenRejectModal(cb, string(metaJSON)); err != nil {
+				log.Warnf("failed to open reject modal: %v", err)
+			}
+			log.Info("sending ack back to slack (reject modal opened)!")
+			s.socketClient.Ack(*ev.Request, nil)
+			return
+		}
+
+		// Approved path — send directly to the processing channel.
 		reviewResponse := MessageReviewResponse{
 			EventKind: fmt.Sprintf("%v", cb.Message.Metadata.EventType),
 			ID:        fmt.Sprintf("%v", cb.Message.Metadata.EventPayload[reviewIDMetadataKey]),
 			SessionID: fmt.Sprintf("%v", cb.Message.Metadata.EventPayload[sessionIDMetadataKey]),
-			Status:    "rejected",
+			Status:    "approved",
 			SlackID:   cb.User.ID,
+			GroupName: groupName,
 			item:      cb,
-		}
-		if cb.ActionCallback.BlockActions[0].ActionID == "review-approved" {
-			reviewResponse.Status = "approved"
-		}
-		// reviewUID:GroupName:IndexNo
-		blockID := cb.ActionCallback.BlockActions[0].BlockID
-		if parts := strings.Split(blockID, ":"); len(parts) == 3 {
-			reviewResponse.GroupName = parts[1]
 		}
 		select {
 		case respCh <- &reviewResponse:
@@ -78,6 +120,66 @@ func (s *SlackService) processInteractive(respCh chan *MessageReviewResponse, ev
 			log.Warnf("timeout (2s) on sending review response, id=%v, status=%v",
 				reviewResponse.ID, reviewResponse.Status)
 		}
+
+	case slack.InteractionTypeViewSubmission:
+		if cb.View.CallbackID != "reject-details-modal" {
+			break
+		}
+		var meta rejectModalMetadata
+		if err := json.Unmarshal([]byte(cb.View.PrivateMetadata), &meta); err != nil {
+			log.Warnf("failed to parse reject modal metadata: %v", err)
+			s.socketClient.Ack(*ev.Request, nil)
+			return
+		}
+		reason := ""
+		if block, ok := cb.View.State.Values["rejection_reason_block"]; ok {
+			if elem, ok := block["rejection_reason"]; ok {
+				reason = elem.Value
+			}
+		}
+		addUsername := false
+		if block, ok := cb.View.State.Values["add_username_block"]; ok {
+			if elem, ok := block["add_username"]; ok && len(elem.SelectedOptions) > 0 {
+				addUsername = true
+			}
+		}
+		if addUsername && meta.SlackName != "" {
+			if reason != "" {
+				reason = reason + "\nRejected by " + meta.SlackName
+			} else {
+				reason = "Rejected by " + meta.SlackName
+			}
+		}
+		// Retrieve the original block-action callback so UpdateMessage has the channel,
+		// message blocks, and responseURL — making reject behave identically to approve.
+		s.pendingRejectMu.Lock()
+		originalCb, hasPending := s.pendingRejectItems[meta.ReviewID]
+		if hasPending {
+			delete(s.pendingRejectItems, meta.ReviewID)
+		}
+		s.pendingRejectMu.Unlock()
+
+		item := cb
+		if hasPending {
+			item = originalCb
+		}
+
+		reviewResponse := MessageReviewResponse{
+			EventKind:       meta.EventKind,
+			ID:              meta.ReviewID,
+			SessionID:       meta.SessionID,
+			Status:          "rejected",
+			SlackID:         meta.SlackID,
+			GroupName:       meta.GroupName,
+			RejectionReason: reason,
+			item:            item,
+		}
+		select {
+		case respCh <- &reviewResponse:
+		case <-time.After(time.Second * 2):
+			log.Warnf("timeout (2s) on sending rejection review response, id=%v", reviewResponse.ID)
+		}
+
 	default:
 	}
 	log.Info("sending ack back to slack!")

--- a/gateway/slack/service.go
+++ b/gateway/slack/service.go
@@ -297,25 +297,6 @@ func (s *SlackService) OpenRejectModal(cb slack.InteractionCallback, privateMeta
 	)
 	commentBlock.Optional = true
 
-	usernameCheckbox := &slack.CheckboxGroupsBlockElement{
-		Type:     slack.METCheckboxGroups,
-		ActionID: "add_username",
-		Options: []*slack.OptionBlockObject{
-			{
-				Text:        &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Add username"},
-				Description: &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Include your username to the details when rejecting this access request."},
-				Value:       "add_username",
-			},
-		},
-	}
-	usernameBlock := slack.NewInputBlock(
-		"add_username_block",
-		&slack.TextBlockObject{Type: slack.PlainTextType, Text: "Add username"},
-		nil,
-		usernameCheckbox,
-	)
-	usernameBlock.Optional = true
-
 	_, err := s.apiClient.OpenView(cb.TriggerID, slack.ModalViewRequest{
 		Type:            slack.VTModal,
 		CallbackID:      "reject-details-modal",
@@ -327,10 +308,9 @@ func (s *SlackService) OpenRejectModal(cb slack.InteractionCallback, privateMeta
 			BlockSet: []slack.Block{
 				slack.NewSectionBlock(&slack.TextBlockObject{
 					Type: slack.MarkdownType,
-					Text: "Optionally include more details or identification for this access request rejection.",
+					Text: "Optionally include more details for this access request rejection.",
 				}, nil, nil),
 				commentBlock,
-				usernameBlock,
 			},
 		},
 	})

--- a/gateway/slack/service.go
+++ b/gateway/slack/service.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hoophq/hoop/common/log"
@@ -22,6 +23,11 @@ type SlackService struct {
 	apiURL        string
 	ctx           context.Context
 	cancelFn      context.CancelFunc
+
+	// pendingRejectItems stores the original block-action InteractionCallback while the
+	// reject-reason modal is open. Key is review_id. Cleaned up on modal submission.
+	pendingRejectMu    sync.Mutex
+	pendingRejectItems map[string]slack.InteractionCallback
 }
 
 const (
@@ -52,14 +58,15 @@ func New(slackBotToken, slackAppToken, slackChannel, instanceID, apiURL string) 
 	)
 	ctx, cancelFn := context.WithCancel(context.Background())
 	return &SlackService{
-		apiClient:     apiClient,
-		socketClient:  socketClient,
-		slackChannel:  slackChannel,
-		slackBotToken: slackBotToken,
-		instanceID:    instanceID,
-		apiURL:        apiURL,
-		ctx:           ctx,
-		cancelFn:      cancelFn,
+		apiClient:          apiClient,
+		socketClient:       socketClient,
+		slackChannel:       slackChannel,
+		slackBotToken:      slackBotToken,
+		instanceID:         instanceID,
+		apiURL:             apiURL,
+		ctx:                ctx,
+		cancelFn:           cancelFn,
+		pendingRejectItems: make(map[string]slack.InteractionCallback),
 	}, nil
 
 }
@@ -83,12 +90,13 @@ type MessageReviewRequest struct {
 }
 
 type MessageReviewResponse struct {
-	ID        string
-	EventKind string
-	Status    string
-	SessionID string
-	SlackID   string
-	GroupName string
+	ID              string
+	EventKind       string
+	Status          string
+	SessionID       string
+	SlackID         string
+	GroupName       string
+	RejectionReason string
 
 	item slack.InteractionCallback
 }
@@ -265,6 +273,67 @@ func (s *SlackService) UpdateMessagePartialApproval(msg *MessageReviewResponse, 
 	_, _, err := s.apiClient.PostMessage(msg.item.Channel.ID,
 		slack.MsgOptionReplaceOriginal(msg.item.ResponseURL),
 		slack.MsgOptionBlocks(blocks...))
+	return err
+}
+
+// OpenRejectModal opens a Slack modal prompting the reviewer to optionally enter a rejection reason.
+// privateMetadata is a JSON string encoding the review context (review ID, session ID, event kind, group name).
+// Must be called before socketClient.Ack() since TriggerID expires ~3s after the interaction.
+func (s *SlackService) OpenRejectModal(cb slack.InteractionCallback, privateMetadata string) error {
+	commentInput := &slack.PlainTextInputBlockElement{
+		Type:     slack.METPlainTextInput,
+		ActionID: "rejection_reason",
+		Placeholder: &slack.TextBlockObject{
+			Type: slack.PlainTextType,
+			Text: "Share the details here...",
+		},
+		Multiline: true,
+	}
+	commentBlock := slack.NewInputBlock(
+		"rejection_reason_block",
+		&slack.TextBlockObject{Type: slack.PlainTextType, Text: "Comment"},
+		nil,
+		commentInput,
+	)
+	commentBlock.Optional = true
+
+	usernameCheckbox := &slack.CheckboxGroupsBlockElement{
+		Type:     slack.METCheckboxGroups,
+		ActionID: "add_username",
+		Options: []*slack.OptionBlockObject{
+			{
+				Text:        &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Add username"},
+				Description: &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Include your username to the details when rejecting this access request."},
+				Value:       "add_username",
+			},
+		},
+	}
+	usernameBlock := slack.NewInputBlock(
+		"add_username_block",
+		&slack.TextBlockObject{Type: slack.PlainTextType, Text: "Add username"},
+		nil,
+		usernameCheckbox,
+	)
+	usernameBlock.Optional = true
+
+	_, err := s.apiClient.OpenView(cb.TriggerID, slack.ModalViewRequest{
+		Type:            slack.VTModal,
+		CallbackID:      "reject-details-modal",
+		PrivateMetadata: privateMetadata,
+		Title:           &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Reject Details"},
+		Submit:          &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Confirm and Reject"},
+		Close:           &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Cancel"},
+		Blocks: slack.Blocks{
+			BlockSet: []slack.Block{
+				slack.NewSectionBlock(&slack.TextBlockObject{
+					Type: slack.MarkdownType,
+					Text: "Optionally include more details or identification for this access request rejection.",
+				}, nil, nil),
+				commentBlock,
+				usernameBlock,
+			},
+		},
+	})
 	return err
 }
 

--- a/gateway/transport/plugins/slack/events.go
+++ b/gateway/transport/plugins/slack/events.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/hoophq/hoop/common/log"
@@ -84,7 +83,7 @@ func (p *slackPlugin) processEventResponse(ev *event) {
 func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status models.ReviewStatusType) {
 	rev, err := reviewapi.DoReview(ctx, ev.msg.ID, status, nil, false)
 	if err == nil && status == models.ReviewStatusRejected && ev.msg.RejectionReason != "" {
-		if setErr := models.SetSessionRejectionReason(ev.orgID, ev.msg.SessionID, ev.msg.RejectionReason); setErr != nil {
+		if setErr := models.SetReviewRejectionReason(ev.orgID, ev.msg.SessionID, ev.msg.RejectionReason); setErr != nil {
 			log.With("sid", ev.msg.SessionID).Warnf("failed storing rejection reason from slack, err=%v", setErr)
 		}
 	}
@@ -160,10 +159,8 @@ func (p *slackPlugin) notifyOwnerRejected(ev *event, ctx *storagev2.Context, rev
 
 	text := fmt.Sprintf("Your access request for *%s* was *rejected* by %s.", rev.ConnectionName, reviewerName)
 
-	// Include the rejection reason, stripping any trailing "Rejected by ..." line
-	// since that attribution is already in the first sentence above.
-	if reason := stripRejectedByLine(ev.msg.RejectionReason); reason != "" {
-		text += fmt.Sprintf("\n>%s", reason)
+	if ev.msg.RejectionReason != "" {
+		text += fmt.Sprintf("\n>%s", ev.msg.RejectionReason)
 	}
 
 	text += fmt.Sprintf("\nFollow this link to see the details: %s/sessions/%s", p.apiURL, rev.SessionID)
@@ -173,12 +170,3 @@ func (p *slackPlugin) notifyOwnerRejected(ev *event, ctx *storagev2.Context, rev
 	}
 }
 
-// stripRejectedByLine removes a trailing "Rejected by ..." line from a rejection reason
-// so it is not shown redundantly in contexts that already identify the reviewer.
-func stripRejectedByLine(reason string) string {
-	lines := strings.Split(strings.TrimRight(reason, "\n"), "\n")
-	for len(lines) > 0 && strings.HasPrefix(strings.TrimSpace(lines[len(lines)-1]), "Rejected by ") {
-		lines = lines[:len(lines)-1]
-	}
-	return strings.TrimSpace(strings.Join(lines, "\n"))
-}

--- a/gateway/transport/plugins/slack/events.go
+++ b/gateway/transport/plugins/slack/events.go
@@ -169,4 +169,3 @@ func (p *slackPlugin) notifyOwnerRejected(ev *event, ctx *storagev2.Context, rev
 		log.With("sid", ev.msg.SessionID).Warnf("failed sending rejection DM to session owner, err=%v", err)
 	}
 }
-

--- a/gateway/transport/plugins/slack/events.go
+++ b/gateway/transport/plugins/slack/events.go
@@ -1,7 +1,9 @@
 package slack
 
 import (
+	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/hoophq/hoop/common/log"
@@ -81,6 +83,11 @@ func (p *slackPlugin) processEventResponse(ev *event) {
 
 func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status models.ReviewStatusType) {
 	rev, err := reviewapi.DoReview(ctx, ev.msg.ID, status, nil, false)
+	if err == nil && status == models.ReviewStatusRejected && ev.msg.RejectionReason != "" {
+		if setErr := models.SetSessionRejectionReason(ev.orgID, ev.msg.SessionID, ev.msg.RejectionReason); setErr != nil {
+			log.With("sid", ev.msg.SessionID).Warnf("failed storing rejection reason from slack, err=%v", setErr)
+		}
+	}
 	var msg string
 	switch err {
 	case reviewapi.ErrNotFound:
@@ -124,6 +131,9 @@ func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status mo
 				rev.Status.Str(),
 			)
 		}
+		if rev.Status == models.ReviewStatusRejected {
+			p.notifyOwnerRejected(ev, ctx, rev)
+		}
 		return
 	default:
 		log.With("sid", ev.msg.SessionID).Warnf("failed reviewing, id=%s, internal error=%v",
@@ -133,4 +143,42 @@ func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status mo
 	if err = ev.ss.PostEphemeralMessage(ev.msg, "%s", msg); err != nil {
 		log.With("sid", ev.msg.SessionID).Warnf("failed updating slack review, reason=%v", err)
 	}
+}
+
+// notifyOwnerRejected sends a DM to the session owner informing them that their
+// access request was rejected. Silently skipped if the owner has no Slack ID.
+func (p *slackPlugin) notifyOwnerRejected(ev *event, ctx *storagev2.Context, rev *models.Review) {
+	ownerSlackID := ptr.ToString(rev.OwnerSlackID)
+	if ownerSlackID == "" {
+		return
+	}
+
+	reviewerName := ctx.UserName
+	if reviewerName == "" {
+		reviewerName = ctx.UserEmail
+	}
+
+	text := fmt.Sprintf("Your access request for *%s* was *rejected* by %s.", rev.ConnectionName, reviewerName)
+
+	// Include the rejection reason, stripping any trailing "Rejected by ..." line
+	// since that attribution is already in the first sentence above.
+	if reason := stripRejectedByLine(ev.msg.RejectionReason); reason != "" {
+		text += fmt.Sprintf("\n>%s", reason)
+	}
+
+	text += fmt.Sprintf("\nFollow this link to see the details: %s/sessions/%s", p.apiURL, rev.SessionID)
+
+	if err := ev.ss.PostMessage(ownerSlackID, text); err != nil {
+		log.With("sid", ev.msg.SessionID).Warnf("failed sending rejection DM to session owner, err=%v", err)
+	}
+}
+
+// stripRejectedByLine removes a trailing "Rejected by ..." line from a rejection reason
+// so it is not shown redundantly in contexts that already identify the reviewer.
+func stripRejectedByLine(reason string) string {
+	lines := strings.Split(strings.TrimRight(reason, "\n"), "\n")
+	for len(lines) > 0 && strings.HasPrefix(strings.TrimSpace(lines[len(lines)-1]), "Rejected by ") {
+		lines = lines[:len(lines)-1]
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
 }

--- a/rootfs/app/migrations/000070_review_rejection_reason.down.sql
+++ b/rootfs/app/migrations/000070_review_rejection_reason.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE private.reviews DROP COLUMN IF EXISTS rejection_reason;

--- a/rootfs/app/migrations/000070_review_rejection_reason.up.sql
+++ b/rootfs/app/migrations/000070_review_rejection_reason.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE private.reviews ADD COLUMN IF NOT EXISTS rejection_reason TEXT NULL;

--- a/webapp/src/webapp/audit/views/reject_details_modal.cljs
+++ b/webapp/src/webapp/audit/views/reject_details_modal.cljs
@@ -1,0 +1,43 @@
+(ns webapp.audit.views.reject-details-modal
+  (:require
+   ["@radix-ui/themes" :refer [Box Button Flex Heading Switch Text]]
+   [reagent.core :as r]
+   [webapp.components.forms :as forms]))
+
+(defn main [{:keys [user on-confirm on-cancel]}]
+  (let [comment (r/atom "")
+        add-username? (r/atom false)]
+    (fn []
+      [:> Box {:class "w-full space-y-radix-7"}
+       [:> Box
+        [:> Heading {:as "h1" :size "6" :weight "bold" :class "text-gray-12"}
+         "Reject Details"]
+        [:> Text {:as "p" :size "3" :class "text-gray-11"}
+         "Optionally include more details or identification for this access request rejection."]]
+
+       [forms/textarea {:label "Comment"
+                        :placeholder "Share the details here..."
+                        :value @comment
+                        :on-change #(reset! comment (-> % .-target .-value))}]
+
+       [:> Flex {:align "start" :gap "3"}
+        [:> Switch {:checked @add-username?
+                    :on-checked-change #(reset! add-username? %)}]
+        [:> Box
+         [:> Text {:size "2" :weight "medium" :class "text-gray-12" :as "p"} "Add username"]
+         [:> Text {:size "2" :class "text-gray-11" :as "p"}
+          "Include your username to the details when rejecting this access request."]]]
+
+       [:> Flex {:justify "between" :align "center"}
+        [:> Button {:size "3"
+                    :variant "ghost"
+                    :color "gray"
+                    :type "button"
+                    :on-click on-cancel}
+         "Cancel"]
+        [:> Button {:size "3"
+                    :type "button"
+                    :on-click #(on-confirm {:comment @comment
+                                            :add-username? @add-username?
+                                            :user-name (-> user :name)})}
+         "Confirm and Reject"]]])))

--- a/webapp/src/webapp/audit/views/reject_details_modal.cljs
+++ b/webapp/src/webapp/audit/views/reject_details_modal.cljs
@@ -1,32 +1,23 @@
 (ns webapp.audit.views.reject-details-modal
   (:require
-   ["@radix-ui/themes" :refer [Box Button Flex Heading Switch Text]]
+   ["@radix-ui/themes" :refer [Box Button Flex Heading Text]]
    [reagent.core :as r]
    [webapp.components.forms :as forms]))
 
-(defn main [{:keys [user on-confirm on-cancel]}]
-  (let [comment (r/atom "")
-        add-username? (r/atom false)]
+(defn main [{:keys [on-confirm on-cancel]}]
+  (let [comment (r/atom "")]
     (fn []
       [:> Box {:class "w-full space-y-radix-7"}
        [:> Box
         [:> Heading {:as "h1" :size "6" :weight "bold" :class "text-gray-12"}
          "Reject Details"]
         [:> Text {:as "p" :size "3" :class "text-gray-11"}
-         "Optionally include more details or identification for this access request rejection."]]
+         "Optionally include more details for this access request rejection."]]
 
        [forms/textarea {:label "Comment"
                         :placeholder "Share the details here..."
                         :value @comment
                         :on-change #(reset! comment (-> % .-target .-value))}]
-
-       [:> Flex {:align "start" :gap "3"}
-        [:> Switch {:checked @add-username?
-                    :on-checked-change #(reset! add-username? %)}]
-        [:> Box
-         [:> Text {:size "2" :weight "medium" :class "text-gray-12" :as "p"} "Add username"]
-         [:> Text {:size "2" :class "text-gray-11" :as "p"}
-          "Include your username to the details when rejecting this access request."]]]
 
        [:> Flex {:justify "between" :align "center"}
         [:> Button {:size "3"
@@ -37,7 +28,5 @@
          "Cancel"]
         [:> Button {:size "3"
                     :type "button"
-                    :on-click #(on-confirm {:comment @comment
-                                            :add-username? @add-username?
-                                            :user-name (-> user :name)})}
+                    :on-click #(on-confirm {:comment @comment})}
          "Confirm and Reject"]]])))

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -16,6 +16,7 @@
    [webapp.audit.views.guardrails-info :as guardrails-info]
    [webapp.features.ai-session-analyzer.views.session-analysis :as session-analysis]
    [webapp.audit.views.time-window-modal :as time-window-modal]
+   [webapp.audit.views.reject-details-modal :as reject-details-modal]
 
    [webapp.components.loaders :as loaders]
    [webapp.formatters :as formatters]
@@ -191,9 +192,25 @@
                                         force-groups
                                         (some #(contains? force-groups %) user-groups)))
               handle-reject (fn []
-                              (rf/dispatch [:audit->add-review
-                                            session
-                                            "rejected"]))
+                              (rf/dispatch
+                               [:modal->open
+                                {:id "reject-details-modal"
+                                 :maxWidth "500px"
+                                 :content [reject-details-modal/main
+                                           {:user user
+                                            :on-confirm
+                                            (fn [{:keys [comment add-username? user-name]}]
+                                              (let [reason (if (and add-username?
+                                                                    (not (cs/blank? user-name))
+                                                                    (not (cs/blank? comment)))
+                                                             (str comment "\nRejected by " user-name)
+                                                             comment)]
+                                                (rf/dispatch [:audit->add-review
+                                                              session
+                                                              "rejected"
+                                                              :rejection-reason reason])
+                                                (rf/dispatch [:modal->close])))
+                                            :on-cancel #(rf/dispatch [:modal->close])}]}]))
               handle-approve (fn []
                                (rf/dispatch [:audit->add-review
                                              session
@@ -300,6 +317,20 @@
             [guardrails-info/main {:guardrails-info (:guardrails_info session)}]
 
             [data-masking-analytics/main {:session session}]
+
+            ;; Rejection reason — shown when session was denied and a reason was recorded
+            (let [rejection-reason (get-in session [:metadata :rejection_reason])]
+              (when (and (= "REJECTED" review-status)
+                         (not (cs/blank? rejection-reason)))
+                [:> Flex {:align "center"
+                           :justify "between"
+                           :class "w-full rounded-lg bg-[--red-2] px-regular py-small gap-2"}
+                 [:> Flex {:align "center" :gap "2" :class "flex-shrink-0"}
+                  [:> OctagonX {:size 16 :class "text-error-11"}]
+                  [:> Text {:size "2" :weight "medium" :class "text-error-11"}
+                   "Reject Details"]]
+                 [:> Text {:size "2" :class "text-error-11 text-right whitespace-pre-wrap"}
+                  rejection-reason]]))
 
             ;; response logs area
             (when-not (or credentials-expire-at

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -16,13 +16,14 @@
    [webapp.audit.views.guardrails-info :as guardrails-info]
    [webapp.features.ai-session-analyzer.views.session-analysis :as session-analysis]
    [webapp.audit.views.time-window-modal :as time-window-modal]
-   [webapp.audit.views.reject-details-modal :as reject-details-modal]
+   [webapp.sessions.components.reject-details-modal :as reject-details-modal]
 
    [webapp.components.loaders :as loaders]
    [webapp.formatters :as formatters]
    [webapp.utilities :as utilities]
    [webapp.sessions.components.session-header :as session-header]
-   [webapp.sessions.components.session-details :as session-details-component]))
+   [webapp.sessions.components.session-details :as session-details-component]
+   [webapp.sessions.components.rejection-reason :as rejection-reason]))
 
 (def ^:private export-dictionary
   {:postgres "csv"
@@ -312,28 +313,7 @@
 
             [data-masking-analytics/main {:session session}]
 
-            ;; Rejection reason — shown when session was rejected
-            (let [rejection-reason (get-in session [:review :rejection_reason])
-                  reviewer-email (->> (get-in session [:review :review_groups_data])
-                                      (filter #(= "REJECTED" (:status %)))
-                                      first
-                                      :reviewed_by
-                                      :email)]
-              (when (= "REJECTED" review-status)
-                [:> Flex {:align "center"
-                           :justify "between"
-                           :class "w-full rounded-lg bg-[--red-2] px-regular py-small gap-2"}
-                 [:> Flex {:align "center" :gap "2" :class "flex-shrink-0"}
-                  [:> OctagonX {:size 16 :class "text-error-11"}]
-                  [:> Text {:size "2" :weight "medium" :class "text-error-11"}
-                   "Reject Details"]]
-                 [:> Flex {:direction "column" :align "end" :gap "1"}
-                  (when (not (cs/blank? rejection-reason))
-                    [:> Text {:size "2" :class "text-error-11 text-right whitespace-pre-wrap"}
-                     rejection-reason])
-                  (when reviewer-email
-                    [:> Text {:size "2" :class "text-error-11 text-right"}
-                     (str "Rejected by " reviewer-email)])]]))
+            [rejection-reason/main {:session session}]
 
             ;; response logs area
             (when-not (or credentials-expire-at

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -197,19 +197,13 @@
                                 {:id "reject-details-modal"
                                  :maxWidth "500px"
                                  :content [reject-details-modal/main
-                                           {:user user
-                                            :on-confirm
-                                            (fn [{:keys [comment add-username? user-name]}]
-                                              (let [reason (if (and add-username?
-                                                                    (not (cs/blank? user-name))
-                                                                    (not (cs/blank? comment)))
-                                                             (str comment "\nRejected by " user-name)
-                                                             comment)]
-                                                (rf/dispatch [:audit->add-review
-                                                              session
-                                                              "rejected"
-                                                              :rejection-reason reason])
-                                                (rf/dispatch [:modal->close])))
+                                           {:on-confirm
+                                            (fn [{:keys [comment]}]
+                                              (rf/dispatch [:audit->add-review
+                                                            session
+                                                            "rejected"
+                                                            :rejection-reason comment])
+                                              (rf/dispatch [:modal->close]))
                                             :on-cancel #(rf/dispatch [:modal->close])}]}]))
               handle-approve (fn []
                                (rf/dispatch [:audit->add-review
@@ -318,10 +312,14 @@
 
             [data-masking-analytics/main {:session session}]
 
-            ;; Rejection reason — shown when session was denied and a reason was recorded
-            (let [rejection-reason (get-in session [:metadata :rejection_reason])]
-              (when (and (= "REJECTED" review-status)
-                         (not (cs/blank? rejection-reason)))
+            ;; Rejection reason — shown when session was rejected
+            (let [rejection-reason (get-in session [:review :rejection_reason])
+                  reviewer-email (->> (get-in session [:review :review_groups_data])
+                                      (filter #(= "REJECTED" (:status %)))
+                                      first
+                                      :reviewed_by
+                                      :email)]
+              (when (= "REJECTED" review-status)
                 [:> Flex {:align "center"
                            :justify "between"
                            :class "w-full rounded-lg bg-[--red-2] px-regular py-small gap-2"}
@@ -329,8 +327,13 @@
                   [:> OctagonX {:size 16 :class "text-error-11"}]
                   [:> Text {:size "2" :weight "medium" :class "text-error-11"}
                    "Reject Details"]]
-                 [:> Text {:size "2" :class "text-error-11 text-right whitespace-pre-wrap"}
-                  rejection-reason]]))
+                 [:> Flex {:direction "column" :align "end" :gap "1"}
+                  (when (not (cs/blank? rejection-reason))
+                    [:> Text {:size "2" :class "text-error-11 text-right whitespace-pre-wrap"}
+                     rejection-reason])
+                  (when reviewer-email
+                    [:> Text {:size "2" :class "text-error-11 text-right"}
+                     (str "Rejected by " reviewer-email)])]]))
 
             ;; response logs area
             (when-not (or credentials-expire-at

--- a/webapp/src/webapp/events/audit.cljs
+++ b/webapp/src/webapp/events/audit.cljs
@@ -426,7 +426,8 @@
  (fn
    [_ [_ session status & {:keys [start-time
                                   end-time
-                                  force-review]}]]
+                                  force-review
+                                  rejection-reason]}]]
    (let [body (cond-> {:status (string/upper-case status)}
                 (and start-time end-time)
                 (assoc :time_window {:type "time_range"
@@ -434,7 +435,10 @@
                                                      :end_time (formatters/local-time->utc-time end-time)}})
 
                 force-review
-                (assoc :force_review true))]
+                (assoc :force_review true)
+
+                (not (string/blank? rejection-reason))
+                (assoc :rejection_reason rejection-reason))]
      {:fx [[:dispatch
             [:fetch {:method "PUT"
                      :uri (str "/reviews/" (-> session :review :id))

--- a/webapp/src/webapp/sessions/components/reject_details_modal.cljs
+++ b/webapp/src/webapp/sessions/components/reject_details_modal.cljs
@@ -1,4 +1,4 @@
-(ns webapp.audit.views.reject-details-modal
+(ns webapp.sessions.components.reject-details-modal
   (:require
    ["@radix-ui/themes" :refer [Box Button Flex Heading Text]]
    [reagent.core :as r]
@@ -8,8 +8,8 @@
   (let [comment (r/atom "")]
     (fn []
       [:> Box {:class "w-full space-y-radix-7"}
-       [:> Box
-        [:> Heading {:as "h1" :size "6" :weight "bold" :class "text-gray-12"}
+       [:> Box {:class "space-y-radix-2"}
+        [:> Heading {:as "h1" :size "7" :weight "bold" :class "text-gray-12"}
          "Reject Details"]
         [:> Text {:as "p" :size "3" :class "text-gray-11"}
          "Optionally include more details for this access request rejection."]]
@@ -21,7 +21,7 @@
 
        [:> Flex {:justify "between" :align "center"}
         [:> Button {:size "3"
-                    :variant "ghost"
+                    :variant "soft"
                     :color "gray"
                     :type "button"
                     :on-click on-cancel}

--- a/webapp/src/webapp/sessions/components/rejection_reason.cljs
+++ b/webapp/src/webapp/sessions/components/rejection_reason.cljs
@@ -1,0 +1,27 @@
+(ns webapp.sessions.components.rejection-reason
+  (:require
+   ["@radix-ui/themes" :refer [Box Flex Text]]
+   ["lucide-react" :refer [OctagonX]]
+   [clojure.string :as cs]))
+
+(defn main [{:keys [session]}]
+  (let [review-status    (-> session :review :status)
+        rejection-reason (get-in session [:review :rejection_reason])
+        reviewer-email   (->> (get-in session [:review :review_groups_data])
+                              (filter #(= "REJECTED" (:status %)))
+                              first
+                              :reviewed_by
+                              :email)]
+    (when (= "REJECTED" review-status)
+      [:> Box {:class "flex items-baseline justify-between w-full bg-error-2 rounded-3 px-4 py-3"}
+       [:> Box {:class "flex items-center gap-2"}
+        [:> OctagonX {:size 16 :class "text-error-12 shrink-0"}]
+        [:> Text {:size "2" :weight "bold" :class "text-error-12"}
+         "Reject Details"]]
+       [:> Flex {:direction "column" :align "end" :gap "1"}
+        (when (not (cs/blank? rejection-reason))
+          [:> Text {:size "2" :class "whitespace-pre-wrap text-right text-error-12"}
+           rejection-reason])
+        (when reviewer-email
+          [:> Text {:size "2" :weight "bold" :class "text-error-12"}
+           (str "Rejected by " reviewer-email)])]])))


### PR DESCRIPTION
## 📝 Description                                         
                                                                                                                                                         
`rejection_reason` was previously stored as a free-form key inside `session.metadata` (a JSONB blob), which made it invisible in review API responses, fragile to read, and semantically misplaced — the reason belongs to the review decision, not session metadata.
                                                                                                                                                         
This PR moves it to a proper `TEXT` column on `private.reviews`, exposes it through the existing `SessionReview` and `Review` response types, and cleans up all write/read paths accordingly.
                                                  
## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)                                                
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update                                                                                                                                 
- [x] ♻️  Code refactor                                    
- [ ] ⚡ Performance improvement                                                                                                                         
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change                                                                                                                      
- [ ] 🧹 Chore                                            

## 📋 Changes Made                                                                                                                                       
 
- Added migration `000070`: `ALTER TABLE private.reviews ADD COLUMN IF NOT EXISTS rejection_reason TEXT NULL`                                            
- Added `RejectionReason *string` field to `Review` and `SessionReview` models with GORM and JSON mapping
- Added `SetReviewRejectionReason()` replacing the old `SetSessionRejectionReason()` (which wrote to session metadata)                                   
- Exposed `rejection_reason` in `SessionReview` and `Review` OpenAPI response types; added `rejection_reason` to `ReviewRequest`                         
- Updated both session SQL queries to include `rejection_reason` in the `jsonb_build_object` for the review join                                         
- Updated the HTTP review handler and Slack plugin write paths to call `SetReviewRejectionReason`                                                         
- Webapp session detail page now always shows "Rejected by \<email\>" when a review is rejected                                                          
- CLI `hoop sessions get <id>` now reads `rejection_reason` from `review` instead of `metadata`   

## GIF
![reason review](https://github.com/user-attachments/assets/6d5a8844-0d88-41e4-a00e-71ab740faa84)
                                                                                                                                                    
## 🧪 Testing                                                                                                                                            
                                                                                                                                                         
### Tests performed:                                      
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
                                                                                                                                                         
Reject a review via HTTP API with `rejection_reason` in the body → confirm `private.reviews.rejection_reason` is populated and returned in `GET /api/sessions/:id` under `review.rejection_reason`.                                                                                                      
                                                                                                                                                         
Reject via Slack modal → confirm same field is written and the DM notification is sent to the session owner.                                             
 
Run `hoop sessions get <id>` → confirm "Rejection Reason" section appears with the message only (reviewer already shown in Groups section above).        
                                                          
Check webapp session detail page for a rejected session → confirm reason text and "Rejected by \<email\>" are displayed.                                 
                                                          
## ✅ Checklist                                                                                                                                          
                                                          
- [x] I have run `make generate-openapi-docs` to update the OpenAPI docs                                                                                 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code                                                                                                      
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes                                                                                           
- [x] I have checked my code and corrected any misspellings