### PR TITLE
feat: implement auto-release workflow and PR label validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+> [!IMPORTANT]
+> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
+> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
+> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).
+
 ## 📝 Description
 
 <!-- Please provide a brief description of the changes in this PR -->

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,127 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+# Serialize runs so two PRs merged back-to-back can't both read the same
+# "latest" tag and race on `gh release create`.
+concurrency:
+  group: auto-release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Tag & Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify GH_TOKEN secret is present
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::secrets.GH_TOKEN (PAT) is required so that tag pushes from this workflow trigger release.yml. Add it in repo settings."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve merged PR and bump type
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(gh api "repos/${REPO}/commits/${SHA}/pulls" --jq '.[0]' || echo "")
+          if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+            echo "::warning::No merged PR is associated with commit $SHA (direct push to main?). Skipping release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          LABELS=$(echo "$PR_JSON" | jq -r '.labels[].name')
+
+          if echo "$LABELS" | grep -qx 'skip-release'; then
+            echo "PR #${PR_NUMBER} has 'skip-release' label — no release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BUMP=$(echo "$LABELS" | grep -E '^(major|minor|patch)$' | head -1 || true)
+          if [ -z "$BUMP" ]; then
+            echo "::warning::PR #${PR_NUMBER} has no major/minor/patch/skip-release label — skipping release. (PR Release Label Check should have blocked this merge.)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Merged PR: #${PR_NUMBER} (bump: ${BUMP})"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "bump=${BUMP}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        if: steps.pr.outputs.skip == 'false'
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP: ${{ steps.pr.outputs.bump }}
+        run: |
+          set -euo pipefail
+          # Fetch the last 10 releases and pick the highest valid semver,
+          # not the most recently created. This avoids out-of-order hotfix
+          # releases (e.g. 1.61.1 published after 1.62.0) tricking the bump.
+          LATEST=$(gh release list -L 10 --json tagName --jq '
+            [.[].tagName | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$"))]
+            | sort_by(sub("^v"; "") | split(".") | map(tonumber))
+            | .[-1] // ""
+          ')
+          if [ -z "$LATEST" ]; then
+            LATEST="0.0.0"
+          fi
+
+          CLEAN="${LATEST#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CLEAN"
+          case "$BUMP" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+          NEXT="${MAJOR}.${MINOR}.${PATCH}"
+
+          echo "Highest existing release: ${LATEST} -> Next: ${NEXT} (bump: ${BUMP})"
+          echo "next=${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "previous=${LATEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.pr.outputs.skip == 'false'
+        env:
+          # Use a PAT (GH_TOKEN) instead of GITHUB_TOKEN so that the resulting
+          # tag push triggers the existing release.yml workflow. Tag pushes made
+          # with GITHUB_TOKEN do not fire downstream `on: push: tags` workflows.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NEXT: ${{ steps.version.outputs.next }}
+          PREVIOUS: ${{ steps.version.outputs.previous }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if gh release view "$NEXT" >/dev/null 2>&1; then
+            echo "::error::Release $NEXT already exists. Another run may have created it; investigate before retrying."
+            exit 1
+          fi
+          gh release create "$NEXT" \
+            --title "$NEXT" \
+            --target "$SHA" \
+            --generate-notes \
+            --notes-start-tag "$PREVIOUS"
+          echo "Created release $NEXT (previous: $PREVIOUS) — release.yml will now build and publish artifacts."

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -1,0 +1,34 @@
+name: PR Release Label Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited, ready_for_review]
+
+jobs:
+  check-label:
+    name: Check Release Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify exactly one release label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
+          COUNT=$(echo "$LABELS" | grep -cE '^(major|minor|patch|skip-release)$' || true)
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::PR must have exactly one of these labels: 'major', 'minor', 'patch', or 'skip-release'."
+            echo "::error::Use 'major'/'minor'/'patch' to publish a release on merge, or 'skip-release' for changes that don't need a release (docs, CI, etc)."
+            exit 1
+          fi
+
+          if [ "$COUNT" -gt 1 ]; then
+            FOUND=$(echo "$LABELS" | grep -E '^(major|minor|patch|skip-release)$' | tr '\n' ' ')
+            echo "::error::PR must have exactly ONE release label, but found multiple: $FOUND"
+            exit 1
+          fi
+
+          MATCHED=$(echo "$LABELS" | grep -E '^(major|minor|patch|skip-release)$')
+          echo "Release label found: $MATCHED"

--- a/scripts/setup-release-labels.sh
+++ b/scripts/setup-release-labels.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# One-time setup: create the major/minor/patch labels used by
+# .github/workflows/pr-label-check.yml and .github/workflows/auto-release.yml.
+#
+# Re-running is safe: existing labels are updated in place.
+set -euo pipefail
+
+gh auth status >/dev/null
+
+upsert_label() {
+  local name=$1 color=$2 desc=$3
+  if gh label list --limit 200 --json name --jq '.[].name' | grep -Fxq "$name"; then
+    gh label edit "$name" --color "$color" --description "$desc"
+    echo "updated: $name"
+  else
+    gh label create "$name" --color "$color" --description "$desc"
+    echo " created: $name"
+  fi
+}
+
+upsert_label "major"        "B60205" "Bumps the major version on release (breaking changes)"
+upsert_label "minor"        "0E8A16" "Bumps the minor version on release (new features)"
+upsert_label "patch"        "FBCA04" "Bumps the patch version on release (bug fixes)"
+upsert_label "skip-release" "C5DEF5" "Merges without publishing a release (docs, CI, refactors, etc.)"
+
+echo
+echo "Release labels are ready."


### PR DESCRIPTION
## 📝 Description

Automates the release-tag creation step that engineers currently run by hand. After this change, merging a labeled PR to `main` triggers a GitHub Action that computes the next semver, creates the GitHub Release, and lets the existing `release.yml` build and publish artifacts.

A companion `PR Release Label Check` workflow blocks merges unless exactly one of `major`, `minor`, `patch`, or `skip-release` is applied — so the auto-release job always has an unambiguous bump type.

## 🔄 Engineering Workflow Change

### Before

```
   ┌─────────┐      ┌──────────┐      ┌──────────────────────┐      ┌──────────┐
   │  Open   │ ───> │  Review  │ ───> │  Merge PR to main    │ ───> │  Engineer│
   │   PR    │      │ /Approve │      │                      │      │  runs    │
   └─────────┘      └──────────┘      └──────────────────────┘      │  release │
                                                                     │  scripts │
                                                                     │  by hand │
                                                                     └────┬─────┘
                                                                          │
                                                                          v
                                                                  ┌───────────────┐
                                                                  │ Tag + Release │
                                                                  │   published   │
                                                                  └───────────────┘
```

### After

```
   ┌─────────┐      ┌────────────────┐      ┌──────────┐      ┌─────────────────┐
   │  Open   │ ───> │  Apply label:  │ ───> │  Review  │ ───> │  Merge PR to    │
   │   PR    │      │ major / minor /│      │ /Approve │      │     main        │
   │         │      │ patch / skip   │      │          │      │                 │
   └─────────┘      └───────┬────────┘      └──────────┘      └────────┬────────┘
                            │                                          │
                            │   PR Release Label Check                 │
                            │   blocks merge if missing                │
                            v                                          v
                    ┌───────────────┐                          ┌───────────────────┐
                    │ Merge gated   │                          │  auto-release.yml │
                    │ until labeled │                          │  reads label,     │
                    └───────────────┘                          │  bumps semver,    │
                                                               │  creates release  │
                                                               └─────────┬─────────┘
                                                                         │
                                                                         v
                                                                 ┌───────────────┐
                                                                 │ Tag + Release │
                                                                 │   published   │
                                                                 │  (no human in │
                                                                 │   the loop)   │
                                                                 └───────────────┘
```

## 🚀 Type of Change

- [x] 🔧 Build configuration change

## 📋 Changes Made

- `.github/workflows/auto-release.yml` — on push to `main`, resolves the merged PR, reads its bump label, computes the next semver from the highest existing release, and creates the GitHub Release. Uses a PAT (`secrets.GH_TOKEN`) so the tag push triggers the existing `release.yml`. Concurrency-grouped so back-to-back merges serialize safely.
- `.github/workflows/pr-label-check.yml` — required check that fails unless the PR has exactly one of `major`, `minor`, `patch`, or `skip-release`.
- `.github/PULL_REQUEST_TEMPLATE.md` — adds a note pointing contributors at the release labels.
- `scripts/setup-release-labels.sh` — one-shot helper to create the four labels in the repo.

## 🧪 Testing

- [x] Validated workflow YAML locally (`actionlint` clean).
- [ ] End-to-end verification will happen on first merge — the workflow is idempotent and refuses to overwrite an existing release tag.

## 📄 Additional Notes

- The `skip-release` label is the escape hatch for docs-only / chore PRs that shouldn't cut a release.
- Highest-semver-wins logic (not most-recent) prevents an out-of-order hotfix (e.g. `1.61.1` published after `1.62.0`) from tricking the bump.