### PR TITLE
feat(gateway): stable per-user connection credentials

### DIFF
--- a/gateway/api/connections/connection_credentials.go
+++ b/gateway/api/connections/connection_credentials.go
@@ -143,32 +143,16 @@ func CreateConnectionCredentials(c *gin.Context) {
 		return
 	}
 
-	connType := proto.ConnectionType(conn.SubType.String)
-	secretKey, secretKeyHash, err := generateSecretKey(connType)
-	if err != nil {
-		log.Warnf("failed to create access credentials, err=%v", err)
-		c.AbortWithStatusJSON(400, gin.H{"message": err.Error()})
-		return
-	}
-
 	expireAt := time.Now().UTC().Add(time.Duration(req.AccessDurationSec) * time.Second)
 	if expireAt.After(time.Now().UTC().Add(48 * time.Hour)) {
 		c.AbortWithStatusJSON(400, gin.H{"message": "access duration cannot exceed 48 hours"})
 		return
 	}
 
-	db, err := models.CreateConnectionCredentials(&models.ConnectionCredentials{
-		ID:             uuid.NewString(),
-		OrgID:          ctx.OrgID,
-		UserSubject:    ctx.UserID,
-		ConnectionName: conn.Name,
-		ConnectionType: proto.ToConnectionType(conn.Type, conn.SubType.String).String(),
-		SecretKeyHash:  secretKeyHash,
-		SessionID:      sid,
-		CreatedAt:      time.Now().UTC(),
-		ExpireAt:       expireAt,
-	})
+	connType := proto.ConnectionType(conn.SubType.String)
+	secretKey, db, err := issueOrRefreshCredential(ctx.OrgID, ctx.UserID, conn, connType, sid, expireAt)
 	if err != nil {
+		log.Warnf("failed to issue credential, err=%v", err)
 		c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})
 		return
 	}
@@ -179,6 +163,104 @@ func CreateConnectionCredentials(c *gin.Context) {
 	}
 
 	c.JSON(201, buildConnectionCredentialsResponse(db, conn, serverConf, secretKey, false, ""))
