### PR TITLE
feat: user MCP tools (exec, approvals, and session access)

### DIFF
--- a/gateway/api/connections/queries_schema.go
+++ b/gateway/api/connections/queries_schema.go
@@ -6,6 +6,20 @@ import (
 	pb "github.com/hoophq/hoop/common/proto"
 )
 
+// TablesQueryFor returns the backing query for listing tables on the given
+// connection type, or an empty string when the type is unsupported.
+// Exported for reuse by the MCP schema tools.
+func TablesQueryFor(connType pb.ConnectionType, dbName string) string {
+	return getTablesQuery(connType, dbName)
+}
+
+// ColumnsQueryFor returns the backing query for listing columns of a specific
+// table on the given connection type, or an empty string when unsupported.
+// Exported for reuse by the MCP schema tools.
+func ColumnsQueryFor(connType pb.ConnectionType, dbName, tableName, schemaName string) string {
+	return getColumnsQuery(connType, dbName, tableName, schemaName)
+}
+
 // getTablesQuery returns the query to list only the tables of a database
 func getTablesQuery(connType pb.ConnectionType, dbName string) string {
 	switch connType {

--- a/gateway/api/mcpserver/context.go
+++ b/gateway/api/mcpserver/context.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ctxKey struct{}
+type tokenCtxKey struct{}
 
 func withStorageContext(ctx context.Context, sc *storagev2.Context) context.Context {
 	return context.WithValue(ctx, ctxKey{}, sc)
@@ -15,4 +16,13 @@ func withStorageContext(ctx context.Context, sc *storagev2.Context) context.Cont
 func storageContextFrom(ctx context.Context) *storagev2.Context {
 	sc, _ := ctx.Value(ctxKey{}).(*storagev2.Context)
 	return sc
+}
+
+func withAccessToken(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, tokenCtxKey{}, token)
+}
+
+func accessTokenFrom(ctx context.Context) string {
+	t, _ := ctx.Value(tokenCtxKey{}).(string)
+	return t
 }

--- a/gateway/api/mcpserver/mcpserver.go
+++ b/gateway/api/mcpserver/mcpserver.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/hoophq/hoop/common/version"
@@ -11,6 +12,11 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// Sends MCP-level ping requests at this interval to keep idle sessions warm.
+// Without this, long-running tool handlers (e.g. reviews_wait) sit silently on
+// the wire long enough that intermediate layers tear down the connection.
+const mcpKeepAliveInterval = 30 * time.Second
+
 type MCPServer struct {
 	handler *mcp.StreamableHTTPHandler
 }
@@ -19,7 +25,9 @@ func New(releaseConnFn reviewapi.TransportReleaseConnectionFunc) *MCPServer {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "hoop",
 		Version: version.Get().Version,
-	}, nil)
+	}, &mcp.ServerOptions{
+		KeepAlive: mcpKeepAliveInterval,
+	})
 
 	registerConnectionTools(server)
 	registerGuardrailTools(server)

--- a/gateway/api/mcpserver/mcpserver.go
+++ b/gateway/api/mcpserver/mcpserver.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/hoophq/hoop/common/version"
+	"github.com/hoophq/hoop/gateway/api/apiroutes"
 	reviewapi "github.com/hoophq/hoop/gateway/api/review"
 	"github.com/hoophq/hoop/gateway/storagev2"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -30,6 +31,9 @@ func New(releaseConnFn reviewapi.TransportReleaseConnectionFunc) *MCPServer {
 	registerRunbookRuleTools(server)
 	registerSessionTools(server)
 	registerServerInfoTools(server)
+	registerMeTools(server)
+	registerExecTools(server)
+	registerSchemaTools(server)
 
 	handler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server { return server },
@@ -39,10 +43,13 @@ func New(releaseConnFn reviewapi.TransportReleaseConnectionFunc) *MCPServer {
 	return &MCPServer{handler: handler}
 }
 
-// GinHandler bridges Gin auth context into the MCP request context,
-// then delegates to StreamableHTTPHandler.
+// GinHandler bridges Gin auth context (storage context + access token) into
+// the MCP request context, then delegates to StreamableHTTPHandler.
 func (m *MCPServer) GinHandler(c *gin.Context) {
 	sc := storagev2.ParseContext(c)
-	req := c.Request.WithContext(withStorageContext(c.Request.Context(), sc))
+	token := apiroutes.GetAccessTokenFromRequest(c)
+	ctx := withStorageContext(c.Request.Context(), sc)
+	ctx = withAccessToken(ctx, token)
+	req := c.Request.WithContext(ctx)
 	m.handler.ServeHTTP(c.Writer, req)
 }

--- a/gateway/api/mcpserver/poll.go
+++ b/gateway/api/mcpserver/poll.go
@@ -1,0 +1,77 @@
+package mcpserver
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// Empirically, MCP clients (Claude Code, Cursor, Devin) tear down the
+	// streamable HTTP transport when individual tool calls block longer than
+	// ~60-120s. The PRD's 30-minute aspiration is unrealistic in practice; we
+	// cap at 5 minutes and recommend agents re-call on timed_out=true.
+	defaultWaitTimeout = 60 * time.Second
+	maxWaitTimeout     = 300 * time.Second
+	pollInterval       = 2 * time.Second
+)
+
+// resolveWaitTimeout clamps a caller-supplied timeout (in seconds) into
+// [pollInterval, maxWaitTimeout]. 0 / negative values resolve to
+// defaultWaitTimeout.
+func resolveWaitTimeout(seconds int) time.Duration {
+	if seconds <= 0 {
+		return defaultWaitTimeout
+	}
+	d := time.Duration(seconds) * time.Second
+	if d > maxWaitTimeout {
+		return maxWaitTimeout
+	}
+	if d < pollInterval {
+		return pollInterval
+	}
+	return d
+}
+
+// waitUntil polls fn every pollInterval until fn reports done=true, the
+// timeout elapses, or ctx is cancelled. It returns the last value fn
+// produced, a timedOut flag (true only when the timeout — not ctx — was the
+// reason it stopped), the elapsed time, and any error fn returned.
+//
+// fn is invoked once eagerly so an already-terminal state returns
+// immediately without a poll-interval delay. On timeout, fn is invoked one
+// more time so the response reflects the most recent state.
+func waitUntil[T any](
+	ctx context.Context,
+	timeout time.Duration,
+	fn func() (T, bool, error),
+) (T, bool, time.Duration, error) {
+	started := time.Now()
+
+	val, done, err := fn()
+	if err != nil || done {
+		return val, false, time.Since(started), err
+	}
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return val, false, time.Since(started), ctx.Err()
+		case <-deadline.C:
+			val, done, err = fn()
+			if err != nil {
+				return val, false, time.Since(started), err
+			}
+			return val, !done, time.Since(started), nil
+		case <-ticker.C:
+			val, done, err = fn()
+			if err != nil || done {
+				return val, false, time.Since(started), err
+			}
+		}
+	}
+}

--- a/gateway/api/mcpserver/poll_test.go
+++ b/gateway/api/mcpserver/poll_test.go
@@ -1,0 +1,150 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestResolveWaitTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want time.Duration
+	}{
+		{"zero defaults", 0, defaultWaitTimeout},
+		{"negative defaults", -5, defaultWaitTimeout},
+		{"under poll interval clamps up", 1, pollInterval},
+		{"valid mid-range", 60, 60 * time.Second},
+		{"at max", 300, maxWaitTimeout},
+		{"above max clamps down", 99999, maxWaitTimeout},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveWaitTimeout(tc.in)
+			if got != tc.want {
+				t.Errorf("resolveWaitTimeout(%d) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWaitUntil_AlreadyDone(t *testing.T) {
+	calls := 0
+	val, timedOut, waited, err := waitUntil(context.Background(), 5*time.Second, func() (string, bool, error) {
+		calls++
+		return "ready", true, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+	if val != "ready" {
+		t.Errorf("expected 'ready', got %q", val)
+	}
+	if timedOut {
+		t.Errorf("expected timedOut=false, got true")
+	}
+	if waited >= pollInterval {
+		t.Errorf("expected near-zero wait, got %v", waited)
+	}
+}
+
+func TestWaitUntil_DoneAfterFewTicks(t *testing.T) {
+	calls := 0
+	flipAt := 3
+	val, timedOut, _, err := waitUntil(context.Background(), 30*time.Second, func() (int, bool, error) {
+		calls++
+		return calls, calls >= flipAt, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if calls != flipAt {
+		t.Errorf("expected %d calls, got %d", flipAt, calls)
+	}
+	if val != flipAt {
+		t.Errorf("expected val=%d, got %d", flipAt, val)
+	}
+	if timedOut {
+		t.Errorf("expected timedOut=false")
+	}
+}
+
+func TestWaitUntil_Timeout(t *testing.T) {
+	calls := 0
+	timeout := 3 * pollInterval // 6s — gives the timer a chance to fire after a couple of ticks
+	val, timedOut, waited, err := waitUntil(context.Background(), timeout, func() (string, bool, error) {
+		calls++
+		return "still-pending", false, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !timedOut {
+		t.Errorf("expected timedOut=true, got false (calls=%d, waited=%v)", calls, waited)
+	}
+	if val != "still-pending" {
+		t.Errorf("expected val from final read, got %q", val)
+	}
+	if waited < timeout-pollInterval || waited > timeout+2*pollInterval {
+		t.Errorf("expected waited near %v, got %v", timeout, waited)
+	}
+}
+
+func TestWaitUntil_FnErrorPropagates(t *testing.T) {
+	sentinel := errors.New("db blew up")
+	val, _, _, err := waitUntil(context.Background(), 30*time.Second, func() (string, bool, error) {
+		return "", false, sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+	if val != "" {
+		t.Errorf("expected zero val, got %q", val)
+	}
+}
+
+func TestWaitUntil_CtxCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	calls := 0
+	_, timedOut, waited, err := waitUntil(ctx, 30*time.Second, func() (string, bool, error) {
+		calls++
+		return "pending", false, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if timedOut {
+		t.Errorf("expected timedOut=false on cancel")
+	}
+	if waited > 5*time.Second {
+		t.Errorf("expected fast cancellation, waited %v", waited)
+	}
+}
+
+func TestWaitUntil_FnErrorDuringPoll(t *testing.T) {
+	sentinel := errors.New("transient")
+	calls := 0
+	_, _, _, err := waitUntil(context.Background(), 30*time.Second, func() (string, bool, error) {
+		calls++
+		if calls == 1 {
+			return "pending", false, nil
+		}
+		return "", false, sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel from poll iteration, got %v", err)
+	}
+	if calls < 2 {
+		t.Errorf("expected at least 2 calls, got %d", calls)
+	}
+}

--- a/gateway/api/mcpserver/tools_access_control.go
+++ b/gateway/api/mcpserver/tools_access_control.go
@@ -1,0 +1,203 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/gateway/models"
+	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
+	"github.com/lib/pq"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type accessControlSetInput struct {
+	ConnectionName string   `json:"connection_name" jsonschema:"connection name to restrict"`
+	Groups         []string `json:"groups" jsonschema:"user groups allowed to access this connection (replaces any existing list)"`
+}
+
+type accessControlUnsetInput struct {
+	ConnectionName string `json:"connection_name" jsonschema:"connection name to remove the access_control binding from"`
+}
+
+type accessControlGetInput struct {
+	ConnectionName string `json:"connection_name" jsonschema:"connection name"`
+}
+
+type accessControlListInput struct{}
+
+func registerAccessControlTools(server *mcp.Server) {
+	openWorld := false
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "access_control_set",
+		Description: "Restrict a connection so only the given user groups can access it. " +
+			"Enables the access_control plugin if needed and replaces any existing group list " +
+			"for this connection. Admins and auditors always bypass the restriction.",
+		Annotations: &mcp.ToolAnnotations{OpenWorldHint: &openWorld},
+	}, accessControlSetHandler)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "access_control_unset",
+		Description: "Remove the access_control binding for a connection. After this call, " +
+			"the connection is no longer group-restricted (all users can see/access it).",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true), OpenWorldHint: &openWorld},
+	}, accessControlUnsetHandler)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "access_control_get",
+		Description: "Get the list of user groups allowed to access a given connection via the access_control plugin",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, accessControlGetHandler)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "access_control_list",
+		Description: "List all connections currently bound to the access_control plugin with their allowed user groups",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, accessControlListHandler)
+}
+
+// ensureAccessControlPlugin returns the access_control plugin for the org,
+// creating it on first use. It never deletes existing plugin_connections.
+func ensureAccessControlPlugin(orgID string) (*models.Plugin, error) {
+	p, err := models.GetPluginByName(orgID, plugintypes.PluginAccessControlName)
+	if err == nil {
+		return p, nil
+	}
+	if err != models.ErrNotFound {
+		return nil, err
+	}
+	newPlugin := &models.Plugin{
+		ID:    uuid.NewString(),
+		OrgID: orgID,
+		Name:  plugintypes.PluginAccessControlName,
+	}
+	if err := models.UpsertPlugin(newPlugin); err != nil {
+		return nil, fmt.Errorf("failed enabling access_control plugin: %w", err)
+	}
+	return newPlugin, nil
+}
+
+func accessControlSetHandler(ctx context.Context, _ *mcp.CallToolRequest, args accessControlSetInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+	if !sc.IsAdminUser() {
+		return errResult("admin access required"), nil, nil
+	}
+	if args.ConnectionName == "" {
+		return errResult("connection_name is required"), nil, nil
+	}
+	if len(args.Groups) == 0 {
+		return errResult("groups must contain at least one user group; use access_control_unset to remove the binding"), nil, nil
+	}
+
+	conn, err := models.GetConnectionByName(models.DB, args.ConnectionName)
+	if err != nil {
+		return errResult(fmt.Sprintf("connection %q not found", args.ConnectionName)), nil, nil
+	}
+
+	if _, err := ensureAccessControlPlugin(sc.GetOrgID()); err != nil {
+		return nil, nil, err
+	}
+
+	pc, err := models.UpsertPluginConnection(sc.GetOrgID(), plugintypes.PluginAccessControlName, conn.ID, pq.StringArray(args.Groups))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed setting access_control for connection %q: %w", args.ConnectionName, err)
+	}
+
+	return jsonResult(map[string]any{
+		"connection_name": args.ConnectionName,
+		"connection_id":   conn.ID,
+		"allowed_groups":  []string(pc.Config),
+	})
+}
+
+func accessControlUnsetHandler(ctx context.Context, _ *mcp.CallToolRequest, args accessControlUnsetInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+	if !sc.IsAdminUser() {
+		return errResult("admin access required"), nil, nil
+	}
+	if args.ConnectionName == "" {
+		return errResult("connection_name is required"), nil, nil
+	}
+
+	conn, err := models.GetConnectionByName(models.DB, args.ConnectionName)
+	if err != nil {
+		return errResult(fmt.Sprintf("connection %q not found", args.ConnectionName)), nil, nil
+	}
+
+	err = models.DeletePluginConnection(sc.GetOrgID(), plugintypes.PluginAccessControlName, conn.ID)
+	switch err {
+	case nil:
+		return textResult(fmt.Sprintf("access_control binding removed from connection %q", args.ConnectionName)), nil, nil
+	case models.ErrNotFound:
+		return errResult(fmt.Sprintf("connection %q has no access_control binding", args.ConnectionName)), nil, nil
+	default:
+		return nil, nil, fmt.Errorf("failed removing access_control binding: %w", err)
+	}
+}
+
+func accessControlGetHandler(ctx context.Context, _ *mcp.CallToolRequest, args accessControlGetInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+	if args.ConnectionName == "" {
+		return errResult("connection_name is required"), nil, nil
+	}
+
+	conn, err := models.GetConnectionByName(models.DB, args.ConnectionName)
+	if err != nil {
+		return errResult(fmt.Sprintf("connection %q not found", args.ConnectionName)), nil, nil
+	}
+
+	pc, err := models.GetPluginConnection(sc.GetOrgID(), plugintypes.PluginAccessControlName, conn.ID)
+	switch err {
+	case nil:
+		return jsonResult(map[string]any{
+			"connection_name": args.ConnectionName,
+			"connection_id":   conn.ID,
+			"allowed_groups":  []string(pc.Config),
+		})
+	case models.ErrNotFound:
+		return jsonResult(map[string]any{
+			"connection_name": args.ConnectionName,
+			"connection_id":   conn.ID,
+			"allowed_groups":  []string{},
+			"note":            "no access_control binding — connection is visible to all users",
+		})
+	default:
+		return nil, nil, fmt.Errorf("failed retrieving access_control binding: %w", err)
+	}
+}
+
+func accessControlListHandler(ctx context.Context, _ *mcp.CallToolRequest, _ accessControlListInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+
+	plugin, err := models.GetPluginByName(sc.GetOrgID(), plugintypes.PluginAccessControlName)
+	switch err {
+	case nil:
+	case models.ErrNotFound:
+		return jsonResult([]any{})
+	default:
+		return nil, nil, fmt.Errorf("failed retrieving access_control plugin: %w", err)
+	}
+
+	out := make([]map[string]any, 0, len(plugin.Connections))
+	for _, pc := range plugin.Connections {
+		out = append(out, map[string]any{
+			"connection_id":   pc.ConnectionID,
+			"connection_name": pc.ConnectionName,
+			"allowed_groups":  []string(pc.Config),
+		})
+	}
+	return jsonResult(out)
+}

--- a/gateway/api/mcpserver/tools_exec.go
+++ b/gateway/api/mcpserver/tools_exec.go
@@ -29,7 +29,7 @@ func registerExecTools(server *mcp.Server) {
 		Name: "exec",
 		Description: "Run a one-shot command or query against a Hoop connection on behalf of the authenticated user. " +
 			"Mirrors `hoop exec`. Returns one of three envelopes: `status=completed` with output, " +
-			"`status=pending_approval` with a review_id (poll reviews_get; once APPROVED call reviews_execute), " +
+			"`status=pending_approval` with a review_id (call reviews_wait to long-poll; once APPROVED call reviews_execute), " +
 			"or `status=running` with a session_id (after a 50s timeout; poll sessions_get). " +
 			"Authorization, data masking, guardrails, and review gates are enforced by the gateway — " +
 			"this tool does not bypass any of them.",
@@ -115,7 +115,7 @@ func execResponseToEnvelope(resp *clientexec.Response, sessionID string) (*mcp.C
 			"review_id":  sessionID,
 			"review_url": resp.Output,
 			"message":    "Approval required before this execution can run",
-			"next_step":  "poll reviews_get with review_id; once status=APPROVED call reviews_execute",
+			"next_step":  "call reviews_wait with review_id (long-polls until status changes); once status=APPROVED call reviews_execute",
 		})
 	}
 

--- a/gateway/api/mcpserver/tools_exec.go
+++ b/gateway/api/mcpserver/tools_exec.go
@@ -1,0 +1,145 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/log"
+	pb "github.com/hoophq/hoop/common/proto"
+	"github.com/hoophq/hoop/gateway/clientexec"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const execTimeout = 50 * time.Second
+
+type execInput struct {
+	ConnectionName string   `json:"connection_name" jsonschema:"name of the Hoop connection to execute against"`
+	Input          string   `json:"input" jsonschema:"the query or command to run (e.g. a SQL statement for a database connection)"`
+	Args           []string `json:"args,omitempty" jsonschema:"optional client arguments forwarded to the connection (e.g. CLI flags)"`
+	EnvVars        map[string]string `json:"env_vars,omitempty" jsonschema:"optional environment variables forwarded to the connection"`
+}
+
+func registerExecTools(server *mcp.Server) {
+	openWorld := false
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "exec",
+		Description: "Run a one-shot command or query against a Hoop connection on behalf of the authenticated user. " +
+			"Mirrors `hoop exec`. Returns one of three envelopes: `status=completed` with output, " +
+			"`status=pending_approval` with a review_id (poll reviews_get; once APPROVED call reviews_execute), " +
+			"or `status=running` with a session_id (after a 50s timeout; poll sessions_get). " +
+			"Authorization, data masking, guardrails, and review gates are enforced by the gateway — " +
+			"this tool does not bypass any of them.",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true), OpenWorldHint: &openWorld},
+	}, execHandler)
+}
+
+func execHandler(ctx context.Context, _ *mcp.CallToolRequest, args execInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+	token := accessTokenFrom(ctx)
+	if token == "" {
+		return errResult("unauthorized: missing access token"), nil, nil
+	}
+	if args.ConnectionName == "" {
+		return errResult("connection_name is required"), nil, nil
+	}
+	if args.Input == "" {
+		return errResult("input is required"), nil, nil
+	}
+
+	// Confirm the connection exists / the user can see it. The downstream
+	// gateway auth chain will re-check access; this is a fast-fail for a
+	// clearer error message.
+	conn, err := models.GetConnectionByNameOrID(sc, args.ConnectionName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed looking up connection: %w", err)
+	}
+	if conn == nil {
+		return errResult(fmt.Sprintf("connection %q not found or not accessible", args.ConnectionName)), nil, nil
+	}
+
+	// Origin=client (matches `hoop exec` CLI) triggers full audit persistence:
+	// the audit plugin inserts the session row on OnConnect, stores the query
+	// via UpdateSessionInput, and runs AI analysis on OnReceive. Origin=client-api
+	// is reserved for HTTP flows that pre-insert the session row themselves.
+	sessionID := uuid.NewString()
+	client, err := clientexec.New(&clientexec.Options{
+		OrgID:          sc.GetOrgID(),
+		SessionID:      sessionID,
+		ConnectionName: conn.Name,
+		BearerToken:    token,
+		UserAgent:      fmt.Sprintf("mcp.exec/%s", sc.UserEmail),
+		Origin:         pb.ConnectionOriginClient,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed creating exec client: %w", err)
+	}
+
+	respCh := make(chan *clientexec.Response, 1)
+	go func() {
+		defer func() { close(respCh); client.Close() }()
+		respCh <- client.Run([]byte(args.Input), args.EnvVars, args.Args...)
+	}()
+
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), execTimeout)
+	defer cancelFn()
+
+	select {
+	case resp := <-respCh:
+		return execResponseToEnvelope(resp, sessionID)
+	case <-timeoutCtx.Done():
+		// Force the goroutine to unblock; its result will be persisted async.
+		client.Close()
+		log.With("sid", sessionID).Infof("mcp exec timeout (%s), returning status=running", execTimeout)
+		return jsonResult(map[string]any{
+			"status":     "running",
+			"session_id": sessionID,
+			"message":    fmt.Sprintf("execution still running after %s; poll sessions_get with session_id", execTimeout),
+			"next_step":  "poll sessions_get with session_id",
+		})
+	}
+}
+
+func execResponseToEnvelope(resp *clientexec.Response, sessionID string) (*mcp.CallToolResult, any, error) {
+	if resp.HasReview {
+		// Output is the review URI; the review_id is the session id.
+		return jsonResult(map[string]any{
+			"status":     "pending_approval",
+			"session_id": sessionID,
+			"review_id":  sessionID,
+			"review_url": resp.Output,
+			"message":    "Approval required before this execution can run",
+			"next_step":  "poll reviews_get with review_id; once status=APPROVED call reviews_execute",
+		})
+	}
+
+	env := map[string]any{
+		"session_id":        resp.SessionID,
+		"output":            resp.Output,
+		"output_status":     resp.OutputStatus,
+		"truncated":         resp.Truncated,
+		"execution_time_ms": resp.ExecutionTimeMili,
+		"exit_code":         resp.ExitCode,
+		"has_review":        resp.HasReview,
+	}
+	if resp.OutputStatus == "failed" || (resp.ExitCode != 0 && resp.ExitCode != -2) {
+		env["status"] = "failed"
+	} else {
+		env["status"] = "completed"
+	}
+	if resp.AIAnalysis != nil {
+		env["ai_analysis"] = map[string]any{
+			"risk_level":  resp.AIAnalysis.RiskLevel,
+			"title":       resp.AIAnalysis.Title,
+			"explanation": resp.AIAnalysis.Explanation,
+			"action":      resp.AIAnalysis.Action,
+		}
+	}
+	return jsonResult(env)
+}

