### PR TITLE
feat: async RDP PII detection for session replay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ RUN mkdir -p /app && \
         openssh-client \
         procps \
         gettext-base \
-        curl
+        curl \
+        tesseract-ocr \
+        tesseract-ocr-eng
 
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
     locale-gen

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -528,6 +528,11 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		sessionapi.GetRDPFrames)
 
+	r.GET("/sessions/:session_id/rdp-detections",
+		apiroutes.ReadOnlyAccessRole,
+		r.AuthMiddleware,
+		sessionapi.GetRDPDetections)
+
 	r.GET("/sessions/:session_id/result/stream",
 		apiroutes.ReadOnlyAccessRole,
 		r.AuthMiddleware,

--- a/gateway/api/session/rdp_detections.go
+++ b/gateway/api/session/rdp_detections.go
@@ -1,0 +1,108 @@
+package sessionapi
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/gateway/api/httputils"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2"
+)
+
+// RDPDetection represents a single PII entity detection with screen-space coordinates.
+type RDPDetection struct {
+	FrameIndex int     `json:"frame_index"`
+	Timestamp  float64 `json:"timestamp"`
+	EntityType string  `json:"entity_type"`
+	Score      float64 `json:"score"`
+	X          int     `json:"x"`
+	Y          int     `json:"y"`
+	Width      int     `json:"width"`
+	Height     int     `json:"height"`
+}
+
+// RDPDetectionsResponse is the response for the RDP detections endpoint.
+type RDPDetectionsResponse struct {
+	Detections     []RDPDetection `json:"detections"`
+	Total          int            `json:"total"`
+	AnalysisStatus string         `json:"analysis_status"`
+}
+
+// GetRDPDetections returns PII entity detections for an RDP session recording.
+// Each detection includes screen-space bounding box coordinates for overlay rendering.
+//
+//	@Summary		Get RDP session PII detections
+//	@Description	Returns PII entity detections with screen-space coordinates for an RDP session recording
+//	@Tags			Sessions
+//	@Param			session_id	path	string	true	"The id of the session"
+//	@Produce		json
+//	@Success		200		{object}	RDPDetectionsResponse
+//	@Failure		400,403,404,500	{object}	openapi.HTTPError
+//	@Router			/sessions/{session_id}/rdp-detections [get]
+func GetRDPDetections(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	sessionID := c.Param("session_id")
+
+	// Get session
+	session, err := models.GetSessionByID(ctx.OrgID, sessionID)
+	switch err {
+	case models.ErrNotFound:
+		c.JSON(http.StatusNotFound, gin.H{"message": "session not found"})
+		return
+	case nil:
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching session")
+		return
+	}
+
+	// Check access
+	canAccess := session.UserID == ctx.UserID || ctx.IsAuditorOrAdminUser()
+	if !canAccess {
+		c.JSON(http.StatusForbidden, gin.H{"message": "user is not allowed to access this session"})
+		return
+	}
+
+	// Check if it's an RDP session
+	if session.ConnectionSubtype != "rdp" {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "session is not an RDP recording"})
+		return
+	}
+
+	// Get analysis status from session metrics
+	analysisStatus := ""
+	if session.Metrics != nil {
+		if status, ok := session.Metrics["rdp_analysis_status"]; ok {
+			if s, ok := status.(string); ok {
+				analysisStatus = s
+			}
+		}
+	}
+
+	// Fetch detections from database
+	dbDetections, err := models.GetRDPEntityDetections(sessionID)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching detections")
+		return
+	}
+
+	// Convert to API response format (omit internal ID and session_id)
+	detections := make([]RDPDetection, 0, len(dbDetections))
+	for _, d := range dbDetections {
+		detections = append(detections, RDPDetection{
+			FrameIndex: d.FrameIndex,
+			Timestamp:  d.Timestamp,
+			EntityType: d.EntityType,
+			Score:      d.Score,
+			X:          d.X,
+			Y:          d.Y,
+			Width:      d.Width,
+			Height:     d.Height,
+		})
+	}
+
+	c.JSON(http.StatusOK, RDPDetectionsResponse{
+		Detections:     detections,
+		Total:          len(detections),
+		AnalysisStatus: analysisStatus,
+	})
+}

--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/hoophq/hoop/common/envloader"
@@ -61,6 +62,10 @@ type Config struct {
 	gatewaySkipTLSVerify            bool
 	sshClientHostKey                string
 	integrationAWSInstanceRoleAllow bool
+
+	rdpPIISnapshotInterval float64
+	rdpPIIScoreThreshold   float64
+	rdpPIIEntityDenylist   []string
 
 	isLoaded bool
 }
