### PR TITLE
ci: wire integration tests into PR workflow [ENG-393]

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -23,3 +23,29 @@ jobs:
 
       - name: Test
         run: make test-oss
+
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.26.0'
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+
+      # testcontainers-go manages container lifecycle itself via the Docker
+      # daemon. ubuntu-latest runners have Docker pre-installed and running,
+      # so no services: block is required. See:
+      # https://golang.testcontainers.org/system_requirements/
+      - name: Integration Test
+        run: make test-integration

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -30,8 +30,23 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout
+      - name: Checkout Hoop
         uses: actions/checkout@v3
+
+      # Integration tests drive the real controller.Agent against real upstream
+      # containers via libhoop. The OSS _libhoop stub returns "missing protocol
+      # hoop library for X" for every protocol, so we need the enterprise
+      # libhoop checked out at ./libhoop. The Makefile's libhoop-map target
+      # tries to overwrite this with a symlink, but `rm libhoop || true` is a
+      # no-op against a non-empty directory — the checkout wins. Matches the
+      # build jobs in pullrequest-release.yml.
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+
       - name: Setup Go
         uses: actions/setup-go@v6
         with:

--- a/DEV.md
+++ b/DEV.md
@@ -165,7 +165,7 @@ End-to-end tests under `agent/integration/` that drive the real `controller.Agen
 Requirements:
 
 - **Docker daemon** running on the host — [testcontainers-go](https://golang.testcontainers.org/) manages the upstream container lifecycle.
-- **Enterprise `libhoop`** symlinked in place (the OSS stub at `_libhoop/libhoop.go` returns "missing protocol hoop library for X" and tests will fail at handshake). The Makefile target runs `libhoop-map` as a prerequisite, so if you have the enterprise repo checked out, this works automatically.
+- **Enterprise `libhoop`** checked out as a sibling directory (`../libhoop`, matching the `replace libhoop => ../libhoop` directive in `agent/go.mod` and `gateway/go.mod`). The OSS stub at `_libhoop/libhoop.go` returns "missing protocol hoop library for X" and integration tests will fail at handshake. CI clones `hoophq/libhoop` into `./libhoop` via `secrets.GH_TOKEN` (same as the build jobs).
 - **CGO enabled** — required for the `-race` flag, which is on by default for this target. Production binaries still build with `CGO_ENABLED=0`; only the test binary uses cgo.
 
 CI runs integration tests on every PR via the `Integration Test` job in `.github/workflows/pullrequest.yml`.

--- a/DEV.md
+++ b/DEV.md
@@ -144,6 +144,32 @@ To rotate the signing key too, delete `dist/dev/spiffe/priv.pem` before running 
 
 Edit `.env` and change `HOOP_SPIFFE_MODE=enforce` to `HOOP_SPIFFE_MODE=disabled` (or remove the managed block entirely), then restart `run-dev`. `enforce` is the only "on" value — the gateway always rejects invalid SVIDs and never falls back to DSN on a JWT-shaped token.
 
+## Running Tests
+
+### Unit tests
+
+```sh
+make test-oss
+```
+
+Fast, no external dependencies. Runs in CI on every PR.
+
+### Integration tests
+
+```sh
+make test-integration
+```
+
+End-to-end tests under `agent/integration/` that drive the real `controller.Agent` against real upstream servers (Postgres today; SSH and MySQL coming). They live behind the `//go:build integration` tag so they're invisible to `make test-oss`.
+
+Requirements:
+
+- **Docker daemon** running on the host — [testcontainers-go](https://golang.testcontainers.org/) manages the upstream container lifecycle.
+- **Enterprise `libhoop`** symlinked in place (the OSS stub at `_libhoop/libhoop.go` returns "missing protocol hoop library for X" and tests will fail at handshake). The Makefile target runs `libhoop-map` as a prerequisite, so if you have the enterprise repo checked out, this works automatically.
+- **CGO enabled** — required for the `-race` flag, which is on by default for this target. Production binaries still build with `CGO_ENABLED=0`; only the test binary uses cgo.
+
+CI runs integration tests on every PR via the `Integration Test` job in `.github/workflows/pullrequest.yml`.
+
 ## Swagger / OpenAPI
 
 This project uses [swag](https://github.com/swaggo/swag) to generate the api documentation. Make sure to generate it every time a change is made in the API:

--- a/DEV.md
+++ b/DEV.md
@@ -169,8 +169,6 @@ Requirements:
 
 CI runs integration tests on every PR via the `Integration Test` job in `.github/workflows/pullrequest.yml`.
 
-> **Note**: `-race` is not enabled by default. The enterprise `libhoop` has pre-existing data races in some of its proxy buffer code that the race detector will surface. Enabling `-race` will be addressed in a follow-up ticket alongside fixes to `libhoop`.
-
 ## Swagger / OpenAPI
 
 This project uses [swag](https://github.com/swaggo/swag) to generate the api documentation. Make sure to generate it every time a change is made in the API:

--- a/DEV.md
+++ b/DEV.md
@@ -166,9 +166,10 @@ Requirements:
 
 - **Docker daemon** running on the host — [testcontainers-go](https://golang.testcontainers.org/) manages the upstream container lifecycle.
 - **Enterprise `libhoop`** checked out as a sibling directory (`../libhoop`, matching the `replace libhoop => ../libhoop` directive in `agent/go.mod` and `gateway/go.mod`). The OSS stub at `_libhoop/libhoop.go` returns "missing protocol hoop library for X" and integration tests will fail at handshake. CI clones `hoophq/libhoop` into `./libhoop` via `secrets.GH_TOKEN` (same as the build jobs).
-- **CGO enabled** — required for the `-race` flag, which is on by default for this target. Production binaries still build with `CGO_ENABLED=0`; only the test binary uses cgo.
 
 CI runs integration tests on every PR via the `Integration Test` job in `.github/workflows/pullrequest.yml`.
+
+> **Note**: `-race` is not enabled by default. The enterprise `libhoop` has pre-existing data races in some of its proxy buffer code that the race detector will surface. Enabling `-race` will be addressed in a follow-up ticket alongside fixes to `libhoop`.
 
 ## Swagger / OpenAPI
 

--- a/Makefile
+++ b/Makefile
@@ -87,17 +87,6 @@ test-oss: libhoop-map generate-wasm
 test-enterprise: libhoop-map generate-wasm
 	env CGO_ENABLED=0 go test -json -v github.com/hoophq/hoop/...
 
-# Integration tests run real testcontainers (Postgres today; SSH and MySQL
-# follow in ENG-391 / ENG-387). They require Docker on the host and a
-# functional libhoop (the OSS stub at _libhoop/libhoop.go returns
-# "missing protocol hoop library for X" — CI uses the enterprise libhoop).
-#
-# -race is intentionally NOT enabled here. The enterprise libhoop has
-# pre-existing data races (notably libhoop/agent/postgres/buf.go's
-# blockingReader, see surfaced via the race detector when this target
-# runs with -race). Those need their own ticket in libhoop before we can
-# turn -race on for this target. The concurrency tests in ENG-394 will
-# use -race once those libhoop fixes land.
 test-integration: libhoop-map generate-wasm
 	env CGO_ENABLED=0 go test -tags integration -v -timeout 10m -count=1 ./agent/integration/...
 

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,15 @@ test-enterprise: libhoop-map generate-wasm
 # follow in ENG-391 / ENG-387). They require Docker on the host and a
 # functional libhoop (the OSS stub at _libhoop/libhoop.go returns
 # "missing protocol hoop library for X" — CI uses the enterprise libhoop).
+#
+# -race is intentionally NOT enabled here. The enterprise libhoop has
+# pre-existing data races (notably libhoop/agent/postgres/buf.go's
+# blockingReader, see surfaced via the race detector when this target
+# runs with -race). Those need their own ticket in libhoop before we can
+# turn -race on for this target. The concurrency tests in ENG-394 will
+# use -race once those libhoop fixes land.
 test-integration: libhoop-map generate-wasm
-	env CGO_ENABLED=1 go test -tags integration -race -v -timeout 10m -count=1 ./agent/integration/...
+	env CGO_ENABLED=0 go test -tags integration -v -timeout 10m -count=1 ./agent/integration/...
 
 generate-openapi-docs:
 	cd ./gateway/ && go run github.com/swaggo/swag/cmd/swag@v1.16.3 init -g api/server.go -o api/openapi/autogen --outputTypes go --markdownFiles api/openapi/docs/ --parseDependency

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,12 @@ test-oss: libhoop-map generate-wasm
 test-enterprise: libhoop-map generate-wasm
 	env CGO_ENABLED=0 go test -json -v github.com/hoophq/hoop/...
 
-test-integration:
-	env CGO_ENABLED=0 go test -tags integration -v -timeout 5m -count=1 ./agent/integration/...
+# Integration tests run real testcontainers (Postgres today; SSH and MySQL
+# follow in ENG-391 / ENG-387). They require Docker on the host and a
+# functional libhoop (the OSS stub at _libhoop/libhoop.go returns
+# "missing protocol hoop library for X" — CI uses the enterprise libhoop).
+test-integration: libhoop-map generate-wasm
+	env CGO_ENABLED=1 go test -tags integration -race -v -timeout 10m -count=1 ./agent/integration/...
 
 generate-openapi-docs:
 	cd ./gateway/ && go run github.com/swaggo/swag/cmd/swag@v1.16.3 init -g api/server.go -o api/openapi/autogen --outputTypes go --markdownFiles api/openapi/docs/ --parseDependency


### PR DESCRIPTION
## Summary

- Add `libhoop-map` + `generate-wasm` prerequisites to `make test-integration` so a fresh checkout works without manual setup
- Add `Integration Test` job to `.github/workflows/pullrequest.yml` so the existing PG integration tests stop being developer-local only
- Checkout `hoophq/libhoop` in the new job (same pattern as build jobs) so tests run against real libhoop, not the OSS stub
- Document the workflow in `DEV.md` (Docker dep, libhoop checkout, the deferred `-race` situation)

## Why

The existing PG integration tests at `agent/integration/postgres_test.go` are well-designed but invisible to CI. `pullrequest.yml` only ran `make test-oss`. This is foundation work for the SSH/PG/MySQL concurrency tests that will validate the fix for the customer's SSH hangs (ENG-370).

## A finding worth noting

Initial CI run had `-race` enabled and surfaced a real data race in **enterprise libhoop's PG proxy** (`libhoop/agent/postgres/buf.go` — `blockingReader` wraps a `bytes.Buffer` with concurrent unprotected Read/Write across goroutines). This is a pre-existing race that's been latent in production; it likely contributes to some of the "random PG flakiness" customer reports that motivated the original sync revert in `a002d3f4`.

To keep this PR scoped to CI plumbing, I dropped `-race` from `test-integration` and filed ENG-396 to fix the libhoop race separately. The Makefile comment and DEV.md both explain the deferral.

ENG-394's concurrency tests will re-enable `-race` once the libhoop fix lands.

## Verification

- Local `make test-integration`: works against OSS stub with documented "missing protocol" failures (expected).
- CI Integration Test job: ✅ green (passes in ~2m).
- CI Unit Test job: ✅ green (still works, no regression).
- libhoop checkout step matches the pattern used by every build job in `pullrequest-release.yml`.

## Linear

- ENG-393 (this PR, parent ENG-370)
- ENG-396 (follow-up: fix the libhoop blockingReader race so we can re-enable `-race`)

## Out of scope

- The libhoop race itself (ENG-396)
- New tests (ENG-394, ENG-391, ENG-392, ENG-387, ENG-388)
- The actual SSH fix (ENG-395)

Automated by MisterMal