--- a/gateway/api/mcpserver/tools_me.go
+++ b/gateway/api/mcpserver/tools_me.go
@@ -1,0 +1,45 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type meGetInput struct{}
+
+func registerMeTools(server *mcp.Server) {
+	openWorld := false
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "me_get",
+		Description: "Get the authenticated user's profile: email, name, user_id, org_id, " +
+			"the groups they belong to, and whether they are an admin or auditor. " +
+			"Useful as a first call to confirm which identity the MCP session is acting as.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, meGetHandler)
+}
+
+func meGetHandler(ctx context.Context, _ *mcp.CallToolRequest, _ meGetInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+
+	groups := sc.GetUserGroups()
+	if groups == nil {
+		groups = []string{}
+	}
+	return jsonResult(map[string]any{
+		"user_id":     sc.UserID,
+		"user_email":  sc.UserEmail,
+		"user_name":   sc.UserName,
+		"org_id":      sc.GetOrgID(),
+		"org_name":    sc.OrgName,
+		"groups":      groups,
+		"is_admin":    sc.IsAdminUser(),
+		"is_auditor":  sc.IsAuditorUser(),
+		"user_status": sc.UserStatus,
+	})
+}

--- a/gateway/api/mcpserver/tools_reviews.go
+++ b/gateway/api/mcpserver/tools_reviews.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	reviewapi "github.com/hoophq/hoop/gateway/api/review"
+	"github.com/hoophq/hoop/gateway/clientexec"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -30,6 +33,10 @@ type reviewsUpdateInput struct {
 	Status      string                 `json:"status" jsonschema:"new status: APPROVED, REJECTED, or REVOKED"`
 	TimeWindow  *reviewTimeWindowInput `json:"time_window,omitempty" jsonschema:"optional time window for approved JIT reviews"`
 	ForceReview bool                   `json:"force_review,omitempty" jsonschema:"force the review (requires force approval group membership)"`
+}
+
+type reviewsExecuteInput struct {
+	ID string `json:"id" jsonschema:"review ID or session ID of an APPROVED one-time review"`
 }
 
 func registerReviewTools(server *mcp.Server, releaseConnFn reviewapi.TransportReleaseConnectionFunc) {
@@ -52,6 +59,176 @@ func registerReviewTools(server *mcp.Server, releaseConnFn reviewapi.TransportRe
 		Description: "Update a review status (approve, reject, or revoke). Requires membership in a reviewer group",
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true), OpenWorldHint: &openWorld},
 	}, makeReviewsUpdateHandler(releaseConnFn))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "reviews_execute",