@@ -180,6 +185,26 @@ func Load() error {
 	gatewayUseTLS := os.Getenv("USE_TLS") == "true" || grpcClientTLSCa != "" || gatewayTLSKey != "" || gatewayTLSCert != ""
 	gatewaySkipTLSVerify := os.Getenv("HOOP_TLS_SKIP_VERIFY") == "true"
 
+	// RDP PII analysis defaults (overridable via env)
+	rdpPIISnapshotInterval := 0.25 // 250ms
+	if v := os.Getenv("RDP_PII_SNAPSHOT_INTERVAL"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			rdpPIISnapshotInterval = f
+		}
+	}
+	rdpPIIScoreThreshold := 0.9
+	if v := os.Getenv("RDP_PII_SCORE_THRESHOLD"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f >= 0 && f <= 1 {
+			rdpPIIScoreThreshold = f
+		}
+	}
+	var rdpPIIEntityDenylist []string
+	if v := os.Getenv("RDP_PII_ENTITY_DENYLIST"); v != "" {
+		rdpPIIEntityDenylist = strings.Split(v, ",")
+	} else {
+		rdpPIIEntityDenylist = []string{"DATE_TIME", "NRP"}
+	}
+
 	runtimeConfig = Config{
 		apiKey:                          os.Getenv("API_KEY"),
 		apiURL:                          fmt.Sprintf("%s://%s", apiRawURL.Scheme, apiRawURL.Host),
@@ -217,6 +242,9 @@ func Load() error {
 		gatewaySkipTLSVerify:            gatewaySkipTLSVerify,
 		sshClientHostKey:                sshClientHostKey,
 		integrationAWSInstanceRoleAllow: os.Getenv("INTEGRATION_AWS_INSTANCE_ROLE_ALLOW") == "true",
+		rdpPIISnapshotInterval:          rdpPIISnapshotInterval,
+		rdpPIIScoreThreshold:            rdpPIIScoreThreshold,
+		rdpPIIEntityDenylist:            rdpPIIEntityDenylist,
 		// Temporary solution to force token exchange through URL, because the JWT could be too large for cookies.
 		// This will be removed in future versions
 		forceUrlTokenExchange: os.Getenv("URL_TOKEN_EXCHANGE") == "force",
@@ -377,6 +405,9 @@ func (c Config) GatewayTLSCert() string                { return c.gatewayTLSCert
 func (c Config) GatewaySkipTLSVerify() bool            { return c.gatewaySkipTLSVerify }
 func (c Config) SSHClientHostKey() string              { return c.sshClientHostKey }
 func (c Config) IntegrationAWSInstanceRoleAllow() bool { return c.integrationAWSInstanceRoleAllow }
+func (c Config) RDPPIISnapshotInterval() float64       { return c.rdpPIISnapshotInterval }
+func (c Config) RDPPIIScoreThreshold() float64         { return c.rdpPIIScoreThreshold }
+func (c Config) RDPPIIEntityDenylist() []string        { return c.rdpPIIEntityDenylist }
 func (c Config) AskAIApiURL() (u string) {
 	if c.IsAskAIAvailable() {
 		return fmt.Sprintf("%s://%s", c.askAICredentials.Scheme, c.askAICredentials.Host)

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/hoophq/hoop/gateway/proxyproto/postgresproxy"
 	"github.com/hoophq/hoop/gateway/proxyproto/sshproxy"
 	"github.com/hoophq/hoop/gateway/rdp"
+	"github.com/hoophq/hoop/gateway/rdp/analyzer"
 	"github.com/hoophq/hoop/gateway/transport"
 	"github.com/hoophq/hoop/gateway/webappjs"
 
@@ -212,6 +214,11 @@ func Run() {
 			}
 		}
 	}
+
+	// Start async RDP PII analysis workers if Presidio is configured.
+	// Workers poll for pending jobs regardless of whether the RDP proxy server is running,
+	// since analysis jobs can be processed by any gateway instance.
+	analyzer.StartWorkerPool(context.Background(), appconfig.Get().MSPresidioAnalyzerURL())
 
 	log.Infof("starting api servers, env-authmethod=%v, env-api-key-set=%v",
 		appconfig.Get().AuthMethod(), len(appconfig.Get().ApiKey()) > 0)

--- a/gateway/models/rdp_analysis_job.go
+++ b/gateway/models/rdp_analysis_job.go
@@ -1,0 +1,147 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// RDPAnalysisJob represents an async job for PII analysis of an RDP session recording.
+type RDPAnalysisJob struct {
+	ID         string     `gorm:"column:id;primaryKey"`
+	OrgID      string     `gorm:"column:org_id"`
+	SessionID  string     `gorm:"column:session_id"`
+	Status     string     `gorm:"column:status"`
+	Priority   int        `gorm:"column:priority"`
+	Attempt    int        `gorm:"column:attempt"`
+	LastError  *string    `gorm:"column:last_error"`
+	CreatedAt  time.Time  `gorm:"column:created_at"`
+	StartedAt  *time.Time `gorm:"column:started_at"`
+	FinishedAt *time.Time `gorm:"column:finished_at"`
+}
+
+// RDP analysis job status constants
+const (
+	RDPJobStatusPending = "pending"
+	RDPJobStatusRunning = "running"
+	RDPJobStatusDone    = "done"
+	RDPJobStatusFailed  = "failed"
+)
+
+// maxJobAttempts is the number of times a job will be retried before giving up.
+const maxJobAttempts = 3
+
+// CreateRDPAnalysisJob inserts a new pending analysis job for the given session.
+func CreateRDPAnalysisJob(orgID, sessionID string) error {
+	return DB.Table("private.rdp_analysis_jobs").
+		Omit("id").
+		Create(&RDPAnalysisJob{
+			OrgID:     orgID,
+			SessionID: sessionID,
+			Status:    RDPJobStatusPending,
+		}).Error
+}
+
+// ClaimRDPAnalysisJob atomically claims the next available job using SELECT FOR UPDATE SKIP LOCKED.
+// Returns the claimed job, or nil if no jobs are available.
+func ClaimRDPAnalysisJob(db *gorm.DB) (*RDPAnalysisJob, error) {
+	var job RDPAnalysisJob
+	err := db.Transaction(func(tx *gorm.DB) error {
+		// Use a raw SQL query for the atomic claim with SKIP LOCKED
+		result := tx.Raw(`
+			UPDATE private.rdp_analysis_jobs
+			SET status = ?, started_at = now(), attempt = attempt + 1
+			WHERE id = (
+				SELECT id FROM private.rdp_analysis_jobs
+				WHERE status IN (?, ?) AND attempt < ?
+				ORDER BY priority DESC, created_at ASC
+				LIMIT 1
+				FOR UPDATE SKIP LOCKED
+			)
+			RETURNING *`,
+			RDPJobStatusRunning,
+			RDPJobStatusPending, RDPJobStatusFailed,
+			maxJobAttempts,
+		).Scan(&job)
+
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return gorm.ErrRecordNotFound
+		}
+		return nil
+	})
+
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &job, err
+}
+
+// CompleteRDPAnalysisJob marks a job as done.
+func CompleteRDPAnalysisJob(db *gorm.DB, jobID string) error {
+	return db.Table("private.rdp_analysis_jobs").
+		Where("id = ?", jobID).
+		Updates(map[string]any{
+			"status":      RDPJobStatusDone,
+			"finished_at": gorm.Expr("now()"),
+		}).Error
+}
+
+// FailRDPAnalysisJob marks a job as failed with an error message.
+// If the job has exceeded max attempts, it stays as 'failed' permanently.
+func FailRDPAnalysisJob(db *gorm.DB, jobID string, errMsg string) error {
+	return db.Table("private.rdp_analysis_jobs").
+		Where("id = ?", jobID).
+		Updates(map[string]any{
+			"status":      RDPJobStatusFailed,
+			"last_error":  errMsg,
+			"finished_at": gorm.Expr("now()"),
+		}).Error
+}
+
+// GetRDPAnalysisJobBySessionID returns the analysis job for a session, if any.
+func GetRDPAnalysisJobBySessionID(sessionID string) (*RDPAnalysisJob, error) {
+	var job RDPAnalysisJob
+	err := DB.Table("private.rdp_analysis_jobs").
+		Where("session_id = ?", sessionID).
+		Order("created_at DESC").
+		First(&job).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &job, err
+}
+
+// UpdateSessionRDPAnalysisStatus updates the rdp_analysis_status key in sessions.metrics JSONB.
+func UpdateSessionRDPAnalysisStatus(orgID, sessionID, status string) error {
+	statusJSON, err := json.Marshal(status)
+	if err != nil {
+		return err
+	}
+	return DB.Table("private.sessions AS s").
+		Where("s.id = ? AND s.org_id = ?", sessionID, orgID).
+		Update("metrics", gorm.Expr(`
+			jsonb_set(
+				COALESCE(s.metrics, '{}'::jsonb),
+				'{rdp_analysis_status}',
+				?::jsonb,
+				true
+			)
+		`, string(statusJSON))).Error
+}
+
+// ResetOrphanedRDPAnalysisJobs resets jobs left in 'running' state back to 'pending'.
+// Called at gateway startup to recover from crashes/restarts that left jobs
+// stuck in 'running' with no worker processing them.
+// Returns the number of jobs that were reset.
+func ResetOrphanedRDPAnalysisJobs(db *gorm.DB) (int64, error) {
+	result := db.Exec(`
+		UPDATE private.rdp_analysis_jobs
+		SET status = ?, started_at = NULL
+		WHERE status = ?
+	`, RDPJobStatusPending, RDPJobStatusRunning)
+	return result.RowsAffected, result.Error
+}

--- a/gateway/models/rdp_entity_detection.go
+++ b/gateway/models/rdp_entity_detection.go
@@ -1,0 +1,46 @@
+package models
+
+// RDPEntityDetection represents a single PII entity detected in an RDP session frame.
+// Coordinates (X, Y, Width, Height) are in screen-space pixels, matching the canvas
+// coordinate system used by the RDP session replay player.
+type RDPEntityDetection struct {
+	ID         string  `gorm:"column:id;primaryKey" json:"id"`
+	SessionID  string  `gorm:"column:session_id" json:"session_id"`
+	FrameIndex int     `gorm:"column:frame_index" json:"frame_index"`
+	Timestamp  float64 `gorm:"column:timestamp" json:"timestamp"`
+	EntityType string  `gorm:"column:entity_type" json:"entity_type"`
+	Score      float64 `gorm:"column:score" json:"score"`
+	X          int     `gorm:"column:x" json:"x"`
+	Y          int     `gorm:"column:y" json:"y"`
+	Width      int     `gorm:"column:width" json:"width"`
+	Height     int     `gorm:"column:height" json:"height"`
+}
+
+// BulkInsertRDPEntityDetections inserts a batch of entity detections for an RDP session.
+// Uses CreateInBatches to avoid oversized INSERT statements.
+func BulkInsertRDPEntityDetections(detections []RDPEntityDetection) error {
+	if len(detections) == 0 {
+		return nil
+	}
+	return DB.Table("private.rdp_entity_detections").
+		Omit("id").
+		CreateInBatches(detections, 100).Error
+}
+
+// GetRDPEntityDetections returns all entity detections for a session, ordered by frame index.
+func GetRDPEntityDetections(sessionID string) ([]RDPEntityDetection, error) {
+	var detections []RDPEntityDetection
+	err := DB.Table("private.rdp_entity_detections").
+		Where("session_id = ?", sessionID).
+		Order("frame_index ASC, id ASC").
+		Find(&detections).Error
+	return detections, err
+}
+
+// DeleteRDPEntityDetections removes all entity detections for a session.
+// Useful for re-analysis scenarios.
+func DeleteRDPEntityDetections(sessionID string) error {
+	return DB.Table("private.rdp_entity_detections").
+		Where("session_id = ?", sessionID).
+		Delete(&RDPEntityDetection{}).Error
+}

--- a/gateway/rdp/analyzer/presidio.go
+++ b/gateway/rdp/analyzer/presidio.go
@@ -1,0 +1,114 @@
+// Package analyzer implements async PII detection for RDP session recordings.
+package analyzer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// presidioTimeout is the HTTP timeout for Presidio API calls.
+const presidioTimeout = 30 * time.Second
+
+// PresidioClient is a lightweight HTTP client for the Presidio Analyzer API.
+// It only supports the /analyze endpoint (no anonymization needed).
+type PresidioClient struct {
+	analyzerURL string
+	httpClient  *http.Client
+}
+
+// AnalyzerRequest is the request payload for Presidio's /analyze endpoint.
+type AnalyzerRequest struct {
+	Text           string   `json:"text"`
+	Language       string   `json:"language"`
+	ScoreThreshold float64  `json:"score_threshold,omitempty"`
+	Entities       []string `json:"entities,omitempty"`
+}
+
+// AnalyzerResult is a single PII entity found by Presidio.
+type AnalyzerResult struct {
+	Start      int     `json:"start"`
+	End        int     `json:"end"`
+	Score      float64 `json:"score"`
+	EntityType string  `json:"entity_type"`
+}
+
+// NewPresidioClient creates a new Presidio analyzer client.
+// analyzerURL is the base URL for the Presidio Analyzer service (e.g. "http://localhost:5001").
+func NewPresidioClient(analyzerURL string) *PresidioClient {
+	return &PresidioClient{
+		analyzerURL: strings.TrimSuffix(analyzerURL, "/"),
+		httpClient: &http.Client{
+			Timeout: presidioTimeout,
+		},
+	}
+}
+
+// Analyze sends text to Presidio for PII detection and returns the results.
+// scoreThreshold controls the minimum confidence score (0.0-1.0). Use 0 for default (0.5).
+// Returns nil (no error) with empty results if no PII is found.
+func (c *PresidioClient) Analyze(ctx context.Context, text string, scoreThreshold ...float64) ([]AnalyzerResult, error) {
+	if text == "" {
+		return nil, nil
+	}
+
+	threshold := 0.5
+	if len(scoreThreshold) > 0 && scoreThreshold[0] > 0 {
+		threshold = scoreThreshold[0]
+	}
+
+	reqBody := AnalyzerRequest{
+		Text:           text,
+		Language:       "en",
+		ScoreThreshold: threshold,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("presidio: failed to marshal request: %w", err)
+	}
+
+	apiURL := c.analyzerURL + "/analyze"
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("presidio: failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("presidio: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("presidio: failed to read response (status=%d): %w", resp.StatusCode, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("presidio: analyzer returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var results []AnalyzerResult
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, fmt.Errorf("presidio: failed to decode response: %w", err)
+	}
+
+	return results, nil
+}
+
+// AggregateResults counts PII entities by type from a slice of AnalyzerResults.
+// Returns a map of entity_type -> count.
+func AggregateResults(results []AnalyzerResult) map[string]int64 {
+	counts := make(map[string]int64)
+	for _, r := range results {
+		counts[r.EntityType]++
+	}
+	return counts
+}

--- a/gateway/rdp/analyzer/worker.go
+++ b/gateway/rdp/analyzer/worker.go
@@ -1,0 +1,645 @@
+package analyzer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/gateway/appconfig"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/rdp/ocr"
+	"github.com/hoophq/hoop/gateway/rdp/rle"
+)
+
+const (
+	// defaultWorkerCount is the number of worker goroutines if RDP_ANALYSIS_WORKERS is not set.
+	defaultWorkerCount = 2
+	// pollInterval is how long workers sleep when the queue is empty.
+	pollInterval = 5 * time.Second
+)
+
+// resolveWorkerCount reads RDP_ANALYSIS_WORKERS and returns the configured count.
+// An unset env var returns defaultWorkerCount. Any value <= 0 or an unparseable value
+// returns 0 (feature explicitly disabled).
+func resolveWorkerCount() int {
+	envVal := os.Getenv("RDP_ANALYSIS_WORKERS")
+	if envVal == "" {
+		return defaultWorkerCount
+	}
+	n, err := strconv.Atoi(envVal)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// IsEnabled reports whether the RDP PII analysis pipeline is currently active.
+// It is enabled only when Presidio is configured and the worker pool is running
+// (analyzerURL is set, RDP_ANALYSIS_WORKERS resolves to > 0, and tesseract is in PATH).
+//
+// Callers should gate any work that depends on the pipeline (e.g. enqueueing
+// analysis jobs on session close) to avoid leaving sessions stuck in 'pending'.
+func IsEnabled(analyzerURL string) bool {
+	return analyzerURL != "" && resolveWorkerCount() > 0 && ocr.IsAvailable()
+}
+
+// BitmapEvent mirrors the struct in gateway/rdp/recorder.go.
+// Duplicated here to avoid circular imports.
+type BitmapEvent struct {
+	X            uint16 `json:"x"`
+	Y            uint16 `json:"y"`
+	Width        uint16 `json:"width"`
+	Height       uint16 `json:"height"`
+	BitsPerPixel uint16 `json:"bits_per_pixel"`
+	Compressed   bool   `json:"compressed"`
+	Data         []byte `json:"data"`
+}
+
+// wordRange tracks a word's character range in the reconstructed text string.
+type wordRange struct {
+	start int // inclusive byte offset in full text
+	end   int // exclusive byte offset in full text
+	word  ocr.Word
+}
+
+// StartWorkerPool launches the RDP analysis worker pool.
+// It reads the worker count from RDP_ANALYSIS_WORKERS env var.
+// Workers are started only if analyzerURL is non-empty (Presidio is configured),
+// RDP_ANALYSIS_WORKERS resolves to a positive count, and tesseract is in PATH.
+//
+// Call this once at gateway boot. The pool runs until ctx is cancelled.
+func StartWorkerPool(ctx context.Context, analyzerURL string) {
+	if analyzerURL == "" {
+		log.Infof("rdp-analyzer: Presidio not configured, skipping worker pool startup")
+		return
+	}
+
+	workerCount := resolveWorkerCount()
+	if workerCount == 0 {
+		log.Infof("rdp-analyzer: RDP_ANALYSIS_WORKERS=0, skipping worker pool startup")
+		return
+	}
+
+	if !ocr.IsAvailable() {
+		log.Warnf("rdp-analyzer: tesseract not found in PATH, skipping worker pool startup")
+		return
+	}
+
+	// Rescue jobs left in 'running' state from a previous crash/restart.
+	// Without this, those jobs would be orphaned forever since ClaimRDPAnalysisJob
+	// only picks up 'pending' and 'failed' jobs.
+	if rescued, err := models.ResetOrphanedRDPAnalysisJobs(models.DB); err != nil {
+		log.Warnf("rdp-analyzer: failed to reset orphaned jobs: %v", err)
+	} else if rescued > 0 {
+		log.Infof("rdp-analyzer: reset %d orphaned running job(s) to pending", rescued)
+	}
+
+	presidioClient := NewPresidioClient(analyzerURL)
+
+	log.Infof("rdp-analyzer: starting %d workers (presidio=%s)", workerCount, analyzerURL)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			runWorker(ctx, workerID, presidioClient)
+		}(i)
+	}
+
+	go func() {
+		wg.Wait()
+		log.Infof("rdp-analyzer: all workers stopped")
+	}()
+}
+
+// runWorker is the main loop for a single worker goroutine.
+func runWorker(ctx context.Context, workerID int, presidio *PresidioClient) {
+	logger := log.With("worker", fmt.Sprintf("rdp-analyzer-%d", workerID))
+	logger.Infof("worker started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Infof("worker stopping (context cancelled)")
+			return
+		default:
+		}
+
+		job, err := models.ClaimRDPAnalysisJob(models.DB)
+		if err != nil {
+			logger.Errorf("failed to claim job: %v", err)
+			sleep(ctx, pollInterval)
+			continue
+		}
+
+		if job == nil {
+			// No jobs available, wait before polling again
+			sleep(ctx, pollInterval)
+			continue
+		}
+
+		logger.With("sid", job.SessionID, "job_id", job.ID, "attempt", job.Attempt).
+			Infof("processing job")
+
+		// Mark the session as "analyzing"
+		_ = models.UpdateSessionRDPAnalysisStatus(job.OrgID, job.SessionID, "analyzing")
+
+		if err := processJob(ctx, job, presidio); err != nil {
+			logger.With("sid", job.SessionID, "job_id", job.ID).
+				Errorf("job failed: %v", err)
+			errMsg := err.Error()
+			if len(errMsg) > 1000 {
+				errMsg = errMsg[:1000]
+			}
+			_ = models.FailRDPAnalysisJob(models.DB, job.ID, errMsg)
+			_ = models.UpdateSessionRDPAnalysisStatus(job.OrgID, job.SessionID, "failed")
+			continue
+		}
+
+		_ = models.CompleteRDPAnalysisJob(models.DB, job.ID)
+		_ = models.UpdateSessionRDPAnalysisStatus(job.OrgID, job.SessionID, "done")
+
+		logger.With("sid", job.SessionID, "job_id", job.ID).
+			Infof("job completed successfully")
+
+		// Immediately re-poll for next job (no sleep)
+	}
+}
+
+const (
+	// defaultCanvasWidth / Height are fallbacks if the session metrics are missing.
+	defaultCanvasWidth  = 1280
+	defaultCanvasHeight = 720
+)
+
+// AnalysisParams holds tunable parameters for the RDP PII analysis pipeline.
+// Values are read from env vars (via appconfig) at worker startup.
+type AnalysisParams struct {
+	ScoreThreshold   float64  // Minimum Presidio score (env: RDP_PII_SCORE_THRESHOLD, default 0.9)
+	EntityDenylist   []string // Entity types to exclude (env: RDP_PII_ENTITY_DENYLIST, default "DATE_TIME,NRP")
+	SnapshotInterval float64  // Seconds between snapshots (env: RDP_PII_SNAPSHOT_INTERVAL, default 0.25)
+}
+
+// DefaultAnalysisParams returns the analysis parameters from appconfig (env vars).
+func DefaultAnalysisParams() AnalysisParams {
+	cfg := appconfig.Get()
+	return AnalysisParams{
+		ScoreThreshold:   cfg.RDPPIIScoreThreshold(),
+		EntityDenylist:   cfg.RDPPIIEntityDenylist(),
+		SnapshotInterval: cfg.RDPPIISnapshotInterval(),
+	}
+}
+
+// isEntityDenied checks if an entity type is in the denylist.
+func isEntityDenied(entityType string, denylist []string) bool {
+	for _, denied := range denylist {
+		if denied == entityType {
+			return true
+		}
+	}
+	return false
+}
+
+// getCanvasDimensions reads the canvas size from session metrics, falling back to defaults.
+func getCanvasDimensions(session *models.Session) (int, int) {
+	w, h := defaultCanvasWidth, defaultCanvasHeight
+	if session.Metrics != nil {
+		if cw, ok := session.Metrics["canvas_width"]; ok {
+			switch v := cw.(type) {
+			case float64:
+				w = int(v)
+			case json.Number:
+				if n, err := v.Int64(); err == nil {
+					w = int(n)
+				}
+			}
+		}
+		if ch, ok := session.Metrics["canvas_height"]; ok {
+			switch v := ch.(type) {
+			case float64:
+				h = int(v)
+			case json.Number:
+				if n, err := v.Int64(); err == nil {
+					h = int(n)
+				}
+			}
+		}
+	}
+	if w <= 0 {
+		w = defaultCanvasWidth
+	}
+	if h <= 0 {
+		h = defaultCanvasHeight
+	}
+	return w, h
+}
+
+// compositeBitmap draws a decoded RGBA bitmap patch onto the full framebuffer at (dstX, dstY).
+func compositeBitmap(framebuffer []byte, fbWidth, fbHeight int, patch []byte, patchW, patchH, dstX, dstY int) {
+	for row := 0; row < patchH; row++ {
+		fbY := dstY + row
+		if fbY < 0 || fbY >= fbHeight {
+			continue
+		}
+		srcOff := row * patchW * 4
+		dstOff := (fbY*fbWidth + dstX) * 4
+		for col := 0; col < patchW; col++ {
+			fbX := dstX + col
+			if fbX < 0 || fbX >= fbWidth {
+				continue
+			}
+			si := srcOff + col*4
+			di := dstOff + col*4
+			if si+3 < len(patch) && di+3 < len(framebuffer) {
+				framebuffer[di] = patch[si]
+				framebuffer[di+1] = patch[si+1]
+				framebuffer[di+2] = patch[si+2]
+				framebuffer[di+3] = patch[si+3]
+			}
+		}
+	}
+}
+
+// sampleFramebuffer extracts every 64th scanline from the framebuffer for fast hashing.
+// This captures enough visual information to detect meaningful screen changes while
+// avoiding the cost of hashing the entire framebuffer (which can be 8MB+ for 2048x1083).
+func sampleFramebuffer(fb []byte, width, height int) []byte {
+	stride := width * 4
+	var sample []byte
+	for y := 0; y < height; y += 64 {
+		offset := y * stride
+		end := offset + stride
+		if end > len(fb) {
+			end = len(fb)
+		}
+		sample = append(sample, fb[offset:end]...)
+	}
+	return sample
+}
+
+// analyzeSnapshot runs OCR + Presidio on the full framebuffer and returns detections.
+// The params control score threshold and entity denylist filtering.
+func analyzeSnapshot(
+	ctx context.Context,
+	framebuffer []byte,
+	fbWidth, fbHeight int,
+	sessionID string,
+	frameIndex int,
+	timestamp float64,
+	presidio *PresidioClient,
+	params AnalysisParams,
+) ([]models.RDPEntityDetection, map[string]int64, error) {
+	ocrResult, err := ocr.ExtractWords(ctx, framebuffer, fbWidth, fbHeight)
+	if err != nil {
+		return nil, nil, fmt.Errorf("OCR failed: %w", err)
+	}
+	if ocrResult.Text == "" || len(ocrResult.Words) == 0 {
+		return nil, nil, nil
+	}
+
+	results, err := presidio.Analyze(ctx, ocrResult.Text, params.ScoreThreshold)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Presidio failed: %w", err)
+	}
+
+	// Filter out denied entity types
+	if len(params.EntityDenylist) > 0 {
+		filtered := results[:0]
+		for _, r := range results {
+			if !isEntityDenied(r.EntityType, params.EntityDenylist) {
+				filtered = append(filtered, r)
+			}
+		}
+		results = filtered
+	}
+
+	counts := AggregateResults(results)
+
+	var detections []models.RDPEntityDetection
+	if len(results) > 0 {
+		wordRanges := buildWordRanges(ocrResult.Words)
+		for _, result := range results {
+			bbox := mapEntityToPixelBBox(result, wordRanges)
+			if bbox == nil {
+				continue
+			}
+			// Coordinates are already in screen-space (full framebuffer)
+			detections = append(detections, models.RDPEntityDetection{
+				SessionID:  sessionID,
+				FrameIndex: frameIndex,
+				Timestamp:  timestamp,
+				EntityType: result.EntityType,
+				Score:      result.Score,
+				X:          bbox.x,
+				Y:          bbox.y,
+				Width:      bbox.w,
+				Height:     bbox.h,
+			})
+		}
+	}
+
+	return detections, counts, nil
+}
+
+// processJob does the actual analysis work for a single job.
+//
+// It reconstructs a full RGBA framebuffer from the differential bitmap patches,
+// then periodically snapshots the full frame for OCR + Presidio analysis.
+// This ensures PII that spans multiple bitmap updates (e.g. a long email address)
+// is detected correctly, since OCR sees the complete screen content.
+func processJob(ctx context.Context, job *models.RDPAnalysisJob, presidio *PresidioClient) error {
+	// 1. Fetch the session and its blob stream
+	session, err := models.GetSessionByID(job.OrgID, job.SessionID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch session: %w", err)
+	}
+
+	blob, err := session.GetBlobStream()
+	if err != nil {
+		return fmt.Errorf("failed to fetch blob stream: %w", err)
+	}
+	if blob == nil || len(blob.BlobStream) == 0 {
+		return nil // No recording data, nothing to analyze
+	}
+
+	// 2. Parse the blob stream (JSON array of events)
+	var events []json.RawMessage
+	if err := json.Unmarshal(blob.BlobStream, &events); err != nil {
+		return fmt.Errorf("failed to parse blob stream: %w", err)
+	}
+
+	// 3. Allocate the full-screen framebuffer and read analysis params
+	fbWidth, fbHeight := getCanvasDimensions(session)
+	framebuffer := make([]byte, fbWidth*fbHeight*4) // RGBA, initialized to black (zeroes)
+	params := DefaultAnalysisParams()
+
+	log.With("sid", job.SessionID).
+		Infof("rdp-analyzer: params score_threshold=%.2f, snapshot_interval=%.1fs, entity_denylist=%v",
+			params.ScoreThreshold, params.SnapshotInterval, params.EntityDenylist)
+
+	// 4. Iterate events, composite patches, and snapshot periodically
+	aggregatedCounts := make(map[string]int64)
+	var allDetections []models.RDPEntityDetection
+	var prevTextHash [32]byte
+	var prevFBHash [32]byte
+	snapshotsRun := 0
+	bitmapsComposited := 0
+	lastSnapshotTime := -params.SnapshotInterval // ensure first eligible frame triggers a snapshot
+	fbDirty := false                             // has the framebuffer changed since last snapshot?
+	var lastEventTimestamp float64               // timestamp of the most recent bitmap event
+	frameIndex := 0
+
+	for _, rawEvent := range events {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Parse the event: [timestamp, type, base64data]
+		var event [3]json.RawMessage
+		if err := json.Unmarshal(rawEvent, &event); err != nil {
+			continue
+		}
+
+		var eventType string
+		if err := json.Unmarshal(event[1], &eventType); err != nil || eventType != "b" {
+			continue
+		}
+
+		var timestamp float64
+		if err := json.Unmarshal(event[0], &timestamp); err != nil {
+			continue
+		}
+
+		var b64Str string
+		if err := json.Unmarshal(event[2], &b64Str); err != nil {
+			frameIndex++
+			continue
+		}
+		bitmapJSON, err := base64.StdEncoding.DecodeString(b64Str)
+		if err != nil {
+			frameIndex++
+			continue
+		}
+
+		var bmpEvent BitmapEvent
+		if err := json.Unmarshal(bitmapJSON, &bmpEvent); err != nil {
+			frameIndex++
+			continue
+		}
+
+		currentFrameIndex := frameIndex
+		frameIndex++
+
+		if len(bmpEvent.Data) == 0 || bmpEvent.Width == 0 || bmpEvent.Height == 0 {
+			continue
+		}
+
+		// Decompress the patch to RGBA
+		patchW := int(bmpEvent.Width)
+		patchH := int(bmpEvent.Height)
+		bpp := int(bmpEvent.BitsPerPixel)
+
+		var rgba []byte
+		if bmpEvent.Compressed {
+			rgba, err = rle.DecompressToRGBA(bmpEvent.Data, patchW, patchH, bpp)
+		} else {
+			rgba, err = rle.ToRGBA(bmpEvent.Data, patchW, patchH, bpp)
+		}
+		if err != nil {
+			log.With("sid", job.SessionID).Debugf("failed to decode bitmap frame %d: %v", currentFrameIndex, err)
+			continue
+		}
+
+		// Composite the patch onto the full framebuffer
+		compositeBitmap(framebuffer, fbWidth, fbHeight, rgba, patchW, patchH, int(bmpEvent.X), int(bmpEvent.Y))
+		fbDirty = true
+		lastEventTimestamp = timestamp
+		bitmapsComposited++
+
+		// Check if it's time for a snapshot (every params.SnapshotInterval of session time)
+		if (timestamp - lastSnapshotTime) < params.SnapshotInterval {
+			continue
+		}
+
+		// Take a snapshot of the full framebuffer
+		lastSnapshotTime = timestamp
+		fbDirty = false
+
+		// Quick framebuffer dedup: sample a few scanlines and hash them.
+		// This avoids expensive OCR+Presidio calls when only minor changes
+		// happened (cursor blink, clock tick, etc.)
+		fbSample := sampleFramebuffer(framebuffer, fbWidth, fbHeight)
+		fbHash := sha256.Sum256(fbSample)
+		if fbHash == prevFBHash {
+			continue
+		}
+		prevFBHash = fbHash
+
+		// Text dedup: hash the full framebuffer is too expensive, so we still
+		// dedup based on OCR text output. We run OCR and if the text is identical
+		// to the previous snapshot, skip the Presidio call.
+		detections, counts, analyzeErr := analyzeSnapshot(
+			ctx, framebuffer, fbWidth, fbHeight,
+			job.SessionID, currentFrameIndex, timestamp, presidio, params,
+		)
+		if analyzeErr != nil {
+			log.With("sid", job.SessionID).Debugf("snapshot analysis failed at t=%.1fs: %v", timestamp, analyzeErr)
+			continue
+		}
+
+		snapshotsRun++
+
+		if len(detections) == 0 && len(counts) == 0 {
+			continue
+		}
+
+		// Detection dedup: skip writing duplicate rows when the same entities
+		// are detected at the same bounding boxes as the previous snapshot.
+		// This avoids flooding the detections table during long stretches of
+		// identical screen content that still pass the framebuffer-sample hash
+		// (e.g. anti-aliased text that pixel-samples differently but OCRs the same).
+		var bboxFingerprint string
+		for _, d := range detections {
+			bboxFingerprint += fmt.Sprintf("%s:%d:%d:%d:%d,", d.EntityType, d.X, d.Y, d.Width, d.Height)
+		}
+		bboxHash := sha256.Sum256([]byte(bboxFingerprint))
+		if bboxHash == prevTextHash && len(detections) > 0 {
+			continue
+		}
+		prevTextHash = bboxHash
+
+		for infoType, count := range counts {
+			aggregatedCounts[infoType] += count
+		}
+		allDetections = append(allDetections, detections...)
+	}
+
+	// Final snapshot: if the framebuffer was modified after the last snapshot, analyze it
+	if fbDirty {
+		detections, counts, analyzeErr := analyzeSnapshot(
+			ctx, framebuffer, fbWidth, fbHeight,
+			job.SessionID, frameIndex-1, lastEventTimestamp, presidio, params,
+		)
+		if analyzeErr == nil && (len(detections) > 0 || len(counts) > 0) {
+			snapshotsRun++
+			for infoType, count := range counts {
+				aggregatedCounts[infoType] += count
+			}
+			allDetections = append(allDetections, detections...)
+		}
+	}
+
+	log.With("sid", job.SessionID).
+		Infof("rdp-analyzer: bitmaps=%d composited, snapshots=%d analyzed, entities=%d types, detections=%d",
+			bitmapsComposited, snapshotsRun, len(aggregatedCounts), len(allDetections))
+
+	// 5. Write aggregate results to session_metrics and sessions.metrics
+	if len(aggregatedCounts) > 0 {
+		if err := models.IncrementSessionAnalyzedMetrics(models.DB, job.SessionID, aggregatedCounts); err != nil {
+			log.With("sid", job.SessionID).Warnf("failed to write session_metrics: %v", err)
+		}
+		if err := models.UpdateSessionAnalyzerMetrics(job.OrgID, job.SessionID, aggregatedCounts); err != nil {
+			log.With("sid", job.SessionID).Warnf("failed to update session analyzer metrics: %v", err)
+		}
+	}
+
+	// 6. Bulk-insert per-frame entity detections
+	if len(allDetections) > 0 {
+		if err := models.BulkInsertRDPEntityDetections(allDetections); err != nil {
+			log.With("sid", job.SessionID).Warnf("failed to write entity detections: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// buildWordRanges constructs a character-offset index from OCR words.
+// The full text is reconstructed as "word1 word2 word3..." (space-separated),
+// and each wordRange records the start/end byte offsets of each word in that string.
+func buildWordRanges(words []ocr.Word) []wordRange {
+	ranges := make([]wordRange, 0, len(words))
+	offset := 0
+	for _, w := range words {
+		end := offset + len(w.Text)
+		ranges = append(ranges, wordRange{
+			start: offset,
+			end:   end,
+			word:  w,
+		})
+		offset = end + 1 // +1 for the space separator
+	}
+	return ranges
+}
+
+// pixelBBox is a bounding box in bitmap-local pixel coordinates.
+type pixelBBox struct {
+	x, y, w, h int
+}
+
+// mapEntityToPixelBBox maps a Presidio AnalyzerResult (character offsets) to a merged
+// bounding box from the OCR words that overlap the entity's character range.
+// Returns nil if no overlapping words are found.
+func mapEntityToPixelBBox(entity AnalyzerResult, ranges []wordRange) *pixelBBox {
+	var minX, minY, maxX2, maxY2 int
+	found := false
+
+	for _, wr := range ranges {
+		// Check if this word overlaps the entity's character range [Start, End)
+		if wr.end <= entity.Start || wr.start >= entity.End {
+			continue // No overlap
+		}
+
+		x2 := wr.word.Left + wr.word.Width
+		y2 := wr.word.Top + wr.word.Height
+
+		if !found {
+			minX = wr.word.Left
+			minY = wr.word.Top
+			maxX2 = x2
+			maxY2 = y2
+			found = true
+		} else {
+			if wr.word.Left < minX {
+				minX = wr.word.Left
+			}
+			if wr.word.Top < minY {
+				minY = wr.word.Top
+			}
+			if x2 > maxX2 {
+				maxX2 = x2
+			}
+			if y2 > maxY2 {
+				maxY2 = y2
+			}
+		}
+	}
+
+	if !found {
+		return nil
+	}
+
+	return &pixelBBox{
+		x: minX,
+		y: minY,
+		w: maxX2 - minX,
+		h: maxY2 - minY,
+	}
+}
+
+// sleep waits for duration or until context is cancelled.
+func sleep(ctx context.Context, d time.Duration) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(d):
+	}
+}

--- a/gateway/rdp/ocr/ocr.go
+++ b/gateway/rdp/ocr/ocr.go
@@ -1,0 +1,241 @@
+// Package ocr provides text extraction from bitmap images using Tesseract OCR.
+//
+// Tesseract is invoked as a subprocess to avoid CGO/libtesseract-dev build dependencies.
+// Images are encoded as PNG in memory and piped to tesseract via stdin.
+package ocr
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/png"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/hoophq/hoop/common/log"
+)
+
+// minWidthForUpscale is the threshold below which frames are 2x upscaled
+// to improve OCR accuracy. RDP-captured screenshots need upscaling even at
+// high resolutions because ClearType rendering + RDP compression degrades
+// text quality enough that Tesseract misses characters like '@'.
+// Set high enough to always upscale typical RDP resolutions (up to 4K).
+const minWidthForUpscale = 4096
+
+// Word represents a single word extracted by Tesseract OCR with its bounding box.
+// Coordinates are in the original image pixel space (before any upscaling).
+type Word struct {
+	Text   string
+	Left   int
+	Top    int
+	Width  int
+	Height int
+	Conf   float64 // Confidence score (0-100)
+}
+
+// ExtractResult contains the full OCR output: reconstructed text and per-word bounding boxes.
+type ExtractResult struct {
+	// Text is the full reconstructed text (words joined by spaces).
+	Text string
+	// Words contains each detected word with its bounding box.
+	Words []Word
+	// Upscaled is true if the image was 2x upscaled for OCR.
+	// When true, word coordinates have already been halved back to original scale.
+	Upscaled bool
+}
+
+// ExtractText runs Tesseract OCR on RGBA pixel data and returns the extracted text.
+//
+// The RGBA data must be in top-down row order (as returned by rle.ToRGBA).
+// width and height are the image dimensions.
+//
+// Tesseract is invoked with PSM 11 (sparse text) which works best for UI screenshots
+// where text is scattered across the screen rather than forming a single block.
+func ExtractText(ctx context.Context, rgba []byte, width, height int) (string, error) {
+	result, err := ExtractWords(ctx, rgba, width, height)
+	if err != nil {
+		return "", err
+	}
+	return result.Text, nil
+}
+
+// ExtractWords runs Tesseract OCR on RGBA pixel data and returns structured word-level results.
+//
+// Each word includes its bounding box in the original (pre-upscale) image coordinate space.
+// The reconstructed text is the words joined by spaces, suitable for passing to Presidio.
+func ExtractWords(ctx context.Context, rgba []byte, width, height int) (*ExtractResult, error) {
+	if len(rgba) == 0 {
+		return &ExtractResult{}, nil
+	}
+
+	expectedLen := width * height * 4
+	if len(rgba) < expectedLen {
+		return nil, fmt.Errorf("ocr: RGBA data too short: got %d, expected %d", len(rgba), expectedLen)
+	}
+
+	// Build an image.NRGBA from the raw RGBA bytes
+	img := &image.NRGBA{
+		Pix:    rgba,
+		Stride: width * 4,
+		Rect:   image.Rect(0, 0, width, height),
+	}
+
+	// Upscale 2x if image is small (improves accuracy on small fonts)
+	upscaled := false
+	if width < minWidthForUpscale {
+		img = nearestNeighbor2x(img)
+		upscaled = true
+	}
+
+	// Encode as PNG in memory
+	var pngBuf bytes.Buffer
+	if err := png.Encode(&pngBuf, img); err != nil {
+		return nil, fmt.Errorf("ocr: failed to encode PNG: %w", err)
+	}
+
+	// Run tesseract with TSV output for word-level bounding boxes
+	tsvOutput, err := runTesseractTSV(ctx, pngBuf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse TSV output into words
+	words := parseTSV(tsvOutput, upscaled)
+
+	// Reconstruct full text from words
+	var textParts []string
+	for _, w := range words {
+		textParts = append(textParts, w.Text)
+	}
+
+	return &ExtractResult{
+		Text:     strings.Join(textParts, " "),
+		Words:    words,
+		Upscaled: upscaled,
+	}, nil
+}
+
+// runTesseractTSV invokes tesseract with TSV output to get word-level bounding boxes.
+func runTesseractTSV(ctx context.Context, pngData []byte) (string, error) {
+	cmd := exec.CommandContext(ctx, "tesseract", "stdin", "stdout", "--psm", "6", "-l", "eng", "tsv")
+	cmd.Stdin = bytes.NewReader(pngData)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		stderrStr := strings.TrimSpace(stderr.String())
+		if stderrStr != "" {
+			log.Debugf("tesseract stderr: %s", stderrStr)
+		}
+		return "", fmt.Errorf("ocr: tesseract failed: %w (stderr: %s)", err, stderrStr)
+	}
+
+	return stdout.String(), nil
+}
+
+// parseTSV parses Tesseract TSV output into a slice of Words.
+// TSV columns: level, page_num, block_num, par_num, line_num, word_num, left, top, width, height, conf, text
+// We only care about level 5 (individual words) with non-empty text.
+// If upscaled is true, coordinates are halved back to original image scale.
+func parseTSV(tsv string, upscaled bool) []Word {
+	lines := strings.Split(tsv, "\n")
+	var words []Word
+
+	for i, line := range lines {
+		if i == 0 {
+			continue // Skip header line
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Split(line, "\t")
+		if len(fields) < 12 {
+			continue
+		}
+
+		// Only process word-level entries (level 5)
+		level, err := strconv.Atoi(fields[0])
+		if err != nil || level != 5 {
+			continue
+		}
+
+		text := fields[11]
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+
+		conf, _ := strconv.ParseFloat(fields[10], 64)
+		if conf < 0 {
+			continue // Skip entries with invalid confidence
+		}
+
+		left, _ := strconv.Atoi(fields[6])
+		top, _ := strconv.Atoi(fields[7])
+		width, _ := strconv.Atoi(fields[8])
+		height, _ := strconv.Atoi(fields[9])
+
+		// If the image was 2x upscaled, halve coordinates back to original scale
+		if upscaled {
+			left /= 2
+			top /= 2
+			width /= 2
+			height /= 2
+		}
+
+		words = append(words, Word{
+			Text:   text,
+			Left:   left,
+			Top:    top,
+			Width:  width,
+			Height: height,
+			Conf:   conf,
+		})
+	}
+
+	return words
+}
+
+// nearestNeighbor2x scales an NRGBA image by 2x using nearest-neighbor interpolation.
+// This is intentionally simple — no smoothing, which preserves text edges for OCR.
+func nearestNeighbor2x(src *image.NRGBA) *image.NRGBA {
+	srcW := src.Rect.Dx()
+	srcH := src.Rect.Dy()
+	dstW := srcW * 2
+	dstH := srcH * 2
+
+	dst := image.NewNRGBA(image.Rect(0, 0, dstW, dstH))
+
+	for y := 0; y < srcH; y++ {
+		srcRowOff := y * src.Stride
+		dstRow1Off := (y * 2) * dst.Stride
+		dstRow2Off := (y*2 + 1) * dst.Stride
+
+		for x := 0; x < srcW; x++ {
+			si := srcRowOff + x*4
+			r, g, b, a := src.Pix[si], src.Pix[si+1], src.Pix[si+2], src.Pix[si+3]
+
+			di1 := dstRow1Off + x*2*4
+			di2 := dstRow2Off + x*2*4
+
+			// Write 2x2 block
+			dst.Pix[di1], dst.Pix[di1+1], dst.Pix[di1+2], dst.Pix[di1+3] = r, g, b, a
+			dst.Pix[di1+4], dst.Pix[di1+5], dst.Pix[di1+6], dst.Pix[di1+7] = r, g, b, a
+			dst.Pix[di2], dst.Pix[di2+1], dst.Pix[di2+2], dst.Pix[di2+3] = r, g, b, a
+			dst.Pix[di2+4], dst.Pix[di2+5], dst.Pix[di2+6], dst.Pix[di2+7] = r, g, b, a
+		}
+	}
+
+	return dst
+}
+
+// IsAvailable checks whether the tesseract binary is available in PATH.
+func IsAvailable() bool {
+	_, err := exec.LookPath("tesseract")
+	return err == nil
+}

--- a/gateway/rdp/recorder.go
+++ b/gateway/rdp/recorder.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/rdp/analyzer"
 	"github.com/hoophq/hoop/gateway/rdp/parser"
 )
 
@@ -318,6 +320,18 @@ func (r *RDPSessionRecorder) Close(err error) {
 	if dbErr := models.UpdateSessionEventStream(sessDone); dbErr != nil {
 		log.With("sid", r.sessionID).Errorf("failed to finalize RDP session: %v", dbErr)
 		return
+	}
+
+	// Enqueue async PII analysis if there are bitmap frames to analyze AND the
+	// analysis pipeline is actually enabled on this gateway. Otherwise the job
+	// would sit 'pending' forever and the session would appear stuck.
+	if r.bitmapCount > 0 && analyzer.IsEnabled(appconfig.Get().MSPresidioAnalyzerURL()) {
+		if enqueueErr := models.CreateRDPAnalysisJob(r.orgID, r.sessionID); enqueueErr != nil {
+			log.With("sid", r.sessionID).Warnf("failed to enqueue RDP analysis job: %v", enqueueErr)
+		} else {
+			_ = models.UpdateSessionRDPAnalysisStatus(r.orgID, r.sessionID, "pending")
+			log.With("sid", r.sessionID).Infof("enqueued RDP PII analysis job")
+		}
 	}
 
 	log.With("sid", r.sessionID).Infof("RDP session finalized, events=%d, bitmaps=%d, size=%d bytes",

--- a/gateway/rdp/rle/rle.go
+++ b/gateway/rdp/rle/rle.go
@@ -1,0 +1,435 @@
+// Package rle implements RDP Interleaved Run-Length Encoding (RLE) bitmap decompression
+// and pixel format conversion.
+//
+// Ported from the JavaScript implementation at webapp/resources/public/rdpclient/rle.js,
+// which itself was ported from IronRDP's ironrdp-graphics/src/rle.rs.
+//
+// References:
+//   - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/b3b60873-16a8-4cbc-8aaa-5f0a93083280
+//   - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/b6a3f5c2-0804-4c10-9d25-a321720fd23e
+package rle
+
+import (
+	"fmt"
+)
+
+// Order codes
+const (
+	regularBGRun  = 0x00
+	regularFGRun  = 0x01
+	regularFGBG   = 0x02
+	regularColor  = 0x03
+	regularCImage = 0x04
+
+	megaMegaBGRun    = 0xF0
+	megaMegaFGRun    = 0xF1
+	megaMegaFGBG     = 0xF2
+	megaMegaColor    = 0xF3
+	megaMegaCImage   = 0xF4
+	megaMegaSetFGRun = 0xF6
+	megaMegaSetFGBG  = 0xF7
+	megaMegaDithered = 0xF8
+
+	liteSetFGRun = 0x0C
+	liteSetFGBG  = 0x0D
+	liteDithered = 0x0E
+
+	specialFGBG1 = 0xF9
+	specialFGBG2 = 0xFA
+	specialWhite = 0xFD
+	specialBlack = 0xFE
+
+	maskRegularRunLength = 0x1F
+	maskLiteRunLength    = 0x0F
+)
+
+// decodeCode extracts the order code from the header byte.
+func decodeCode(header byte) byte {
+	if header&0xC0 != 0xC0 {
+		return header >> 5
+	}
+	if header&0xF0 == 0xF0 {
+		return header
+	}
+	return header >> 4
+}
+
+// Decompress decompresses RLE-encoded RDP bitmap data.
+//
+// src is the compressed data, width and height are the bitmap dimensions,
+// bpp is bits per pixel (8, 15, 16, or 24).
+// Returns decompressed pixel data in the native RDP format (not RGBA).
+func Decompress(src []byte, width, height, bpp int) ([]byte, error) {
+	if len(src) == 0 {
+		return nil, fmt.Errorf("rle: empty source data")
+	}
+
+	var colorDepth int
+	switch {
+	case bpp <= 8:
+		colorDepth = 1
+	case bpp <= 16:
+		colorDepth = 2
+	default:
+		colorDepth = 3
+	}
+
+	rowDelta := colorDepth * width
+	dst := make([]byte, rowDelta*height)
+
+	srcPos := 0
+	dstPos := 0
+
+	var whitePixel uint32
+	switch bpp {
+	case 24:
+		whitePixel = 0xFFFFFF
+	case 16:
+		whitePixel = 0xFFFF
+	case 15:
+		whitePixel = 0x7FFF
+	default:
+		whitePixel = 0xFF
+	}
+	const blackPixel uint32 = 0
+
+	fgPel := whitePixel
+	insertFgPel := false
+	isFirstLine := true
+
+	readU8 := func() byte {
+		if srcPos >= len(src) {
+			return 0
+		}
+		v := src[srcPos]
+		srcPos++
+		return v
+	}
+
+	readU16 := func() uint16 {
+		if srcPos+1 >= len(src) {
+			srcPos = len(src)
+			return 0
+		}
+		v := uint16(src[srcPos]) | uint16(src[srcPos+1])<<8
+		srcPos += 2
+		return v
+	}
+
+	readPixel := func() uint32 {
+		if colorDepth == 1 {
+			return uint32(readU8())
+		}
+		if colorDepth == 2 {
+			return uint32(readU16())
+		}
+		// 24bpp: 3 bytes LE
+		if srcPos+2 >= len(src) {
+			srcPos = len(src)
+			return 0
+		}
+		b0, b1, b2 := src[srcPos], src[srcPos+1], src[srcPos+2]
+		srcPos += 3
+		return uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16
+	}
+
+	writePixel := func(pixel uint32) {
+		if dstPos >= len(dst) {
+			return
+		}
+		if colorDepth == 1 {
+			dst[dstPos] = byte(pixel)
+			dstPos++
+		} else if colorDepth == 2 {
+			if dstPos+1 >= len(dst) {
+				return
+			}
+			dst[dstPos] = byte(pixel)
+			dst[dstPos+1] = byte(pixel >> 8)
+			dstPos += 2
+		} else {
+			if dstPos+2 >= len(dst) {
+				return
+			}
+			dst[dstPos] = byte(pixel)
+			dst[dstPos+1] = byte(pixel >> 8)
+			dst[dstPos+2] = byte(pixel >> 16)
+			dstPos += 3
+		}
+	}
+
+	readPixelAbove := func() uint32 {
+		abovePos := dstPos - rowDelta
+		if abovePos < 0 {
+			return 0
+		}
+		if colorDepth == 1 {
+			return uint32(dst[abovePos])
+		}
+		if colorDepth == 2 {
+			return uint32(dst[abovePos]) | uint32(dst[abovePos+1])<<8
+		}
+		return uint32(dst[abovePos]) | uint32(dst[abovePos+1])<<8 | uint32(dst[abovePos+2])<<16
+	}
+
+	extractRunLengthRegular := func(header byte) int {
+		rl := int(header & maskRegularRunLength)
+		if rl == 0 {
+			return int(readU8()) + 32
+		}
+		return rl
+	}
+
+	extractRunLengthLite := func(header byte) int {
+		rl := int(header & maskLiteRunLength)
+		if rl == 0 {
+			return int(readU8()) + 16
+		}
+		return rl
+	}
+
+	extractRunLengthFgBg := func(header byte, mask byte) int {
+		rl := int(header & mask)
+		if rl == 0 {
+			return int(readU8()) + 1
+		}
+		return rl * 8
+	}
+
+	extractRunLengthMegaMega := func() int {
+		return int(readU16())
+	}
+
+	extractRunLength := func(code, header byte) int {
+		switch code {
+		case regularFGBG:
+			return extractRunLengthFgBg(header, maskRegularRunLength)
+		case liteSetFGBG:
+			return extractRunLengthFgBg(header, maskLiteRunLength)
+		case regularBGRun, regularFGRun, regularColor, regularCImage:
+			return extractRunLengthRegular(header)
+		case liteSetFGRun, liteDithered:
+			return extractRunLengthLite(header)
+		case megaMegaBGRun, megaMegaFGRun, megaMegaSetFGRun,
+			megaMegaDithered, megaMegaColor,
+			megaMegaFGBG, megaMegaSetFGBG, megaMegaCImage:
+			return extractRunLengthMegaMega()
+		default:
+			return 0
+		}
+	}
+
+	writeFgBgImage := func(bitmask byte, cBits int) {
+		var mask byte = 0x01
+		for i := 0; i < cBits; i++ {
+			if isFirstLine {
+				if bitmask&mask != 0 {
+					writePixel(fgPel)
+				} else {
+					writePixel(blackPixel)
+				}
+			} else {
+				above := readPixelAbove()
+				if bitmask&mask != 0 {
+					writePixel(above ^ fgPel)
+				} else {
+					writePixel(above)
+				}
+			}
+			mask <<= 1
+		}
+	}
+
+	for srcPos < len(src) {
+		if isFirstLine && dstPos >= rowDelta {
+			isFirstLine = false
+			insertFgPel = false
+		}
+
+		header := readU8()
+		code := decodeCode(header)
+		runLength := extractRunLength(code, header)
+
+		// Background Run
+		if code == regularBGRun || code == megaMegaBGRun {
+			count := runLength
+			if insertFgPel {
+				if isFirstLine {
+					writePixel(fgPel)
+				} else {
+					writePixel(readPixelAbove() ^ fgPel)
+				}
+				count--
+			}
+			for i := 0; i < count; i++ {
+				if isFirstLine {
+					writePixel(blackPixel)
+				} else {
+					writePixel(readPixelAbove())
+				}
+			}
+			insertFgPel = true
+			continue
+		}
+
+		insertFgPel = false
+
+		switch {
+		// Foreground Run
+		case code == regularFGRun || code == megaMegaFGRun ||
+			code == liteSetFGRun || code == megaMegaSetFGRun:
+			if code == liteSetFGRun || code == megaMegaSetFGRun {
+				fgPel = readPixel()
+			}
+			for i := 0; i < runLength; i++ {
+				if isFirstLine {
+					writePixel(fgPel)
+				} else {
+					writePixel(readPixelAbove() ^ fgPel)
+				}
+			}
+
+		// Dithered Run
+		case code == liteDithered || code == megaMegaDithered:
+			pixelA := readPixel()
+			pixelB := readPixel()
+			for i := 0; i < runLength; i++ {
+				writePixel(pixelA)
+				writePixel(pixelB)
+			}
+
+		// Color Run
+		case code == regularColor || code == megaMegaColor:
+			pixel := readPixel()
+			for i := 0; i < runLength; i++ {
+				writePixel(pixel)
+			}
+
+		// Foreground/Background Image
+		case code == regularFGBG || code == megaMegaFGBG ||
+			code == liteSetFGBG || code == megaMegaSetFGBG:
+			if code == liteSetFGBG || code == megaMegaSetFGBG {
+				fgPel = readPixel()
+			}
+			remaining := runLength
+			for remaining > 0 {
+				cBits := remaining
+				if cBits > 8 {
+					cBits = 8
+				}
+				bitmask := readU8()
+				writeFgBgImage(bitmask, cBits)
+				remaining -= cBits
+			}
+
+		// Color Image
+		case code == regularCImage || code == megaMegaCImage:
+			byteCount := runLength * colorDepth
+			for i := 0; i < byteCount; i++ {
+				if dstPos < len(dst) && srcPos < len(src) {
+					dst[dstPos] = src[srcPos]
+					dstPos++
+					srcPos++
+				}
+			}
+
+		// Special FgBg 1
+		case code == specialFGBG1:
+			writeFgBgImage(0x03, 8)
+
+		// Special FgBg 2
+		case code == specialFGBG2:
+			writeFgBgImage(0x05, 8)
+
+		// Special White
+		case code == specialWhite:
+			writePixel(whitePixel)
+
+		// Special Black
+		case code == specialBlack:
+			writePixel(blackPixel)
+		}
+	}
+
+	return dst, nil
+}
+
+// ToRGBA converts decompressed RDP bitmap pixel data to RGBA format.
+// Handles bottom-up row order (RDP bitmaps are bottom-up) and BGR->RGB conversion.
+//
+// src is the decompressed pixel data (from Decompress or raw uncompressed data),
+// width and height are the bitmap dimensions, bpp is bits per pixel (16, 24, or 32).
+// Returns RGBA pixel data (4 bytes per pixel, top-down row order).
+func ToRGBA(src []byte, width, height, bpp int) ([]byte, error) {
+	bytesPerPixel := bpp >> 3 // 2, 3, or 4
+	srcRowBytes := width * bytesPerPixel
+	totalPixels := width * height
+	dst := make([]byte, totalPixels*4)
+
+	for row := 0; row < height; row++ {
+		// RDP bitmaps are bottom-up: first row in data = bottom row on screen
+		srcRow := height - 1 - row
+		srcRowOffset := srcRow * srcRowBytes
+		dstRowOffset := row * width * 4
+
+		switch bpp {
+		case 16:
+			// RGB565 little-endian
+			for col := 0; col < width; col++ {
+				si := srcRowOffset + col*2
+				di := dstRowOffset + col*4
+				if si+1 >= len(src) {
+					break
+				}
+				pixel := uint16(src[si]) | uint16(src[si+1])<<8
+				r := (pixel >> 11) & 0x1F
+				g := (pixel >> 5) & 0x3F
+				b := pixel & 0x1F
+				dst[di] = byte((r << 3) | (r >> 2))
+				dst[di+1] = byte((g << 2) | (g >> 4))
+				dst[di+2] = byte((b << 3) | (b >> 2))
+				dst[di+3] = 255
+			}
+		case 24:
+			// BGR format
+			for col := 0; col < width; col++ {
+				si := srcRowOffset + col*3
+				di := dstRowOffset + col*4
+				if si+2 >= len(src) {
+					break
+				}
+				dst[di] = src[si+2]   // R
+				dst[di+1] = src[si+1] // G
+				dst[di+2] = src[si]   // B
+				dst[di+3] = 255
+			}
+		case 32:
+			// BGRX format
+			for col := 0; col < width; col++ {
+				si := srcRowOffset + col*4
+				di := dstRowOffset + col*4
+				if si+3 >= len(src) {
+					break
+				}
+				dst[di] = src[si+2]   // R
+				dst[di+1] = src[si+1] // G
+				dst[di+2] = src[si]   // B
+				dst[di+3] = 255
+			}
+		default:
+			return nil, fmt.Errorf("rle: unsupported bpp %d for RGBA conversion", bpp)
+		}
+	}
+
+	return dst, nil
+}
+
+// DecompressToRGBA is a convenience function that decompresses RLE data and converts to RGBA.
+// For uncompressed frames, pass the raw data directly to ToRGBA instead.
+func DecompressToRGBA(src []byte, width, height, bpp int) ([]byte, error) {
+	decompressed, err := Decompress(src, width, height, bpp)
+	if err != nil {
+		return nil, err
+	}
+	return ToRGBA(decompressed, width, height, bpp)
+}

--- a/gateway/rdp/rle/rle_test.go
+++ b/gateway/rdp/rle/rle_test.go
@@ -1,0 +1,201 @@
+package rle
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestDecodeCode verifies the header-to-order-code extraction.
+func TestDecodeCode(t *testing.T) {
+	tests := []struct {
+		header byte
+		want   byte
+	}{
+		// Regular codes: top 2 bits != 11, shift >> 5
+		{0x00, regularBGRun},  // 0x00 >> 5 = 0
+		{0x20, regularFGRun},  // 0x20 >> 5 = 1
+		{0x40, regularFGBG},   // 0x40 >> 5 = 2
+		{0x60, regularColor},  // 0x60 >> 5 = 3
+		{0x80, regularCImage}, // 0x80 >> 5 = 4
+		// Lite codes: top 2 bits = 11 but top 4 != 1111, shift >> 4
+		{0xC0, liteSetFGRun}, // 0xC0 >> 4 = 0x0C
+		{0xD0, liteSetFGBG},  // 0xD0 >> 4 = 0x0D
+		{0xE0, liteDithered}, // 0xE0 >> 4 = 0x0E
+		// Mega-mega / special: top 4 bits = 1111, return as-is
+		{0xF0, megaMegaBGRun},
+		{0xF1, megaMegaFGRun},
+		{0xF9, specialFGBG1},
+		{0xFA, specialFGBG2},
+		{0xFD, specialWhite},
+		{0xFE, specialBlack},
+	}
+
+	for _, tt := range tests {
+		got := decodeCode(tt.header)
+		if got != tt.want {
+			t.Errorf("decodeCode(0x%02X) = 0x%02X, want 0x%02X", tt.header, got, tt.want)
+		}
+	}
+}
+
+// TestDecompressEmptySource verifies error on empty input.
+func TestDecompressEmptySource(t *testing.T) {
+	_, err := Decompress(nil, 10, 10, 16)
+	if err == nil {
+		t.Error("expected error for nil source, got nil")
+	}
+	_, err = Decompress([]byte{}, 10, 10, 16)
+	if err == nil {
+		t.Error("expected error for empty source, got nil")
+	}
+}
+
+// TestDecompressSpecialBlack verifies the special black pixel code (0xFE).
+// A single 0xFE byte should produce one black pixel.
+func TestDecompressSpecialBlack(t *testing.T) {
+	// 16bpp: black = 0x0000 (2 bytes)
+	src := []byte{specialBlack}
+	dst, err := Decompress(src, 1, 1, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []byte{0x00, 0x00}
+	if !bytes.Equal(dst, expected) {
+		t.Errorf("Decompress(specialBlack, 1x1, 16bpp) = %v, want %v", dst, expected)
+	}
+}
+
+// TestDecompressSpecialWhite verifies the special white pixel code (0xFD).
+func TestDecompressSpecialWhite(t *testing.T) {
+	// 16bpp: white = 0xFFFF (2 bytes LE)
+	src := []byte{specialWhite}
+	dst, err := Decompress(src, 1, 1, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []byte{0xFF, 0xFF}
+	if !bytes.Equal(dst, expected) {
+		t.Errorf("Decompress(specialWhite, 1x1, 16bpp) = %v, want %v", dst, expected)
+	}
+}
+
+// TestDecompressColorRun verifies a regular color run.
+func TestDecompressColorRun(t *testing.T) {
+	// Regular Color Run: header = 0x60 | runLength (1-31)
+	// Let's make a run of 3 pixels with color 0x1234 (16bpp)
+	// Header: 0x60 | 3 = 0x63
+	// Then the pixel: 0x34, 0x12 (little-endian)
+	src := []byte{0x63, 0x34, 0x12}
+	dst, err := Decompress(src, 3, 1, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []byte{0x34, 0x12, 0x34, 0x12, 0x34, 0x12}
+	if !bytes.Equal(dst, expected) {
+		t.Errorf("Decompress(colorRun) = %v, want %v", dst, expected)
+	}
+}
+
+// TestDecompressBGRun verifies a background run on the first line (black pixels).
+func TestDecompressBGRun(t *testing.T) {
+	// Regular BG Run on first line: should produce black pixels
+	// Header: 0x00 | runLength = 0x04 (4 pixels)
+	src := []byte{0x04}
+	dst, err := Decompress(src, 4, 1, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := make([]byte, 8) // 4 pixels * 2 bytes = 8 bytes, all zeros
+	if !bytes.Equal(dst, expected) {
+		t.Errorf("Decompress(bgRun) = %v, want %v", dst, expected)
+	}
+}
+
+// TestToRGBA16bpp verifies RGB565 to RGBA conversion with bottom-up flip.
+func TestToRGBA16bpp(t *testing.T) {
+	// 1x2 image, 16bpp
+	// Row 0 (bottom in RDP) = pure red: RGB565 = 0xF800 -> LE: 0x00, 0xF8
+	// Row 1 (top in RDP)    = pure blue: RGB565 = 0x001F -> LE: 0x1F, 0x00
+	src := []byte{
+		0x00, 0xF8, // row 0 (bottom on screen)
+		0x1F, 0x00, // row 1 (top on screen)
+	}
+
+	rgba, err := ToRGBA(src, 1, 2, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// After flip: row 0 on screen (top) = blue, row 1 on screen (bottom) = red
+	// Blue: RGB565 0x001F -> R=0, G=0, B=0x1F -> expand: R=0, G=0, B=(0x1F<<3|0x1F>>2)=0xFF
+	// Red: RGB565 0xF800 -> R=0x1F, G=0, B=0 -> expand: R=0xFF, G=0, B=0
+	expectedTop := []byte{0, 0, 255, 255} // blue pixel (was row 1 in data)
+	expectedBot := []byte{255, 0, 0, 255} // red pixel (was row 0 in data)
+	expected := append(expectedTop, expectedBot...)
+
+	if !bytes.Equal(rgba, expected) {
+		t.Errorf("ToRGBA 16bpp:\ngot:  %v\nwant: %v", rgba, expected)
+	}
+}
+
+// TestToRGBA24bpp verifies BGR->RGB conversion with bottom-up flip.
+func TestToRGBA24bpp(t *testing.T) {
+	// 1x1 image, 24bpp BGR
+	// BGR = (0x11, 0x22, 0x33) -> RGB = (0x33, 0x22, 0x11)
+	src := []byte{0x11, 0x22, 0x33}
+	rgba, err := ToRGBA(src, 1, 1, 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []byte{0x33, 0x22, 0x11, 0xFF}
+	if !bytes.Equal(rgba, expected) {
+		t.Errorf("ToRGBA 24bpp = %v, want %v", rgba, expected)
+	}
+}
+
+// TestToRGBA32bpp verifies BGRX->RGBA conversion.
+func TestToRGBA32bpp(t *testing.T) {
+	// 1x1 image, 32bpp BGRX
+	// BGRX = (0xAA, 0xBB, 0xCC, 0x00) -> RGBA = (0xCC, 0xBB, 0xAA, 0xFF)
+	src := []byte{0xAA, 0xBB, 0xCC, 0x00}
+	rgba, err := ToRGBA(src, 1, 1, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []byte{0xCC, 0xBB, 0xAA, 0xFF}
+	if !bytes.Equal(rgba, expected) {
+		t.Errorf("ToRGBA 32bpp = %v, want %v", rgba, expected)
+	}
+}
+
+// TestDecompressToRGBA verifies the convenience function end-to-end.
+func TestDecompressToRGBA(t *testing.T) {
+	// Use a color run of 2 pixels, 16bpp
+	// Color = 0x0000 (black), run length = 2
+	src := []byte{0x62, 0x00, 0x00} // regularColor | 2, pixel 0x0000
+	rgba, err := DecompressToRGBA(src, 2, 1, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 2 black pixels in RGBA
+	expected := []byte{0, 0, 0, 255, 0, 0, 0, 255}
+	if !bytes.Equal(rgba, expected) {
+		t.Errorf("DecompressToRGBA = %v, want %v", rgba, expected)
+	}
+}
+
+// TestColorImageRun verifies color image (raw pixel copy).
+func TestColorImageRun(t *testing.T) {
+	// Regular Color Image: header = 0x80 | runLength
+	// 2 pixels of 16bpp raw data
+	// Header: 0x80 | 2 = 0x82
+	src := []byte{0x82, 0xAB, 0xCD, 0xEF, 0x01}
+	dst, err := Decompress(src, 2, 1, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []byte{0xAB, 0xCD, 0xEF, 0x01}
+	if !bytes.Equal(dst[:4], expected) {
+		t.Errorf("Decompress(colorImage) = %v, want %v", dst[:4], expected)
+	}
+}

--- a/rootfs/app/migrations/000075_rdp_analysis_jobs.down.sql
+++ b/rootfs/app/migrations/000075_rdp_analysis_jobs.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path TO private;
+
+DROP TABLE IF EXISTS rdp_analysis_jobs;
+
+COMMIT;

--- a/rootfs/app/migrations/000075_rdp_analysis_jobs.up.sql
+++ b/rootfs/app/migrations/000075_rdp_analysis_jobs.up.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+SET search_path TO private;
+
+CREATE TABLE rdp_analysis_jobs (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id        UUID NOT NULL REFERENCES orgs(id),
+    session_id    UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    status        TEXT NOT NULL DEFAULT 'pending',
+    priority      INT  NOT NULL DEFAULT 0,
+    attempt       INT  NOT NULL DEFAULT 0,
+    last_error    TEXT,
+    created_at    TIMESTAMP NOT NULL DEFAULT now(),
+    started_at    TIMESTAMP,
+    finished_at   TIMESTAMP
+);
+
+CREATE INDEX idx_rdp_analysis_jobs_status_priority
+    ON rdp_analysis_jobs (status, priority DESC, created_at ASC)
+    WHERE status IN ('pending', 'failed');
+
+CREATE INDEX idx_rdp_analysis_jobs_session_id
+    ON rdp_analysis_jobs (session_id);
+
+COMMIT;

--- a/rootfs/app/migrations/000076_rdp_entity_detections.down.sql
+++ b/rootfs/app/migrations/000076_rdp_entity_detections.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path TO private;
+
+DROP TABLE IF EXISTS rdp_entity_detections;
+
+COMMIT;

--- a/rootfs/app/migrations/000076_rdp_entity_detections.up.sql
+++ b/rootfs/app/migrations/000076_rdp_entity_detections.up.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+SET search_path TO private;
+
+CREATE TABLE rdp_entity_detections (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id  UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    frame_index INT  NOT NULL,
+    timestamp   DOUBLE PRECISION NOT NULL,
+    entity_type TEXT NOT NULL,
+    score       DOUBLE PRECISION NOT NULL,
+    x           INT NOT NULL,
+    y           INT NOT NULL,
+    width       INT NOT NULL,
+    height      INT NOT NULL
+);
+
+CREATE INDEX idx_rdp_entity_detections_session
+    ON rdp_entity_detections (session_id);
+
+COMMIT;

--- a/webapp/src/webapp/audit/views/session_data_rdp.cljs
+++ b/webapp/src/webapp/audit/views/session_data_rdp.cljs
@@ -46,7 +46,6 @@
         data-bytes (if (string? data) (decode-b64 data) data)]
     (when (and canvas-ctx data-bytes (> width 0) (> height 0))
       (try
-        (js/console.time "draw-bitmap")  ;; ← adiciona
         (let [bpp (or bits_per_pixel 16)
               ;; Decompress if needed
               pixel-data (if compressed
@@ -56,7 +55,6 @@
               rgba (js/window.rdpBitmapToRGBA pixel-data width height bpp)
               image-data (js/ImageData. rgba width height)]
           (.putImageData canvas-ctx image-data x y))
-        (js/console.timeEnd "draw-bitmap")  ;; ← e esse
         (catch :default e
           (js/console.error "Error drawing bitmap:" e))))))
 
@@ -67,6 +65,93 @@
                 :query-params {:offset offset :limit limit}
                 :on-success on-success
                 :on-failure on-error}))
+
+(defn- fetch-detections [session-id on-success on-error]
+  (api/request {:method "GET"
+                :uri (str "/sessions/" session-id "/rdp-detections")
+                :on-success on-success
+                :on-failure on-error}))
+
+(def ^:private entity-colors
+  {"PERSON" {:fill "rgba(239, 68, 68, 0.25)" :stroke "rgba(239, 68, 68, 0.85)"}
+   "EMAIL_ADDRESS" {:fill "rgba(249, 115, 22, 0.25)" :stroke "rgba(249, 115, 22, 0.85)"}
+   "PHONE_NUMBER" {:fill "rgba(234, 179, 8, 0.25)" :stroke "rgba(234, 179, 8, 0.85)"}
+   "URL" {:fill "rgba(59, 130, 246, 0.25)" :stroke "rgba(59, 130, 246, 0.85)"}
+   "LOCATION" {:fill "rgba(34, 197, 94, 0.25)" :stroke "rgba(34, 197, 94, 0.85)"}
+   "DATE_TIME" {:fill "rgba(168, 85, 247, 0.25)" :stroke "rgba(168, 85, 247, 0.85)"}
+   "NRP" {:fill "rgba(14, 165, 233, 0.25)" :stroke "rgba(14, 165, 233, 0.85)"}})
+
+(defn- get-entity-color [entity-type]
+  (get entity-colors entity-type {:fill "rgba(107, 114, 128, 0.25)"
+                                   :stroke "rgba(107, 114, 128, 0.85)"}))
+
+(defn- group-detections-by-snapshot
+  "Groups detections by their snapshot timestamp. Returns a sorted vector of
+   [timestamp, detections] pairs for efficient binary search during playback."
+  [detections]
+  (let [by-ts (reduce (fn [acc detection]
+                        (update acc (:timestamp detection) (fnil conj []) detection))
+                      {}
+                      detections)]
+    (->> by-ts
+         (sort-by first)
+         vec)))
+
+(defn- find-active-detections
+  "Binary-search the sorted snapshot list to find detections for the most recent
+   snapshot whose timestamp is <= current-time."
+  [sorted-snapshots current-time]
+  (when (seq sorted-snapshots)
+    (loop [lo 0
+           hi (dec (count sorted-snapshots))
+           best nil]
+      (if (> lo hi)
+        best
+        (let [mid (quot (+ lo hi) 2)
+              [ts dets] (nth sorted-snapshots mid)]
+          (if (<= ts current-time)
+            (recur (inc mid) hi dets)
+            (recur lo (dec mid) best)))))))
+
+(defn- draw-overlay-detections [overlay-ctx detections enabled-entity-types]
+  (doseq [{:keys [x y width height entity_type]} detections
+          :when (and (> width 0)
+                     (> height 0)
+                     (contains? enabled-entity-types entity_type))]
+    (let [{:keys [fill stroke]} (get-entity-color entity_type)]
+      (set! (.-fillStyle overlay-ctx) fill)
+      (set! (.-strokeStyle overlay-ctx) stroke)
+      (set! (.-lineWidth overlay-ctx) 1)
+      (.fillRect overlay-ctx x y width height)
+      (.strokeRect overlay-ctx x y width height))))
+
+(defn- entity-legend [{:keys [entity-types enabled-entity-types on-toggle detections-loading analysis-status]}]
+  (when (or detections-loading (seq entity-types) (seq analysis-status))
+    [:> Flex {:align "center"
+              :gap "2"
+              :wrap "wrap"
+              :class "px-radix-4 py-radix-3 rounded-b-lg bg-[--gray-1] border-t border-[--gray-6]"}
+     [:> Text {:size "1" :weight "medium" :class "uppercase tracking-[0.08em] text-[--gray-11]"}
+      "PII highlights"]
+     (when (seq analysis-status)
+       [:> Badge {:variant "soft" :color "gray" :size "1"}
+        (str "Status: " analysis-status)])
+     (when detections-loading
+       [:> Badge {:variant "soft" :color "blue" :size "1"}
+        "Loading detections..."])
+     (for [entity-type entity-types]
+       (let [{:keys [fill stroke]} (get-entity-color entity-type)
+             enabled? (contains? enabled-entity-types entity-type)]
+         ^{:key entity-type}
+         [:> Badge {:variant (if enabled? "solid" "soft")
+                    :size "1"
+                    :class "cursor-pointer select-none"
+                    :on-click #(on-toggle entity-type)
+                    :style {:border (str "1px solid " stroke)
+                            :backgroundColor (if enabled? fill "transparent")
+                            :color (if enabled? stroke "var(--gray-11)")
+                            :opacity (if enabled? 1 0.6)}}
+          entity-type]))]))
 
 ;; Format time as MM:SS
 (defn- format-time [seconds]
@@ -154,54 +239,84 @@
 ;; Canvas component that renders frames differentially
 (defn- canvas-renderer []
   (let [canvas-ref (atom nil)
+        overlay-canvas-ref (atom nil)
         ;; Track last rendered frame index to know what's new
-        last-rendered-idx (atom -1)]
+        last-rendered-idx (atom -1)
+        last-overlay-sig (atom nil)]
     (r/create-class
      {:display-name "rdp-canvas-renderer"
       :component-did-update
       (fn [this]
-        (let [[_ frames canvas-width canvas-height current-frame-idx _fullscreen?] (r/argv this)
-              canvas @canvas-ref]
-          (when (and canvas (seq frames)
-                     ;; Only redraw when frame index actually changed
-                     (not= current-frame-idx @last-rendered-idx))
+        (let [[_ frames canvas-width canvas-height current-frame-idx _fullscreen?
+               current-time sorted-snapshots enabled-entity-types] (r/argv this)
+              canvas @canvas-ref
+              overlay-canvas @overlay-canvas-ref]
+          (when (and canvas overlay-canvas (seq frames))
             (let [ctx (.getContext canvas "2d" (clj->js {:alpha false
                                                          :desynchronized true
-                                                         :willReadFrequently false}))]
+                                                         :willReadFrequently false}))
+                  overlay-ctx (.getContext overlay-canvas "2d" (clj->js {:alpha true
+                                                                         :desynchronized true
+                                                                         :willReadFrequently false}))
+                  bitmap-changed? (not= current-frame-idx @last-rendered-idx)
+                  ;; Find detections for the current playback time
+                  active-detections (find-active-detections sorted-snapshots current-time)
+                  overlay-sig [current-time enabled-entity-types (count sorted-snapshots)]
+                  overlay-changed? (not= overlay-sig @last-overlay-sig)]
               ;; Disable image smoothing for better performance
               (set! (.-imageSmoothingEnabled ctx) false)
               ;; If seeking backwards or first render, clear and redraw from beginning
-              (if (or (< current-frame-idx @last-rendered-idx)
-                      (= @last-rendered-idx -1))
-                (do
-                  ;; Clear canvas
-                  (set! (.-fillStyle ctx) "black")
-                  (.fillRect ctx 0 0 canvas-width canvas-height)
-                  ;; Draw all frames up to current
-                  (doseq [frame (take (inc current-frame-idx) frames)]
-                    (let [bitmap (:bitmap frame)]
-                      (when bitmap
-                        (draw-bitmap ctx bitmap))))
-                  (reset! last-rendered-idx current-frame-idx))
-                ;; Forward playback - draw only new frames since last rendered
-                (do
-                  (doseq [frame (subvec frames (inc @last-rendered-idx) (inc current-frame-idx))]
-                    (let [bitmap (:bitmap frame)]
-                      (when bitmap
-                        (draw-bitmap ctx bitmap))))
-                  (reset! last-rendered-idx current-frame-idx)))))))
-      :reagent-render
-      (fn [_ canvas-width canvas-height _ fullscreen?]
-        [:> Box {:class "rdp-canvas-container relative bg-[--gray-9] rounded-t-lg flex items-center justify-center"
-                 :style (if fullscreen?
-                          {:height "calc(100vh - 90px)" :width "100%"}
-                          {:height "600px" :width "100%"})}
-         [:canvas {:ref #(reset! canvas-ref %)
-                   :width canvas-width
-                   :height canvas-height
-                   :style {:maxWidth "100%"
-                           :maxHeight "100%"
-                           :objectFit "contain"}}]])})))
+              (when bitmap-changed?
+                (if (or (< current-frame-idx @last-rendered-idx)
+                        (= @last-rendered-idx -1))
+                  (do
+                    ;; Clear canvas
+                    (set! (.-fillStyle ctx) "black")
+                    (.fillRect ctx 0 0 canvas-width canvas-height)
+                    ;; Draw all frames up to current
+                    (doseq [frame (take (inc current-frame-idx) frames)]
+                      (let [bitmap (:bitmap frame)]
+                        (when bitmap
+                          (draw-bitmap ctx bitmap))))
+                    (reset! last-rendered-idx current-frame-idx))
+                  ;; Forward playback - draw only new frames since last rendered
+                  (do
+                    (doseq [frame (subvec frames (inc @last-rendered-idx) (inc current-frame-idx))]
+                      (let [bitmap (:bitmap frame)]
+                        (when bitmap
+                          (draw-bitmap ctx bitmap))))
+                    (reset! last-rendered-idx current-frame-idx))))
+
+              (when (or bitmap-changed? overlay-changed?)
+                (.clearRect overlay-ctx 0 0 canvas-width canvas-height)
+                (when active-detections
+                  (draw-overlay-detections overlay-ctx active-detections enabled-entity-types))
+                (reset! last-overlay-sig overlay-sig))))))
+       :reagent-render
+       (fn [_ canvas-width canvas-height _ fullscreen? _ _ _]
+         [:> Box {:class "rdp-canvas-container relative bg-[--gray-9] rounded-t-lg flex items-center justify-center"
+                  :style (if fullscreen?
+                           {:height "calc(100vh - 90px)" :width "100%"}
+                           {:height "600px" :width "100%"})}
+          ;; Main canvas — flex-centered, scales down via objectFit contain
+          [:canvas {:ref #(reset! canvas-ref %)
+                    :width canvas-width
+                    :height canvas-height
+                    :style {:maxWidth "100%"
+                            :maxHeight "100%"
+                            :objectFit "contain"}}]
+          ;; Overlay canvas — absolutely positioned, centered with same scaling
+          [:canvas {:ref #(reset! overlay-canvas-ref %)
+                    :width canvas-width
+                    :height canvas-height
+                    :style {:position "absolute"
+                            :top "50%"
+                            :left "50%"
+                            :transform "translate(-50%, -50%)"
+                            :maxWidth "100%"
+                            :maxHeight "100%"
+                            :objectFit "contain"
+                            :pointerEvents "none"}}]])})))
 
 ;; Find frame index for a given timestamp
 (defn- find-frame-index-for-time [frames target-time]
@@ -221,15 +336,20 @@
                        :current-frame 0
                        :playing false
                        :loading false
-                       :loaded-up-to 0
-                       :total-frames initial-total-frames
-                       :total-duration 0
-                       :playback-speed 1
-                       :fetching false
-                       :fullscreen false
-                       ;; Track virtual time for playback
-                       :start-time nil      ;; Real time when playback started
-                       :start-offset 0})    ;; Time offset when playback started
+                        :detections-loading false
+                        :loaded-up-to 0
+                        :total-frames initial-total-frames
+                        :total-duration 0
+                        :playback-speed 1
+                        :fetching false
+                        :fullscreen false
+                         :sorted-snapshots []
+                         :entity-types []
+                         :enabled-entity-types #{}
+                         :analysis-status ""
+                        ;; Track virtual time for playback
+                        :start-time nil      ;; Real time when playback started
+                        :start-offset 0})    ;; Time offset when playback started
         raf-id (r/atom nil)
         container-ref (r/atom nil)
         fullscreen-listener (r/atom nil)]
@@ -249,15 +369,30 @@
         (fetch-frames
          session-id 0 100
          (fn [data]
-           (swap! state assoc
-                  :frames (:frames data)
-                  :loaded-up-to (count (:frames data))
-                  :loading false
-                  :total-frames (:total_frames data)
-                  :total-duration (:total_duration data)))
-         (fn [err]
-           (js/console.error "Failed to load frames:" err)
-           (swap! state assoc :loading false))))
+            (swap! state assoc
+                   :frames (:frames data)
+                   :loaded-up-to (count (:frames data))
+                   :loading false
+                   :total-frames (:total_frames data)
+                   :total-duration (:total_duration data)
+                   :detections-loading true)
+            (fetch-detections
+             session-id
+             (fn [response]
+               (let [detections (:detections response)
+                     entity-types (->> detections (map :entity_type) (remove nil?) set sort vec)]
+                 (swap! state assoc
+                        :sorted-snapshots (group-detections-by-snapshot detections)
+                        :entity-types entity-types
+                        :enabled-entity-types (set entity-types)
+                        :analysis-status (:analysis_status response)
+                        :detections-loading false)))
+             (fn [err]
+               (js/console.error "Failed to load detections:" err)
+               (swap! state assoc :detections-loading false))))
+          (fn [err]
+            (js/console.error "Failed to load frames:" err)
+            (swap! state assoc :loading false))))
 
       :component-will-unmount
       (fn []
@@ -267,14 +402,15 @@
         (when @fullscreen-listener
           (.removeEventListener js/document "fullscreenchange" @fullscreen-listener)))
 
-      :reagent-render
-      (fn []
-        (let [{:keys [frames current-frame playing loading _loaded-up-to total-frames total-duration playback-speed start-time start-offset fetching fullscreen]} @state
-              ;; Calculate current time position
-              current-time (if playing
-                             (+ start-offset (* (- (js/performance.now) start-time) playback-speed 0.001))
-                             (if (seq frames)
-                               (:timestamp (nth frames current-frame 0))
+       :reagent-render
+       (fn []
+         (let [{:keys [frames current-frame playing loading _loaded-up-to total-frames total-duration playback-speed start-time start-offset fetching fullscreen
+                       sorted-snapshots entity-types enabled-entity-types detections-loading analysis-status]} @state
+               ;; Calculate current time position
+               current-time (if playing
+                              (+ start-offset (* (- (js/performance.now) start-time) playback-speed 0.001))
+                              (if (seq frames)
+                                (:timestamp (nth frames current-frame 0))
                                0))
               toggle-fullscreen (fn []
                                   (if fullscreen
@@ -284,16 +420,16 @@
                                       (when (.-requestFullscreen container)
                                         (.requestFullscreen container))))
                                   (swap! state update :fullscreen not))]
-          [:> Box {:ref #(reset! container-ref %)
-                   :class "rdp-player-container flex flex-col"}
-           ;; Canvas - pass current-frame so it knows what to render
-           [:> Box {:class "flex-1 relative"}
-            [canvas-renderer frames canvas-width canvas-height current-frame fullscreen]
-            ;; Fetching more frames indicator
-            (when fetching
-              [:> Box {:class "absolute top-2 right-2"}
-               [:> Badge {:color "blue" :variant "soft"}
-                "Loading more frames..."]])]
+           [:> Box {:ref #(reset! container-ref %)
+                    :class "rdp-player-container flex flex-col"}
+            ;; Canvas - pass current-frame so it knows what to render
+            [:> Box {:class "flex-1 relative"}
+             [canvas-renderer frames canvas-width canvas-height current-frame fullscreen current-time sorted-snapshots enabled-entity-types]
+             ;; Fetching more frames indicator
+             (when fetching
+               [:> Box {:class "absolute top-2 right-2"}
+                [:> Badge {:color "blue" :variant "soft"}
+                 "Loading more frames..."]])]
            ;; Controls
            [:> Box {:class "playback-controls-container flex-shrink-0"}
             [playback-controls
@@ -360,9 +496,9 @@
               :playback-speed playback-speed
               :on-speed-change (fn [speed]
                                  (swap! state assoc :playback-speed speed))
-              :on-seek (fn [target-time]
-                         ;; Find frame for target time
-                         (let [target-frame (find-frame-index-for-time frames target-time)]
+               :on-seek (fn [target-time]
+                          ;; Find frame for target time
+                          (let [target-frame (find-frame-index-for-time frames target-time)]
                            (swap! state assoc
                                   :current-frame target-frame
                                   :start-offset target-time
@@ -374,12 +510,23 @@
                               (fn [data]
                                 (swap! state assoc :frames (:frames data))
                                 (swap! state assoc :loaded-up-to (+ target-frame (count (:frames data)))))
-                              (fn [err]
-                                (js/console.error "Failed to load frames:" err))))))}]]
-           ;; Loading indicator
-           (when loading
-             [:> Flex {:justify "center" :align "center" :gap "2" :class "py-2"}
-              [loaders/simple-loader {:size 4}]
+                               (fn [err]
+                                 (js/console.error "Failed to load frames:" err))))))}]]
+            [entity-legend
+             {:entity-types entity-types
+              :enabled-entity-types enabled-entity-types
+              :detections-loading detections-loading
+              :analysis-status analysis-status
+              :on-toggle (fn [entity-type]
+                           (swap! state update :enabled-entity-types
+                                  (fn [enabled]
+                                    (if (contains? enabled entity-type)
+                                      (disj enabled entity-type)
+                                      (conj enabled entity-type)))))}]
+            ;; Loading indicator
+            (when loading
+              [:> Flex {:justify "center" :align "center" :gap "2" :class "py-2"}
+               [loaders/simple-loader {:size 4}]
               [:> Badge {:color "blue" :variant "soft"}
                "Loading frames..."]])]))})))
 


