### PR TITLE
feat: limit guardrails creation for free-plan orgs

### DIFF
--- a/gateway/api/guardrails/guardrails.go
+++ b/gateway/api/guardrails/guardrails.go
@@ -1,17 +1,56 @@
 package apiguardrails
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/license"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/hoophq/hoop/gateway/storagev2"
 )
+
+func getLicenseType(ctx *storagev2.Context) string {
+	licenseType := license.OSSType
+	if ctx.OrgLicenseData != nil && len(*ctx.OrgLicenseData) > 0 {
+		var l license.License
+		if err := json.Unmarshal(*ctx.OrgLicenseData, &l); err == nil {
+			licenseType = l.Payload.Type
+		}
+	}
+	return licenseType
+}
+
+func countRules(ruleMap map[string]any) int {
+	if ruleMap == nil {
+		return 0
+	}
+	rules, ok := ruleMap["rules"]
+	if !ok {
+		return 0
+	}
+	list, ok := rules.([]interface{})
+	if !ok {
+		return 0
+	}
+	return len(list)
+}
+
+func validateOssRulesLimitations(req *openapi.GuardRailRuleRequest) error {
+	if countRules(req.Input) > 1 {
+		return fmt.Errorf("input rules are limited to 1 rule in OSS version")
+	}
+	if countRules(req.Output) > 1 {
+		return fmt.Errorf("output rules are limited to 1 rule in OSS version")
+	}
+	return nil
+}
 
 // CreateGuardRailRules
 //
@@ -29,6 +68,22 @@ func Post(c *gin.Context) {
 	req := parseRequestPayload(c)
 	if req == nil {
 		return
+	}
+
+	if getLicenseType(ctx) == license.OSSType {
+		rules, err := models.ListGuardRailRules(ctx.GetOrgID())
+		if err != nil {
+			httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed listing guardrail rules: %v", err)
+			return
+		}
+		if len(rules) >= 1 {
+			c.JSON(http.StatusForbidden, gin.H{"message": "guardrail rules are limited to 1 rule in OSS version"})
+			return
+		}
+		if err := validateOssRulesLimitations(req); err != nil {
+			c.JSON(http.StatusForbidden, gin.H{"message": err.Error()})
+			return
+		}
 	}
 
 	// Filter out empty connection IDs
@@ -87,6 +142,13 @@ func Put(c *gin.Context) {
 	req := parseRequestPayload(c)
 	if req == nil {
 		return
+	}
+
+	if getLicenseType(ctx) == license.OSSType {
+		if err := validateOssRulesLimitations(req); err != nil {
+			c.JSON(http.StatusForbidden, gin.H{"message": err.Error()})
+			return
+		}
 	}
 
 	// Filter out empty connection IDs

--- a/webapp/src/webapp/events/guardrails.cljs
+++ b/webapp/src/webapp/events/guardrails.cljs
@@ -54,7 +54,6 @@
               convert-preset-rules
               remove-empty-rules)})
 
-;; TODO: Handle errors properly
 (rf/reg-event-fx
  :guardrails->create
  (fn [_ [_ guardrails]]
@@ -70,7 +69,9 @@
                                    (rf/dispatch [:guardrails->get-all])
                                    (rf/dispatch [:navigate :guardrails]))
                      :on-failure (fn [error]
-                                   (println :guardrails->create guardrails error))}]]]})))
+                                   (let [error-message (or (:message error) (str error))]
+                                     (rf/dispatch [:show-snackbar {:level :error
+                                                                   :text error-message}])))}]]]})))
 
 (rf/reg-event-fx
  :guardrails->update-by-id

--- a/webapp/src/webapp/guardrails/create_update_form.cljs
+++ b/webapp/src/webapp/guardrails/create_update_form.cljs
@@ -11,7 +11,7 @@
    [webapp.guardrails.connections-section :as connections-section]
    [webapp.guardrails.rules-table :as rules-table]))
 
