### PR TITLE
chore(helm): expose RDP PII analysis env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,15 @@ Protocol-specific proxy servers configured via `server_misc_config`:
 - Run `make generate-openapi-docs` to regenerate `gateway/api/openapi/autogen/`.
 - OpenAPI specs are served at `/api/openapiv2.json` and `/api/openapiv3.json`.
 
+### Environment variables
+- Whenever a new env var is added, removed, or renamed in `gateway/appconfig/appconfig.go` (or anywhere read via `os.Getenv` in the gateway), **update the helm chart in the same PR**:
+  - `deploy/helm-chart/chart/gateway/templates/secret-configs.yaml` — pass-through entry, e.g. `MY_VAR: '{{ .Values.config.MY_VAR | default "..." }}'`.
+  - `deploy/helm-chart/chart/gateway/values.yaml` — add an example or sensible default under the `config:` block (commented if optional).
+  - `deploy/helm-chart/chart/gateway/README.md` — document the new var if it is user-facing.
+- Same rule applies to the agent helm chart at `deploy/helm-chart/chart/agent/` for agent-side env vars.
+- For deployments managed in the `infra` repo (sandbox, hoopcloud envs), open a follow-up PR there if the new var needs to be enabled per-environment.
+- The local dev `.env.sample` should also be updated so contributors discover the new var.
+
 ### Versioning
 - Semantic versioning: `MAJOR.MINOR.PATCH`.
 - Version is injected at build time via `-ldflags` into `common/version`.

--- a/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
@@ -49,6 +49,15 @@ stringData:
   MSPRESIDIO_ANALYZER_URL: '{{ .Values.config.MSPRESIDIO_ANALYZER_URL }}'
   MSPRESIDIO_ANONYMIZER_URL: '{{ .Values.config.MSPRESIDIO_ANONYMIZER_URL }}'
   {{- end }}
+  # Async RDP session-replay PII analysis (see hoophq/hoop PR #1391).
+  # Worker pool runs OCR + Presidio over recorded RDP bitmap frames and stores
+  # entity detections so the webapp can highlight PII on top of the replay.
+  # Defaults to 0 workers (feature disabled). Requires MSPRESIDIO_ANALYZER_URL
+  # to be set and tesseract installed in the gateway image.
+  RDP_ANALYSIS_WORKERS: '{{ .Values.config.RDP_ANALYSIS_WORKERS | default "0" }}'
+  RDP_PII_SNAPSHOT_INTERVAL: '{{ .Values.config.RDP_PII_SNAPSHOT_INTERVAL | default "0.25" }}'
+  RDP_PII_SCORE_THRESHOLD: '{{ .Values.config.RDP_PII_SCORE_THRESHOLD | default "0.9" }}'
+  RDP_PII_ENTITY_DENYLIST: '{{ .Values.config.RDP_PII_ENTITY_DENYLIST | default "DATE_TIME,NRP" }}'
   WEBHOOK_APPKEY: '{{ .Values.config.WEBHOOK_APPKEY }}'
   WEBHOOK_APPURL: '{{ .Values.config.WEBHOOK_APPURL }}'
   INTEGRATION_AWS_INSTANCE_ROLE_ALLOW: '{{ .Values.config.INTEGRATION_AWS_INSTANCE_ROLE_ALLOW }}'

--- a/deploy/helm-chart/chart/gateway/values.yaml
+++ b/deploy/helm-chart/chart/gateway/values.yaml
@@ -134,6 +134,16 @@ config:
   # GOOGLE_APPLICATION_CREDENTIALS_JSON: ''
   # PLUGIN_AUDIT_PATH: ''
   # PLUGIN_INDEX_PATH: ''
+  #
+  # Async RDP session-replay PII analysis. Workers run OCR + Presidio over
+  # recorded RDP bitmap frames so the webapp can highlight PII on top of the
+  # replay. Defaults to 0 (disabled). Set RDP_ANALYSIS_WORKERS >= 1 and ensure
+  # MSPRESIDIO_ANALYZER_URL is reachable and tesseract is installed in the
+  # gateway image to enable.
+  # RDP_ANALYSIS_WORKERS: '0'
+  # RDP_PII_SNAPSHOT_INTERVAL: '0.25'
+  # RDP_PII_SCORE_THRESHOLD: '0.9'
+  # RDP_PII_ENTITY_DENYLIST: 'DATE_TIME,NRP'
 
 mainService:
   # -- Annotations to add in the main service


### PR DESCRIPTION
## Summary

The async RDP session-replay PII analysis feature (#1391) introduced four env vars in `gateway/appconfig/appconfig.go` but the helm chart was never updated. Without this PR users can only enable the feature by editing helm templates by hand.

This PR also adds a convention note in `CLAUDE.md` so future env var changes in the gateway always ship with the matching helm chart updates in the same PR — the omission that prompted this fix.

## Changes

### `deploy/helm-chart/chart/gateway/templates/secret-configs.yaml`
Pass-through entries for the four RDP env vars with sensible defaults:

| Var | Default | Purpose |
|---|---|---|
| `RDP_ANALYSIS_WORKERS` | `0` | Worker pool size; **disabled by default** |
| `RDP_PII_SNAPSHOT_INTERVAL` | `0.25` | Seconds between bitmap frame snapshots |
| `RDP_PII_SCORE_THRESHOLD` | `0.9` | Minimum Presidio confidence (0-1) |
| `RDP_PII_ENTITY_DENYLIST` | `DATE_TIME,NRP` | Comma-separated entity types to skip |

### `deploy/helm-chart/chart/gateway/values.yaml`
Added a commented example block under `config:` documenting the four vars and the prerequisites (Presidio reachable + tesseract in the gateway image).

### `CLAUDE.md`
New section under "Coding Conventions" titled **Environment variables** describing the rule: any new/removed/renamed env var read via `os.Getenv` in the gateway must update the helm chart (`secret-configs.yaml`, `values.yaml`, `README.md` if user-facing), the agent helm chart for agent-side vars, the `infra` repo where appropriate, and `.env.sample` for dev.

## Verification

- `helm lint deploy/helm-chart/chart/gateway` passes (only pre-existing warnings about required values)
- `helm template ... --set config.POSTGRES_DB_URI=... --set config.API_URL=...` renders the four vars at their defaults
- `helm template ... --set config.RDP_ANALYSIS_WORKERS=4 --set config.RDP_PII_SCORE_THRESHOLD=0.85` correctly overrides them
- Defaults match the validated sandbox configuration (modulo workers count which the sandbox PR sets to 1, see hoophq/infra#22)

## Rollout

- Existing deployments are unaffected: `RDP_ANALYSIS_WORKERS=0` keeps the worker pool idle, identical to current behavior.
- Sandbox is being enabled separately in [hoophq/infra#22](https://github.com/hoophq/infra/pull/22).

Automated by MisterMal

 🤖 Generated with Mister Maluco

Co-Authored-By: MisterMal <teskeslab@lucasteske.dev>