### PR DESCRIPTION
## Summary

Async pipeline that extracts text from RDP session recording frames via OCR, runs it through Presidio for PII detection, stores per-frame entity detections with pixel-level bounding boxes, and renders them as highlight overlays in the web UI RDP replay player.

## Pipeline

```
RDP session ends
    ↓ (recorder.go enqueues job)
private.rdp_analysis_jobs (pending)
    ↓ (worker claims via SELECT FOR UPDATE SKIP LOCKED)
Reconstruct full framebuffer from differential bitmap events
    ↓ (every N seconds)
Framebuffer sample hash → skip if unchanged
    ↓
Tesseract OCR (PSM 6, 2x upscale, TSV word-level output)
    ↓
Presidio /analyze (configurable score threshold + entity denylist)
    ↓
Map Presidio char offsets → OCR word bboxes → screen-space rects
    ↓
Bulk insert into private.rdp_entity_detections
    ↓
GET /api/sessions/:id/rdp-detections
    ↓
Webapp overlay canvas renders highlights
```

## Backend

- `gateway/rdp/rle/` — Go RLE decompressor + tests (port of IronRDP's implementation)
- `gateway/rdp/ocr/ocr.go` — Tesseract subprocess wrapper with TSV word-level bbox output; 2x nearest-neighbor upscale for RDP frames (ClearType + compression needs it even at 2048px)
- `gateway/rdp/analyzer/worker.go` — Worker pool, framebuffer reconstruction, framebuffer-sample dedup, detection-bbox dedup
- `gateway/rdp/analyzer/presidio.go` — Minimal HTTP client for Presidio Analyzer
- `gateway/models/rdp_analysis_job.go` — Job queue with `SELECT FOR UPDATE SKIP LOCKED` polling
- `gateway/models/rdp_entity_detection.go` — Per-frame detection storage
- `gateway/api/session/rdp_detections.go` — `GET /sessions/:id/rdp-detections`
- `gateway/rdp/recorder.go` — Enqueue job on session close
- `gateway/main.go` — Worker pool startup + orphaned-job recovery on restart
- `Dockerfile` — `tesseract-ocr tesseract-ocr-eng`
- Migrations `000070_rdp_analysis_jobs`, `000071_rdp_entity_detections`

## Frontend

- `webapp/src/webapp/audit/views/session_data_rdp.cljs` — Overlay canvas, entity legend with per-type toggles, binary-search snapshot matching by timestamp

## Configuration

Env vars (with defaults):
- `RDP_PII_SCORE_THRESHOLD` (default `0.9`) — minimum Presidio confidence score
- `RDP_PII_ENTITY_DENYLIST` (default `DATE_TIME,NRP`) — excluded entity types
- `RDP_PII_SNAPSHOT_INTERVAL` (default `0.25`) — seconds between snapshots
- `RDP_ANALYSIS_WORKERS` (default `2`) — worker pool size
- `MS_PRESIDIO_ANALYZER_URL` — if unset, the worker pool doesn't start (feature disabled)

## Privacy

No raw OCR text or matched word content is ever persisted. The `rdp_entity_detections` table stores only: entity type, confidence score, and bounding box coordinates. The actual PII values exist only transiently in memory during OCR+Presidio processing.

## Debug endpoints (behind build tag)

Two endpoints compiled only with `go build -tags debug_rdp`:
- `GET /sessions/:id/rdp-analysis-debug?t=<seconds>` — runs the pipeline at a given timestamp and returns raw PNG, annotated PNG, OCR words, Presidio results
- `POST /sessions/:id/rdp-analysis-rerun?score_threshold=&entity_denylist=&snapshot_interval=` — re-runs analysis with custom params

Production builds use stub handlers returning 404.

## Test results

| Session | Resolution | Before fixes | After fixes |
|---|---|---|---|
| `43ef14ae` | 1280x720 | 65 detections (26 PERSON FP, 16 DATE_TIME FP, 10 URL dupes, 3 NRP FP, 10 EMAIL) | 10 detections (10 EMAIL_ADDRESS, all score 1.0, zero false positives) |
| `0b200577` | 2048x1083 | 0 detections (PSM 11 missed all Notepad++ content) | 24 detections (24 EMAIL_ADDRESS, all score 1.0, zero false positives) |

## Not included (deferred)

- Webapp polling while analysis is in progress (matches existing one-shot-fetch behavior; user can refresh)
- PHONE_NUMBER detection — Presidio scores Brazilian phone formats at ~0.4, below the 0.9 threshold. Customer-selectable entity types planned for next iteration.

Automated by MisterMal 🤖