+}
+
+// issueOrRefreshCredential implements the stable-key contract documented on
+// CreateConnectionCredentials: for a given (user, connection) pair the plaintext
+// secret key is stable across issuances. The row is reused (and its expiration
+// refreshed to the new value) whenever a non-revoked credential exists; the key
+// only changes when the previous credential was revoked or when the row predates
+// the encrypted_secret_key backfill column.
+func issueOrRefreshCredential(
+	orgID, userSubject string,
+	conn *models.Connection,
+	connType proto.ConnectionType,
+	sessionID string,
+	expireAt time.Time,
+) (string, *models.ConnectionCredentials, error) {
+	existing, err := models.GetActiveCredentialByUserAndConnection(orgID, userSubject, conn.Name)
+	if err != nil && err != models.ErrNotFound {
+		return "", nil, fmt.Errorf("failed to look up existing credential: %w", err)
+	}
+
+	if existing != nil {
+		// Close the previous audit session (if any) so it doesn't remain
+		// perpetually "open" once the credential row is re-pointed at the new
+		// session. Errors here are non-fatal since the lazy cleanup path in
+		// CloseExpiredCredentialSessions will catch stragglers.
+		if existing.SessionID != "" && existing.SessionID != sessionID {
+			if err := models.UpdateSessionStatus(orgID, existing.SessionID, string(openapi.SessionStatusDone)); err != nil {
+				log.Warnf("failed closing previous audit session %s, err=%v", existing.SessionID, err)
+			}
+		}
+
+		// Reuse the stable key: decrypt, refresh expiration, keep the same row.
+		if len(existing.EncryptedSecretKey) > 0 {
+			plaintext, decErr := models.DecryptCredentialSecretKey(existing.EncryptedSecretKey)
+			if decErr == nil {
+				if err := models.RefreshCredentialExpiration(existing.ID, sessionID, expireAt); err != nil {
+					return "", nil, fmt.Errorf("failed to refresh credential expiration: %w", err)
+				}
+				existing.SessionID = sessionID
+				existing.ExpireAt = expireAt
+				return plaintext, existing, nil
+			}
+			log.Warnf("failed to decrypt stored credential (id=%s), regenerating: %v",
+				existing.ID, decErr)
+		}
+
+		// Backfill path: the row exists but has no ciphertext (created before
+		// migration 000081, or decryption failed). Rotate the secret key in
+		// place so the user still keeps the same credential id, but they will
+		// observe a one-time token change.
+		newSecret, newHash, genErr := generateSecretKey(connType)
+		if genErr != nil {
+			return "", nil, fmt.Errorf("failed to generate secret key: %w", genErr)
+		}
+		ciphertext, encErr := models.EncryptCredentialSecretKey(newSecret)
+		if encErr != nil {
+			return "", nil, fmt.Errorf("failed to encrypt secret key: %w", encErr)
+		}
+		if err := models.UpdateConnectionCredentialsSecret(existing.ID, newHash, ciphertext); err != nil {
+			return "", nil, fmt.Errorf("failed to update credential secret: %w", err)
+		}
+		if err := models.RefreshCredentialExpiration(existing.ID, sessionID, expireAt); err != nil {
+			return "", nil, fmt.Errorf("failed to refresh credential expiration: %w", err)
+		}
+		existing.SecretKeyHash = newHash
+		existing.EncryptedSecretKey = ciphertext
+		existing.SessionID = sessionID
+		existing.ExpireAt = expireAt
+		return newSecret, existing, nil
+	}
+
+	// No active credential for this (user, connection) pair. Create a fresh row
+	// and store both the hash (for proxy auth lookup) and the encrypted copy of
+	// the plaintext (for future reuse).
+	newSecret, newHash, err := generateSecretKey(connType)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to generate secret key: %w", err)
+	}
+	ciphertext, err := models.EncryptCredentialSecretKey(newSecret)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to encrypt secret key: %w", err)
+	}
+	db, err := models.CreateConnectionCredentials(&models.ConnectionCredentials{
+		ID:                 uuid.NewString(),
+		OrgID:              orgID,
+		UserSubject:        userSubject,
+		ConnectionName:     conn.Name,
+		ConnectionType:     proto.ToConnectionType(conn.Type, conn.SubType.String).String(),
+		SecretKeyHash:      newHash,
+		EncryptedSecretKey: ciphertext,
+		SessionID:          sessionID,
+		CreatedAt:          time.Now().UTC(),
+		ExpireAt:           expireAt,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+	return newSecret, db, nil
 }
 
 // ResumeConnectionCredentials
@@ -344,7 +426,12 @@ func ResumeConnectionCredentials(c *gin.Context) {
 	}
 
 	// If credentials already exist for this session, update the secret key (preserves expiration)
-	// Otherwise create a new record
+	// Otherwise create a new record.
+	//
+	// Resume keeps the legacy rotate-on-call behavior for review/JIT flows:
+	// repeated Resume calls explicitly rotate the token. The encrypted copy is
+	// cleared on rotation so the credential cannot later be mistaken for a
+	// stable-key row by CreateConnectionCredentials.
 	var db *models.ConnectionCredentials
 	if existingCred != nil {
 		if err := models.UpdateConnectionCredentialsSecretKey(existingCred.ID, secretKeyHash); err != nil {
@@ -352,18 +439,29 @@ func ResumeConnectionCredentials(c *gin.Context) {
 			return
 		}
 		existingCred.SecretKeyHash = secretKeyHash
+		existingCred.EncryptedSecretKey = nil
 		db = existingCred
 	} else {
+		// First issuance after review approval: store the encrypted copy so
+		// that if the review requirement is later removed the same token can
+		// be reused via CreateConnectionCredentials.
+		ciphertext, encErr := models.EncryptCredentialSecretKey(secretKey)
+		if encErr != nil {
+			log.Errorf("failed to encrypt secret key, err=%v", encErr)
+			c.AbortWithStatusJSON(500, gin.H{"message": "failed to encrypt secret key"})
+			return
+		}
 		db, err = models.CreateConnectionCredentials(&models.ConnectionCredentials{
-			ID:             uuid.NewString(),
-			OrgID:          ctx.OrgID,
-			UserSubject:    ctx.UserID,
-			ConnectionName: conn.Name,
-			ConnectionType: proto.ToConnectionType(conn.Type, conn.SubType.String).String(),
-			SecretKeyHash:  secretKeyHash,
-			SessionID:      sessionID,
-			CreatedAt:      createdAt,
-			ExpireAt:       expireAt,
+			ID:                 uuid.NewString(),
+			OrgID:              ctx.OrgID,
+			UserSubject:        ctx.UserID,
+			ConnectionName:     conn.Name,
+			ConnectionType:     proto.ToConnectionType(conn.Type, conn.SubType.String).String(),
+			SecretKeyHash:      secretKeyHash,
+			EncryptedSecretKey: ciphertext,
+			SessionID:          sessionID,
+			CreatedAt:          createdAt,
+			ExpireAt:           expireAt,
 		})
 		if err != nil {
 			c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})

--- a/gateway/api/connections/connection_credentials.go
+++ b/gateway/api/connections/connection_credentials.go
@@ -487,7 +487,7 @@ func ResumeConnectionCredentials(c *gin.Context) {
 // RevokeConnectionCredentials
 //
 //	@Summary		Revoke Connection Credentials
-//	@Description	Revokes a connection credential, invalidating it and disconnecting any active sessions
+//	@Description	Revokes a connection credential, invalidating the stored token and disconnecting any active sessions. The next credential request for the same (user, connection) pair will issue a fresh token.
 //	@Tags			Connections
 //	@Produce		json
 //	@Param			nameOrID		path		string	true	"Name or UUID of the connection"
@@ -500,39 +500,9 @@ func RevokeConnectionCredentials(c *gin.Context) {
 	connNameOrID := c.Param("nameOrID")
 	credentialID := c.Param("ID")
 
-	if credentialID == "" {
-		c.AbortWithStatusJSON(400, gin.H{"message": "credential ID is required"})
-		return
-	}
-
-	conn, err := models.GetConnectionByNameOrID(ctx, connNameOrID)
-	if err != nil {
-		c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})
-		return
-	}
-	if conn == nil {
-		c.AbortWithStatusJSON(404, gin.H{"message": fmt.Sprintf("connection %s not found", connNameOrID)})
-		return
-	}
-
-	cred, err := models.GetConnectionCredentialsByID(ctx.OrgID, credentialID)
-	if err != nil {
-		if err == models.ErrNotFound {
-			c.AbortWithStatusJSON(404, gin.H{"message": fmt.Sprintf("credential %s not found", credentialID)})
-			return
-		}
-		c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})
-		return
-	}
-
-	if cred.ConnectionName != conn.Name {
-		c.AbortWithStatusJSON(404, gin.H{"message": fmt.Sprintf("credential %s does not belong to connection %s", credentialID, connNameOrID)})
-		return
-	}
-
-	// Only the credential owner or org admin can revoke
-	if cred.UserSubject != ctx.UserID && !ctx.IsAdmin() {
-		c.AbortWithStatusJSON(403, gin.H{"message": "only the credential owner or admin can revoke"})
+	cred, conn, errResp := loadCredentialForMutation(ctx, connNameOrID, credentialID)
+	if errResp != nil {
+		c.AbortWithStatusJSON(errResp.status, gin.H{"message": errResp.message})
 		return
 	}
 
@@ -547,22 +517,109 @@ func RevokeConnectionCredentials(c *gin.Context) {
 		}
 	}
 
