### PR TITLE
fix: hoop create connection not firing

### DIFF
--- a/gateway/analytics/segment.go
+++ b/gateway/analytics/segment.go
@@ -323,3 +323,68 @@ func (s *Segment) TrackSessionUsageData(eventName string, orgID string, userID s
 
 	s.Track(userID, eventName, props)
 }
+
+// CreateConnectionEvent is the canonical input for the hoop-create-connection
+// analytics event. Different connection-creation paths fill different subsets of
+// these fields — empty/zero fields are omitted from the emitted properties.
+type CreateConnectionEvent struct {
+	// Always required
+	OrgID   string
+	Source  string // e.g. "connections-api", "resources-api", "mcp", "aws-rds-provisioner", "agent-autoregister"
+	Type    string
+	SubType string
+	Command []string // first token used as the "command" property; empty -> ""
+
+	// User-attributed paths set UserID. System paths leave it empty and the
+	// event is emitted via TrackEvent (UserId="Gateway") instead.
+	UserID      string
+	LicenseType string
+
+	// System / agent-bound metadata. Optional.
+	AgentID   string
+	ManagedBy string
+
+	// HTTP-context metadata. APIHostname acts as the gating signal — if set,
+	// the HTTP triple (content-length, user-agent, api-hostname) is included.
+	ContentLength int64
+	UserAgent     string
+	APIHostname   string
+}
+
+// TrackCreateConnection emits hoop-create-connection with a consistent property
+// shape across every connection-creation path. If evt.UserID is empty the event
+// is emitted as a system event (UserId="Gateway") so dashboards can distinguish
+// user-initiated from background-job creations via the "source" property.
+func (s *Segment) TrackCreateConnection(evt CreateConnectionEvent) {
+	properties := map[string]any{
+		"org-id":      evt.OrgID,
+		"auth-method": appconfig.Get().AuthMethod(),
+		"source":      evt.Source,
+		"type":        evt.Type,
+		"subtype":     evt.SubType,
+		"command":     "",
+	}
+	if len(evt.Command) > 0 {
+		properties["command"] = evt.Command[0]
+	}
+	if evt.LicenseType != "" {
+		properties["license-type"] = evt.LicenseType
+	}
+	if evt.AgentID != "" {
+		properties["agent-id"] = evt.AgentID
+	}
+	if evt.ManagedBy != "" {
+		properties["managed-by"] = evt.ManagedBy
+	}
+	if evt.APIHostname != "" {
+		properties["content-length"] = evt.ContentLength
+		properties["user-agent"] = evt.UserAgent
+		properties["api-hostname"] = evt.APIHostname
+	}
+
+	if evt.UserID == "" {
+		s.TrackEvent(EventCreateConnection, properties)
+		return
+	}
+	s.Track(evt.UserID, EventCreateConnection, properties)
+}

--- a/gateway/api/integrations/aws/provisioner.go
+++ b/gateway/api/integrations/aws/provisioner.go
@@ -349,33 +349,21 @@ func (p *provisioner) handleConnectionProvision(req pbsystem.DBProvisionerReques
 		return err
 	}
 
-	for _, conn := range newConnections {
-		trackCreateConnection(p.orgID, p.apiRequest.AgentID, conn)
+	if len(newConnections) > 0 {
+		trackClient := analytics.New()
+		defer trackClient.Close()
+		for _, conn := range newConnections {
+			trackClient.TrackCreateConnection(analytics.CreateConnectionEvent{
+				OrgID:   p.orgID,
+				Source:  "aws-rds-provisioner",
+				AgentID: p.apiRequest.AgentID,
+				Type:    conn.Type,
+				SubType: conn.SubType.String,
+				Command: conn.Command,
+			})
+		}
 	}
 	return nil
-}
-
-// trackCreateConnection emits the hoop-create-connection analytics event for
-// connections born from the AWS RDS provisioner. The provisioner runs in a
-// background goroutine after the originating HTTP request has returned, so
-// there is no user context — we use the system "Gateway" track helper.
-func trackCreateConnection(orgID, agentID string, conn *models.Connection) {
-	properties := map[string]any{
-		"org-id":      orgID,
-		"agent-id":    agentID,
-		"auth-method": appconfig.Get().AuthMethod(),
-		"type":        conn.Type,
-		"subtype":     conn.SubType.String,
-		"command":     "",
-		"source":      "aws-rds-provisioner",
-	}
-	if len(conn.Command) > 0 {
-		properties["command"] = conn.Command[0]
-	}
-
-	trackClient := analytics.New()
-	defer trackClient.Close()
-	trackClient.TrackEvent(analytics.EventCreateConnection, properties)
 }
 
 func (p *provisioner) Cancel() { p.cancelFn() }

