### PR TITLE
fix(rdp): close TLS connection promptly on WebSocket disconnect

### DIFF
--- a/gateway/rdp/irongw.go
+++ b/gateway/rdp/irongw.go
@@ -305,6 +305,12 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 				sessionErrMu.Lock()
 				sessionErr = err
 				sessionErrMu.Unlock()
+				// The outer loop blocks on tlsClient.Read until the agent-side
+				// TLS connection drops on its own, which can take tens of
+				// seconds (or never on a silent disconnect). Close it here so
+				// the outer loop returns immediately and recorder.Close + the
+				// session-ended persistence path run promptly.
+				_ = tlsClient.Close()
 				return
 			}
 
@@ -316,6 +322,7 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 				sessionErrMu.Lock()
 				sessionErr = err
 				sessionErrMu.Unlock()
+				_ = tlsClient.Close()
 				return
 			}
 		}
@@ -344,8 +351,10 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 		}
 	}
 
-	// Close tlsClient to unblock any pending reads/writes
-	tlsClient.Close()
+	// Make sure the TLS connection is torn down (idempotent if the goroutine
+	// already closed it on browser disconnect) so the websocket-reader goroutine
+	// also unblocks and exits.
+	_ = tlsClient.Close()
 
 	// Wait for the websocket read goroutine to finish
 	<-done


### PR DESCRIPTION
## Summary

Fixes the perceived delay between closing the RDP web client and the gateway recognising the session as ended. The defect is in the IronRDP WebSocket gateway path.

## Root cause

`gateway/rdp/irongw.go` runs two concurrent goroutines:

1. **Inner WebSocket reader** (browser → agent): unblocks immediately on TCP FIN when the browser closes the tab.
2. **Outer TLS reader** (agent → browser): keeps blocking on `tlsClient.Read()` because the agent-side TLS connection is still alive — the agent has no way to know the browser left.

`recorder.Close()` (which writes `status=done`, `ended_at`, and enqueues async PII analysis) only runs from the `defer` after **both** goroutines exit. So the user-visible delay equals however long the agent-side TLS connection takes to also notice and drop — typically tens of seconds, indefinitely on silent disconnects (laptop sleep, network blackhole).

## Fix

Close `tlsClient` from the WebSocket reader goroutine on every exit path so the outer TLS reader unblocks promptly:

```go
go func() {
    defer close(done)
    for {
        _, msg, err := ws.ReadMessage()
        if err != nil {
            sessionErr = err
            _ = tlsClient.Close()  // <-- new: unblocks the outer loop
            return
        }
        // ...
    }
}()
```

The existing `tlsClient.Close()` at the end of `handle()` is preserved as an idempotent safety net for the reverse case (agent-side TLS drops first).

## Effect

- `recorder.Close()` and `models.UpdateSessionEventStream(status=done)` fire within the same tick the browser disconnect is detected.
- PII analysis enqueue happens promptly so the worker pool starts much sooner.
- Session list / audit views show the correct `done` status without minutes of lag.

## Verification

- `go build ./...` clean across all five modules.
- `go vet ./...` clean.
- The change is purely about *when* `tlsClient.Close()` is called — the close itself was already happening downstream, so no new failure modes are introduced. Closing an already-closed `*tls.Conn` is a no-op error that we discard with `_ =`.

## Out of scope

- WebSocket ping/pong for silent-disconnect detection (separate ticket; today both sides rely on OS TCP keepalive ~2h).
- The `PollingUserToken` goroutine leak in `transport/auth.go` (calls pass `context.Background()`; goroutines outlive their session). Tracked separately.
- Native RDP TCP path (`rdp.go`) has a similar asymmetry between `ForwardToAgent` and `ForwardToClient`; not addressed here.
- PII analysis UI status visibility (separate PR coming).

Automated by MisterMal

 🤖 Generated with Mister Maluco

Co-Authored-By: MisterMal <teskeslab@lucasteske.dev>