-	// Cancel active sessions in each proxy
+	terminateActiveCredentialSessions(cred, conn)
+
+	c.Status(204)
+}
+
+// CloseConnectionCredentials
+//
+//	@Summary		Close Connection Credentials Session
+//	@Description	Ends the current audit session for a credential and tears down any active proxy connections, but keeps the credential itself usable. The stored token is preserved so the next credential request for the same (user, connection) pair returns the same value. For explicit token invalidation use the revoke endpoint.
+//	@Tags			Connections
+//	@Produce		json
+//	@Param			nameOrID		path		string	true	"Name or UUID of the connection"
+//	@Param			credentialID	path		string	true	"UUID of the credential"
+//	@Success		204			"No content"
+//	@Failure		400,403,404,500	{object}	openapi.HTTPError
+//	@Router			/connections/{nameOrID}/credentials/{credentialID}/close [post]
+func CloseConnectionCredentials(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	connNameOrID := c.Param("nameOrID")
+	credentialID := c.Param("ID")
+
+	cred, conn, errResp := loadCredentialForMutation(ctx, connNameOrID, credentialID)
+	if errResp != nil {
+		c.AbortWithStatusJSON(errResp.status, gin.H{"message": errResp.message})
+		return
+	}
+
+	// Close the audit session (if still linked) and unlink it from the
+	// credential so the next issuance starts a fresh Session row. The
+	// credential row itself (including the encrypted_secret_key) is preserved
+	// so the stable-key contract holds across disconnects.
+	if cred.SessionID != "" {
+		if err := models.UpdateSessionStatus(ctx.OrgID, cred.SessionID, "done"); err != nil {
+			log.Warnf("failed closing audit session %s, err=%v", cred.SessionID, err)
+		}
+	}
+	if err := models.ClearCredentialSession(cred.ID); err != nil {
+		c.AbortWithStatusJSON(500, gin.H{"message": fmt.Sprintf("failed to close credential session: %v", err)})
+		return
+	}
+
+	terminateActiveCredentialSessions(cred, conn)
+
+	c.Status(204)
+}
+
+type handlerError struct {
+	status  int
+	message string
+}
+
+// loadCredentialForMutation loads a credential and validates that the caller is
+// allowed to mutate it. Used by both Revoke and Close.
+func loadCredentialForMutation(ctx *storagev2.Context, connNameOrID, credentialID string) (*models.ConnectionCredentials, *models.Connection, *handlerError) {
+	if credentialID == "" {
+		return nil, nil, &handlerError{status: 400, message: "credential ID is required"}
+	}
+
+	conn, err := models.GetConnectionByNameOrID(ctx, connNameOrID)
+	if err != nil {
+		return nil, nil, &handlerError{status: 500, message: err.Error()}
+	}
+	if conn == nil {
+		return nil, nil, &handlerError{status: 404, message: fmt.Sprintf("connection %s not found", connNameOrID)}
+	}
+
+	cred, err := models.GetConnectionCredentialsByID(ctx.OrgID, credentialID)
+	if err != nil {
+		if err == models.ErrNotFound {
+			return nil, nil, &handlerError{status: 404, message: fmt.Sprintf("credential %s not found", credentialID)}
+		}
+		return nil, nil, &handlerError{status: 500, message: err.Error()}
+	}
+
+	if cred.ConnectionName != conn.Name {
+		return nil, nil, &handlerError{status: 404, message: fmt.Sprintf("credential %s does not belong to connection %s", credentialID, connNameOrID)}
+	}
+
+	if cred.UserSubject != ctx.UserID && !ctx.IsAdmin() {
+		return nil, nil, &handlerError{status: 403, message: "only the credential owner or admin can perform this action"}
+	}
+
+	return cred, conn, nil
+}
+
+// terminateActiveCredentialSessions tears down any in-flight proxy sessions for
+// the given credential. Shared by Revoke (with DB invalidation) and Close
+// (without DB invalidation).
+func terminateActiveCredentialSessions(cred *models.ConnectionCredentials, conn *models.Connection) {
 	connType := proto.ConnectionType(cred.ConnectionType)
 	switch connType {
 	case proto.ConnectionTypePostgres:
-		postgresproxy.GetServerInstance().RevokeByCredentialID(credentialID)
+		postgresproxy.GetServerInstance().RevokeByCredentialID(cred.ID)
 	case proto.ConnectionTypeSSH:
-		sshproxy.GetServerInstance().RevokeByCredentialID(credentialID)
+		sshproxy.GetServerInstance().RevokeByCredentialID(cred.ID)
 	case proto.ConnectionTypeRDP:
-		broker.RevokeByCredentialID(credentialID)
+		broker.RevokeByCredentialID(cred.ID)
 	case proto.ConnectionTypeHttpProxy, proto.ConnectionTypeKubernetes, proto.ConnectionTypeClaudeCode, proto.ConnectionTypeCommandLine:
 		httpproxy.GetServerInstance().RevokeBySecretKeyHash(cred.SecretKeyHash)
 	case proto.ConnectionTypeSSM:
-		// SSM has no persistent session store; DB invalidation blocks new connections
+		// SSM has no persistent session store; proxies reject new connections
+		// at next auth check when the credential is revoked.
 	}
-
-	c.Status(204)
 }
 
 func mapValidSubtypeToHttpProxy(conn *models.Connection) proto.ConnectionType {

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -383,6 +383,10 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		apiconnections.RevokeConnectionCredentials,
 	)