--- a/gateway/api/integrations/aws/provisioner.go
+++ b/gateway/api/integrations/aws/provisioner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	pbsystem "github.com/hoophq/hoop/common/proto/system"
 	"github.com/hoophq/hoop/common/runbooks"
+	"github.com/hoophq/hoop/gateway/analytics"
 	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	apirunbooks "github.com/hoophq/hoop/gateway/api/runbooks"
@@ -326,10 +327,55 @@ func (p *provisioner) handleConnectionProvision(req pbsystem.DBProvisionerReques
 		})
 	}
 
+	// Resolve which connections are new (vs. updates) inside the same
+	// transaction as the upsert so a concurrent writer cannot make us
+	// double-fire (or miss) the hoop-create-connection event.
+	var newConnections []*models.Connection
 	sess := &gorm.Session{FullSaveAssociations: true}
-	return models.DB.Session(sess).Transaction(func(tx *gorm.DB) error {
+	if err := models.DB.Session(sess).Transaction(func(tx *gorm.DB) error {
+		for _, conn := range connections {
+			var count int64
+			if err := tx.Table("private.connections").
+				Where("org_id = ? AND name = ?", conn.OrgID, conn.Name).
+				Count(&count).Error; err != nil {
+				return fmt.Errorf("failed checking existing connection %v, reason=%v", conn.Name, err)
+			}
+			if count == 0 {
+				newConnections = append(newConnections, conn)
+			}
+		}
 		return models.UpsertBatchConnections(tx, connections)
-	})
+	}); err != nil {
+		return err
+	}
+
+	for _, conn := range newConnections {
+		trackCreateConnection(p.orgID, p.apiRequest.AgentID, conn)
+	}
+	return nil
+}
+
+// trackCreateConnection emits the hoop-create-connection analytics event for
+// connections born from the AWS RDS provisioner. The provisioner runs in a
+// background goroutine after the originating HTTP request has returned, so
+// there is no user context — we use the system "Gateway" track helper.
+func trackCreateConnection(orgID, agentID string, conn *models.Connection) {
+	properties := map[string]any{
+		"org-id":      orgID,
+		"agent-id":    agentID,
+		"auth-method": appconfig.Get().AuthMethod(),
+		"type":        conn.Type,
+		"subtype":     conn.SubType.String,
+		"command":     "",
+		"source":      "aws-rds-provisioner",
+	}
+	if len(conn.Command) > 0 {
+		properties["command"] = conn.Command[0]
+	}
+
+	trackClient := analytics.New()
+	defer trackClient.Close()
+	trackClient.TrackEvent(analytics.EventCreateConnection, properties)
 }
 
 func (p *provisioner) Cancel() { p.cancelFn() }

--- a/gateway/api/mcpserver/tools_connections.go
+++ b/gateway/api/mcpserver/tools_connections.go
@@ -8,10 +8,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hoophq/hoop/gateway/analytics"
-	"github.com/hoophq/hoop/gateway/appconfig"
 	apivalidation "github.com/hoophq/hoop/gateway/api/validation"
 	"github.com/hoophq/hoop/gateway/models"
-	"github.com/hoophq/hoop/gateway/storagev2"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -192,35 +190,21 @@ func connectionsCreateHandler(ctx context.Context, _ *mcp.CallToolRequest, args 
 		return nil, nil, fmt.Errorf("failed creating connection: %w", err)
 	}
 
-	trackCreateConnection(sc, conn)
+	if sc.UserEmail != "" && sc.OrgID != "" {
+		trackClient := analytics.New()
+		defer trackClient.Close()
+		trackClient.TrackCreateConnection(analytics.CreateConnectionEvent{
+			OrgID:       sc.OrgID,
+			UserID:      sc.UserID,
+			Source:      "mcp",
+			LicenseType: sc.GetLicenseType(),
+			Type:        conn.Type,
+			SubType:     conn.SubType.String,
+			Command:     conn.Command,
+		})
+	}
 
 	return jsonResult(connectionToMap(resp, false))
-}
-
-// trackCreateConnection emits the hoop-create-connection analytics event for
-// connections created via the MCP connections_create tool. The MCP route does
-// not run the api.TrackRequest middleware, so we emit explicitly here.
-func trackCreateConnection(sc *storagev2.Context, conn *models.Connection) {
-	if sc.UserEmail == "" || sc.OrgID == "" {
-		return
-	}
-
-	properties := map[string]any{
-		"org-id":       sc.OrgID,
-		"auth-method":  appconfig.Get().AuthMethod(),
-		"license-type": sc.GetLicenseType(),
-		"type":         conn.Type,
-		"subtype":      conn.SubType.String,
-		"command":      "",
-		"source":       "mcp",
-	}
-	if len(conn.Command) > 0 {
-		properties["command"] = conn.Command[0]
-	}
-
-	trackClient := analytics.New()
-	defer trackClient.Close()
-	trackClient.Track(sc.UserID, analytics.EventCreateConnection, properties)
 }
 
 func connectionsUpdateHandler(ctx context.Context, _ *mcp.CallToolRequest, args connectionsUpdateInput) (*mcp.CallToolResult, any, error) {

--- a/gateway/api/mcpserver/tools_connections.go
+++ b/gateway/api/mcpserver/tools_connections.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/hoophq/hoop/gateway/analytics"
+	"github.com/hoophq/hoop/gateway/appconfig"
 	apivalidation "github.com/hoophq/hoop/gateway/api/validation"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -189,7 +192,35 @@ func connectionsCreateHandler(ctx context.Context, _ *mcp.CallToolRequest, args 
 		return nil, nil, fmt.Errorf("failed creating connection: %w", err)
 	}
 
+	trackCreateConnection(sc, conn)
+
 	return jsonResult(connectionToMap(resp, false))
+}
+
+// trackCreateConnection emits the hoop-create-connection analytics event for
+// connections created via the MCP connections_create tool. The MCP route does
+// not run the api.TrackRequest middleware, so we emit explicitly here.
+func trackCreateConnection(sc *storagev2.Context, conn *models.Connection) {
+	if sc.UserEmail == "" || sc.OrgID == "" {
+		return
+	}
+
+	properties := map[string]any{
+		"org-id":       sc.OrgID,
+		"auth-method":  appconfig.Get().AuthMethod(),
+		"license-type": sc.GetLicenseType(),
+		"type":         conn.Type,
+		"subtype":      conn.SubType.String,
+		"command":      "",
+		"source":       "mcp",
+	}
+	if len(conn.Command) > 0 {
+		properties["command"] = conn.Command[0]
+	}
+
+	trackClient := analytics.New()
+	defer trackClient.Close()
+	trackClient.Track(sc.UserID, analytics.EventCreateConnection, properties)
 }
 
 func connectionsUpdateHandler(ctx context.Context, _ *mcp.CallToolRequest, args connectionsUpdateInput) (*mcp.CallToolResult, any, error) {

--- a/gateway/api/middleware.go
+++ b/gateway/api/middleware.go
@@ -44,6 +44,9 @@ func (a *Api) TrackRequest(eventName string) func(c *gin.Context) {
 				properties["mode"] = fmt.Sprintf("%v", agentMode)
 			}
 		case analytics.EventUpdateConnection, analytics.EventCreateConnection:
+			if eventName == analytics.EventCreateConnection {
+				properties["source"] = "connections-api"
+			}
 			requestBody, _ := io.ReadAll(c.Request.Body)
 			data := getBodyAsMap(requestBody)
 			reCopyBody(requestBody, c)

--- a/gateway/api/resources/resources.go
+++ b/gateway/api/resources/resources.go
@@ -208,6 +208,7 @@ func trackCreateConnection(c *gin.Context, ctx *storagev2.Context, req openapi.R
 		"type":           req.Type,
 		"subtype":        req.SubType,
 		"command":        "",
+		"source":         "resources-api",
 	}
 	if len(connections[0].Command) > 0 {
 		properties["command"] = connections[0].Command[0]

--- a/gateway/api/resources/resources.go
+++ b/gateway/api/resources/resources.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	apivalidation "github.com/hoophq/hoop/gateway/api/validation"
-	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/audit"
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/hoophq/hoop/gateway/storagev2"
@@ -181,42 +180,24 @@ func CreateResource(c *gin.Context) {
 		return
 	}
 
-	if len(connections) > 0 {
-		trackCreateConnection(c, ctx, req, connections)
+	if len(connections) > 0 && ctx.UserEmail != "" && ctx.OrgID != "" {
+		trackClient := analytics.New()
+		defer trackClient.Close()
+		trackClient.TrackCreateConnection(analytics.CreateConnectionEvent{
+			OrgID:         ctx.OrgID,
+			UserID:        ctx.UserID,
+			Source:        "resources-api",
+			LicenseType:   ctx.GetLicenseType(),
+			Type:          req.Type,
+			SubType:       req.SubType,
+			Command:       connections[0].Command,
+			ContentLength: c.Request.ContentLength,
+			UserAgent:     apiutils.NormalizeUserAgent(c.Request.Header.Values),
+			APIHostname:   c.Request.Host,
+		})
 	}
 
 	c.JSON(http.StatusCreated, toOpenApi(&resource))
-}
-
-// trackCreateConnection emits the hoop-create-connection analytics event for
-// connections born from a resource creation. The /resources route does not run
-// the api.TrackRequest middleware (which is wired only on POST /connections),
-// so we emit explicitly here to keep the funnel accurate. Property shape mirrors
-// the middleware's EventCreateConnection branch.
-func trackCreateConnection(c *gin.Context, ctx *storagev2.Context, req openapi.ResourceRequest, connections []*models.Connection) {
-	if ctx.UserEmail == "" || ctx.OrgID == "" || len(connections) == 0 {
-		return
-	}
-
-	properties := map[string]any{
-		"org-id":         ctx.OrgID,
-		"auth-method":    appconfig.Get().AuthMethod(),
-		"license-type":   ctx.GetLicenseType(),
-		"content-length": c.Request.ContentLength,
-		"user-agent":     apiutils.NormalizeUserAgent(c.Request.Header.Values),
-		"api-hostname":   c.Request.Host,
-		"type":           req.Type,
-		"subtype":        req.SubType,
-		"command":        "",
-		"source":         "resources-api",
-	}
-	if len(connections[0].Command) > 0 {
-		properties["command"] = connections[0].Command[0]
-	}
-
-	trackClient := analytics.New()
-	defer trackClient.Close()
-	trackClient.Track(ctx.UserID, analytics.EventCreateConnection, properties)
 }
 
 func validateListOptions(urlValues url.Values) (o models.ResourceFilterOption, err error) {

--- a/gateway/api/resources/resources.go
+++ b/gateway/api/resources/resources.go
@@ -7,11 +7,14 @@ import (
 	"net/url"
 
 	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/common/apiutils"
 	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/gateway/analytics"
 	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	apivalidation "github.com/hoophq/hoop/gateway/api/validation"
+	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/audit"
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/hoophq/hoop/gateway/storagev2"
@@ -178,7 +181,41 @@ func CreateResource(c *gin.Context) {
 		return
 	}
 
+	if len(connections) > 0 {
+		trackCreateConnection(c, ctx, req, connections)
+	}
+
 	c.JSON(http.StatusCreated, toOpenApi(&resource))
+}
+
+// trackCreateConnection emits the hoop-create-connection analytics event for
+// connections born from a resource creation. The /resources route does not run
+// the api.TrackRequest middleware (which is wired only on POST /connections),
+// so we emit explicitly here to keep the funnel accurate. Property shape mirrors
+// the middleware's EventCreateConnection branch.
+func trackCreateConnection(c *gin.Context, ctx *storagev2.Context, req openapi.ResourceRequest, connections []*models.Connection) {
+	if ctx.UserEmail == "" || ctx.OrgID == "" || len(connections) == 0 {
+		return
+	}
+
+	properties := map[string]any{
+		"org-id":         ctx.OrgID,
+		"auth-method":    appconfig.Get().AuthMethod(),
+		"license-type":   ctx.GetLicenseType(),
+		"content-length": c.Request.ContentLength,
+		"user-agent":     apiutils.NormalizeUserAgent(c.Request.Header.Values),
+		"api-hostname":   c.Request.Host,
+		"type":           req.Type,
+		"subtype":        req.SubType,
+		"command":        "",
+	}
+	if len(connections[0].Command) > 0 {
+		properties["command"] = connections[0].Command[0]
+	}
+
+	trackClient := analytics.New()
+	defer trackClient.Close()
+	trackClient.Track(ctx.UserID, analytics.EventCreateConnection, properties)
 }
 
 func validateListOptions(urlValues url.Values) (o models.ResourceFilterOption, err error) {

--- a/gateway/transport/connectionrequests/connectionsync.go
+++ b/gateway/transport/connectionrequests/connectionsync.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/common/memory"
 	"github.com/hoophq/hoop/common/proto"
+	"github.com/hoophq/hoop/gateway/analytics"
+	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/models"
 )
 
@@ -97,10 +99,39 @@ func connectionSync(orgID, agentID string, req *proto.PreConnectRequest) error {
 		}
 	}
 
+	isNewConnection := conn == nil
+
 	// update or create a connection with new values
 	if err := upsertConnection(orgID, agentID, req, conn); err != nil {
 		return err
 	}
 	setChecksumCache(orgID, req)
+
+	if isNewConnection {
+		trackCreateConnection(orgID, agentID, req)
+	}
 	return nil
+}
+
+// trackCreateConnection emits the hoop-create-connection analytics event for
+// connections born from agent gRPC PreConnect auto-registration. The agent
+// path has no user context — we use the system "Gateway" track helper.
+func trackCreateConnection(orgID, agentID string, req *proto.PreConnectRequest) {
+	properties := map[string]any{
+		"org-id":      orgID,
+		"agent-id":    agentID,
+		"auth-method": appconfig.Get().AuthMethod(),
+		"type":        req.Type,
+		"subtype":     req.Subtype,
+		"command":     "",
+		"source":      "agent-autoregister",
+		"managed-by":  managedByAgent,
+	}
+	if len(req.Command) > 0 {
+		properties["command"] = req.Command[0]
+	}
+
+	trackClient := analytics.New()
+	defer trackClient.Close()
+	trackClient.TrackEvent(analytics.EventCreateConnection, properties)
 }

--- a/gateway/transport/connectionrequests/connectionsync.go
+++ b/gateway/transport/connectionrequests/connectionsync.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hoophq/hoop/common/memory"
 	"github.com/hoophq/hoop/common/proto"
 	"github.com/hoophq/hoop/gateway/analytics"
-	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/models"
 )
 
@@ -108,30 +107,17 @@ func connectionSync(orgID, agentID string, req *proto.PreConnectRequest) error {
 	setChecksumCache(orgID, req)
 
 	if isNewConnection {
-		trackCreateConnection(orgID, agentID, req)
+		trackClient := analytics.New()
+		defer trackClient.Close()
+		trackClient.TrackCreateConnection(analytics.CreateConnectionEvent{
+			OrgID:     orgID,
+			Source:    "agent-autoregister",
+			AgentID:   agentID,
+			ManagedBy: managedByAgent,
+			Type:      req.Type,
+			SubType:   req.Subtype,
+			Command:   req.Command,
+		})
 	}
 	return nil
-}
-
-// trackCreateConnection emits the hoop-create-connection analytics event for
-// connections born from agent gRPC PreConnect auto-registration. The agent
-// path has no user context — we use the system "Gateway" track helper.
-func trackCreateConnection(orgID, agentID string, req *proto.PreConnectRequest) {
-	properties := map[string]any{
-		"org-id":      orgID,
-		"agent-id":    agentID,
-		"auth-method": appconfig.Get().AuthMethod(),
-		"type":        req.Type,
-		"subtype":     req.Subtype,
-		"command":     "",
-		"source":      "agent-autoregister",
-		"managed-by":  managedByAgent,
-	}
-	if len(req.Command) > 0 {
-		properties["command"] = req.Command[0]
-	}
-
-	trackClient := analytics.New()
-	defer trackClient.Close()
-	trackClient.TrackEvent(analytics.EventCreateConnection, properties)
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

The `hoop-create-connection` analytics event was only fired by the `POST /api/connections` route via the `TrackRequest` middleware. Connections born from any other code path were silently invisible to Segment/Intercom, breaking the user-activation funnel — most notably for OSS users, who create connections via `POST /api/resources` from the webapp.

This PR makes every connection-creation path emit the event, with a new `source` property so dashboards can distinguish user-initiated from system-initiated events.

## 🔗 Related Issue

Fixes ENG-366

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

Emission is now wired on all five connection-creation paths, each tagged with a `source` property:

| Path | File | `source` | Attribution |
|------|------|----------|-------------|
| `POST /api/connections` | `gateway/api/middleware.go` | `connections-api` | real user (existing middleware, only `source` added) |
| `POST /api/resources` | `gateway/api/resources/resources.go` | `resources-api` | real user (inline) |
| MCP `connections_create` tool | `gateway/api/mcpserver/tools_connections.go` | `mcp` | real user (inline) |
| AWS RDS provisioner | `gateway/api/integrations/aws/provisioner.go` | `aws-rds-provisioner` | system (`UserId="Gateway"` via `TrackEvent`) |
| Agent gRPC `PreConnect` autoregister | `gateway/transport/connectionrequests/connectionsync.go` | `agent-autoregister` | system (`UserId="Gateway"` via `TrackEvent`) |

Implementation notes:
- Inline emission (rather than a route-level middleware) on `/api/resources` to avoid over-counting when a resource is created with zero roles, and to avoid firing on 4xx/5xx.
- AWS provisioner: existence check moved **inside the same transaction** as the upsert so concurrent writers cannot cause double-fire or missed events.
- Agent autoregister: only emits when `conn == nil` at the pre-fetch step, so re-syncs of existing connections don't re-fire.
- All emissions use the same `analytics.New()` / `Close()` / `Track`-or-`TrackEvent` pattern as the existing middleware. They are silent no-ops when `SEGMENT_API_KEY` is unset (OSS self-host) or when `appconfig.AnalyticsTracking()` is `false`.

## 🧪 Testing

### Test Configuration:
- **OS**: macOS

### Tests performed:
- [x] `go build ./gateway/...` clean
- [x] `go vet ./gateway/api/mcpserver/... ./gateway/api/integrations/aws/... ./gateway/transport/connectionrequests/... ./gateway/api/resources/...` clean
- [ ] Manual verification post-deploy: confirm Segment receives `hoop-create-connection` from each `source`, and the user-activation funnel recovers.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## 📄 Additional Notes

- The `source` property creates a small backward-compat consideration: existing dashboards will see the new `source` key on events going forward but did not see it on prior events. Funnel queries that don't reference `source` are unaffected.
- System-fired events (`source` ∈ {`aws-rds-provisioner`, `agent-autoregister`}) use `UserId="Gateway"` and will appear in funnel queries unless filtered. If that's undesirable, downstream queries can filter on `source` or `userId != "Gateway"`.
- Out of scope: adding `AuditMiddleware` to the `/resources` routes (currently absent on POST/PUT/DELETE) — separate concern from this funnel bug.