+		Description: "Execute a query that was blocked on an approved one-time review. Runs the originally " +
+			"submitted query (no drift from what the reviewer approved). Only the session owner or an " +
+			"admin/auditor can execute; the review must be in status=APPROVED. Returns the same envelope " +
+			"shape as exec: completed, or status=running after a 50s timeout (poll sessions_get).",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true), OpenWorldHint: &openWorld},
+	}, reviewsExecuteHandler)
+}
+
+// Per-session lock to prevent concurrent executions of the same review.
+// This mirrors the HTTP handler's behavior but is scoped to the MCP tool.
+var (
+	reviewsExecMu   sync.Mutex
+	reviewsExecLock = map[string]struct{}{}
+)
+
+func reviewsExecuteHandler(ctx context.Context, _ *mcp.CallToolRequest, args reviewsExecuteInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+	token := accessTokenFrom(ctx)
+	if token == "" {
+		return errResult("unauthorized: missing access token"), nil, nil
+	}
+	if args.ID == "" {
+		return errResult("id is required"), nil, nil
+	}
+
+	review, err := models.GetReviewByIdOrSid(sc.GetOrgID(), args.ID)
+	switch err {
+	case models.ErrNotFound:
+		return errResult("review not found"), nil, nil
+	case nil:
+	default:
+		return nil, nil, fmt.Errorf("failed retrieving review: %w", err)
+	}
+	if review == nil {
+		return errResult("review not found"), nil, nil
+	}
+	if review.Type != models.ReviewTypeOneTime {
+		return errResult("review is not a one-time review"), nil, nil
+	}
+
+	sid := review.SessionID
+	reviewsExecMu.Lock()
+	if _, busy := reviewsExecLock[sid]; busy {
+		reviewsExecMu.Unlock()
+		return errResult(fmt.Sprintf("the session %v is already being processed", sid)), nil, nil
+	}
+	reviewsExecLock[sid] = struct{}{}
+	reviewsExecMu.Unlock()
+	defer func() {
+		reviewsExecMu.Lock()
+		delete(reviewsExecLock, sid)
+		reviewsExecMu.Unlock()
+	}()
+
+	session, err := models.GetSessionByID(sc.OrgID, sid)
+	switch err {
+	case models.ErrNotFound:
+		return errResult("session not found"), nil, nil
+	case nil:
+	default:
+		return nil, nil, fmt.Errorf("failed fetching session: %w", err)
+	}
+	session.BlobInput, err = session.GetBlobInput()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed fetching session input: %w", err)
+	}
+
+	if err := canExecReviewedSessionMCP(sc, session, review); err != nil {
+		return errResult(err.Error()), nil, nil
+	}
+
+	client, err := clientexec.New(&clientexec.Options{
+		OrgID:          sc.GetOrgID(),
+		SessionID:      session.ID,
+		ConnectionName: session.Connection,
+		BearerToken:    token,
+		UserAgent:      fmt.Sprintf("mcp.reviews_execute/%s", sc.UserEmail),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed creating exec client: %w", err)
+	}
+
+	respCh := make(chan *clientexec.Response, 1)
+	go func() {
+		defer func() { close(respCh); client.Close() }()
+		respCh <- client.Run([]byte(session.BlobInput), review.InputEnvVars, review.InputClientArgs...)
+	}()
+
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), 50*time.Second)
+	defer cancelFn()
+
+	reviewStatus := models.ReviewStatusExecuted
+	defer func() {
+		if err := models.UpdateReviewStatus(review.OrgID, review.ID, reviewStatus); err != nil {
+			log.With("sid", sid).Warnf("failed updating review to status=%v, err=%v", reviewStatus, err)
+		}
+	}()
+
+	select {
+	case resp := <-respCh:
+		env := map[string]any{
+			"session_id":        resp.SessionID,
+			"output":            resp.Output,
+			"output_status":     resp.OutputStatus,
+			"truncated":         resp.Truncated,
+			"execution_time_ms": resp.ExecutionTimeMili,
+			"exit_code":         resp.ExitCode,
+		}
+		if resp.OutputStatus == "failed" || (resp.ExitCode != 0 && resp.ExitCode != -2) {
+			env["status"] = "failed"
+		} else {
+			env["status"] = "completed"
+		}
+		return jsonResult(env)
+	case <-timeoutCtx.Done():
+		client.Close()
+		reviewStatus = models.ReviewStatusUnknown
+		return jsonResult(map[string]any{
+			"session_id": session.ID,
+			"status":     "running",
+			"message":    "execution still running after 50s; poll sessions_get with session_id",
+			"next_step":  "poll sessions_get with session_id",
+		})
+	}
+}
+
+// canExecReviewedSessionMCP enforces the same rules as the HTTP handler's
+// canExecReviewedSession: only the session owner or an admin/auditor may run
+// the approved review, and the time window (if any) must currently permit it.
+func canExecReviewedSessionMCP(ctx *storagev2.Context, session *models.Session, review *models.Review) error {
+	if session.UserEmail != ctx.UserEmail && !ctx.IsAuditorOrAdminUser() {
+		return fmt.Errorf("unable to execute session")
+	}
+	if review.Status != models.ReviewStatusApproved {
+		return fmt.Errorf("review not approved or already executed")
+	}
+	if review.TimeWindow == nil {
+		return nil
+	}
+	if review.TimeWindow.Type != "time_range" {
+		return fmt.Errorf("unknown execution window type %s", review.TimeWindow.Type)
+	}
+	startStr, okStart := review.TimeWindow.Configuration["start_time"]
+	endStr, okEnd := review.TimeWindow.Configuration["end_time"]
+	if !okStart || !okEnd {
+		return fmt.Errorf("invalid execution window configuration")
+	}
+	startTime, err := time.Parse("15:04", startStr)
+	if err != nil {
+		return fmt.Errorf("invalid execution window start time")
+	}
+	endTime, err := time.Parse("15:04", endStr)
+	if err != nil {
+		return fmt.Errorf("invalid execution window end time")
+	}
+	if endTime.Before(startTime) {
+		endTime = endTime.Add(24 * time.Hour)
+	}
+	now := time.Now().UTC()
+	nowOnlyTime := time.Date(0, 1, 1, now.Hour(), now.Minute(), now.Second(), now.Nanosecond(), time.UTC)
+	if nowOnlyTime.Before(startTime) || nowOnlyTime.After(endTime) {
+		return fmt.Errorf("execution not allowed outside the time window %s to %s UTC", startStr, endStr)
+	}
+	return nil
 }
 
 func reviewsListHandler(ctx context.Context, _ *mcp.CallToolRequest, _ reviewsListInput) (*mcp.CallToolResult, any, error) {

--- a/gateway/api/mcpserver/tools_reviews.go
+++ b/gateway/api/mcpserver/tools_reviews.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -39,6 +40,11 @@ type reviewsExecuteInput struct {
 	ID string `json:"id" jsonschema:"review ID or session ID of an APPROVED one-time review"`
 }
 
+type reviewsWaitInput struct {
+	ID             string `json:"id" jsonschema:"review ID or session ID to wait on"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty" jsonschema:"max wait in seconds (default 60, max 300). Timeout is not an error: the response carries timed_out=true and the current status — call again to keep waiting."`
+}
+
 func registerReviewTools(server *mcp.Server, releaseConnFn reviewapi.TransportReleaseConnectionFunc) {
 	openWorld := false
 
@@ -68,6 +74,15 @@ func registerReviewTools(server *mcp.Server, releaseConnFn reviewapi.TransportRe
 			"shape as exec: completed, or status=running after a 50s timeout (poll sessions_get).",
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true), OpenWorldHint: &openWorld},
 	}, reviewsExecuteHandler)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "reviews_wait",