+	r.POST("/connections/:nameOrID/credentials/:ID/close",
+		r.AuthMiddleware,
+		apiconnections.CloseConnectionCredentials,
+	)
 
 	r.GET("/connection-tags",
 		apiroutes.ReadOnlyAccessRole,

--- a/gateway/models/connection_credentials.go
+++ b/gateway/models/connection_credentials.go
@@ -8,15 +8,17 @@ import (
 )
 
 type ConnectionCredentials struct {
-	ID             string    `gorm:"column:id"`
-	OrgID          string    `gorm:"column:org_id"`
-	UserSubject    string    `gorm:"column:user_subject"`
-	ConnectionName string    `gorm:"column:connection_name"`
-	ConnectionType string    `gorm:"column:connection_type"`
-	SecretKeyHash  string    `gorm:"column:secret_key_hash"`
-	SessionID      string    `gorm:"column:session_id"`
-	CreatedAt      time.Time `gorm:"column:created_at"`
-	ExpireAt       time.Time `gorm:"column:expire_at"`
+	ID                 string     `gorm:"column:id"`
+	OrgID              string     `gorm:"column:org_id"`
+	UserSubject        string     `gorm:"column:user_subject"`
+	ConnectionName     string     `gorm:"column:connection_name"`
+	ConnectionType     string     `gorm:"column:connection_type"`
+	SecretKeyHash      string     `gorm:"column:secret_key_hash"`
+	EncryptedSecretKey []byte     `gorm:"column:encrypted_secret_key"`
+	SessionID          string     `gorm:"column:session_id"`
+	CreatedAt          time.Time  `gorm:"column:created_at"`
+	ExpireAt           time.Time  `gorm:"column:expire_at"`
+	RevokedAt          *time.Time `gorm:"column:revoked_at"`
 }
 
 func CreateConnectionCredentials(db *ConnectionCredentials) (*ConnectionCredentials, error) {
@@ -40,7 +42,7 @@ func GetConnectionCredentialsByID(orgID, id string) (*ConnectionCredentials, err
 func GetValidConnectionCredentialsBySecretKey(connectionTypes []string, secretKeyHash string) (*ConnectionCredentials, error) {
 	var resp ConnectionCredentials
 	err := DB.Table("private.connection_credentials").
-		Where("connection_type IN ? AND secret_key_hash = ?", connectionTypes, secretKeyHash).
+		Where("connection_type IN ? AND secret_key_hash = ? AND revoked_at IS NULL", connectionTypes, secretKeyHash).
 		First(&resp).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -75,11 +77,61 @@ func GetConnectionCredentialsBySessionID(orgID, sessionID string) (*ConnectionCr
 	return &resp, err
 }
 
-// UpdateConnectionCredentialsSecretKey updates the secret key hash of an existing credential
+// GetActiveCredentialByUserAndConnection returns the non-revoked credential for the
+// given (org, user, connection) triple. Callers use this to implement stable-key
+// reuse: when present the plaintext secret key is recovered via
+// DecryptCredentialSecretKey and the expiration is refreshed in place.
+// ErrNotFound is returned when the user does not yet have a credential for the
+// connection or when the prior credential has been revoked.
+func GetActiveCredentialByUserAndConnection(orgID, userSubject, connectionName string) (*ConnectionCredentials, error) {
+	var resp ConnectionCredentials
+	err := DB.Table("private.connection_credentials").
+		Where("org_id = ? AND user_subject = ? AND connection_name = ? AND revoked_at IS NULL",
+			orgID, userSubject, connectionName).
+		Order("created_at DESC").
+		First(&resp).
+		Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	return &resp, err
+}
+
+// UpdateConnectionCredentialsSecretKey updates the secret key hash of an existing credential.
+// When the plaintext is available callers should use UpdateConnectionCredentialsSecret to
+// keep the hash and the encrypted copy in sync.
 func UpdateConnectionCredentialsSecretKey(id, secretKeyHash string) error {
 	return DB.Table("private.connection_credentials").
 		Where("id = ?", id).
-		Update("secret_key_hash", secretKeyHash).Error
+		Updates(map[string]any{
+			"secret_key_hash":      secretKeyHash,
+			"encrypted_secret_key": nil,
+		}).Error
+}
+
+// UpdateConnectionCredentialsSecret rotates both the hash and the encrypted copy
+// of the plaintext secret key. Used when backfilling rows that predate the
+// encrypted_secret_key column.
+func UpdateConnectionCredentialsSecret(id, secretKeyHash string, encryptedSecretKey []byte) error {
+	return DB.Table("private.connection_credentials").
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"secret_key_hash":      secretKeyHash,
+			"encrypted_secret_key": encryptedSecretKey,
+		}).Error
+}
+
+// RefreshCredentialExpiration updates the expiration and session_id of an
+// existing credential. Used for stable-key reuse: the row keeps its id and
+// encrypted_secret_key while each issuance refreshes the audit session and the
+// validity window.
+func RefreshCredentialExpiration(id, sessionID string, expireAt time.Time) error {
+	return DB.Table("private.connection_credentials").
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"session_id": sessionID,
+			"expire_at":  expireAt,
+		}).Error
 }
 
 // CloseExpiredCredentialSessions closes sessions for expired connection credentials
@@ -101,7 +153,11 @@ func CloseExpiredCredentialSessions() error {
 			Update("status", "done").
 			Update("ended_at", endTime).Error
 
-		// Clear session_id so this record is not reprocessed on the next lazy call
+		// Clear session_id so this record is not reprocessed on the next lazy call.
+		// The credential row itself is preserved (with its encrypted_secret_key)
+		// so a subsequent CreateConnectionCredentials call can reuse the same
+		// token by re-arming expire_at and session_id via
+		// RefreshCredentialExpiration.
 		_ = DB.Table("private.connection_credentials").
 			Where("id = ?", cred.ID).
 			Update("session_id", nil).Error
@@ -110,11 +166,20 @@ func CloseExpiredCredentialSessions() error {
 	return nil
 }
 
-// RevokeConnectionCredentials invalidates a credential by setting ExpireAt to the past.
-// This prevents new connections and existing sessions will be terminated when proxies
-// check credential validity or when RevokeByCredentialID is called on each proxy.
+// RevokeConnectionCredentials marks a credential as revoked. Revoked rows are
+// kept for forensic queries but are excluded from lookup by hash
+// (GetValidConnectionCredentialsBySecretKey) and from stable-key reuse
+// (GetActiveCredentialByUserAndConnection). The next CreateConnectionCredentials
+// call for the same (user, connection) generates a fresh row with a new key.
 func RevokeConnectionCredentials(orgID, credentialID string) error {
+	now := time.Now().UTC()
 	return DB.Table("private.connection_credentials").
-		Where("org_id = ? AND id = ?", orgID, credentialID).
-		Update("expire_at", time.Now().UTC().Add(-time.Hour)).Error
+		Where("org_id = ? AND id = ? AND revoked_at IS NULL", orgID, credentialID).
+		Updates(map[string]any{
+			"revoked_at": now,
+			// Also push expire_at into the past so any proxy that still reads
+			// the row via the legacy expire_at check rejects new connections
+			// immediately.
+			"expire_at": now.Add(-time.Hour),
+		}).Error
 }

--- a/gateway/models/connection_credentials.go
+++ b/gateway/models/connection_credentials.go
@@ -134,6 +134,16 @@ func RefreshCredentialExpiration(id, sessionID string, expireAt time.Time) error
 		}).Error
 }
 
