### PR TITLE
fix(webapp): broken navigation to settings attributes edit page

### DIFF
--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -728,9 +728,9 @@
      [attributes-form/main :create]]]])
 
 (defmethod routes/panels :settings-attributes-edit-panel []
-  (let [attr-name (-> (bidi/match-route @routes/routes (.. js/window -location -pathname))
-                      :route-params
-                      :name)]
+  (let [attr-name (-> js/window .-location .-search
+                      js/URLSearchParams.
+                      (.get "name"))]
     (rf/dispatch [:destroy-page-loader])
     (rf/dispatch [:attributes/get attr-name])
     [layout :application-hoop

--- a/webapp/src/webapp/features/attributes/views/list.cljs
+++ b/webapp/src/webapp/features/attributes/views/list.cljs
@@ -45,5 +45,5 @@
                  [:> Button {:variant "outline"
                              :color "gray"
                              :size "3"
-                             :on-click #(rf/dispatch [:navigate :settings-attributes-edit {} :name (:name attr)])}
+                             :on-click #(rf/dispatch [:navigate :settings-attributes-edit {:name (:name attr)}])}
                   "Configure"]]])))]]))))

--- a/webapp/src/webapp/routes.cljs
+++ b/webapp/src/webapp/routes.cljs
@@ -82,7 +82,7 @@
                   ["/audit-logs" :settings-audit-logs]
                   ["/attributes" :settings-attributes]
                   ["/attributes/new" :settings-attributes-new]
-                  [["/attributes/edit/" :name] :settings-attributes-edit]
+                  ["/attributes/edit" :settings-attributes-edit]
                   ["/jira" :settings-jira]
                   ["/api-keys" :settings-api-keys]
                   ["/api-keys/new" :settings-api-keys-new]


### PR DESCRIPTION
## 📝 Description

Fixes the settings attributes edit page, which wasn't loading the selected attribute due to a route parameter mismatch. The route is now `/attributes/edit?name=<attr-name>` (query string) and the panel reads the name via `URLSearchParams`, replacing the previous path-parameter setup that wasn't resolving correctly.

## 🔗 Related Issue

Fixes #ENG-330

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Updated the `:settings-attributes-edit` route in `webapp/src/webapp/routes.cljs` from `/attributes/edit/:name` (path parameter) to `/attributes/edit` (query string), so navigation actually matches the registered route.
- Fixed the `:settings-attributes-edit-panel` method in `webapp/src/webapp/app.cljs` to read the attribute name from `window.location.search` using `URLSearchParams`, instead of the previous `bidi/match-route` lookup that was returning `nil`.
- Fixed the "Configure" button dispatch in `webapp/src/webapp/features/attributes/views/list.cljs` to pass `{:name (:name attr)}` as the route params map, matching how `:navigate` expects parameters.

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->

### Test Configuration:
- **Browser(s)**: 
- **OS**:

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed — go to Settings → Attributes, click "Configure" on an attribute, and confirm the edit page loads with the correct attribute selected (URL should be `/settings/attributes/edit?name=<attr-name>`).

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## ✅ Checklist

- [ ] I have run `make generate-openapi-docs` to update the OpenAPI docs (N/A — frontend-only change)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Frontend-only fix on a single route. Worth confirming whether any external links/bookmarks pointed to the old `/settings/attributes/edit/<name>` URL — if so, a redirect may be needed.