### PR TITLE
Self-service org migration for multi-tenant users

### DIFF
--- a/gateway/api/login/oidc/login.go
+++ b/gateway/api/login/oidc/login.go
@@ -161,34 +161,39 @@ func (h *handler) LoginCallback(c *gin.Context) {
 		return
 	}
 	uinfo.Subject = subject
-	// get the user by its email to get the actual subject of that user. This is necessary
-	// due to the user subject when it's created inside hoop is changed after that user
-	// logs in with the IDP. The email should always come from the IDP as a design of how
-	// we handle users in hoop.
-	dbUser, err := models.GetUserByEmail(uinfo.Email)
-	if err != nil {
-		login.Outcome = fmt.Sprintf("failed fetching user by email=%s, reason=%v", uinfo.Email, err)
-		log.Error(login.Outcome)
-		sentry.CaptureException(err)
-		c.Redirect(http.StatusTemporaryRedirect, redirectErrorURL)
-		return
-	}
-
-	// if the user doesn't exist in the database, we should use the subject from the IDP
-	// to allow the user to login. This user will be a new user and will be created at
-	// the end of this method.
-	if dbUser == nil {
-		subject = uinfo.Subject
-	} else {
-		subject = dbUser.Subject
-	}
-	ctx, err := models.GetUserContext(subject)
+	// Try to find user by IDP subject first (unambiguous). Fall back to email lookup only
+	// when no user is found by subject, to handle users whose stored subject is still a
+	// placeholder (e.g. invited users who have not yet completed first login).
+	ctx, err := models.GetUserContext(uinfo.Subject)
 	if err != nil {
 		login.Outcome = fmt.Sprintf("failed fetching user subject=%s, email=%s, reason=%v", uinfo.Subject, uinfo.Email, err)
 		log.Error(login.Outcome)
 		sentry.CaptureException(err)
 		c.Redirect(http.StatusTemporaryRedirect, redirectErrorURL)
 		return
+	}
+	if ctx.IsEmpty() {
+		dbUser, err := models.GetUserByEmail(uinfo.Email)
+		if err != nil {
+			login.Outcome = fmt.Sprintf("failed fetching user by email=%s, reason=%v", uinfo.Email, err)
+			log.Error(login.Outcome)
+			sentry.CaptureException(err)
+			c.Redirect(http.StatusTemporaryRedirect, redirectErrorURL)
+			return
+		}
+		if dbUser != nil {
+			ctx, err = models.GetUserContext(dbUser.Subject)
+			if err != nil {
+				login.Outcome = fmt.Sprintf("failed fetching user subject=%s, email=%s, reason=%v", dbUser.Subject, uinfo.Email, err)
+				log.Error(login.Outcome)
+				sentry.CaptureException(err)
+				c.Redirect(http.StatusTemporaryRedirect, redirectErrorURL)
+				return
+			}
+		}
+	}
+	if !ctx.IsEmpty() {
+		subject = ctx.UserSubject
 	}
 
 	err = models.UpsertUserToken(models.DB, subject, token.AccessToken)

--- a/gateway/api/login/oidc/login.go
+++ b/gateway/api/login/oidc/login.go
@@ -161,39 +161,34 @@ func (h *handler) LoginCallback(c *gin.Context) {
 		return
 	}
 	uinfo.Subject = subject
-	// Try to find user by IDP subject first (unambiguous). Fall back to email lookup only
-	// when no user is found by subject, to handle users whose stored subject is still a
-	// placeholder (e.g. invited users who have not yet completed first login).
-	ctx, err := models.GetUserContext(uinfo.Subject)
+	// get the user by its email to get the actual subject of that user. This is necessary
+	// due to the user subject when it's created inside hoop is changed after that user
+	// logs in with the IDP. The email should always come from the IDP as a design of how
+	// we handle users in hoop.
+	dbUser, err := models.GetUserByEmail(uinfo.Email)
+	if err != nil {
+		login.Outcome = fmt.Sprintf("failed fetching user by email=%s, reason=%v", uinfo.Email, err)
+		log.Error(login.Outcome)
+		sentry.CaptureException(err)
+		c.Redirect(http.StatusTemporaryRedirect, redirectErrorURL)
+		return
+	}
+
+	// if the user doesn't exist in the database, we should use the subject from the IDP
+	// to allow the user to login. This user will be a new user and will be created at
+	// the end of this method.
+	if dbUser == nil {
+		subject = uinfo.Subject
+	} else {
+		subject = dbUser.Subject
+	}
+	ctx, err := models.GetUserContext(subject)
 	if err != nil {
 		login.Outcome = fmt.Sprintf("failed fetching user subject=%s, email=%s, reason=%v", uinfo.Subject, uinfo.Email, err)
 		log.Error(login.Outcome)
 		sentry.CaptureException(err)
 		c.Redirect(http.StatusTemporaryRedirect, redirectErrorURL)
 		return
-	}
-	if ctx.IsEmpty() {
-		dbUser, err := models.GetUserByEmail(uinfo.Email)
-		if err != nil {
-			login.Outcome = fmt.Sprintf("failed fetching user by email=%s, reason=%v", uinfo.Email, err)
-			log.Error(login.Outcome)
-			sentry.CaptureException(err)
-			c.Redirect(http.StatusTemporaryRedirect, redirectErrorURL)
-			return
-		}
-		if dbUser != nil {
-			ctx, err = models.GetUserContext(dbUser.Subject)
-			if err != nil {
-				login.Outcome = fmt.Sprintf("failed fetching user subject=%s, email=%s, reason=%v", dbUser.Subject, uinfo.Email, err)
-				log.Error(login.Outcome)
-				sentry.CaptureException(err)
-				c.Redirect(http.StatusTemporaryRedirect, redirectErrorURL)
-				return
-			}
-		}
-	}
-	if !ctx.IsEmpty() {
-		subject = ctx.UserSubject
 	}
 
 	err = models.UpsertUserToken(models.DB, subject, token.AccessToken)

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -16,9 +16,9 @@ type HTTPSuccess struct {
 	Message string `json:"message" example:"operation completed successfully"`
 }
 
-// AcceptOrgInvitationRequest is used to accept or decline a pending org invitation
-type AcceptOrgInvitationRequest struct {
-	OrgID string `json:"org_id" binding:"required" format:"uuid"`
+// OrgInvitationRequest is used to accept or decline a pending org invitation
+type OrgInvitationRequest struct {
+	Action string `json:"action" binding:"required" enums:"accept,decline"`
 }
 
 type Login struct {
@@ -97,8 +97,6 @@ type UserGroup struct {
 // PendingOrgInvitation represents an organization the user has been invited to
 // but has not yet joined. Only populated in multi-tenant environments.
 type PendingOrgInvitation struct {
-	// Organization unique identifier
-	OrgID string `json:"org_id" format:"uuid"`
 	// Organization name
 	OrgName string `json:"org_name"`
 }

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -12,6 +12,15 @@ type HTTPError struct {
 	Message string `json:"message" example:"the error description"`
 }
 
+type HTTPSuccess struct {
+	Message string `json:"message" example:"operation completed successfully"`
+}
+
+// AcceptOrgInvitationRequest is used to accept or decline a pending org invitation
+type AcceptOrgInvitationRequest struct {
+	OrgID string `json:"org_id" binding:"required" format:"uuid"`
+}
+
 type Login struct {
 	// The URL to redirect the user to the identity provider
 	URL string `json:"login_url"`
@@ -85,6 +94,15 @@ type UserGroup struct {
 	Name string `json:"name" binding:"required" example:"engineering"`
 }
 
+// PendingOrgInvitation represents an organization the user has been invited to
+// but has not yet joined. Only populated in multi-tenant environments.
+type PendingOrgInvitation struct {
+	// Organization unique identifier
+	OrgID string `json:"org_id" format:"uuid"`
+	// Organization name
+	OrgName string `json:"org_name"`
+}
+
 type UserInfo struct {
 	User `json:",inline"`
 	// DEPRECATED in flavor of role
@@ -111,6 +129,9 @@ type UserInfo struct {
 	// * on - Disable the users management view on Webapp
 	WebAppUsersManagement  string `json:"webapp_users_management" enums:"on,off" default:"on"`
 	IntercomUserHmacDigest string `json:"intercom_hmac_digest"`
+	// Pending organization invitations for this user. When non-empty, the user can migrate
+	// to one of these organizations. Only populated in multi-tenant environments.
+	PendingOrgInvitations []PendingOrgInvitation `json:"pending_org_invitations,omitempty"`
 }
 
 type ServiceAccountStatusType string

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -217,14 +217,10 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		apiroutes.ReadOnlyAccessRole,
 		r.AuthMiddleware,
 		userapi.GetUserInfo)
-	r.POST("/userinfo/accept-org-invitation",
+	r.POST("/orgs/invitations",
 		apiroutes.ReadOnlyAccessRole,
 		r.AuthMiddleware,
-		userapi.AcceptOrgInvitation)
-	r.DELETE("/userinfo/pending-org-invitation",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		userapi.DeclineOrgInvitation)
+		userapi.HandleOrgInvitation)
 	r.GET("/users",
 		apiroutes.ReadOnlyAccessRole,
 		r.AuthMiddleware,

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -217,6 +217,14 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		apiroutes.ReadOnlyAccessRole,
 		r.AuthMiddleware,
 		userapi.GetUserInfo)
+	r.POST("/userinfo/accept-org-invitation",
+		apiroutes.ReadOnlyAccessRole,
+		r.AuthMiddleware,
+		userapi.AcceptOrgInvitation)
+	r.DELETE("/userinfo/pending-org-invitation",
+		apiroutes.ReadOnlyAccessRole,
+		r.AuthMiddleware,
+		userapi.DeclineOrgInvitation)
 	r.GET("/users",
 		apiroutes.ReadOnlyAccessRole,
 		r.AuthMiddleware,

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -591,15 +591,6 @@ func AcceptOrgInvitation(c *gin.Context) {
 		return
 	}
 
-	// Remove any stale user_tokens for the invited user's placeholder subject.
-	if invitedUser.Subject != "" {
-		if err := tx.Exec(`DELETE FROM private.user_tokens WHERE user_id = ?`, invitedUser.Subject).Error; err != nil {
-			tx.Rollback()
-			httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed clearing invited user tokens")
-			return
-		}
-	}
-
 	// Delete old user (and their groups via CASCADE) to release the UNIQUE subject constraint.
 	if err := tx.Exec(`DELETE FROM private.users WHERE id = ?`, oldUserUUID).Error; err != nil {
 		tx.Rollback()

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -557,41 +557,6 @@ func AcceptOrgInvitation(c *gin.Context) {
 		return
 	}
 
-	tx := models.DB.Begin()
-	if tx.Error != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, tx.Error, "failed starting transaction")
-		return
-	}
-
-	// Delete old user first to release the UNIQUE subject constraint before activating the invited user
-	if err := tx.Exec(`DELETE FROM private.user_groups WHERE user_id = ?`, oldUserUUID).Error; err != nil {
-		tx.Rollback()
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed removing user groups")
-		return
-	}
-	if err := tx.Exec(`DELETE FROM private.users WHERE id = ?`, oldUserUUID).Error; err != nil {
-		tx.Rollback()
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed removing old user record")
-		return
-	}
-
-	if invitedUser.ID == "" {
-		tx.Rollback()
-		httputils.AbortWithErr(c, http.StatusInternalServerError,
-			fmt.Errorf("invited user record has empty ID"), "invalid invited user record")
-		return
-	}
-
-	// Remove any stale user_tokens referencing the invited user's placeholder subject
-	// so that subsequent operations (and auth lookups) are not confused by orphaned entries.
-	if invitedUser.Subject != "" {
-		if err := tx.Exec(`DELETE FROM private.user_tokens WHERE user_id = ?`, invitedUser.Subject).Error; err != nil {
-			tx.Rollback()
-			httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed clearing invited user tokens")
-			return
-		}
-	}
-
 	name := invitedUser.Name
 	if ctx.UserName != "" {
 		name = ctx.UserName
@@ -600,11 +565,20 @@ func AcceptOrgInvitation(c *gin.Context) {
 	if ctx.UserPicture != "" {
 		picture = ctx.UserPicture
 	}
+
+	tx := models.DB.Begin()
+	if tx.Error != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, tx.Error, "failed starting transaction")
+		return
+	}
+
+	// Update the invited user (except subject) first to confirm the record still exists
+	// before we commit to deleting the current user.
 	result := tx.Exec(`
 		UPDATE private.users
-		SET subject = ?, status = 'active', verified = true, name = ?, picture = ?
-		WHERE id = ?`,
-		idpSubject, name, picture, invitedUser.ID)
+		SET status = 'active', verified = true, name = ?, picture = ?
+		WHERE id = ? AND status = 'invited'`,
+		name, picture, invitedUser.ID)
 	if result.Error != nil {
 		tx.Rollback()
 		httputils.AbortWithErr(c, http.StatusInternalServerError, result.Error, "failed activating invited user")
@@ -614,6 +588,29 @@ func AcceptOrgInvitation(c *gin.Context) {
 		tx.Rollback()
 		httputils.AbortWithErr(c, http.StatusInternalServerError,
 			fmt.Errorf("no rows updated for invited user %s", invitedUser.ID), "failed activating invited user")
+		return
+	}
+
+	// Remove any stale user_tokens for the invited user's placeholder subject.
+	if invitedUser.Subject != "" {
+		if err := tx.Exec(`DELETE FROM private.user_tokens WHERE user_id = ?`, invitedUser.Subject).Error; err != nil {
+			tx.Rollback()
+			httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed clearing invited user tokens")
+			return
+		}
+	}
+
+	// Delete old user (and their groups via CASCADE) to release the UNIQUE subject constraint.
+	if err := tx.Exec(`DELETE FROM private.users WHERE id = ?`, oldUserUUID).Error; err != nil {
+		tx.Rollback()
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed removing old user record")
+		return
+	}
+
+	// Now bind the IDP subject to the invited user (UNIQUE constraint is clear after DELETE above).
+	if err := tx.Exec(`UPDATE private.users SET subject = ? WHERE id = ?`, idpSubject, invitedUser.ID).Error; err != nil {
+		tx.Rollback()
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed setting subject on invited user")
 		return
 	}
 

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -544,6 +544,11 @@ func AcceptOrgInvitation(c *gin.Context) {
 		return
 	}
 
+	if ctx.OrgID == req.OrgID {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "cannot accept invitation: already in target organization"})
+		return
+	}
+
 	oldOrgID := ctx.OrgID
 	oldUserUUID := currentUser.ID
 
@@ -575,6 +580,16 @@ func AcceptOrgInvitation(c *gin.Context) {
 		httputils.AbortWithErr(c, http.StatusInternalServerError,
 			fmt.Errorf("invited user record has empty ID"), "invalid invited user record")
 		return
+	}
+
+	// Remove any stale user_tokens referencing the invited user's placeholder subject
+	// so that subsequent operations (and auth lookups) are not confused by orphaned entries.
+	if invitedUser.Subject != "" {
+		if err := tx.Exec(`DELETE FROM private.user_tokens WHERE user_id = ?`, invitedUser.Subject).Error; err != nil {
+			tx.Rollback()
+			httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed clearing invited user tokens")
+			return
+		}
 	}
 
 	name := invitedUser.Name

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -490,7 +490,7 @@ func GetUserInfo(c *gin.Context) {
 				}
 				userInfoData.PendingOrgInvitations = append(
 					userInfoData.PendingOrgInvitations,
-					openapi.PendingOrgInvitation{OrgID: org.ID, OrgName: org.Name},
+					openapi.PendingOrgInvitation{OrgName: org.Name},
 				)
 			}
 		}
@@ -499,161 +499,79 @@ func GetUserInfo(c *gin.Context) {
 	c.JSON(http.StatusOK, userInfoData)
 }
 
-// AcceptOrgInvitation
+// HandleOrgInvitation
 //
-//	@Summary		Accept Organization Invitation
-//	@Description	Migrate the current user to an organization they were invited to. The current auto-created organization is deleted if it becomes empty.
+//	@Summary		Handle Organization Invitation
+//	@Description	Accept or decline a pending organization invitation. On accept, the current user is migrated to the invited org and the old auto-created org is removed if empty. On decline, the invitation is dismissed permanently.
 //	@Tags			User Management
 //	@Accept			json
 //	@Produce		json
-//	@Param			request	body		openapi.AcceptOrgInvitationRequest	true	"The request body resource"
+//	@Param			request	body		openapi.OrgInvitationRequest	true	"The request body resource"
 //	@Success		200		{object}	openapi.HTTPSuccess
-//	@Failure		400,404,500	{object}	openapi.HTTPError
-//	@Router			/userinfo/accept-org-invitation [post]
-func AcceptOrgInvitation(c *gin.Context) {
+//	@Failure		400,404,409,500	{object}	openapi.HTTPError
+//	@Router			/orgs/invitations [post]
+func HandleOrgInvitation(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
-	var req openapi.AcceptOrgInvitationRequest
+	var req openapi.OrgInvitationRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
 		return
 	}
 
-	// ctx.UserID holds the IDP subject (subject claim from the access token)
-	idpSubject := ctx.UserID
-
-	// Use subject-based lookup to unambiguously identify the current user,
-	// avoiding false matches when multiple records share the same email in an org
-	currentUser, err := models.GetUserBySubjectAndOrg(idpSubject, ctx.OrgID)
+	allUsers, err := models.ListUsersByEmail(ctx.UserEmail)
 	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching current user")
-		return
-	}
-	if currentUser == nil {
-		c.JSON(http.StatusNotFound, gin.H{"message": "current user not found"})
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed looking up invitations")
 		return
 	}
 
-	// Only match invited users to avoid accidentally targeting an active user from a previous failed migration
-	invitedUser, err := models.GetInvitedUserByEmailAndOrg(ctx.UserEmail, req.OrgID)
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching invited user")
-		return
-	}
-	if invitedUser == nil {
-		c.JSON(http.StatusNotFound, gin.H{"message": "pending invitation not found for this organization"})
-		return
+	var invitations []models.User
+	for _, u := range allUsers {
+		if u.OrgID != ctx.OrgID && u.Status == string(openapi.StatusInvited) {
+			invitations = append(invitations, u)
+		}
 	}
 
-	if ctx.OrgID == req.OrgID {
-		c.JSON(http.StatusBadRequest, gin.H{"message": "cannot accept invitation: already in target organization"})
+	if len(invitations) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"message": "no pending invitation found"})
 		return
 	}
-
-	oldOrgID := ctx.OrgID
-	oldUserUUID := currentUser.ID
-
-	if oldUserUUID == invitedUser.ID {
-		c.JSON(http.StatusBadRequest, gin.H{"message": "cannot migrate: current user and invited user are the same record"})
+	if len(invitations) > 1 {
+		c.JSON(http.StatusConflict, gin.H{"message": "multiple pending invitations found, contact support"})
 		return
 	}
 
-	name := invitedUser.Name
-	if ctx.UserName != "" {
-		name = ctx.UserName
-	}
-	picture := invitedUser.Picture
-	if ctx.UserPicture != "" {
-		picture = ctx.UserPicture
-	}
+	invitedUser := invitations[0]
 
-	tx := models.DB.Begin()
-	if tx.Error != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, tx.Error, "failed starting transaction")
-		return
-	}
+	switch req.Action {
+	case "accept":
+		name := invitedUser.Name
+		if ctx.UserName != "" {
+			name = ctx.UserName
+		}
+		picture := invitedUser.Picture
+		if ctx.UserPicture != "" {
+			picture = ctx.UserPicture
+		}
+		oldOrgID := ctx.OrgID
+		if err := models.PromoteInvitedUser(invitedUser.ID, ctx.OrgID, ctx.UserID, name, picture); err != nil {
+			httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed migrating user to organization")
+			return
+		}
+		if err := models.DeleteOrganizationIfEmpty(oldOrgID); err != nil {
+			log.Warnf("could not delete old org %s after user migration: %v", oldOrgID, err)
+		}
+		c.JSON(http.StatusOK, gin.H{"message": "successfully migrated to organization"})
 
-	// Update the invited user (except subject) first to confirm the record still exists
-	// before we commit to deleting the current user.
-	result := tx.Exec(`
-		UPDATE private.users
-		SET status = 'active', verified = true, name = ?, picture = ?
-		WHERE id = ? AND status = 'invited'`,
-		name, picture, invitedUser.ID)
-	if result.Error != nil {
-		tx.Rollback()
-		httputils.AbortWithErr(c, http.StatusInternalServerError, result.Error, "failed activating invited user")
-		return
-	}
-	if result.RowsAffected == 0 {
-		tx.Rollback()
-		httputils.AbortWithErr(c, http.StatusInternalServerError,
-			fmt.Errorf("no rows updated for invited user %s", invitedUser.ID), "failed activating invited user")
-		return
-	}
+	case "decline":
+		if err := models.DeletePendingInvitationByEmail(ctx.UserEmail); err != nil {
+			httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed declining invitation")
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"message": "invitation declined"})
 
-	// Delete old user (and their groups via CASCADE) to release the UNIQUE subject constraint.
-	if err := tx.Exec(`DELETE FROM private.users WHERE id = ?`, oldUserUUID).Error; err != nil {
-		tx.Rollback()
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed removing old user record")
-		return
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"message": "action must be accept or decline"})
 	}
-
-	// Now bind the IDP subject to the invited user (UNIQUE constraint is clear after DELETE above).
-	if err := tx.Exec(`UPDATE private.users SET subject = ? WHERE id = ?`, idpSubject, invitedUser.ID).Error; err != nil {
-		tx.Rollback()
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed setting subject on invited user")
-		return
-	}
-
-	if err := tx.Commit().Error; err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed committing migration")
-		return
-	}
-
-	if err := models.DeleteOrganizationIfEmpty(oldOrgID); err != nil {
-		log.Warnf("could not delete old org %s after user migration: %v", oldOrgID, err)
-	}
-
-	c.JSON(http.StatusOK, gin.H{"message": "successfully migrated to organization"})
-}
-
-// DeclineOrgInvitation
-//
-//	@Summary		Decline Organization Invitation
-//	@Description	Removes a pending organization invitation so the dialog is dismissed permanently.
-//	@Tags			User Management
-//	@Accept			json
-//	@Produce		json
-//	@Param			request	body		openapi.AcceptOrgInvitationRequest	true	"The request body resource"
-//	@Success		200		{object}	openapi.HTTPSuccess
-//	@Failure		400,404,500	{object}	openapi.HTTPError
-//	@Router			/userinfo/pending-org-invitation [delete]
-func DeclineOrgInvitation(c *gin.Context) {
-	ctx := storagev2.ParseContext(c)
-	var req openapi.AcceptOrgInvitationRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
-		return
-	}
-
-	invitedUser, err := models.GetUserByEmailAndOrg(ctx.UserEmail, req.OrgID)
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching invited user")
-		return
-	}
-	if invitedUser == nil || invitedUser.Status != string(openapi.StatusInvited) {
-		c.JSON(http.StatusNotFound, gin.H{"message": "pending invitation not found for this organization"})
-		return
-	}
-
-	result := models.DB.Exec(`DELETE FROM private.users WHERE org_id = ? AND email = ? AND status = 'invited'`,
-		req.OrgID, ctx.UserEmail)
-	if result.Error != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, result.Error, "failed declining invitation")
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"message": "invitation declined"})
 }
 
 // PatchUserSlackID

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -475,7 +475,182 @@ func GetUserInfo(c *gin.Context) {
 		userInfoData.Picture = ctx.UserAnonPicture
 		userInfoData.ID = ctx.UserAnonSubject
 	}
+
+	if isOrgMultiTenant && !ctx.IsAnonymous() {
+		allUsers, err := models.ListUsersByEmail(ctx.UserEmail)
+		if err != nil {
+			log.Warnf("failed listing users by email for pending invitations, err=%v", err)
+		}
+		for _, u := range allUsers {
+			if u.OrgID != ctx.OrgID && u.Status == string(openapi.StatusInvited) {
+				org, err := models.GetOrganizationByNameOrID(u.OrgID)
+				if err != nil {
+					log.Warnf("failed fetching org %s for pending invitation, err=%v", u.OrgID, err)
+					continue
+				}
+				userInfoData.PendingOrgInvitations = append(
+					userInfoData.PendingOrgInvitations,
+					openapi.PendingOrgInvitation{OrgID: org.ID, OrgName: org.Name},
+				)
+			}
+		}
+	}
+
 	c.JSON(http.StatusOK, userInfoData)
+}
+
+// AcceptOrgInvitation
+//
+//	@Summary		Accept Organization Invitation
+//	@Description	Migrate the current user to an organization they were invited to. The current auto-created organization is deleted if it becomes empty.
+//	@Tags			User Management
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		openapi.AcceptOrgInvitationRequest	true	"The request body resource"
+//	@Success		200		{object}	openapi.HTTPSuccess
+//	@Failure		400,404,500	{object}	openapi.HTTPError
+//	@Router			/userinfo/accept-org-invitation [post]
+func AcceptOrgInvitation(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	var req openapi.AcceptOrgInvitationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	// ctx.UserID holds the IDP subject (subject claim from the access token)
+	idpSubject := ctx.UserID
+
+	// Use subject-based lookup to unambiguously identify the current user,
+	// avoiding false matches when multiple records share the same email in an org
+	currentUser, err := models.GetUserBySubjectAndOrg(idpSubject, ctx.OrgID)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching current user")
+		return
+	}
+	if currentUser == nil {
+		c.JSON(http.StatusNotFound, gin.H{"message": "current user not found"})
+		return
+	}
+
+	// Only match invited users to avoid accidentally targeting an active user from a previous failed migration
+	invitedUser, err := models.GetInvitedUserByEmailAndOrg(ctx.UserEmail, req.OrgID)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching invited user")
+		return
+	}
+	if invitedUser == nil {
+		c.JSON(http.StatusNotFound, gin.H{"message": "pending invitation not found for this organization"})
+		return
+	}
+
+	oldOrgID := ctx.OrgID
+	oldUserUUID := currentUser.ID
+
+	if oldUserUUID == invitedUser.ID {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "cannot migrate: current user and invited user are the same record"})
+		return
+	}
+
+	tx := models.DB.Begin()
+	if tx.Error != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, tx.Error, "failed starting transaction")
+		return
+	}
+
+	// Delete old user first to release the UNIQUE subject constraint before activating the invited user
+	if err := tx.Exec(`DELETE FROM private.user_groups WHERE user_id = ?`, oldUserUUID).Error; err != nil {
+		tx.Rollback()
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed removing user groups")
+		return
+	}
+	if err := tx.Exec(`DELETE FROM private.users WHERE id = ?`, oldUserUUID).Error; err != nil {
+		tx.Rollback()
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed removing old user record")
+		return
+	}
+
+	if invitedUser.ID == "" {
+		tx.Rollback()
+		httputils.AbortWithErr(c, http.StatusInternalServerError,
+			fmt.Errorf("invited user record has empty ID"), "invalid invited user record")
+		return
+	}
+
+	name := invitedUser.Name
+	if ctx.UserName != "" {
+		name = ctx.UserName
+	}
+	picture := invitedUser.Picture
+	if ctx.UserPicture != "" {
+		picture = ctx.UserPicture
+	}
+	result := tx.Exec(`
+		UPDATE private.users
+		SET subject = ?, status = 'active', verified = true, name = ?, picture = ?
+		WHERE id = ?`,
+		idpSubject, name, picture, invitedUser.ID)
+	if result.Error != nil {
+		tx.Rollback()
+		httputils.AbortWithErr(c, http.StatusInternalServerError, result.Error, "failed activating invited user")
+		return
+	}
+	if result.RowsAffected == 0 {
+		tx.Rollback()
+		httputils.AbortWithErr(c, http.StatusInternalServerError,
+			fmt.Errorf("no rows updated for invited user %s", invitedUser.ID), "failed activating invited user")
+		return
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed committing migration")
+		return
+	}
+
+	if err := models.DeleteOrganizationIfEmpty(oldOrgID); err != nil {
+		log.Warnf("could not delete old org %s after user migration: %v", oldOrgID, err)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "successfully migrated to organization"})
+}
+
+// DeclineOrgInvitation
+//
+//	@Summary		Decline Organization Invitation
+//	@Description	Removes a pending organization invitation so the dialog is dismissed permanently.
+//	@Tags			User Management
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		openapi.AcceptOrgInvitationRequest	true	"The request body resource"
+//	@Success		200		{object}	openapi.HTTPSuccess
+//	@Failure		400,404,500	{object}	openapi.HTTPError
+//	@Router			/userinfo/pending-org-invitation [delete]
+func DeclineOrgInvitation(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	var req openapi.AcceptOrgInvitationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	invitedUser, err := models.GetUserByEmailAndOrg(ctx.UserEmail, req.OrgID)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching invited user")
+		return
+	}
+	if invitedUser == nil || invitedUser.Status != string(openapi.StatusInvited) {
+		c.JSON(http.StatusNotFound, gin.H{"message": "pending invitation not found for this organization"})
+		return
+	}
+
+	result := models.DB.Exec(`DELETE FROM private.users WHERE org_id = ? AND email = ? AND status = 'invited'`,
+		req.OrgID, ctx.UserEmail)
+	if result.Error != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, result.Error, "failed declining invitation")
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "invitation declined"})
 }
 
 // PatchUserSlackID

--- a/gateway/models/orgs.go
+++ b/gateway/models/orgs.go
@@ -97,3 +97,31 @@ func UpdateOrgLicense(orgID string, licenseDataJSON []byte) error {
 		Update("license_data", licenseDataJSON).
 		Error
 }
+
+// DeleteOrganizationIfEmpty removes an org and its default scaffolding data (plugins, runbooks).
+// It returns an error if the org still has users or if FK constraints prevent deletion
+// (connections, sessions, agents, etc.).
+func DeleteOrganizationIfEmpty(orgID string) error {
+	return DB.Transaction(func(tx *gorm.DB) error {
+		var userCount int64
+		if err := tx.Table("private.users").Where("org_id = ?", orgID).Count(&userCount).Error; err != nil {
+			return err
+		}
+		if userCount > 0 {
+			return fmt.Errorf("org %s still has %d users, cannot delete", orgID, userCount)
+		}
+		if err := tx.Exec(`DELETE FROM private.user_groups WHERE org_id = ?`, orgID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`DELETE FROM private.runbook_rules WHERE org_id = ?`, orgID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`DELETE FROM private.runbooks WHERE org_id = ?`, orgID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`DELETE FROM private.plugins WHERE org_id = ?`, orgID).Error; err != nil {
+			return err
+		}
+		return tx.Table("private.orgs").Where("id = ?", orgID).Delete(nil).Error
+	})
+}

--- a/gateway/models/users.go
+++ b/gateway/models/users.go
@@ -78,6 +78,18 @@ func GetUserByEmailAndOrg(email, orgID string) (*User, error) {
 	return user, nil
 }
 
+func GetInvitedUserByEmailAndOrg(email, orgID string) (*User, error) {
+	var user *User
+	if err := DB.Where("org_id = ? AND email = ? AND status = 'invited'", orgID, email).First(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return user, nil
+}
+
 func GetUserByEmail(email string) (*User, error) {
 	var user *User
 	if err := DB.Where("email = ?", email).First(&user).Error; err != nil {
@@ -88,6 +100,12 @@ func GetUserByEmail(email string) (*User, error) {
 	}
 
 	return user, nil
+}
+
+func ListUsersByEmail(email string) ([]User, error) {
+	var users []User
+	err := DB.Where("email = ?", email).Find(&users).Error
+	return users, err
 }
 
 func CreateUser(user User) error {
@@ -108,6 +126,10 @@ func DeleteUser(orgID, subject string) error {
 		Where("org_id = ? AND subject = ?", orgID, subject).
 		Delete(&User{}).
 		Error
+}
+
+func DeleteUserByID(id string) error {
+	return DB.Where("id = ?", id).Delete(&User{}).Error
 }
 
 func UpdateUserAndUserGroups(user *User, userGroups []UserGroup) error {

--- a/gateway/models/users.go
+++ b/gateway/models/users.go
@@ -132,6 +132,28 @@ func DeleteUserByID(id string) error {
 	return DB.Where("id = ?", id).Delete(&User{}).Error
 }
 
+// PromoteInvitedUser atomically migrates a user to an invited org.
+// It deletes the current user record first (releasing the UNIQUE subject constraint)
+// then promotes the invited record by binding the subject and activating it.
+func PromoteInvitedUser(invitedUserID, currentUserOrgID, idpSubject, name, picture string) error {
+	return DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(
+			`DELETE FROM private.users WHERE org_id = ? AND subject = ?`,
+			currentUserOrgID, idpSubject,
+		).Error; err != nil {
+			return err
+		}
+		return tx.Exec(
+			`UPDATE private.users SET status = 'active', verified = true, subject = ?, name = ?, picture = ? WHERE id = ? AND status = 'invited'`,
+			idpSubject, name, picture, invitedUserID,
+		).Error
+	})
+}
+
+func DeletePendingInvitationByEmail(email string) error {
+	return DB.Exec(`DELETE FROM private.users WHERE email = ? AND status = 'invited'`, email).Error
+}
+
 func UpdateUserAndUserGroups(user *User, userGroups []UserGroup) error {
 	tx := DB.Begin()
 	if err := tx.Save(&user).Error; err != nil {

--- a/gateway/models/users.go
+++ b/gateway/models/users.go
@@ -92,13 +92,15 @@ func GetInvitedUserByEmailAndOrg(email, orgID string) (*User, error) {
 
 func GetUserByEmail(email string) (*User, error) {
 	var user *User
-	if err := DB.Where("email = ?", email).First(&user).Error; err != nil {
+	err := DB.Where("email = ?", email).
+		Order("CASE WHEN status = 'active' THEN 0 WHEN status = 'invited' THEN 1 ELSE 2 END, id").
+		First(&user).Error
+	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
-
 	return user, nil
 }
 

--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -101,6 +101,7 @@
    [webapp.features.users.events]
    [webapp.features.users.main :as users]
    [webapp.features.users.subs]
+   [webapp.features.users.views.org-migration-dialog :as org-migration-dialog]
    [webapp.guardrails.create-update-form :as guardrail-create-update]
    [webapp.guardrails.main :as guardrails]
    [webapp.integrations.aws-connect :as aws-connect-page]
@@ -271,6 +272,7 @@
              [draggable-card/main]
              [command-palette/command-palette]
              [command-palette/keyboard-listener]
+             [org-migration-dialog/main]
              [sidebar/main panels]]))))))
 
 (defmulti layout identity)

--- a/webapp/src/webapp/events/users.cljs
+++ b/webapp/src/webapp/events/users.cljs
@@ -55,17 +55,17 @@
 (rf/reg-event-fx
  :users->accept-org-invitation
  (fn
-   [_ [_ org-id]]
+   [_ [_ org-id on-failure]]
    {:fx [[:dispatch [:fetch
                      {:method "POST"
                       :uri "/userinfo/accept-org-invitation"
                       :body {:org_id org-id}
                       :on-success (fn [_]
-                                    ;; Force a full page reload so all org-scoped state
-                                    ;; (connections, agents, groups, etc.) is loaded fresh
-                                    ;; from the new organization context
-                                    (js/window.location.reload))
+                                    ;; Keep the loading screen visible briefly so the
+                                    ;; transition feels intentional, then reload fresh.
+                                    (js/setTimeout #(js/window.location.reload) 1500))
                       :on-failure (fn [error]
+                                    (when on-failure (on-failure))
                                     (rf/dispatch [:show-snackbar {:level :error
                                                                    :text (or (:message error) "Failed to migrate organization")}]))}]]]}))
 

--- a/webapp/src/webapp/events/users.cljs
+++ b/webapp/src/webapp/events/users.cljs
@@ -55,14 +55,12 @@
 (rf/reg-event-fx
  :users->accept-org-invitation
  (fn
-   [_ [_ org-id on-failure]]
+   [_ [_ on-failure]]
    {:fx [[:dispatch [:fetch
                      {:method "POST"
-                      :uri "/userinfo/accept-org-invitation"
-                      :body {:org_id org-id}
+                      :uri "/orgs/invitations"
+                      :body {:action "accept"}
                       :on-success (fn [_]
-                                    ;; Keep the loading screen visible briefly so the
-                                    ;; transition feels intentional, then reload fresh.
                                     (js/setTimeout #(js/window.location.reload) 2500))
                       :on-failure (fn [error]
                                     (when on-failure (on-failure))
@@ -72,11 +70,11 @@
 (rf/reg-event-fx
  :users->decline-org-invitation
  (fn
-   [_ [_ org-id]]
+   [_ _]
    {:fx [[:dispatch [:fetch
-                     {:method "DELETE"
-                      :uri "/userinfo/pending-org-invitation"
-                      :body {:org_id org-id}
+                     {:method "POST"
+                      :uri "/orgs/invitations"
+                      :body {:action "decline"}
                       :on-success (fn [_]
                                     (rf/dispatch [:users->clear-pending-org-invitations]))
                       :on-failure (fn [_]

--- a/webapp/src/webapp/events/users.cljs
+++ b/webapp/src/webapp/events/users.cljs
@@ -39,18 +39,53 @@
  ::users->set-current-user
  (fn
    [{:keys [db]} [_ user server-info]]
-   (let [license-info (:license_info server-info)]
-
-     {:db (assoc db :users->current-user {:loading false
-                                          :data (assoc user
-                                                       :user-management? (= (:webapp_users_management user) "on")
-                                                       :free-license? (not (and (:is_valid license-info)
-                                                                                (= (:type license-info) "enterprise")))
-                                                       :admin? (:is_admin user)
-                                                       ;;:tenancy_type "multi-tenant"
-                                                       )})
+   (let [license-info (:license_info server-info)
+         pending-invitations (:pending_org_invitations user)]
+     {:db (-> db
+              (assoc :users->current-user {:loading false
+                                           :data (assoc user
+                                                        :user-management? (= (:webapp_users_management user) "on")
+                                                        :free-license? (not (and (:is_valid license-info)
+                                                                                 (= (:type license-info) "enterprise")))
+                                                        :admin? (:is_admin user))})
+              (assoc :users->pending-org-invitations (when (seq pending-invitations) pending-invitations)))
       :fx [[:dispatch [:initialize-intercom user]]
            [:dispatch [:close-page-loader]]]})))
+
+(rf/reg-event-fx
+ :users->accept-org-invitation
+ (fn
+   [_ [_ org-id]]
+   {:fx [[:dispatch [:fetch
+                     {:method "POST"
+                      :uri "/userinfo/accept-org-invitation"
+                      :body {:org_id org-id}
+                      :on-success (fn [_]
+                                    ;; Force a full page reload so all org-scoped state
+                                    ;; (connections, agents, groups, etc.) is loaded fresh
+                                    ;; from the new organization context
+                                    (js/window.location.reload))
+                      :on-failure (fn [error]
+                                    (rf/dispatch [:show-snackbar {:level :error
+                                                                   :text (or (:message error) "Failed to migrate organization")}]))}]]]}))
+
+(rf/reg-event-fx
+ :users->decline-org-invitation
+ (fn
+   [_ [_ org-id]]
+   {:fx [[:dispatch [:fetch
+                     {:method "DELETE"
+                      :uri "/userinfo/pending-org-invitation"
+                      :body {:org_id org-id}
+                      :on-success (fn [_]
+                                    (rf/dispatch [:users->clear-pending-org-invitations]))
+                      :on-failure (fn [_]
+                                    (rf/dispatch [:users->clear-pending-org-invitations]))}]]]}))
+
+(rf/reg-event-db
+ :users->clear-pending-org-invitations
+ (fn [db _]
+   (assoc db :users->pending-org-invitations nil)))
 
 (rf/reg-event-fx
  :users->create-new-user

--- a/webapp/src/webapp/events/users.cljs
+++ b/webapp/src/webapp/events/users.cljs
@@ -63,11 +63,11 @@
                       :on-success (fn [_]
                                     ;; Keep the loading screen visible briefly so the
                                     ;; transition feels intentional, then reload fresh.
-                                    (js/setTimeout #(js/window.location.reload) 1500))
+                                    (js/setTimeout #(js/window.location.reload) 2500))
                       :on-failure (fn [error]
                                     (when on-failure (on-failure))
                                     (rf/dispatch [:show-snackbar {:level :error
-                                                                   :text (or (:message error) "Failed to migrate organization")}]))}]]]}))
+                                                                  :text (or (:message error) "Failed to migrate organization")}]))}]]]}))
 
 (rf/reg-event-fx
  :users->decline-org-invitation

--- a/webapp/src/webapp/features/users/subs.cljs
+++ b/webapp/src/webapp/features/users/subs.cljs
@@ -34,3 +34,8 @@
  (fn [db]
    (or (get-in db [:features :users :promotion-seen])
        (boolean (.getItem (.-localStorage js/window) "users-promotion-seen")))))
+
+(rf/reg-sub
+ :users/pending-org-invitations
+ (fn [db _]
+   (:users->pending-org-invitations db)))

--- a/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
+++ b/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
@@ -40,12 +40,11 @@
                [:> Button {:color "gray"
                            :highContrast true
                            :variant "soft"
-                           :on-click #(rf/dispatch [:users->decline-org-invitation (:org_id invitation)])}
+                           :on-click #(rf/dispatch [:users->decline-org-invitation])}
                 "Stay in current org"]]
               [:> AlertDialog.Action
                [:> Button {:on-click (fn []
                                        (reset! migrating? true)
                                        (rf/dispatch [:users->accept-org-invitation
-                                                     (:org_id invitation)
                                                      #(reset! migrating? false)]))}
                 (str "Join " (:org_name invitation))]]]])]]))))

--- a/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
+++ b/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
@@ -1,16 +1,14 @@
 (ns webapp.features.users.views.org-migration-dialog
   (:require
    ["@radix-ui/themes" :refer [AlertDialog Button Flex Text Strong]]
+   ["lucide-react" :refer [Building2 Loader2]]
    [re-frame.core :as rf]
    [reagent.core :as r]))
 
 (defn- migration-loading [org-name]
-  [:div.flex.flex-col.items-center.justify-center.gap-5.py-8
-   [:div.relative.flex.items-center.justify-center
-    [:div.w-16.h-16.rounded-full.border-4.border-gray-100.border-t-blue-600.animate-spin]
-    [:div.absolute.w-8.h-8.rounded-full.bg-blue-50.flex.items-center.justify-center.animate-pulse
-     [:span.text-blue-600.text-lg "✦"]]]
-   [:div.flex.flex-col.items-center.gap-2
+  [:> Flex {:direction "column" :align "center" :justify "center" :gap "4" :py "8"}
+   [:> Loader2 {:size 40 :class "animate-spin text-blue-600"}]
+   [:> Flex {:direction "column" :align "center" :gap "1"}
     [:> Text {:size "4" :weight "bold" :align "center"}
      "Migrating your organization"]
     [:> Text {:size "2" :color "gray" :align "center"}
@@ -24,12 +22,13 @@
     (fn []
       (when-let [invitation (first @invitations)]
         [:> AlertDialog.Root {:open true}
-         [:> AlertDialog.Content {:size "3"
-                                  :max-width "500px"}
+         [:> AlertDialog.Content {:size "3" :max-width "500px"}
           (if @migrating?
             [migration-loading (:org_name invitation)]
             [:<>
-             [:> AlertDialog.Title "Organization Invitation"]
+             [:> Flex {:align "center" :gap "2" :mb "1"}
+              [:> Building2 {:size 20 :class "text-gray-11"}]
+              [:> AlertDialog.Title "Organization Invitation"]]
              [:> AlertDialog.Description {:size "2"}
               [:> Text
                "You have been invited to join "
@@ -49,4 +48,4 @@
                                        (rf/dispatch [:users->accept-org-invitation
                                                      (:org_id invitation)
                                                      #(reset! migrating? false)]))}
-                (str "Join " (:org_name invitation))]]]]]]]))))
+                (str "Join " (:org_name invitation))]]]])]]))))

--- a/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
+++ b/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
@@ -1,0 +1,32 @@
+(ns webapp.features.users.views.org-migration-dialog
+  (:require
+   ["@radix-ui/themes" :refer [AlertDialog Button Flex Text Strong]]
+   [re-frame.core :as rf]))
+
+(defn main []
+  (let [invitations (rf/subscribe [:users/pending-org-invitations])]
+    (fn []
+      (when-let [invitation (first @invitations)]
+        [:> AlertDialog.Root {:open true
+                              :on-open-change (fn [open?]
+                                               (when-not open?
+                                                 (rf/dispatch [:users->decline-org-invitation (:org_id invitation)])))}
+         [:> AlertDialog.Content {:size "3"
+                                  :max-width "500px"}
+          [:> AlertDialog.Title "Organization Invitation"]
+          [:> AlertDialog.Description {:size "2"}
+           [:> Text
+            "You have been invited to join "
+            [:> Strong (:org_name invitation)]
+            ". Would you like to migrate to this organization? "
+            "Your current organization will be removed."]]
+          [:> Flex {:gap "3" :mt "4" :justify "end"}
+           [:> AlertDialog.Cancel
+            [:> Button {:color "gray"
+                        :highContrast true
+                        :variant "soft"
+                        :on-click #(rf/dispatch [:users->decline-org-invitation (:org_id invitation)])}
+             "Stay in current org"]]
+           [:> AlertDialog.Action
+            [:> Button {:on-click #(rf/dispatch [:users->accept-org-invitation (:org_id invitation)])}
+             (str "Join " (:org_name invitation))]]]]]))))

--- a/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
+++ b/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
@@ -1,32 +1,52 @@
 (ns webapp.features.users.views.org-migration-dialog
   (:require
    ["@radix-ui/themes" :refer [AlertDialog Button Flex Text Strong]]
-   [re-frame.core :as rf]))
+   [re-frame.core :as rf]
+   [reagent.core :as r]))
+
+(defn- migration-loading [org-name]
+  [:div.flex.flex-col.items-center.justify-center.gap-5.py-8
+   [:div.relative.flex.items-center.justify-center
+    [:div.w-16.h-16.rounded-full.border-4.border-gray-100.border-t-blue-600.animate-spin]
+    [:div.absolute.w-8.h-8.rounded-full.bg-blue-50.flex.items-center.justify-center.animate-pulse
+     [:span.text-blue-600.text-lg "✦"]]]
+   [:div.flex.flex-col.items-center.gap-2
+    [:> Text {:size "4" :weight "bold" :align "center"}
+     "Migrating your organization"]
+    [:> Text {:size "2" :color "gray" :align "center"}
+     "Setting up your account in "
+     [:> Strong org-name]
+     ". This may take a moment."]]])
 
 (defn main []
-  (let [invitations (rf/subscribe [:users/pending-org-invitations])]
+  (let [invitations (rf/subscribe [:users/pending-org-invitations])
+        migrating? (r/atom false)]
     (fn []
       (when-let [invitation (first @invitations)]
-        [:> AlertDialog.Root {:open true
-                              :on-open-change (fn [open?]
-                                               (when-not open?
-                                                 (rf/dispatch [:users->decline-org-invitation (:org_id invitation)])))}
+        [:> AlertDialog.Root {:open true}
          [:> AlertDialog.Content {:size "3"
                                   :max-width "500px"}
-          [:> AlertDialog.Title "Organization Invitation"]
-          [:> AlertDialog.Description {:size "2"}
-           [:> Text
-            "You have been invited to join "
-            [:> Strong (:org_name invitation)]
-            ". Would you like to migrate to this organization? "
-            "Your current organization will be removed."]]
-          [:> Flex {:gap "3" :mt "4" :justify "end"}
-           [:> AlertDialog.Cancel
-            [:> Button {:color "gray"
-                        :highContrast true
-                        :variant "soft"
-                        :on-click #(rf/dispatch [:users->decline-org-invitation (:org_id invitation)])}
-             "Stay in current org"]]
-           [:> AlertDialog.Action
-            [:> Button {:on-click #(rf/dispatch [:users->accept-org-invitation (:org_id invitation)])}
-             (str "Join " (:org_name invitation))]]]]]))))
+          (if @migrating?
+            [migration-loading (:org_name invitation)]
+            [:<>
+             [:> AlertDialog.Title "Organization Invitation"]
+             [:> AlertDialog.Description {:size "2"}
+              [:> Text
+               "You have been invited to join "
+               [:> Strong (:org_name invitation)]
+               ". Would you like to migrate to this organization? "
+               "Your current organization will be removed."]]
+             [:> Flex {:gap "3" :mt "4" :justify "end"}
+              [:> AlertDialog.Cancel
+               [:> Button {:color "gray"
+                           :highContrast true
+                           :variant "soft"
+                           :on-click #(rf/dispatch [:users->decline-org-invitation (:org_id invitation)])}
+                "Stay in current org"]]
+              [:> AlertDialog.Action
+               [:> Button {:on-click (fn []
+                                       (reset! migrating? true)
+                                       (rf/dispatch [:users->accept-org-invitation
+                                                     (:org_id invitation)
+                                                     #(reset! migrating? false)]))}
+                (str "Join " (:org_name invitation))]]]]]]]))))

--- a/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
+++ b/webapp/src/webapp/features/users/views/org_migration_dialog.cljs
@@ -26,8 +26,8 @@
           (if @migrating?
             [migration-loading (:org_name invitation)]
             [:<>
-             [:> Flex {:align "center" :gap "2" :mb "1"}
-              [:> Building2 {:size 20 :class "text-gray-11"}]
+             [:> Flex {:gap "2" :mb "1"}
+              [:> Building2 {:size 20 :class "mb-3 text-gray-11"}]
               [:> AlertDialog.Title "Organization Invitation"]]
              [:> AlertDialog.Description {:size "2"}
               [:> Text


### PR DESCRIPTION
## 📝 Description                                                                                                  
                                                                                                                   
In multi-tenant environments (e.g., `use.hoop.dev`), users who sign in via SSO before being explicitly invited to  
their organization are automatically placed in a newly created org. When they later receive an invitation to the   
correct org, the database ends up with two rows for the same email: one active user in the wrong org and one       
invited user in the right org. Resolving this requires manual database intervention, generating recurring support  
tickets.

This PR introduces a self-service org migration flow. On the next login, users with a pending invitation see a     
dialog offering them to migrate to the correct organization. Accepting atomically promotes the invited record,     
binds the IDP subject to it, removes the old record, and cleans up the now-empty org. 

## 🚀 Type of Change                                                                                               
 
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)                                                        
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)          
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update                                                                                           
- [ ] ♻️  Code refactor                                    
- [ ] ⚡ Performance improvement                                                                                   
- [ ] ✅ Test update                                      
- [ ] 🔧 Build configuration change                                                                                
- [ ] 🧹 Chore                                                                                                     
 
## 📋 Changes Made                                                                                                 
                                                          
**Backend**                                                                                                        
- Improved OIDC login user lookup: resolves by IDP subject first, falls back to email — ensures invited users (with
 placeholder subject) are matched correctly on first login                                                         
- `GET /userinfo` now returns `pending_org_invitations` for multi-tenant users, listing orgs they were invited to
but haven't joined                                                                                                 
- `POST /userinfo/accept-org-invitation`: atomically promotes the invited user record, transfers the IDP subject,
deletes the old record, and removes the orphaned org if empty                                                      
- `DELETE /userinfo/pending-org-invitation`: dismisses a pending invitation without migrating (dialog won't show
again)                                                                                                             
- Added model helpers: `ListUsersByEmail`, `GetInvitedUserByEmailAndOrg`, `DeleteOrganizationIfEmpty`
                                                                                                                   
**Frontend**                                              
- New `OrgMigrationDialog` component: shown globally on login when a pending invitation exists, built with Radix UI
 + Lucide icons                                                                                                    
- Re-frame events and subscriptions to handle accept/decline flows with proper loading and error states
- On accept, reloads the app after a short delay so the new org session takes effect cleanly                       
                                                                                                                   
## 🧪 Testing                                                                                                      
                                                                                                                   
### Test Configuration:                                   
- **Browser(s)**: Chrome
- **OS**: macOS                                                                                                    
 
### Tests performed:                                                                                               
- [x] Manual testing completed                            
- [ ] Unit tests pass                                                                                              
- [ ] Integration tests pass
                                                                                                                   
**Scenario tested:**                                      
1. User signs in via SSO before being invited → lands in auto-created org
2. Admin invites that same email to the correct org                                                                
3. User logs in again → migration dialog appears                                                                   
4. User accepts → migrated to correct org, old org deleted, SSO works normally                                     
5. User declines → dialog dismissed, user stays in current org                                                     
                                                                                                                   
## ✅ Checklist                                                                                                    
                                                                                                                   
- [x] My code follows the style guidelines of this project                                                         
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings                                                                          
- [ ] I have run `make generate-openapi-docs` to update the OpenAPI docs
                                                                                                                   
## 📄 Additional Notes
                                                                                                                   
The migration is intentionally scoped to multi-tenant environments only (`isOrgMultiTenant` gate on the backend).  
The org cleanup after migration is best-effort — if the old org still has other resources (connections, sessions,
agents), deletion is skipped with a warning log rather than failing the migration.