+// ClearCredentialSession unlinks the credential from its audit session without
+// invalidating the credential itself. Used by the "close session" endpoint so
+// the user can reconnect later with the same token while the prior audit
+// session is finalised.
+func ClearCredentialSession(id string) error {
+	return DB.Table("private.connection_credentials").
+		Where("id = ?", id).
+		Update("session_id", nil).Error
+}
+
 // CloseExpiredCredentialSessions closes sessions for expired connection credentials
 // This is called lazily when accessing credentials or sessions
 func CloseExpiredCredentialSessions() error {

--- a/gateway/models/credential_crypto.go
+++ b/gateway/models/credential_crypto.go
@@ -1,0 +1,163 @@
+package models
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"gorm.io/gorm"
+)
+
+// credentialEncryptionKey caches the symmetric key used to encrypt the plaintext
+// secret keys stored in private.connection_credentials. It is loaded once on
+// first use from private.serverconfig.credential_encryption_key and reused for
+// the rest of the process lifetime.
+var (
+	credentialEncryptionKeyMu sync.Mutex
+	credentialEncryptionKey   []byte
+)
+
+// loadOrGenerateCredentialEncryptionKey returns the decoded 32-byte AES key.
+// On first call it reads from private.serverconfig; if the row is missing it
+// generates a fresh key, persists it and caches the decoded bytes.
+func loadOrGenerateCredentialEncryptionKey() ([]byte, error) {
+	credentialEncryptionKeyMu.Lock()
+	defer credentialEncryptionKeyMu.Unlock()
+
+	if credentialEncryptionKey != nil {
+		return credentialEncryptionKey, nil
+	}
+
+	var encoded string
+	err := DB.Raw(`
+		SELECT credential_encryption_key
+		FROM private.serverconfig
+		WHERE credential_encryption_key IS NOT NULL
+		LIMIT 1
+	`).Scan(&encoded).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("failed to read credential encryption key: %v", err)
+	}
+
+	if encoded != "" {
+		raw, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode credential encryption key: %v", err)
+		}
+		if len(raw) != 32 {
+			return nil, fmt.Errorf("invalid credential encryption key length: %d (want 32)", len(raw))
+		}
+		credentialEncryptionKey = raw
+		return raw, nil
+	}
+
+	// Generate a fresh 32-byte AES-256 key and persist it. The upsert pattern
+	// mirrors CreateServerSharedSigningKey so concurrent first-start calls
+	// cannot insert duplicate values.
+	raw := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, raw); err != nil {
+		return nil, fmt.Errorf("failed to generate credential encryption key: %v", err)
+	}
+	newEncoded := base64.StdEncoding.EncodeToString(raw)
+
+	res := DB.Exec(`
+		UPDATE private.serverconfig
+		SET credential_encryption_key = ?
+		WHERE credential_encryption_key IS NULL
+	`, newEncoded)
+	if res.Error != nil {
+		return nil, fmt.Errorf("failed to persist credential encryption key: %v", res.Error)
+	}
+
+	// If the serverconfig row doesn't exist yet, insert it.
+	if res.RowsAffected == 0 {
+		res = DB.Exec(`
+			INSERT INTO private.serverconfig (credential_encryption_key)
+			SELECT ?
+			WHERE NOT EXISTS (
+				SELECT 1 FROM private.serverconfig
+				WHERE credential_encryption_key IS NOT NULL
+			)
+		`, newEncoded)
+		if res.Error != nil {
+			return nil, fmt.Errorf("failed to bootstrap credential encryption key: %v", res.Error)
+		}
+	}
+
+	// Re-read to guarantee we use whatever value was actually persisted (a
+	// competing gateway instance might have inserted a different key).
+	err = DB.Raw(`
+		SELECT credential_encryption_key
+		FROM private.serverconfig
+		WHERE credential_encryption_key IS NOT NULL
+		LIMIT 1
+	`).Scan(&encoded).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-read credential encryption key: %v", err)
+	}
+	final, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode stored credential encryption key: %v", err)
+	}
+	if len(final) != 32 {
+		return nil, fmt.Errorf("persisted credential encryption key has invalid length: %d", len(final))
+	}
+	credentialEncryptionKey = final
+	return final, nil
+}
+
+// EncryptCredentialSecretKey returns the AES-256-GCM ciphertext of the plaintext
+// secret key. The nonce is prepended to the ciphertext.
+func EncryptCredentialSecretKey(plaintext string) ([]byte, error) {
+	key, err := loadOrGenerateCredentialEncryptionKey()
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %v", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %v", err)
+	}
+	return gcm.Seal(nonce, nonce, []byte(plaintext), nil), nil
+}
+
+// DecryptCredentialSecretKey reverses EncryptCredentialSecretKey.
+func DecryptCredentialSecretKey(ciphertext []byte) (string, error) {
+	key, err := loadOrGenerateCredentialEncryptionKey()
+	if err != nil {
+		return "", err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to create cipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %v", err)
+	}
+	if len(ciphertext) < gcm.NonceSize() {
+		return "", fmt.Errorf("credential ciphertext shorter than nonce")
+	}
+	nonce := ciphertext[:gcm.NonceSize()]
+	payload := ciphertext[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, payload, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt credential secret key: %v", err)
+	}
+	return string(plaintext), nil
+}

--- a/rootfs/app/migrations/000081_stable_connection_credentials.down.sql
+++ b/rootfs/app/migrations/000081_stable_connection_credentials.down.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+SET search_path TO private;
+
+DROP INDEX IF EXISTS idx_conn_cred_active_user_conn;
+
+ALTER TABLE connection_credentials
+    DROP COLUMN IF EXISTS encrypted_secret_key,
+    DROP COLUMN IF EXISTS revoked_at;
+
+ALTER TABLE serverconfig
+    DROP COLUMN IF EXISTS credential_encryption_key;
+
+COMMIT;

--- a/rootfs/app/migrations/000081_stable_connection_credentials.up.sql
+++ b/rootfs/app/migrations/000081_stable_connection_credentials.up.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+SET search_path TO private;
+
+-- Stable-key support: store an encrypted copy of the plaintext secret key so
+-- repeated calls to CreateConnectionCredentials for the same (user, connection)
+-- pair can return the same token. The existing secret_key_hash column stays and
+-- remains the lookup index for proxy auth.
+ALTER TABLE connection_credentials
+    ADD COLUMN IF NOT EXISTS encrypted_secret_key BYTEA NULL,
+    ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMP NULL;
+
+-- Partial index used to locate the active (non-revoked) credential for a
+-- (org, user, connection) triple. Revoked rows are kept for forensics.
+CREATE INDEX IF NOT EXISTS idx_conn_cred_active_user_conn
+    ON connection_credentials (org_id, user_subject, connection_name)
+    WHERE revoked_at IS NULL;
+
+-- Server-wide symmetric key used to encrypt/decrypt the stored plaintext secret
+-- keys. Auto-generated on first startup by the gateway, following the same
+-- pattern as shared_signing_key.
+ALTER TABLE serverconfig
+    ADD COLUMN IF NOT EXISTS credential_encryption_key TEXT NULL;
+
+COMMIT;