-(defn guardrail-form [form-type guardrails scroll-pos]
+(defn guardrail-form [form-type guardrails scroll-pos free-license?]
   (let [state (helpers/create-form-state guardrails)
         handlers (helpers/create-form-handlers state)
         attributes-data (rf/subscribe [:attributes/list-data])]
@@ -81,6 +81,7 @@
              [rules-table/main
               (merge
                {:title "Input rules"
+                :free-license? free-license?
                 :state (:input state)
                 :words-state (:input-words state)
                 :pattern-state (:input-pattern state)
@@ -91,6 +92,7 @@
              [rules-table/main
               (merge
                {:title "Output rules"
+                :free-license? free-license?
                 :state (:output state)
                 :words-state (:output-words state)
                 :pattern-state (:output-pattern state)
@@ -104,6 +106,7 @@
 
 (defn main [form-type]
   (let [guardrails->active-guardrail (rf/subscribe [:guardrails->active-guardrail])
+        user (rf/subscribe [:users->current-user])
         scroll-pos (r/atom 0)]
 
     (rf/dispatch [:attributes/list])
@@ -111,10 +114,9 @@
     (fn []
       (r/with-let [handle-scroll #(reset! scroll-pos (.-scrollY js/window))]
         (.addEventListener js/window "scroll" handle-scroll)
-        
         (if (= :loading (:status @guardrails->active-guardrail))
           [loading]
-          [guardrail-form form-type (:data @guardrails->active-guardrail) scroll-pos])
+          [guardrail-form form-type (:data @guardrails->active-guardrail) scroll-pos (-> @user :data :free-license?)])
 
         (finally
           (.removeEventListener js/window "scroll" handle-scroll)

--- a/webapp/src/webapp/guardrails/create_update_form.cljs
+++ b/webapp/src/webapp/guardrails/create_update_form.cljs
@@ -116,7 +116,10 @@
         (.addEventListener js/window "scroll" handle-scroll)
         (if (= :loading (:status @guardrails->active-guardrail))
           [loading]
-          [guardrail-form form-type (:data @guardrails->active-guardrail) scroll-pos (-> @user :data :free-license?)])
+          [guardrail-form form-type
+           (:data @guardrails->active-guardrail)
+           scroll-pos
+           (-> @user :data :free-license?)])
 
         (finally
           (.removeEventListener js/window "scroll" handle-scroll)

--- a/webapp/src/webapp/guardrails/form_header.cljs
+++ b/webapp/src/webapp/guardrails/form_header.cljs
@@ -1,30 +1,49 @@
 (ns webapp.guardrails.form-header
   (:require
-   ["@radix-ui/themes" :refer [Box Button Flex Heading]]
+   ["@radix-ui/themes" :refer [Box Button Callout Flex Heading Link]]
+   ["lucide-react" :refer [Info]]
    [webapp.components.button :as button]
-   [re-frame.core :as rf]))
+   [re-frame.core :as rf]
+   [webapp.features.promotion :as promotion]))
 
-(defn main [{:keys [form-type id scroll-pos]}]
-  [:<>
-   [:> Flex {:p "5" :gap "2"}
-    [button/HeaderBack]]
-   [:> Box {:class (str "sticky top-0 z-50 bg-gray-1 px-7 py-7 "
-                        (when (>= @scroll-pos 30)
-                          "border-b border-[--gray-a6]"))}
-    [:> Flex {:justify "between"
-              :align "center"}
-     [:> Heading {:as "h2" :size "8"}
-      (if (= :edit form-type)
-        "Configure Guardrail"
-        "Create a new Guardrail")]
-     [:> Flex {:gap "5" :align "center"}
-      (when (= :edit form-type)
-        [:> Button {:size "4"
-                    :variant "ghost"
-                    :color "red"
-                    :type "button"
-                    :on-click #(rf/dispatch [:guardrails->delete-by-id id])}
-         "Delete"])
-      [:> Button {:size "4"
-                  :type "submit"}
-       "Save"]]]]])
+(defn main [_]
+  (let [user (rf/subscribe [:users->current-user])]
+    (fn [{:keys [form-type id scroll-pos]}]
+      (let [free-license? (-> @user :data :free-license?)]
+        [:<>
+         [:> Flex {:p "5" :gap "2"}
+          [button/HeaderBack]]
+         [:> Box {:class (str "sticky top-0 z-50 bg-gray-1 px-7 py-7 "
+                              (when (>= @scroll-pos 30)
+                                "border-b border-[--gray-a6]"))}
+          [:> Flex {:justify "between"
+                    :align "center"}
+           [:> Heading {:as "h2" :size "8"}
+            (if (= :edit form-type)
+              "Configure Guardrail"
+              "Create a new Guardrail")]
+           [:> Flex {:gap "5" :align "center"}
+            (when (= :edit form-type)
+              [:> Button {:size "4"
+                          :variant "ghost"
+                          :color "red"
+                          :type "button"
+                          :on-click #(rf/dispatch [:guardrails->delete-by-id id])}
+               "Delete"])
+            [:> Button {:size "4"
+                        :type "submit"}
+             "Save"]]]]
+
+         (when free-license?
+           [:> Callout.Root {:size "1" :color "blue" :class "mx-7 mt-4" :highContrast true}
+            [:> Callout.Icon
+             [:> Info {:size 16}]]
+            [:> Callout.Text
+             "Organizations with Free plan have limited data protection. Upgrade to Enterprise to have unlimited access to Guardrails. "
+             [:> Link {:href "#"
+                       :class "font-medium"
+                       :style {:color "var(--blue-12)"}
+                       :on-click (fn [e]
+                                   (.preventDefault e)
+                                   (promotion/request-demo))}
+              "Contact our Sales team \u2197"]]])]))))

--- a/webapp/src/webapp/guardrails/main.cljs
+++ b/webapp/src/webapp/guardrails/main.cljs
@@ -1,6 +1,7 @@
 (ns webapp.guardrails.main
   (:require
-   ["@radix-ui/themes" :refer [Box Button Flex Heading Text]]
+   ["@radix-ui/themes" :refer [Box Button Callout Flex Heading Link Text]]
+   ["lucide-react" :refer [AlertCircle]]
    [re-frame.core :as rf]
    [reagent.core :as r]
    [webapp.components.attribute-filter :as attribute-filter]
@@ -14,7 +15,8 @@
         min-loading-done (r/atom false)
         selected-connection (r/atom nil)
         selected-attribute (r/atom nil)
-        connections (rf/subscribe [:connections])]
+        connections (rf/subscribe [:connections])
+        user (rf/subscribe [:users->current-user])]
     (rf/dispatch [:guardrails->get-all])
 
     (js/setTimeout #(reset! min-loading-done true) 1500)
@@ -23,6 +25,8 @@
       (let [loading? (or (= :loading (:status @guardrails-rules-list))
                          (not @min-loading-done))
             all-rules (:data @guardrails-rules-list)
+            free-license? (-> @user :data :free-license?)
+            limit-reached? (and free-license? (>= (count all-rules) 1))
             connections-data @connections
             connections-results (:results connections-data)
             by-connection (if (nil? @selected-connection)
@@ -60,8 +64,23 @@
              (when (seq all-rules)
                [:> Button {:size "3"
                            :variant "solid"
+                           :disabled limit-reached?
                            :on-click #(rf/dispatch [:navigate :create-guardrail])}
                 "Create a new Guardrail"])]]
+
+           (when limit-reached?
+             [:> Callout.Root {:color "red" :class "mb-5"}
+              [:> Callout.Icon
+               [:> AlertCircle {:size 16}]]
+              [:> Callout.Text
+               "Your organization has reached Guardrails free usage limits. Upgrade to Enterprise to keep your sensitive data protected. "
+               [:> Link {:href "#"
+                         :class "font-medium"
+                         :color "red"
+                         :on-click (fn [e]
+                                     (.preventDefault e)
+                                     (promotion/request-demo))}
+                "Contact our Sales team \u2197"]]])
 
            [:> Flex {:mb "6" :gap "2"}
             [resource-role-filter/main {:selected @selected-connection

--- a/webapp/src/webapp/guardrails/rule_buttons.cljs
+++ b/webapp/src/webapp/guardrails/rule_buttons.cljs
@@ -2,12 +2,13 @@
   (:require
    ["@radix-ui/themes" :refer [Button Flex]]))
 
-(defn main [{:keys [on-rule-add on-toggle-select select-state selected? on-toggle-all on-rules-delete]}]
+(defn main [{:keys [on-rule-add on-toggle-select select-state selected? on-toggle-all on-rules-delete disable-new?]}]
   [:> Flex {:gap "2"}
    [:> Button
     {:variant "soft"
      :size "2"
      :type "button"
+     :disabled disable-new?
      :on-click on-rule-add}
     "+ New"]
    [:> Button

--- a/webapp/src/webapp/guardrails/rules_table.cljs
+++ b/webapp/src/webapp/guardrails/rules_table.cljs
@@ -91,6 +91,7 @@
 
 (defn main [{:keys [title
                     state
+                    free-license?
                     select-state
                     words-state
                     pattern-state
@@ -102,7 +103,8 @@
                     on-toggle-select
                     on-toggle-all
                     on-rules-delete]}]
-  (let [selected? (every? :selected @state)]
+  (let [selected? (every? :selected @state)
+        disable-new? (and free-license? (>= (count @state) 1))]
     [:> Box {:class "space-y-radix-5"}
      [:> Text {:size "3" :weight "bold" :class "text-[--gray-12]"}
       title]
@@ -173,6 +175,7 @@
      ;; Action buttons
      [rule-buttons/main
       {:on-rule-add #(on-rule-add state)
+       :disable-new? disable-new?
        :on-toggle-select #(on-toggle-select select-state)
        :select-state select-state
        :selected? selected?


### PR DESCRIPTION
## 📝 Description

Free organizations can now create only one Guardrail total, and within each Guardrail they can add only one input rule and one output rule. 

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added free-plan guardrail list gating in `webapp/src/webapp/guardrails/main.cljs`:
- reads `:users->current-user`, computes `limit-reached?`, disables Create a new Guardrail, and shows red upgrade callout with promotion/request-demo.
- Added free-plan informational callout in `webapp/src/webapp/guardrails/form_header.cljs`.
- Enforced rule-row limits for free orgs:
- `webapp/src/webapp/guardrails/rules_table.cljs`computes `disable-new?` when free plan and one row exists.
-` webapp/src/webapp/guardrails/rule_buttons.cljs` accepts `disable-new?` and disables + New.
- `webapp/src/webapp/guardrails/create_update_form.cljs` passes `free-license?` into input/output rule tables.


## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**:  Chrome
- **OS**: MacOs

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots

<img width="1382" height="949" alt="CleanShot 2026-04-29 at 15 37 10" src="https://github.com/user-attachments/assets/a403a01f-a988-418e-b212-6ffba13b24df" />


<img width="1403" height="801" alt="CleanShot 2026-04-29 at 15 37 36" src="https://github.com/user-attachments/assets/c8ea539f-dd72-4e5e-af35-d2beea40f0ba" />


## ✅ Checklist

- [x] I have run `make generate-openapi-docs` to update the OpenAPI docs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings