### PR TITLE
fix(ci): resolve auto-release PR by parsing merge commit subject

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -42,15 +42,21 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          PR_JSON=$(gh api "repos/${REPO}/commits/${SHA}/pulls" --jq '.[0]' || echo "")
-          if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
-            echo "::warning::No merged PR is associated with commit $SHA (direct push to main?). Skipping release."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+
+          # Repo policy is squash-merge only, so the merge commit subject always
+          # ends with `(#NNNN)`. Anchor the match to end-of-line so an issue
+          # reference earlier in the subject (e.g. "fix: refs #1234 (#1429)")
+          # doesn't get picked up instead of the actual PR number.
+          SUBJECT=$(git log -1 --pretty=%s "$SHA")
+          PR_NUMBER=$(echo "$SUBJECT" | sed -nE 's/.*\(#([0-9]+)\)$/\1/p')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Could not parse PR number from merge commit subject: ${SUBJECT}"
+            echo "::error::Direct push to main, or repo merge settings changed to allow rebase/merge-commit?"
+            exit 1
           fi
 
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          LABELS=$(echo "$PR_JSON" | jq -r '.labels[].name')
+          LABELS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.labels[].name')
 
           if echo "$LABELS" | grep -qx 'skip-release'; then
             echo "PR #${PR_NUMBER} has 'skip-release' label — no release."
@@ -60,9 +66,8 @@ jobs:
 
           BUMP=$(echo "$LABELS" | grep -E '^(major|minor|patch)$' | head -1 || true)
           if [ -z "$BUMP" ]; then
-            echo "::warning::PR #${PR_NUMBER} has no major/minor/patch/skip-release label — skipping release. (PR Release Label Check should have blocked this merge.)"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::PR #${PR_NUMBER} has no major/minor/patch/skip-release label. (PR Release Label Check should have blocked this merge.)"
+            exit 1
           fi
 
           echo "Merged PR: #${PR_NUMBER} (bump: ${BUMP})"


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Fixes a silent failure in `auto-release.yml` that caused PR #1429 to merge without producing a release. The workflow run ([25567772351](https://github.com/hoophq/hoop/actions/runs/25567772351/job/75055504568)) finished green with this warning:

```
::warning::No merged PR is associated with commit f8fa02ed... (direct push to main?). Skipping release.
```

There was no direct push — PR #1429 was a normal squash merge.

**Root cause.** The workflow resolved the merged PR via `gh api repos/${REPO}/commits/${SHA}/pulls`, which depends on GitHub's commit-to-PR association index. That index lags a few seconds after merge, and the workflow starts on `push: main` ~3s after the merge commit lands — often hitting the empty window. Querying the same endpoint moments later returns the PR correctly, so it's purely an indexing race. The previous logic also treated this case as a non-error (`skip=true`, `exit 0`), so the run stayed green and nothing alerted while a release was silently dropped.

**Fix.** Drop `commits/{sha}/pulls` entirely. The repo only allows squash merges (`allow_merge_commit: false`, `allow_rebase_merge: false`), so the merge commit subject is guaranteed to end with `(#NNNN)`. Parse that directly and read labels via `gh api repos/${REPO}/pulls/${PR_NUMBER}`. No retries, no race, no fallback. The regex is anchored to end-of-line so an issue reference earlier in the title (e.g. `fix: refs #1234 (#1429)`) doesn't get picked up instead of the trailing PR number.

Both prior silent-skip branches now `exit 1` so the workflow goes red instead of green-with-warning.

**Recovery.** `1.64.3` was created manually against `f8fa02e` to fill the gap from the original failed run. `release.yml` picked it up and published artifacts.

## 🔗 Related Issue

No tracking issue. Triggered by the failed Auto Release run for PR #1429.

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [x] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Resolve the merged PR by parsing `(#NNNN)` from the squash merge commit subject instead of `gh api commits/{sha}/pulls`, eliminating the indexing-lag race.
- Anchor the regex to end-of-line (`\(#([0-9]+)\)$`) so issue references earlier in the subject can't be mistaken for the trailing PR number.
- Convert both silent-skip paths (no PR resolved, no bump label) to `exit 1` so the workflow turns red instead of green-with-warning when something is wrong.

## 🧪 Testing

Verified the regex against representative subjects:

| Merge commit subject | Result |
|---|---|
| `feat: add workflow timeline view (#1429)` | resolves `1429` ✓ |
| `fix: resolve regression from #1234 (#1429)` | resolves `1429` ✓ |
| `revert: feat: thing (#1400) (#1431)` | resolves `1431` ✓ |
| `manual edit: removed the suffix` | exit 1 — red workflow ✓ |
| direct push to main, no `(#N)` in subject | exit 1 — red workflow ✓ |
| PR exists but has no bump label | exit 1 — red workflow ✓ |

### Test Configuration:
- **Browser(s)**: N/A (CI workflow change)
- **OS**: GitHub Actions `ubuntu-latest`

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed (regex validated locally against the matrix above)

## 📸 Screenshots (if applicable)

N/A.

## ✅ Checklist

- [ ] I have run `make generate-openapi-docs` to update the OpenAPI docs (N/A — workflow-only change)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (N/A — workflow-only change)
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**Trade-off worth flagging for reviewers:** if the repo merge settings ever change to allow rebase-merge or merge-commit, rebased commits won't have `(#N)` in their subject and this workflow will fail loudly on the first such merge. That's the intended outcome — you'd want to know immediately rather than have releases silently stop. Update this workflow alongside any change to the repo's allowed merge methods.

End-to-end validation will happen when this PR itself merges with the `patch` label: confirm Auto Release resolves the PR via the new parser, creates the next release tag, and `release.yml` runs to completion off it.