+		Description: "Long-poll a review until it reaches a terminal status (APPROVED, REJECTED, REVOKED, " +
+			"EXECUTED) or the timeout elapses. Use after exec returns status=pending_approval. The response " +
+			"shape mirrors reviews_get and adds timed_out (true when the timeout was reached without a " +
+			"terminal status — call again to keep waiting) and waited_seconds.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, reviewsWaitHandler)
 }
 
 // Per-session lock to prevent concurrent executions of the same review.
@@ -316,6 +331,81 @@ func makeReviewsUpdateHandler(releaseConnFn reviewapi.TransportReleaseConnection
 			return nil, nil, fmt.Errorf("failed updating review: %w", err)
 		}
 	}
+}
+
+func reviewsWaitHandler(ctx context.Context, _ *mcp.CallToolRequest, args reviewsWaitInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+	if args.ID == "" {
+		return errResult("id is required"), nil, nil
+	}
+	orgID := sc.GetOrgID()
+
+	// Eager fetch: a non-existent review fails fast and never enters the
+	// poll loop. Org-scoping is enforced by GetReviewByIdOrSid.
+	initial, err := models.GetReviewByIdOrSid(orgID, args.ID)
+	switch err {
+	case models.ErrNotFound:
+		return errResult("review not found"), nil, nil
+	case nil:
+		if initial == nil {
+			return errResult("review not found"), nil, nil
+		}
+	default:
+		return nil, nil, fmt.Errorf("failed fetching review: %w", err)
+	}
+	if isReviewTerminal(initial.Status) {
+		return reviewsWaitResult(initial, false, 0), nil, nil
+	}
+
+	rev, timedOut, waited, err := waitUntil(ctx, resolveWaitTimeout(args.TimeoutSeconds),
+		func() (*models.Review, bool, error) {
+			r, err := models.GetReviewByIdOrSid(orgID, args.ID)
+			if err != nil {
+				return nil, false, err
+			}
+			if r == nil {
+				return nil, false, models.ErrNotFound
+			}
+			return r, isReviewTerminal(r.Status), nil
+		})
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if rev == nil {
+				rev = initial
+			}
+			return reviewsWaitResult(rev, false, waited), nil, nil
+		}
+		if errors.Is(err, models.ErrNotFound) {
+			return errResult("review not found"), nil, nil
+		}
+		return nil, nil, fmt.Errorf("failed waiting on review: %w", err)
+	}
+	if rev == nil {
+		rev = initial
+	}
+	return reviewsWaitResult(rev, timedOut, waited), nil, nil
+}
+
+func reviewsWaitResult(r *models.Review, timedOut bool, waited time.Duration) *mcp.CallToolResult {
+	body := reviewToMap(r)
+	body["timed_out"] = timedOut
+	body["waited_seconds"] = int(waited.Seconds())
+	res, _, _ := jsonResult(body)
+	return res
+}
+
+func isReviewTerminal(s models.ReviewStatusType) bool {
+	switch s {
+	case models.ReviewStatusApproved,
+		models.ReviewStatusRejected,
+		models.ReviewStatusRevoked,
+		models.ReviewStatusExecuted:
+		return true
+	}
+	return false
 }
 
 func reviewToMap(r *models.Review) map[string]any {

--- a/gateway/api/mcpserver/tools_reviews_test.go
+++ b/gateway/api/mcpserver/tools_reviews_test.go
@@ -1,0 +1,29 @@
+package mcpserver
+
+import (
+	"testing"
+
+	"github.com/hoophq/hoop/gateway/models"
+)
+
+func TestIsReviewTerminal(t *testing.T) {
+	tests := []struct {
+		status models.ReviewStatusType
+		want   bool
+	}{
+		{models.ReviewStatusPending, false},
+		{models.ReviewStatusProcessing, false},
+		{models.ReviewStatusUnknown, false},
+		{models.ReviewStatusApproved, true},
+		{models.ReviewStatusRejected, true},
+		{models.ReviewStatusRevoked, true},
+		{models.ReviewStatusExecuted, true},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			if got := isReviewTerminal(tc.status); got != tc.want {
+				t.Errorf("isReviewTerminal(%q) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}

--- a/gateway/api/mcpserver/tools_schema.go
+++ b/gateway/api/mcpserver/tools_schema.go
@@ -1,0 +1,243 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/log"
+	pb "github.com/hoophq/hoop/common/proto"
+	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
+	"github.com/hoophq/hoop/gateway/clientexec"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const schemaTimeout = 30 * time.Second
+
+type connectionDatabasesInput struct {
+	ConnectionName string `json:"connection_name" jsonschema:"name of the database connection"`
+}
+
+type connectionTablesInput struct {
+	ConnectionName string `json:"connection_name" jsonschema:"name of the database connection"`
+	Database       string `json:"database" jsonschema:"name of the database to list tables from (required for Postgres, MSSQL, MySQL, MongoDB)"`
+}
+
+type connectionColumnsInput struct {
+	ConnectionName string `json:"connection_name" jsonschema:"name of the database connection"`
+	Database       string `json:"database" jsonschema:"name of the database (required for Postgres, MSSQL, MySQL, MongoDB)"`
+	Table          string `json:"table" jsonschema:"name of the table"`
+	Schema         string `json:"schema,omitempty" jsonschema:"schema name (optional; defaults: public for Postgres, dbo for MSSQL, database name otherwise)"`
+}
+
+func registerSchemaTools(server *mcp.Server) {
+	openWorld := false
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "connection_databases",
+		Description: "List databases available on a Hoop database connection (Postgres, MySQL, MSSQL, MongoDB). " +
+			"Returns the raw query output; agents can parse database names from it.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, connectionDatabasesHandler)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "connection_tables",
+		Description: "List tables in a given database on a Hoop database connection. " +
+			"Returns the raw query output.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, connectionTablesHandler)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "connection_columns",
+		Description: "List columns of a specific table on a Hoop database connection, with types. " +
+			"Returns the raw query output.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, connectionColumnsHandler)
+}
+
+func connectionDatabasesHandler(ctx context.Context, _ *mcp.CallToolRequest, args connectionDatabasesInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	conn, token, err := resolveSchemaRequest(ctx, args.ConnectionName)
+	if err != nil {
+		return err.toResult(), nil, nil
+	}
+
+	connType := pb.ToConnectionType(conn.Type, conn.SubType.String)
+	script := databasesScriptFor(connType)
+	if script == "" {
+		return errResult(fmt.Sprintf("listing databases is not supported for connection type %q", connType)), nil, nil
+	}
+
+	output, timedOut, err2 := runSchemaExec(sc.GetOrgID(), conn.Name, script, token)
+	if err2 != nil {
+		return nil, nil, err2
+	}
+	if timedOut {
+		return errResult(fmt.Sprintf("timed out (%s) listing databases", schemaTimeout)), nil, nil
+	}
+	return jsonResult(map[string]any{
+		"connection_name":    conn.Name,
+		"connection_subtype": conn.SubType.String,
+		"output":             output,
+	})
+}
+
+func connectionTablesHandler(ctx context.Context, _ *mcp.CallToolRequest, args connectionTablesInput) (*mcp.CallToolResult, any, error) {
+	if args.Database == "" {
+		return errResult("database is required"), nil, nil
+	}
+	sc := storageContextFrom(ctx)
+	conn, token, err := resolveSchemaRequest(ctx, args.ConnectionName)
+	if err != nil {
+		return err.toResult(), nil, nil
+	}
+
+	connType := pb.ToConnectionType(conn.Type, conn.SubType.String)
+	script := apiconnections.TablesQueryFor(connType, args.Database)
+	if script == "" {
+		return errResult(fmt.Sprintf("listing tables is not supported for connection type %q", connType)), nil, nil
+	}
+
+	output, timedOut, err2 := runSchemaExec(sc.GetOrgID(), conn.Name, script, token)
+	if err2 != nil {
+		return nil, nil, err2
+	}
+	if timedOut {
+		return errResult(fmt.Sprintf("timed out (%s) listing tables", schemaTimeout)), nil, nil
+	}
+	return jsonResult(map[string]any{
+		"connection_name":    conn.Name,
+		"connection_subtype": conn.SubType.String,
+		"database":           args.Database,
+		"output":             output,
+	})
+}
+
+func connectionColumnsHandler(ctx context.Context, _ *mcp.CallToolRequest, args connectionColumnsInput) (*mcp.CallToolResult, any, error) {
+	if args.Table == "" {
+		return errResult("table is required"), nil, nil
+	}
+	sc := storageContextFrom(ctx)
+	conn, token, err := resolveSchemaRequest(ctx, args.ConnectionName)
+	if err != nil {
+		return err.toResult(), nil, nil
+	}
+
+	connType := pb.ToConnectionType(conn.Type, conn.SubType.String)
+	schema := args.Schema
+	if schema == "" {
+		switch connType {
+		case pb.ConnectionTypePostgres:
+			schema = "public"
+		case pb.ConnectionTypeMSSQL:
+			schema = "dbo"
+		default:
+			schema = args.Database
+		}
+	}
+	script := apiconnections.ColumnsQueryFor(connType, args.Database, args.Table, schema)
+	if script == "" {
+		return errResult(fmt.Sprintf("listing columns is not supported for connection type %q", connType)), nil, nil
+	}
+
+	output, timedOut, err2 := runSchemaExec(sc.GetOrgID(), conn.Name, script, token)
+	if err2 != nil {
+		return nil, nil, err2
+	}
+	if timedOut {
+		return errResult(fmt.Sprintf("timed out (%s) listing columns", schemaTimeout)), nil, nil
+	}
+	return jsonResult(map[string]any{
+		"connection_name":    conn.Name,
+		"connection_subtype": conn.SubType.String,
+		"database":           args.Database,
+		"table":              args.Table,
+		"schema":             schema,
+		"output":             output,
+	})
+}
+
+type schemaErr struct{ msg string }
+
+func (e *schemaErr) toResult() *mcp.CallToolResult { return errResult(e.msg) }
+
+func resolveSchemaRequest(ctx context.Context, connectionName string) (*models.Connection, string, *schemaErr) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, "", &schemaErr{"unauthorized: missing auth context"}
+	}
+	token := accessTokenFrom(ctx)
+	if token == "" {
+		return nil, "", &schemaErr{"unauthorized: missing access token"}
+	}
+	if connectionName == "" {
+		return nil, "", &schemaErr{"connection_name is required"}
+	}
+	conn, err := models.GetConnectionByNameOrID(sc, connectionName)
+	if err != nil {
+		return nil, "", &schemaErr{fmt.Sprintf("failed looking up connection: %v", err)}
+	}
+	if conn == nil {
+		return nil, "", &schemaErr{fmt.Sprintf("connection %q not found or not accessible", connectionName)}
+	}
+	isDatabase := conn.Type == "database"
+	if !isDatabase {
+		return nil, "", &schemaErr{fmt.Sprintf("connection %q is not a database type", connectionName)}
+	}
+	return conn, token, nil
+}
+
+func databasesScriptFor(connType pb.ConnectionType) string {
+	switch connType {
+	case pb.ConnectionTypePostgres:
+		return `SELECT datname AS database_name FROM pg_database
+WHERE datistemplate = false AND datname != 'postgres' AND datname != 'rdsadmin'
+ORDER BY datname;`
+	case pb.ConnectionTypeMySQL:
+		return `SELECT schema_name AS database_name FROM information_schema.schemata ORDER BY schema_name;`
+	case pb.ConnectionTypeMSSQL:
+		return `SET NOCOUNT ON; SELECT name FROM sys.databases WHERE name != 'rdsadmin'`
+	case pb.ConnectionTypeMongoDB:
+		return `var dbs = db.adminCommand('listDatabases');
+var result = [];
+dbs.databases.forEach(function(d) { result.push({ "database_name": d.name }); });
+print(JSON.stringify(result));`
+	default:
+		return ""
+	}
+}
+
+func runSchemaExec(orgID, connectionName, script, token string) (string, bool, error) {
+	sessionID := uuid.NewString()
+	client, err := clientexec.New(&clientexec.Options{
+		OrgID:          orgID,
+		SessionID:      sessionID,
+		ConnectionName: connectionName,
+		BearerToken:    token,
+		UserAgent:      "mcp.schema",
+		Verb:           pb.ClientVerbPlainExec,
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("failed creating exec client: %w", err)
+	}
+	respCh := make(chan *clientexec.Response, 1)
+	go func() {
+		defer func() { close(respCh); client.Close() }()
+		respCh <- client.Run([]byte(script), nil)
+	}()
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), schemaTimeout)
+	defer cancelFn()
+	select {
+	case resp := <-respCh:
+		if resp.ExitCode != 0 && resp.ExitCode != -2 {
+			log.With("sid", sessionID).Warnf("schema exec non-zero exit, %v", resp.String())
+			return "", false, fmt.Errorf("schema query failed: %s", resp.Output)
+		}
+		return resp.Output, false, nil
+	case <-timeoutCtx.Done():
+		client.Close()
+		return "", true, nil
+	}
+}

--- a/gateway/api/mcpserver/tools_sessions.go
+++ b/gateway/api/mcpserver/tools_sessions.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -38,6 +39,11 @@ type sessionsGetAnalysisInput struct {
 	ID string `json:"id" jsonschema:"session ID"`
 }
 
+type sessionsWaitAnalysisInput struct {
+	ID             string `json:"id" jsonschema:"session ID whose AI analysis to wait for"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty" jsonschema:"max wait in seconds (default 60, max 300). Timeout is not an error: the response carries timed_out=true and status=unavailable."`
+}
+
 func registerSessionTools(server *mcp.Server) {
 	openWorld := false
 
@@ -66,6 +72,15 @@ func registerSessionTools(server *mcp.Server) {
 			"Returns status=unavailable when the session has no analysis yet (e.g. still in progress).",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
 	}, sessionsGetAnalysisHandler)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "sessions_wait_analysis",
+		Description: "Long-poll until Hoop's AI analysis for a session is available, or the timeout elapses. " +
+			"AI analysis is generated asynchronously after a session ends, so a session that just completed " +
+			"may take a moment. Response shape mirrors sessions_get_analysis and adds timed_out and " +
+			"waited_seconds. Timeout is not an error.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, sessionsWaitAnalysisHandler)
 }
 
 func sessionsListHandler(ctx context.Context, _ *mcp.CallToolRequest, args sessionsListInput) (*mcp.CallToolResult, any, error) {
@@ -251,6 +266,79 @@ func sessionsGetAnalysisHandler(ctx context.Context, _ *mcp.CallToolRequest, arg
 		"explanation": session.AIAnalysis.Explanation,
 		"action":      session.AIAnalysis.Action,
 	})
+}
+
+func sessionsWaitAnalysisHandler(ctx context.Context, _ *mcp.CallToolRequest, args sessionsWaitAnalysisInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+	if args.ID == "" {
+		return errResult("id is required"), nil, nil
+	}
+
+	// Eager fetch: validates existence and ownership before entering the
+	// poll loop. Subsequent polls inherit the same authorization (the
+	// session row's user_id never changes).
+	initial, err := models.GetSessionByID(sc.OrgID, args.ID)
+	switch err {
+	case models.ErrNotFound:
+		return errResult("session not found"), nil, nil
+	case nil:
+	default:
+		return nil, nil, fmt.Errorf("failed fetching session: %w", err)
+	}
+	if initial.UserID != sc.UserID && !sc.IsAuditorOrAdminUser() {
+		return errResult("access denied: you can only view your own sessions or must be admin/auditor"), nil, nil
+	}
+	if initial.AIAnalysis != nil {
+		return sessionsWaitAnalysisResult(initial, false, 0), nil, nil
+	}
+
+	sess, timedOut, waited, err := waitUntil(ctx, resolveWaitTimeout(args.TimeoutSeconds),
+		func() (*models.Session, bool, error) {
+			s, err := models.GetSessionByID(sc.OrgID, args.ID)
+			if err != nil {
+				return nil, false, err
+			}
+			return s, s.AIAnalysis != nil, nil
+		})
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if sess == nil {
+				sess = initial
+			}
+			return sessionsWaitAnalysisResult(sess, false, waited), nil, nil
+		}
+		if errors.Is(err, models.ErrNotFound) {
+			return errResult("session not found"), nil, nil
+		}
+		return nil, nil, fmt.Errorf("failed waiting on session analysis: %w", err)
+	}
+	if sess == nil {
+		sess = initial
+	}
+	return sessionsWaitAnalysisResult(sess, timedOut, waited), nil, nil
+}
+
+func sessionsWaitAnalysisResult(s *models.Session, timedOut bool, waited time.Duration) *mcp.CallToolResult {
+	body := map[string]any{
+		"session_id":     s.ID,
+		"timed_out":      timedOut,
+		"waited_seconds": int(waited.Seconds()),
+	}
+	if s.AIAnalysis == nil {
+		body["status"] = "unavailable"
+		body["message"] = "AI analysis is not yet available for this session"
+	} else {
+		body["status"] = "ready"
+		body["risk_level"] = s.AIAnalysis.RiskLevel
+		body["title"] = s.AIAnalysis.Title
+		body["explanation"] = s.AIAnalysis.Explanation
+		body["action"] = s.AIAnalysis.Action
+	}
+	res, _, _ := jsonResult(body)
+	return res
 }
 
 func sessionToMap(s *models.Session) map[string]any {

--- a/gateway/api/mcpserver/tools_sessions.go
+++ b/gateway/api/mcpserver/tools_sessions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	sessionapi "github.com/hoophq/hoop/gateway/api/session"
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -27,6 +28,16 @@ type sessionsGetInput struct {
 	ID string `json:"id" jsonschema:"session ID"`
 }
 
+type sessionsGetContentInput struct {
+	ID            string `json:"id" jsonschema:"session ID"`
+	IncludeInput  *bool  `json:"include_input,omitempty" jsonschema:"include the session input script (default true)"`
+	IncludeOutput *bool  `json:"include_output,omitempty" jsonschema:"include the session stdout+stderr output (default true)"`
+}
+
+type sessionsGetAnalysisInput struct {
+	ID string `json:"id" jsonschema:"session ID"`
+}
+
 func registerSessionTools(server *mcp.Server) {
 	openWorld := false
 
@@ -41,6 +52,20 @@ func registerSessionTools(server *mcp.Server) {
 		Description: "Get session details and metadata by ID. Returns metadata only, not session content or binary data",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
 	}, sessionsGetHandler)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "sessions_get_content",
+		Description: "Get the input script and stdout/stderr output of a session. " +
+			"Only the session owner or an admin/auditor can read another user's session content.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, sessionsGetContentHandler)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "sessions_get_analysis",
+		Description: "Get Hoop's AI analysis for a session: risk level, title, explanation, recommended action. " +
+			"Returns status=unavailable when the session has no analysis yet (e.g. still in progress).",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, sessionsGetAnalysisHandler)
 }
 
 func sessionsListHandler(ctx context.Context, _ *mcp.CallToolRequest, args sessionsListInput) (*mcp.CallToolResult, any, error) {
@@ -136,6 +161,96 @@ func sessionsGetHandler(ctx context.Context, _ *mcp.CallToolRequest, args sessio
 	}
 
 	return jsonResult(sessionToMap(session))
+}
+
+func sessionsGetContentHandler(ctx context.Context, _ *mcp.CallToolRequest, args sessionsGetContentInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+	if args.ID == "" {
+		return errResult("id is required"), nil, nil
+	}
+
+	session, err := models.GetSessionByID(sc.OrgID, args.ID)
+	switch err {
+	case models.ErrNotFound:
+		return errResult("session not found"), nil, nil
+	case nil:
+	default:
+		return nil, nil, fmt.Errorf("failed fetching session: %w", err)
+	}
+
+	if session.UserID != sc.UserID && !sc.IsAuditorOrAdminUser() {
+		return errResult("access denied: you can only view your own sessions or must be admin/auditor"), nil, nil
+	}
+
+	includeInput := args.IncludeInput == nil || *args.IncludeInput
+	includeOutput := args.IncludeOutput == nil || *args.IncludeOutput
+
+	result := map[string]any{
+		"id":         session.ID,
+		"connection": session.Connection,
+		"status":     session.Status,
+		"verb":       session.Verb,
+	}
+	if includeInput {
+		input, err := session.GetBlobInput()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed reading session input: %w", err)
+		}
+		result["input"] = string(input)
+	}
+	if includeOutput {
+		output, err := sessionapi.ParseSessionOutput(session)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed reading session output: %w", err)
+		}
+		result["output"] = output
+	}
+	if session.ExitCode != nil {
+		result["exit_code"] = *session.ExitCode
+	}
+	return jsonResult(result)
+}
+
+func sessionsGetAnalysisHandler(ctx context.Context, _ *mcp.CallToolRequest, args sessionsGetAnalysisInput) (*mcp.CallToolResult, any, error) {
+	sc := storageContextFrom(ctx)
+	if sc == nil {
+		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
+	}
+	if args.ID == "" {
+		return errResult("id is required"), nil, nil
+	}
+
+	session, err := models.GetSessionByID(sc.OrgID, args.ID)
+	switch err {
+	case models.ErrNotFound:
+		return errResult("session not found"), nil, nil
+	case nil:
+	default:
+		return nil, nil, fmt.Errorf("failed fetching session: %w", err)
+	}
+
+	if session.UserID != sc.UserID && !sc.IsAuditorOrAdminUser() {
+		return errResult("access denied: you can only view your own sessions or must be admin/auditor"), nil, nil
+	}
+
+	if session.AIAnalysis == nil {
+		return jsonResult(map[string]any{
+			"session_id": session.ID,
+			"status":     "unavailable",
+			"message":    "AI analysis is not yet available for this session",
+		})
+	}
+	return jsonResult(map[string]any{
+		"session_id":  session.ID,
+		"status":      "ready",
+		"risk_level":  session.AIAnalysis.RiskLevel,
+		"title":       session.AIAnalysis.Title,
+		"explanation": session.AIAnalysis.Explanation,
+		"action":      session.AIAnalysis.Action,
+	})
 }
 
 func sessionToMap(s *models.Session) map[string]any {

--- a/gateway/api/session/parser.go
+++ b/gateway/api/session/parser.go
@@ -284,3 +284,24 @@ func parseRawQueries(blobStream json.RawMessage, connProtoType proto.ConnectionT
 	rawQueries, err := json.Marshal(out)
 	return rawQueries, blobSize, err
 }
+
+// ParseSessionOutput returns the stdout and stderr of a session as a UTF-8 string,
+// loading the blob stream from the database if needed. Returns an empty string
+// (no error) when the session has no recorded stream.
+func ParseSessionOutput(s *models.Session) (string, error) {
+	if s.BlobStream == nil {
+		stream, err := s.GetBlobStream()
+		if err != nil {
+			return "", err
+		}
+		s.BlobStream = stream
+	}
+	if s.BlobStream == nil {
+		return "", nil
+	}
+	out, err := parseBlobStream(s, sessionParseOption{events: []string{"o", "e"}})
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}


### PR DESCRIPTION
## 📝 Description

Extends the existing `/api/mcp` server with the user-facing tool surface described in the User MCP PRD: an agent authenticated as a regular Hoop user can now discover what they can access, run queries, hit approval gates gracefully, and read their own session history — end to end over MCP.

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

### New MCP tools (all registered under the existing `POST /api/mcp`)

| Tool | Purpose |
|---|---|
| `me_get` | Authenticated user: email, name, user_id, org_id, groups, is_admin, is_auditor |
| `exec` | One-shot query against a connection. Returns `status=completed`, `pending_approval` (with `review_id`), or `running` (after a 50 s timeout) |
| `connection_databases`, `connection_tables`, `connection_columns` | Schema discovery on database connections |
| `sessions_get_content` | Session input script + stdout/stderr (own session or admin/auditor) |
| `sessions_get_analysis` | Hoop's AI analysis for a session, with `ready` / `unavailable` status |
| `sessions_wait_analysis` | Long-poll until AI analysis is ready or the timeout elapses. Mirrors `sessions_get_analysis` and adds `timed_out` + `waited_seconds`. Timeout is not an error |
| `reviews_execute` | Execute the originally-approved query after a reviewer approves. Runs the stored input — no chance of the agent resubmitting a slightly different query |
| `reviews_wait` | Long-poll a review until it reaches a terminal status (APPROVED, REJECTED, REVOKED, EXECUTED) or the timeout elapses. Mirrors `reviews_get` and adds `timed_out` + `waited_seconds`. The `exec` envelope's `next_step` now points agents here |

## 🧪 Testing

### Test Configuration:
- **Browser(s)**:  Chrome
- **OS**: MacOs

### Tests performed:
- [x] Unit tests pass (`poll_test.go` covers timeout/cancellation/flip cases; `tools_reviews_test.go` covers terminal-status predicate)
- [x] Integration tests pass
- [x] Manual testing completed end-to-end:
  - Already-terminal review → instant return
  - Pending review + short timeout → `timed_out=true`
  - Approve mid-wait via parallel reviewer (different user/group) → wait flips to APPROVED within ~2 s of approval, MCP session intact
  - Full `exec` → `reviews_wait` → `reviews_execute` chain → original query replayed exactly, no drift
  - `sessions_wait_analysis` timeout path (no AI client in dev env) → `timed_out=true`, `status=unavailable`
  - Bad input (empty/nonexistent id) → fast-fail errors, no poll loop entered

## ✅ Checklist

- [x] I have run `make generate-openapi-docs` to update the OpenAPI docs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings