### PR TITLE
feat: add hoop claude configure command to apply native connection credentials to Claude Code settings

### DIFF
--- a/client/cmd/claude.go
+++ b/client/cmd/claude.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/hoophq/hoop/client/cmd/styles"
+	clientconfig "github.com/hoophq/hoop/client/config"
+	"github.com/hoophq/hoop/common/httpclient"
+	"github.com/hoophq/hoop/common/version"
+	"github.com/spf13/cobra"
+)
+
+var claudeSettingsFile string
+
+var claudeCmd = &cobra.Command{
+	Use:   "claude",
+	Short: "Manage Claude Code integration",
+}
+
+var claudeConfigureCmd = &cobra.Command{
+	Use:   "configure CONNECTION",
+	Short: "Apply active native connection credentials to ~/.claude/settings.json",
+	Long: `Reads the current active credentials for a claude-code connection and writes
+them to ~/.claude/settings.json. The connection must already be open via the
+webapp or 'hoop connect' — this command does not create a new session.`,
+	Example: `hoop claude configure my-claude-conn
+hoop claude configure my-claude-conn --file /custom/path/settings.json`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		runClaudeConfigure(args[0])
+	},
+}
+
+func init() {
+	claudeConfigureCmd.Flags().StringVarP(&claudeSettingsFile, "file", "f", "", "Path to Claude settings file (default: ~/.claude/settings.json)")
+	claudeCmd.AddCommand(claudeConfigureCmd)
+}
+
+func runClaudeConfigure(connectionName string) {
+	config := clientconfig.GetClientConfigOrDie()
+
+	creds, err := fetchActiveConnectionCredentials(config, connectionName)
+	if err != nil {
+		printErrorAndExit("%s", err.Error())
+	}
+
+	scheme := "http"
+	baseURL := fmt.Sprintf("%s://%s:%s", scheme, creds.Hostname, creds.Port)
+	proxyToken := creds.ProxyToken
+
+	if err := updateClaudeSettings(baseURL, proxyToken, claudeSettingsFile); err != nil {
+		printErrorAndExit("failed to update Claude settings: %s", err.Error())
+	}
+
+	path, _ := claudeSettingsFilePath(claudeSettingsFile)
+	printClaudeConfigureSuccess(path, connectionName, baseURL, proxyToken)
+}
+
+func printClaudeConfigureSuccess(settingsPath, connectionName, baseURL, token string) {
+	labelStyle := lipgloss.NewStyle().Faint(true).Width(14)
+	valueStyle := lipgloss.NewStyle()
+	successStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10"))
+
+	// truncate token for display
+	displayToken := token
+	if len(token) > 24 {
+		displayToken = token[:24] + "..."
+	}
+
+	fmt.Println()
+	fmt.Printf("  %s %s\n", successStyle.Render("✓"), styles.Fainted(settingsPath+" updated"))
+	fmt.Println()
+	fmt.Printf("  %s%s\n", labelStyle.Render("Connection"), valueStyle.Render(connectionName))
+	fmt.Printf("  %s%s\n", labelStyle.Render("Base URL"), valueStyle.Render(baseURL))
+	fmt.Printf("  %s%s\n", labelStyle.Render("Token"), valueStyle.Render(displayToken))
+	fmt.Println()
+	fmt.Println(styles.Fainted("  Claude Code requests are now routed through hoop."))
+	fmt.Println(styles.Fainted("  Run " + strings.TrimSpace(styles.Keyword(" claude ")) + styles.Fainted(" to start.")))
+	fmt.Println()
+}
+
+type activeCredentials struct {
+	Hostname   string `json:"hostname"`
+	Port       string `json:"port"`
+	ProxyToken string `json:"proxy_token"`
+}
+
+type credentialsEnvelope struct {
+	ConnectionCredentials activeCredentials `json:"connection_credentials"`
+}
+
+func fetchActiveConnectionCredentials(config *clientconfig.Config, connectionName string) (*activeCredentials, error) {
+	url := fmt.Sprintf("%s/api/connections/%s/credentials", config.ApiURL, connectionName)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", config.Token))
+	if config.IsApiKey() {
+		req.Header.Set("Api-Key", config.Token)
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("hoopcli/%v", version.Get().Version))
+
+	resp, err := httpclient.NewHttpClient(config.TlsCA()).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed performing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		respBody, _ := io.ReadAll(resp.Body)
+		var body struct {
+			Message string `json:"message"`
+		}
+		if jsonErr := json.Unmarshal(respBody, &body); jsonErr == nil && body.Message != "" {
+			return nil, fmt.Errorf("%s", body.Message)
+		}
+		return nil, fmt.Errorf("no active credentials found for %q; open a native connection first", connectionName)
+	}
+
+	if resp.StatusCode != 200 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("request failed (status=%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var envelope credentialsEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("failed decoding response: %w", err)
+	}
+
+	creds := &envelope.ConnectionCredentials
+	if creds.Hostname == "" || creds.Port == "" {
+		return nil, fmt.Errorf("connection %q is not of type claude-code or the proxy server is not configured", connectionName)
+	}
+
+	return creds, nil
+}

