### PR TITLE
fix: footer pushed down by large logs output in webclient 

### DIFF
--- a/webapp/src/webapp/webclient/log_area/main.cljs
+++ b/webapp/src/webapp/webclient/log_area/main.cljs
@@ -1,5 +1,6 @@
 (ns webapp.webclient.log-area.main
   (:require ["papaparse" :as papa]
+            ["@radix-ui/themes" :refer [Box]]
             [clojure.string :as cs]
             [re-frame.core :as rf]
             [reagent.core :as r]
@@ -73,23 +74,23 @@
           (.setItem js/localStorage "webclient-selected-tab" (first (vals available-tabs)))
           (reset! selected-tab (first (vals available-tabs))))
 
-        [:div {:class "h-full flex flex-col"}
-         [:div {:class "h-full flex flex-col bg-gray-1 border-b border-gray-3"}
+        [:> Box {:class "flex-1 min-h-0 flex flex-col overflow-hidden"}
+         [:> Box {:class "h-full flex flex-col bg-gray-1 border-b border-gray-3"}
           [tabs {:on-click (fn [_ value]
                              (.setItem js/localStorage "webclient-selected-tab" value)
                              (reset! selected-tab value))
                  :tabs available-tabs
                  :selected-tab @selected-tab}]
-          [:div {:role "tabpanel"
-                 :id (str "tabpanel-" (case @selected-tab
-                                        "Tabular" :tabular
-                                        "Logs" :logs
-                                        :logs))
-                 :aria-labelledby (str "tab-" (case @selected-tab
-                                                "Tabular" :tabular
-                                                "Logs" :logs
-                                                :logs))
-                 :class "h-full"}
+          [:> Box {:role "tabpanel"
+                   :id (str "tabpanel-" (case @selected-tab
+                                          "Tabular" :tabular
+                                          "Logs" :logs
+                                          :logs))
+                   :aria-labelledby (str "tab-" (case @selected-tab
+                                                  "Tabular" :tabular
+                                                  "Logs" :logs
+                                                  :logs))
+                   :class "flex-1 min-h-0 overflow-hidden"}
            (case @selected-tab
              "Tabular" [ag-grid-table/main results-heads results-body tabular-loading? dark-mode?
                         {:height "100%"


### PR DESCRIPTION
## 📝 Description                                                                                                                                        
                                                                                                                                                         
Fix footer being pushed off-screen when the Logs tab contains a large output in the webclient.                                                           
                                                                                                                                                         
## 🔗 Related Issue
                                                                                                                                                         
Fixes ENG-333                                                 

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)                                                                                              
 
## 📋 Changes Made                                                                                                                                       
                                                          
- Changed log-area root div from `h-full` to `flex-1 min-h-0` so it grows to fill available space without overflowing the parent flex container
- Changed tabpanel div from `h-full` to `flex-1 min-h-0` so it consumes only the remaining height after the tabs bar, enabling internal scroll instead of container expansion                

## Screenshots
<img width="1391" height="1070" alt="Screenshot 2026-05-04 at 11 50 05" src="https://github.com/user-attachments/assets/9c03010f-3970-4e61-ac98-0ad26b4f658b" />                                                                                                                    
                                                          
## 🧪 Testing                                                                                                                                            
                                                          
### Tests performed:
- [x] Manual testing completed

Ran a command returning a large output in the webclient. Verified the Logs tab scrolls internally and the footer remains visible at the bottom.

## ✅ Checklist                                                                                                                                          
 
- [x] My code follows the style guidelines of this project                                                                                               
- [x] I have performed a self-review of my own code       
- [x] My changes generate no new warnings