--- a/webapp/src/webapp/connections/native_client_access/events.cljs
+++ b/webapp/src/webapp/connections/native_client_access/events.cljs
@@ -126,16 +126,19 @@
                                                 :user-is-admin? is-admin?}]
                                      :maxWidth "446px"}]]]})))
 
-;; Revoke credential via API and clear session
+;; Disconnect via API: ends the audit session and tears down active proxy
+;; connections but keeps the stored token alive. The same secret key will be
+;; returned on the next credential request. Use :native-client-access->revoke-credential
+;; for explicit token invalidation.
 (rf/reg-event-fx
- :native-client-access->revoke-credential
+ :native-client-access->disconnect-credential
  (fn [_ [_ connection-name credential-id]]
    (if (or (nil? credential-id) (str/blank? credential-id))
      ;; No credential ID (e.g. legacy session) - just clear locally
      {:fx [[:dispatch [:native-client-access->clear-session connection-name]]
            [:dispatch [:modal->close]]]}
      {:fx [[:dispatch [:fetch {:method "POST"
-                              :uri (str "/connections/" connection-name "/credentials/" credential-id "/revoke")
+                              :uri (str "/connections/" connection-name "/credentials/" credential-id "/close")
                               :on-success (fn []
                                             (rf/dispatch [:native-client-access->clear-session connection-name])
                                             (rf/dispatch [:modal->close])
@@ -145,6 +148,28 @@
                                             (let [msg (or (:message err)
                                                           (get-in err [:response :message])
                                                           "Failed to disconnect")]
+                                              (rf/dispatch [:show-snackbar {:level :error :text msg}])))}]]]})))
+
+;; Revoke credential via API: invalidates the stored token and ends active
+;; sessions. Reserved for an explicit "revoke credential" UI action; the next
+;; credential request will generate a new token.
+(rf/reg-event-fx
+ :native-client-access->revoke-credential
+ (fn [_ [_ connection-name credential-id]]
+   (if (or (nil? credential-id) (str/blank? credential-id))
+     {:fx [[:dispatch [:native-client-access->clear-session connection-name]]
+           [:dispatch [:modal->close]]]}
+     {:fx [[:dispatch [:fetch {:method "POST"
+                              :uri (str "/connections/" connection-name "/credentials/" credential-id "/revoke")
+                              :on-success (fn []
+                                            (rf/dispatch [:native-client-access->clear-session connection-name])
+                                            (rf/dispatch [:modal->close])
+                                            (rf/dispatch [:show-snackbar {:level :success
+                                                                         :text "Credential revoked successfully."}]))
+                              :on-failure (fn [err]
+                                            (let [msg (or (:message err)
+                                                          (get-in err [:response :message])
+                                                          "Failed to revoke credential")]
                                               (rf/dispatch [:show-snackbar {:level :error :text msg}])))}]]]})))
 
 ;; Clear specific native client access session

--- a/webapp/src/webapp/connections/native_client_access/main.cljs
+++ b/webapp/src/webapp/connections/native_client_access/main.cljs
@@ -13,14 +13,16 @@
    [webapp.resources.constants :refer [http-proxy-subtypes]]))
 
 (defn disconnect-session
-  "Handle disconnect with confirmation. Calls revoke API to invalidate credential and disconnect active sessions."
+  "Handle disconnect with confirmation. Calls the close-session API which ends
+   the audit session and tears down active proxy connections but keeps the
+   stored token alive, so reconnecting returns the same credential."
   [connection-name credential-id]
   (let [dialog-text (str "Are you sure you want to disconnect the native client session for \"" connection-name "\"?")
         open-dialog #(rf/dispatch [:dialog->open {:text dialog-text
                                                   :type :danger
                                                   :action-button? true
                                                   :on-success (fn []
-                                                                (rf/dispatch [:native-client-access->revoke-credential connection-name credential-id])
+                                                                (rf/dispatch [:native-client-access->disconnect-credential connection-name credential-id])
                                                                 (rf/dispatch [:modal->close]))
                                                   :text-action-button "Disconnect"}])]
     (open-dialog)))


### PR DESCRIPTION
## Summary

Make the connection credential token stable across issuances for a given `(user, connection)` pair. Previously every call to `POST /connections/{name}/credentials` generated a fresh random secret key, forcing the user to update their local client config each time. Now the plaintext key is stored encrypted at rest and returned again whenever the user requests credentials for the same connection — only the expiration is refreshed.

This PR also splits the "disconnect" and "revoke" semantics, which were previously conflated in the UI: disconnect ends the session but keeps the token; revoke invalidates the token.

## Behavior matrix

| Trigger | Token |
|---|---|
| First `POST /credentials` | new |
| Repeated `POST /credentials`, no revoke | **same** |
| Repeated `POST /credentials` after expire | **same** (expire_at refreshed) |
| UI "Disconnect" then `POST /credentials` | **same** |
| `POST /credentials/{id}/revoke` then `POST /credentials` | new |
| `POST /credentials/{sid}` (review/JIT resume) | rotated (unchanged from dev) |

## Disconnect vs. revoke

- **`POST /connections/:nameOrID/credentials/:ID/close`** (new) — ends the audit session and tears down active proxy connections but **preserves** the credential row (and its `encrypted_secret_key`). The next credential request returns the same token. Used by the UI "Disconnect" action.
- **`POST /connections/:nameOrID/credentials/:ID/revoke`** (existing, semantics preserved) — marks the credential as revoked (`revoked_at`) and tears down active proxy connections. Excluded from future stable-key lookups so the next credential request issues a brand-new token. Reserved for an explicit "Revoke credential" action.

## Implementation

### Migration `000081_stable_connection_credentials`
- `connection_credentials.encrypted_secret_key BYTEA` — AES-256-GCM ciphertext of the plaintext key
- `connection_credentials.revoked_at TIMESTAMP` — keeps revoked rows for forensics
- `serverconfig.credential_encryption_key TEXT` — base64 server-wide symmetric key
- Partial index `idx_conn_cred_active_user_conn` on `(org_id, user_subject, connection_name) WHERE revoked_at IS NULL`

Migration number 000081 chosen to sit above all currently-claimed numbers on `main` and in-flight branches: `000077_api_keys`, `000078_session_correlation_id` (#1399), `000079_agent_spiffe_mappings` (#1393, SPIFFE), and `000080` which is in use by two unmerged branches (`feat/auth-mcp` for mcp_auth_config and `feature-experimental` for org_feature_flags).

### Crypto (`gateway/models/credential_crypto.go`)
AES-256-GCM. The server-wide key is lazily generated on first use and persisted via `private.serverconfig` (mirrors the existing `shared_signing_key` pattern — no new env var).

### Handler changes (`gateway/api/connections/connection_credentials.go`)
- **`CreateConnectionCredentials`** now delegates to `issueOrRefreshCredential`:
  - Looks up the active credential for `(org, user, connection)` via `GetActiveCredentialByUserAndConnection` (`ORDER BY created_at DESC` picks the latest non-revoked row).
  - If found with ciphertext → decrypt stored ciphertext → return same plaintext → refresh `expire_at` / `session_id` → close the previous audit session.
  - If found without ciphertext (rows created before this migration) → rotate the key in place and backfill the ciphertext (one-time token change on first post-deploy reuse).
  - If not found → generate a fresh key and store both the hash and the encrypted copy.
- **New `CloseConnectionCredentials`** handler — closes audit session, clears `session_id` on the credential row via new `models.ClearCredentialSession`, and tears down active proxy sessions. Does NOT set `revoked_at`.
- **`RevokeConnectionCredentials`** — refactored to share `loadCredentialForMutation` and `terminateActiveCredentialSessions` helpers with Close. Now uses `revoked_at` and pushes `expire_at` into the past so any proxy still reading the legacy column rejects new connections immediately.
- **`ResumeConnectionCredentials`** (review/JIT flow) keeps its rotation-on-call semantics, but now persists the encrypted copy on first issuance and clears it on every rotation.

### Model changes (`gateway/models/connection_credentials.go`)
- New fields: `EncryptedSecretKey []byte`, `RevokedAt *time.Time`.
- New: `GetActiveCredentialByUserAndConnection`, `RefreshCredentialExpiration`, `UpdateConnectionCredentialsSecret`, `ClearCredentialSession`.
- `GetValidConnectionCredentialsBySecretKey` now also filters `revoked_at IS NULL` for defense in depth.
- `CloseExpiredCredentialSessions` now only clears `session_id` (keeps the row for stable-key reuse); the session status transition is unchanged.

### WebApp (`webapp/src/webapp/connections/native_client_access/`)
- New event `:native-client-access->disconnect-credential` calls `/close`.
- Existing `:native-client-access->revoke-credential` kept for future explicit "Revoke credential" UI action (still calls `/revoke`).
- `disconnect-session` in `main.cljs` now dispatches the disconnect event.

### Route registration
- `POST /connections/:nameOrID/credentials/:ID/close` added next to the existing revoke route in `gateway/api/server.go`.

## Verification

- `go build ./...` clean in all five modules (agent, client, common, gateway, libhoop)
- `go vet ./...` clean
- `go test ./gateway/api/connections/... ./gateway/models/...` passes
- Manually tested: create → disconnect → create returns the same token; create → revoke → create returns a fresh token.

## Backward compatibility

- Pre-migration rows exist with `encrypted_secret_key = NULL`. First reuse after deploy rotates the key once per row, then stabilises forever.
- `GetValidConnectionCredentialsBySecretKey` filters revoked rows — revoked credentials are no longer accepted by proxies even if the proxy hasn't called `RevokeByCredentialID` yet.

## Out of scope

- Duplicate credential rows from legacy data (same `(user, connection)` with multiple non-revoked entries). The new lookup tolerates duplicates via `ORDER BY created_at DESC` but does not clean them up.
- Adding an explicit "Revoke credential" UI action. The event is wired but no button dispatches it yet.

Automated by MisterMal

 🤖 Generated with Mister Maluco

Co-Authored-By: MisterMal <teskeslab@lucasteske.dev>