--- a/client/cmd/claudesettings.go
+++ b/client/cmd/claudesettings.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const claudeSettingsPath = ".claude/settings.json"
+
+func claudeSettingsFilePath(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not resolve home directory: %w", err)
+	}
+	return filepath.Join(home, claudeSettingsPath), nil
+}
+
+// updateClaudeSettings merges ANTHROPIC_BASE_URL (and optionally ANTHROPIC_CUSTOM_HEADERS)
+// into ~/.claude/settings.json, preserving all other existing keys.
+// If proxyToken is empty, ANTHROPIC_CUSTOM_HEADERS is removed from the env section.
+func updateClaudeSettings(baseURL, proxyToken, settingsFile string) error {
+	path, err := claudeSettingsFilePath(settingsFile)
+	if err != nil {
+		return err
+	}
+
+	settings := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil {
+		if jsonErr := json.Unmarshal(data, &settings); jsonErr != nil {
+			return fmt.Errorf("could not parse %s: %w", path, jsonErr)
+		}
+	}
+
+	env, _ := settings["env"].(map[string]any)
+	if env == nil {
+		env = map[string]any{}
+	}
+	env["ANTHROPIC_BASE_URL"] = baseURL
+	if proxyToken != "" {
+		env["ANTHROPIC_CUSTOM_HEADERS"] = "Authorization: " + proxyToken
+	} else {
+		delete(env, "ANTHROPIC_CUSTOM_HEADERS")
+	}
+	settings["env"] = env
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("could not create directory for %s: %w", path, err)
+	}
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(out, '\n'), 0600)
+}

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -55,6 +55,7 @@ func init() {
 	rootCmd.AddCommand(runbooks.MainCmd)
 	rootCmd.AddCommand(config.MainCmd)
 	rootCmd.AddCommand(admin.MainCmd)
+	rootCmd.AddCommand(claudeCmd)
 }
 
 func printErrorAndExit(format string, v ...any) {

--- a/gateway/api/connections/connection_credentials.go
+++ b/gateway/api/connections/connection_credentials.go
@@ -563,6 +563,72 @@ func CloseConnectionCredentials(c *gin.Context) {
 	c.Status(204)
 }
 
+// GetConnectionCredentials
+//
+//	@Summary		Get Active Connection Credentials
+//	@Description	Returns the current active, non-expired credentials for the authenticated user on the given connection without creating a new session. Returns 404 if no active credentials exist or they have expired.
+//	@Tags			Connections
+//	@Produce		json
+//	@Param			nameOrID	path		string									true	"Name or UUID of the connection"
+//	@Success		200			{object}	openapi.ConnectionCredentialsResponse
+//	@Failure		404			{object}	openapi.HTTPError
+//	@Failure		400,500		{object}	openapi.HTTPError
+//	@Router			/connections/{nameOrID}/credentials [get]
+func GetConnectionCredentials(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	connNameOrID := c.Param("nameOrID")
+
+	conn, err := models.GetConnectionByNameOrID(ctx, connNameOrID)
+	if err != nil {
+		c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})
+		return
+	}
+	if conn == nil {
+		c.AbortWithStatusJSON(404, gin.H{"message": fmt.Sprintf("connection %s not found", connNameOrID)})
+		return
+	}
+
+	serverConf, err := models.GetServerMiscConfig()
+	if err != nil && err != models.ErrNotFound {
+		c.AbortWithStatusJSON(500, gin.H{"message": fmt.Sprintf("failed to retrieve server config, err=%v", err)})
+		return
+	}
+
+	cred, err := models.GetActiveCredentialByUserAndConnection(ctx.OrgID, ctx.UserID, conn.Name)
+	if err == models.ErrNotFound {
+		c.AbortWithStatusJSON(404, gin.H{"message": "no active credentials found for this connection; open a native connection first"})
+		return
+	}
+	if err != nil {
+		c.AbortWithStatusJSON(500, gin.H{"message": fmt.Sprintf("failed to retrieve credentials: %v", err)})
+		return
+	}
+
+	if time.Now().UTC().After(cred.ExpireAt) {
+		c.AbortWithStatusJSON(404, gin.H{"message": "credentials have expired; open a new native connection"})
+		return
+	}
+
+	if len(cred.EncryptedSecretKey) == 0 {
+		c.AbortWithStatusJSON(404, gin.H{"message": "no credentials available for this connection"})
+		return
+	}
+
+	plaintext, err := models.DecryptCredentialSecretKey(cred.EncryptedSecretKey)
+	if err != nil {
+		c.AbortWithStatusJSON(500, gin.H{"message": "failed to recover credential secret key"})
+		return
+	}
+
+	resp := buildConnectionCredentialsResponse(cred, conn, serverConf, plaintext, false, "")
+	if resp == nil {
+		c.AbortWithStatusJSON(400, gin.H{"message": "connection type not supported for credential retrieval"})
+		return
+	}
+
+	c.JSON(200, resp)
+}
+
 type handlerError struct {
 	status  int
 	message string

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -396,6 +396,10 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		apiroutes.ReadOnlyAccessRole,
 		r.AuthMiddleware,
 		apiconnections.TestConnection)
