### PR TITLE
fix: more space for video block

### DIFF
--- a/webapp/src/webapp/audit/views/session_data_video.cljs
+++ b/webapp/src/webapp/audit/views/session_data_video.cljs
@@ -64,7 +64,7 @@
     (rf/dispatch [:audit->get-session-logs-data session-id])
 
     (fn [event-stream]
-      [:div {:class "flex flex-col h-[660px] min-h-0 overflow-hidden"}
+      [:div {:class "flex flex-col min-h-[660px] overflow-hidden"}
        [tabs/tabs {:on-change handle-tab-change
                    :tabs ["Logs" "Video"]
                    :default-value "Logs"}]


### PR DESCRIPTION
## 📝 Description

Let modal grow in height to no cut off part of `asciinema` block

## 🔗 Related Issue

Fixes #1435

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Replaced `height: 660px` with `min-height: 660px`

## 🧪 Testing

- Go to Sessions
- Open any SSH session
- Take a look at `asciinema` block

### Test Configuration:
- **Browser(s)**: Firefox
- **OS**: Manjaro

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

Before:

<img width="1618" height="903" alt="Screenshot From 2026-05-08 21-55-18" src="https://github.com/user-attachments/assets/791073ba-998a-42ac-938a-891e442cd059" />

After:

<img width="1674" height="1353" alt="Screenshot From 2026-05-08 21-54-45" src="https://github.com/user-attachments/assets/1155e145-fe4e-4c07-9348-efbf5878c6d7" />

## ✅ Checklist

(Minor change, so not all items are relevant)

- [x] I have run `make generate-openapi-docs` to update the OpenAPI docs - produced diff, but not relevant to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

No additional notes

---

Thanks!
