### PR TITLE
PRD - Email-Addressable Analytics for OSS Users

### DIFF
--- a/gateway/analytics/segment.go
+++ b/gateway/analytics/segment.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/license"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/common/version"
 	"github.com/hoophq/hoop/gateway/appconfig"
@@ -52,6 +53,25 @@ func (s *Segment) Close() {
 	}
 }
 
+// identifyTraits builds the trait set for an Identify call. On OSS installs
+// the user's real email and name are attached so Intercom can address them;
+// Enterprise keeps the pseudonymous hashed user-id as the only identifier.
+func identifyTraits(ctx *types.APIContext, hashedUserID, environmentName string) analytics.Traits {
+	traits := analytics.NewTraits().
+		Set("org-id", ctx.OrgID).
+		Set("user-id", hashedUserID).
+		Set("is-admin", ctx.IsAdminUser()).
+		Set("environment", environmentName).
+		Set("status", ctx.UserStatus).
+		Set("client-version", version.Get().Version)
+
+	if ctx.GetLicenseType() == license.OSSType && ctx.UserEmail != "" {
+		traits = traits.SetEmail(ctx.UserEmail).SetName(ctx.UserName)
+	}
+
+	return traits
+}
+
 func (s *Segment) Identify(ctx *types.APIContext) {
 	if s.Client == nil || ctx == nil || ctx.UserID == "" || ctx.OrgID == "" ||
 		!appconfig.Get().AnalyticsTracking() {
@@ -63,13 +83,7 @@ func (s *Segment) Identify(ctx *types.APIContext) {
 	_ = s.Client.Enqueue(analytics.Identify{
 		UserId:      hashedUserID,
 		AnonymousId: ctx.UserAnonSubject,
-		Traits: analytics.NewTraits().
-			Set("org-id", ctx.OrgID).
-			Set("user-id", hashedUserID).
-			Set("is-admin", ctx.IsAdminUser()).
-			Set("environment", s.environmentName).
-			Set("status", ctx.UserStatus).
-			Set("client-version", version.Get().Version),
+		Traits:      identifyTraits(ctx, hashedUserID, s.environmentName),
 	})
 
 	_ = s.Client.Enqueue(analytics.Group{

--- a/gateway/analytics/segment_test.go
+++ b/gateway/analytics/segment_test.go
@@ -7,9 +7,98 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/license"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2/types"
 	"github.com/lib/pq"
 )
+
+func TestIdentifyTraits(t *testing.T) {
+	ossLicense := json.RawMessage(`{"payload":{"type":"oss"}}`)
+	enterpriseLicense := json.RawMessage(`{"payload":{"type":"enterprise"}}`)
+
+	t.Run("OSS install with email sends email and name traits", func(t *testing.T) {
+		ctx := &types.APIContext{
+			OrgID:          "org-1",
+			OrgLicenseData: &ossLicense,
+			UserID:         "user-1",
+			UserEmail:      "alice@example.com",
+			UserName:       "Alice",
+		}
+
+		traits := identifyTraits(ctx, "hashed-id", "env-1")
+
+		assertTrait(t, traits, "email", "alice@example.com")
+		assertTrait(t, traits, "name", "Alice")
+		assertTrait(t, traits, "user-id", "hashed-id")
+		assertTrait(t, traits, "org-id", "org-1")
+	})
+
+	t.Run("Enterprise install omits email and name traits", func(t *testing.T) {
+		ctx := &types.APIContext{
+			OrgID:          "org-1",
+			OrgLicenseData: &enterpriseLicense,
+			UserID:         "user-1",
+			UserEmail:      "alice@example.com",
+			UserName:       "Alice",
+		}
+
+		traits := identifyTraits(ctx, "hashed-id", "env-1")
+
+		assertTraitAbsent(t, traits, "email")
+		assertTraitAbsent(t, traits, "name")
+		assertTrait(t, traits, "user-id", "hashed-id")
+	})
+
+	t.Run("OSS install with empty email omits email and name traits", func(t *testing.T) {
+		ctx := &types.APIContext{
+			OrgID:          "org-1",
+			OrgLicenseData: &ossLicense,
+			UserID:         "user-1",
+		}
+
+		traits := identifyTraits(ctx, "hashed-id", "env-1")
+
+		assertTraitAbsent(t, traits, "email")
+		assertTraitAbsent(t, traits, "name")
+	})
+
+	t.Run("empty license data defaults to OSS and sends email", func(t *testing.T) {
+		ctx := &types.APIContext{
+			OrgID:     "org-1",
+			UserID:    "user-1",
+			UserEmail: "alice@example.com",
+			UserName:  "Alice",
+		}
+
+		if got := ctx.GetLicenseType(); got != license.OSSType {
+			t.Fatalf("expected empty license data to resolve to %q, got %q", license.OSSType, got)
+		}
+		traits := identifyTraits(ctx, "hashed-id", "env-1")
+
+		assertTrait(t, traits, "email", "alice@example.com")
+		assertTrait(t, traits, "name", "Alice")
+	})
+}
+
+func assertTrait(t *testing.T, traits map[string]any, key string, expected any) {
+	t.Helper()
+	val, ok := traits[key]
+	if !ok {
+		t.Errorf("expected trait %q to exist", key)
+		return
+	}
+	if val != expected {
+		t.Errorf("trait %q = %v, want %v", key, val, expected)
+	}
+}
+
+func assertTraitAbsent(t *testing.T, traits map[string]any, key string) {
+	t.Helper()
+	if _, ok := traits[key]; ok {
+		t.Errorf("expected trait %q to be absent", key)
+	}
+}
 
 func TestSessionUsageProperties(t *testing.T) {
 	now := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)

--- a/gateway/api/login/local/register.go
+++ b/gateway/api/login/local/register.go
@@ -106,7 +106,10 @@ func Register(c *gin.Context) {
 
 	trackClient.Identify(&types.APIContext{
 		OrgID:           org.ID,
+		OrgLicenseData:  &org.LicenseData,
 		UserID:          userSubject,
+		UserEmail:       user.Email,
+		UserName:        user.Name,
 		UserAnonSubject: org.ID,
 	})
 	trackClient.Track(userSubject, analytics.EventSingleTenantFirstUserCreated, map[string]any{

--- a/gateway/api/login/oidc/login.go
+++ b/gateway/api/login/oidc/login.go
@@ -458,7 +458,10 @@ func syncSingleTenantUser(ctx *models.Context, uinfo idptypes.ProviderUserInfo) 
 		// merge this anonymous event with the identified user
 		trackClient.Identify(&types.APIContext{
 			OrgID:           org.ID,
+			OrgLicenseData:  &org.LicenseData,
 			UserID:          newUser.Subject,
+			UserEmail:       newUser.Email,
+			UserName:        newUser.Name,
 			UserAnonSubject: org.ID,
 		})
 		trackClient.Track(newUser.Subject, analytics.EventSingleTenantFirstUserCreated, map[string]any{
@@ -504,8 +507,11 @@ func (h *handler) analyticsTrack(isNewUser bool, userAgent string, ctx *models.C
 		return
 	}
 	trackClient.Identify(&types.APIContext{
-		OrgID:  ctx.OrgID,
-		UserID: ctx.UserID,
+		OrgID:          ctx.OrgID,
+		OrgLicenseData: &ctx.OrgLicenseData,
+		UserID:         ctx.UserID,
+		UserEmail:      ctx.UserEmail,
+		UserName:       ctx.UserName,
 	})
 	go func() {
 		// wait some time until the identify call get times to reach to intercom

--- a/gateway/api/signup/signup.go
+++ b/gateway/api/signup/signup.go
@@ -114,7 +114,7 @@ func Post(c *gin.Context) {
 	_ = models.UpsertBatchConnectionTags(apiconnections.DefaultConnectionTags(org.ID))
 
 	log.With("org_name", req.OrgName, "org_id", org.ID).Infof("user signup up with success")
-	identifySignup(user, c.GetHeader("user-agent"), c.Request.Host, ctx.GetLicenseType())
+	identifySignup(user, c.GetHeader("user-agent"), c.Request.Host, ctx.GetLicenseType(), licenseDataJSONBytes)
 	c.JSON(http.StatusOK, openapi.SignupRequest{
 		OrgID:          org.ID,
 		OrgName:        req.OrgName,
@@ -123,11 +123,14 @@ func Post(c *gin.Context) {
 	})
 }
 
-func identifySignup(u models.User, userAgent, host, licenseType string) {
+func identifySignup(u models.User, userAgent, host, licenseType string, licenseData json.RawMessage) {
 	trackClient := analytics.New()
 	trackClient.Identify(&types.APIContext{
-		OrgID:  u.OrgID,
-		UserID: u.Subject,
+		OrgID:          u.OrgID,
+		OrgLicenseData: &licenseData,
+		UserID:         u.Subject,
+		UserEmail:      u.Email,
+		UserName:       u.Name,
 	})
 	go func() {
 		// wait some time until the identify call get times to reach to intercom

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -124,8 +124,11 @@ func Create(c *gin.Context) {
 
 	trackClient := ctx.Analytics()
 	trackClient.Identify(&types.APIContext{
-		OrgID:  ctx.OrgID,
-		UserID: userSubject,
+		OrgID:          ctx.OrgID,
+		OrgLicenseData: ctx.OrgLicenseData,
+		UserID:         userSubject,
+		UserEmail:      newUser.Email,
+		UserName:       newUser.Name,
 	})
 	go func() {
 		// wait some time until the identify call get times to reach to intercom
@@ -214,10 +217,13 @@ func Update(c *gin.Context) {
 	trackClient := analytics.New()
 	defer trackClient.Close()
 	trackClient.Identify(&types.APIContext{
-		OrgID:      ctx.OrgID,
-		UserID:     existingUser.ID,
-		UserStatus: existingUser.Status,
-		SlackID:    existingUser.SlackID,
+		OrgID:          ctx.OrgID,
+		OrgLicenseData: ctx.OrgLicenseData,
+		UserID:         existingUser.ID,
+		UserEmail:      existingUser.Email,
+		UserName:       existingUser.Name,
+		UserStatus:     existingUser.Status,
+		SlackID:        existingUser.SlackID,
 	})
 
 	c.JSON(http.StatusOK, openapi.User{

--- a/gateway/storagev2/types/meta.go
+++ b/gateway/storagev2/types/meta.go
@@ -1,8 +1,10 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/hoophq/hoop/common/license"
 	pb "github.com/hoophq/hoop/common/proto"
 )
 
@@ -20,6 +22,17 @@ func (c *ConnectionInfo) Validate() error {
 		return fmt.Errorf("missing required connection attributes")
 	}
 	return nil
+}
+
+func (c *APIContext) GetLicenseType() string {
+	if c == nil || c.OrgLicenseData == nil || len(*c.OrgLicenseData) == 0 {
+		return license.OSSType
+	}
+	var l license.License
+	if err := json.Unmarshal(*c.OrgLicenseData, &l); err != nil {
+		return license.OSSType
+	}
+	return l.Payload.Type
 }
 
 func (c *APIContext) IsAdminUser() bool   { return pb.IsInList(GroupAdmin, c.UserGroups) }


### PR DESCRIPTION
## 📝 Description

Attach user email and name traits to Segment `Identify` calls on OSS installations so Intercom can address users directly. Enterprise installations continue to send only the pseudonymous hashed user-id, preserving the existing privacy posture.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Introduce `identifyTraits` in `gateway/analytics/segment.go` that branches on license type: OSS installs get `email`/`name` traits, Enterprise stays pseudonymous.
- Add `APIContext.GetLicenseType()` helper in `gateway/storagev2/types/meta.go` that safely decodes `OrgLicenseData` and defaults to OSS when absent/invalid.
- Propagate `OrgLicenseData`, `UserEmail`, and `UserName` through every `Identify` call site: local register, OIDC login (both new-user and per-login paths), signup, and user create/update.
- Add unit tests covering OSS-with-email, Enterprise (omits PII), OSS-with-empty-email, and empty-license-defaults-to-OSS cases.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (backend only)
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass (`TestIdentifyTraits` covers all four license/email permutations)
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

N/A — backend analytics change with no UI surface.

## ✅ Checklist

- [ ] I have run `make generate-openapi-docs` to update the OpenAPI docs (no API schema changes)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Reviewers: please double-check the license gate in `identifyTraits` — the intent is that only OSS installs (including empty/invalid license data, which defaults to OSS) leak PII to Segment/Intercom, while any non-OSS license type keeps the hashed-id-only behavior.