### PR TITLE
[WIP] Revert change to make packets async on agent controller

### DIFF
--- a/agent/controller/agent.go
+++ b/agent/controller/agent.go
@@ -131,25 +131,10 @@ func (a *Agent) Close(cause error) {
 	_, _ = a.client.Close()
 }
 
-func (a *Agent) getOrAddConnMutex(connId string, connType string) *sync.Mutex {
-	a.connMtxStoreMtx.Lock()
-	defer a.connMtxStoreMtx.Unlock()
-
-	if _, ok := a.connMtx[connId+connType]; !ok {
-		a.connMtx[connId+connType] = &sync.Mutex{}
-	}
-	return a.connMtx[connId+connType]
-}
-
 func (a *Agent) processPacket(pkt *pb.Packet) {
 	sid := string(pkt.Spec[pb.SpecGatewaySessionID])
 	clientConnectionID := string(pkt.Spec[pb.SpecClientConnectionID])
 	clientStreamID := sid + clientConnectionID
-
-	// Make it pipelined for each connection but parallel between connections
-	mtx := a.getOrAddConnMutex(clientStreamID, pkt.Type)
-	mtx.Lock()
-	defer mtx.Unlock()
 
 	log.With("sid", sid).Debugf("received client packet [%v]", pkt.Type)
 	switch pkt.Type {
@@ -230,7 +215,7 @@ func (a *Agent) Run() error {
 		}
 
 		// We don't need to wait here for the result, so we just spawn a goroutine to process it.
-		go a.processPacket(pkt)
+		a.processPacket(pkt)
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Currently we're having issues with Postgres and SQL Server (Dbeaver & SMMS). Users reported weird behavior on those clients. 

From local tests, it seems that packets are not being processed correctly. This a debugging from Wireshark:
_The incoming tabular data stream (TDS) protocol stream is incorrect. The TDS headers contained errors._

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