+	r.GET("/connections/:nameOrID/credentials",
+		r.AuthMiddleware,
+		apiconnections.GetConnectionCredentials,
+	)
 	r.POST("/connections/:nameOrID/credentials",
 		r.AuthMiddleware,
 		apiconnections.CreateConnectionCredentials,

--- a/webapp/src/webapp/connections/native_client_access/custom_credential_views.cljs
+++ b/webapp/src/webapp/connections/native_client_access/custom_credential_views.cljs
@@ -19,7 +19,7 @@
 
 (defn claude-code-credentials-fields
   "Claude Code specific credentials fields"
-  [{:keys [connection_credentials]}]
+  [{:keys [connection_credentials connection_name]}]
   (let [hostname (:hostname connection_credentials)
         port (:port connection_credentials)
         proxy-token (:proxy_token connection_credentials)
@@ -38,7 +38,6 @@
        :log-id "anthropic-settings-json"
        :log-content "~/.claude/settings.json"}]
 
-
      ;; Anthropic API Key
      [block-with-heading-and-text
       {:heading "If the file or folder doesn’t exist"
@@ -46,13 +45,12 @@
        :log-id "create-anthropic-settings-folder"
        :log-content "mkdir -p ~/.claude && touch ~/.claude/settings.json"}]
 
-
      [:> Box {:class "space-y-2"}
       [:> Box
        [:> Heading {:as "h3" :size "4" :weight "bold" :class "text-[--gray-12]"}
         "Add the following configuration"]
        [:> Text {:size "2" :weight "regular" :class "text-[--gray-11]"}
-        "Modify the following values accordingly. If you have more settings, you can leave then, you only need to modify "
+        "Modify the following values accordingly. If you have more settings, you can leave them, you only need to modify "
         [:> Text {:as "span" :size "2" :weight "bold" :class "text-[--gray-11]"}
          "ANTHROPIC_BASE_URL"]
         " and "
@@ -64,7 +62,15 @@
         :id "anthropic-authorization-header"
         :logs [:pre (js/JSON.stringify (clj->js (build-json-content
                                                  base-url
-                                                 custom-headers)) nil 2)]}]]
+                                                 custom-headers)) nil 2)]}]
+      [:> Box {:class "pt-1"}
+       [:> Text {:size "2" :weight "regular" :class "text-[--gray-11]"}
+        "Or run this command to apply automatically:"]
+       [:> Box {:class "mt-2"}
+        [logs/new-container
+         {:status :success
+          :id "claude-code-cli-configure"
+          :logs (str "hoop claude configure " connection_name)}]]]]
 
      [:> Box {:class "space-y-2"}
       [:> Box

--- a/webapp/src/webapp/webclient/log_area/main.cljs
+++ b/webapp/src/webapp/webclient/log_area/main.cljs
@@ -1,5 +1,6 @@
 (ns webapp.webclient.log-area.main
   (:require ["papaparse" :as papa]
+            ["@radix-ui/themes" :refer [Box]]
             [clojure.string :as cs]
             [re-frame.core :as rf]
             [reagent.core :as r]
@@ -73,23 +74,23 @@
           (.setItem js/localStorage "webclient-selected-tab" (first (vals available-tabs)))
           (reset! selected-tab (first (vals available-tabs))))
 
-        [:div {:class "h-full flex flex-col"}
-         [:div {:class "h-full flex flex-col bg-gray-1 border-b border-gray-3"}
+        [:> Box {:class "flex-1 min-h-0 flex flex-col overflow-hidden"}
+         [:> Box {:class "h-full flex flex-col bg-gray-1 border-b border-gray-3"}
           [tabs {:on-click (fn [_ value]
                              (.setItem js/localStorage "webclient-selected-tab" value)
                              (reset! selected-tab value))
                  :tabs available-tabs
                  :selected-tab @selected-tab}]
-          [:div {:role "tabpanel"
-                 :id (str "tabpanel-" (case @selected-tab
-                                        "Tabular" :tabular
-                                        "Logs" :logs
-                                        :logs))
-                 :aria-labelledby (str "tab-" (case @selected-tab
-                                                "Tabular" :tabular
-                                                "Logs" :logs
-                                                :logs))
-                 :class "h-full"}
+          [:> Box {:role "tabpanel"
+                   :id (str "tabpanel-" (case @selected-tab
+                                          "Tabular" :tabular
+                                          "Logs" :logs
+                                          :logs))
+                   :aria-labelledby (str "tab-" (case @selected-tab
+                                                  "Tabular" :tabular
+                                                  "Logs" :logs
+                                                  :logs))
+                   :class "flex-1 min-h-0 overflow-hidden"}
            (case @selected-tab
              "Tabular" [ag-grid-table/main results-heads results-body tabular-loading? dark-mode?
                         {:height "100%"


### PR DESCRIPTION
## 📝 Description                                         
                                                                                                                                                         
Adds a `hoop claude configure` CLI command that writes active native connection credentials to `~/.claude/settings.json`, removing the need to manually copy-paste `ANTHROPIC_BASE_URL` and `ANTHROPIC_CUSTOM_HEADERS` from the webapp.
                                                                                                                                                         
Also adds a `GET /api/connections/:nameOrID/credentials` endpoint that returns existing valid credentials without creating a new session, and updates the native connection credentials screen to surface the CLI command inline.
                                                                                                                                                         
## 🔗 Related Issue                                                                                                                                      
 
Fixes #                                                                                                                                                  
                                                          
## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)                                                                                      
 
## 📋 Changes Made                                                                                                                                       
                                                          
- **`client/cmd/claude.go`** — new `hoop claude configure <connection>` command; reads active credentials via REST and writes `~/.claude/settings.json`, 
with a polished terminal output using lipgloss
- **`client/cmd/claudesettings.go`** — shared helper that merges `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS` into `~/.claude/settings.json` while  
preserving all other existing keys                                                                                                                       
- **`gateway/api/connections/connection_credentials.go`** — new `GET /connections/:nameOrID/credentials` handler that returns the current active, 
non-expired credential for the authenticated user without creating a new session (returns 404 if none exists or expired)                                 
- **`gateway/api/server.go`** — registers the new GET route
- **`webapp/.../custom_credential_views.cljs`** — adds `hoop claude configure <connection>` in a code block under the "Add the following configuration"  
section with the label "Or run this command to apply automatically:"                                                                                     
 
## 🧪 Testing                                                                                                                                            
                                                          
### Tests performed:
- [x] Manual testing completed
                                                                                                                                                         
**No active session:**
```                                                                                                                                                      
$ hoop claude configure my-claude-conn                                                                                                                   
no active credentials found for this connection; open a native connection first
```                                                                                                                                                      
                                                          
**Active session:**                                                                                                                                      
```                                                       
$ hoop claude configure my-claude-conn

  ✓ ~/.claude/settings.json updated
                                                                                                                                                         
  Connection    my-claude-conn
  Base URL      http://gateway.example.com:18888                                                                                                         
  Token         claude-code_xK9mP2...                                                                                                                    
                                                                                                                                                         
  Claude Code requests are now routed through hoop.                                                                                                      
  Run  claude  to start.                                                                                                                                 
```                                                                                                                                                      
                                                                                                                                                         
- `~/.claude/settings.json` with existing keys (e.g. `theme`) → other keys are preserved after update                                                    
- Expired credentials → returns 404 with clear message                                                                                                   
                                                                                                                                                         
## ✅ Checklist                                                                                                                                          
                                                                                                                                                         
- [x] I have run `make generate-openapi-docs` to update the OpenAPI docs
- [x] My code follows the style guidelines of this project                                                                                               
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings