### PR TITLE
test: PG concurrency / race integration tests [ENG-394]

### DIFF
--- a/agent/integration/postgres_concurrency_test.go
+++ b/agent/integration/postgres_concurrency_test.go
@@ -1,0 +1,228 @@
+//go:build integration
+
+package integration
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/agent/integration/testutil"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+)
+
+// TestPG_ConcurrentFirstPackets_SameConnID fires 50 goroutines that each
+// send the first PG packet (SSLRequest + StartupMessage) for the same
+// (sessionID, connID) tuple, then asserts exactly one Postgres backend
+// connection is dialed.
+//
+// The invariant being protected: concurrent first-packets for the same
+// connection must deduplicate at the proxy-creation step. A naive
+// implementation that does connStore.Get → dial → connStore.Set without
+// a synchronization primitive will race — multiple goroutines miss the
+// cache, all dial the upstream, last-write-wins leaves orphan proxies
+// still pumping bytes into the gRPC stream.
+func TestPG_ConcurrentFirstPackets_SameConnID(t *testing.T) {
+	pg := testutil.StartPostgres(t)
+	agent, tr := startAgent(t)
+
+	// OpenPGSession reads SessionOpenOK directly from the transport.
+	// Start the demux only after the session is open so it doesn't
+	// intercept the handshake reply.
+	sessionID := testutil.OpenPGSession(t, tr, pg.Host, pg.Port, pg.User, pg.Password, pg.Database)
+	demux := testutil.StartRecvDemux(t, tr)
+	connID := "conn-shared"
+
+	const numGoroutines = 50
+	handshake := append(testutil.PGSSLRequest(), testutil.PGStartupMessage(pg.User, pg.Database)...)
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	startGate := make(chan struct{})
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-startGate
+			pkt := &pb.Packet{
+				Type: pbagent.PGConnectionWrite,
+				Spec: map[string][]byte{
+					pb.SpecGatewaySessionID:   []byte(sessionID),
+					pb.SpecClientConnectionID: []byte(connID),
+				},
+				Payload: handshake,
+			}
+			tr.Inject(pkt)
+		}()
+	}
+	close(startGate)
+	wg.Wait()
+
+	// Drain until ReadyForQuery on the shared conn. We don't assert on
+	// response content; only the upstream-connection count matters here.
+	testutil.WaitForReadyOnConn(t, demux, connID, pgTestTimeout)
+
+	// Settle: even after the agent has buffered Z, the PG backend may
+	// still be in handshake. Give it a moment to land in pg_stat_activity.
+	time.Sleep(500 * time.Millisecond)
+
+	got := testutil.PGBackendCount(t, pg)
+	if got != 1 {
+		t.Errorf("expected exactly 1 upstream PG backend, got %d (duplicate-proxy race?)", got)
+	}
+
+	shutdownAgent(t, agent, tr)
+}
+
+// TestPG_SessionCloseRace opens a connection, fires a query, then sends
+// SessionClose while the query is in flight. Asserts that teardown is
+// clean: upstream backend exits, no goroutine leak.
+//
+// The invariant: a SessionClose arriving while a packet handler is still
+// running for that session must wait for the handler to finish, or at
+// minimum must not leave the system in a partially-torn-down state with
+// orphaned upstream connections or leaked goroutines.
+func TestPG_SessionCloseRace(t *testing.T) {
+	pg := testutil.StartPostgres(t)
+	agent, tr := startAgent(t)
+
+	leak := testutil.SnapshotGoroutines(t, 20)
+
+	sessionID := testutil.OpenPGSession(t, tr, pg.Host, pg.Port, pg.User, pg.Password, pg.Database)
+	demux := testutil.StartRecvDemux(t, tr)
+	connID := "conn-1"
+
+	// Establish the connection first so subsequent writes hit the cached
+	// proxy path. Isolates the SessionClose race from any duplicate-proxy
+	// interactions on the create path.
+	testutil.SendPGConnectHandshake(t, tr, sessionID, connID, pg.User, pg.Database)
+	testutil.WaitForReadyOnConn(t, demux, connID, pgTestTimeout)
+
+	// Fire a query that takes ~1s on the upstream so SessionClose has a
+	// chance to arrive while it's in flight. pg_sleep runs in libhoop's
+	// goroutine, not the recv loop — the recv loop returns after queuing
+	// the query bytes into libhoop's blockingReader.
+	testutil.SendPGWrite(t, tr, sessionID, connID, testutil.PGSimpleQuery("SELECT pg_sleep(1)"))
+
+	// SessionClose fires 100ms in, during the query's pg_sleep.
+	time.Sleep(100 * time.Millisecond)
+	closePkt := testutil.BuildSessionClosePacket(sessionID, "0")
+	tr.Inject(closePkt)
+
+	// Drain whatever the agent emits afterward: query response, error,
+	// session-close acks. We don't assert on content; the cleanup
+	// invariants are what matter.
+	deadline := time.After(pgTestTimeout)
+drain:
+	for {
+		select {
+		case <-demux.Channel(connID):
+		case <-demux.SessionChannel():
+		case <-deadline:
+			break drain
+		case <-time.After(500 * time.Millisecond):
+			// idle long enough — done draining
+			break drain
+		}
+	}
+
+	// Upstream backend should fully disconnect within a few seconds.
+	testutil.WaitForPGBackendCount(t, pg, 0, 10*time.Second)
+
+	shutdownAgent(t, agent, tr)
+
+	// No significant goroutine leak after teardown. Tolerance is generous
+	// to absorb testcontainer / docker-client noise.
+	leak.Assert(t)
+}
+
+// TestPG_ParallelSessions_OneHangs opens two independent sessions on the
+// same agent. One points at 192.0.2.1 (TEST-NET-1, RFC 5737, guaranteed
+// non-routable) so libhoop's 10-second net.DialTimeout blocks on its
+// first PGConnectionWrite. The other points at a real Postgres container.
+//
+// Asserts the fast session's handshake completes in under 2 seconds —
+// independent of the slow session's stalled dial.
+//
+// The invariant: a slow or stalled operation on one session must not
+// block packet processing for other sessions on the same agent.
+//
+// This test currently fails because the agent's recv loop processes
+// packets synchronously, so the slow session's dial blocks the fast
+// session's packet behind it. The test is skipped until the dispatch
+// model changes; unskip it once the agent dispatches concurrent
+// sessions independently.
+func TestPG_ParallelSessions_OneHangs(t *testing.T) {
+	t.Skip("known failure: agent recv loop is synchronous; fast session blocks behind slow session's dial. " +
+		"Unskip when the dispatch model supports independent per-session processing.")
+
+	pg := testutil.StartPostgres(t)
+	agent, tr := startAgent(t)
+
+	// Two independent sessions. The slow one points at a non-routable
+	// address so libhoop's dial blocks until its 10s timeout fires.
+	// SessionOpen itself doesn't dial — only PGConnectionWrite does —
+	// so both OpenPGSession calls return quickly.
+	sidSlow := testutil.OpenPGSession(t, tr, "192.0.2.1", "5432", pg.User, pg.Password, pg.Database)
+	sidFast := testutil.OpenPGSession(t, tr, pg.Host, pg.Port, pg.User, pg.Password, pg.Database)
+	demux := testutil.StartRecvDemux(t, tr)
+
+	connSlow := "conn-slow"
+	connFast := "conn-fast"
+
+	// Fire the slow handshake. The agent's recv loop picks it up, calls
+	// processPGProtocol → libhoop.Postgres() → net.DialTimeout("192.0.2.1:5432",
+	// 10s). The recv loop is now blocked here.
+	go func() {
+		testutil.SendPGConnectHandshake(t, tr, sidSlow, connSlow, pg.User, pg.Database)
+	}()
+
+	// Brief delay so the slow handshake reaches the dial state before
+	// we fire the fast one. 200ms is generous — the recv loop picks up
+	// the slow packet within a few microseconds.
+	time.Sleep(200 * time.Millisecond)
+
+	// Fire the fast handshake. Under sync dispatch, this packet sits in
+	// recvCh until the slow dial times out. Under async dispatch, it
+	// gets its own goroutine and proceeds immediately.
+	start := time.Now()
+	testutil.SendPGConnectHandshake(t, tr, sidFast, connFast, pg.User, pg.Database)
+
+	fastReady := make(chan struct{})
+	go func() {
+		testutil.WaitForReadyOnConn(t, demux, connFast, 15*time.Second)
+		close(fastReady)
+	}()
+
+	select {
+	case <-fastReady:
+		elapsed := time.Since(start)
+		t.Logf("fast session ready in %v", elapsed)
+		// 2 seconds is generous for async — typical PG handshake completes
+		// in ~50-200ms locally. The slow session's 10s dial timeout sets
+		// the upper bound for the sync path.
+		if elapsed > 2*time.Second {
+			t.Errorf("fast session ready in %v; expected <2s — slow session is blocking the fast one", elapsed)
+		}
+	case <-time.After(15 * time.Second):
+		t.Errorf("fast session never became ready — agent recv loop appears wedged")
+	}
+
+	// Drain so shutdown is clean. The slow session is still stuck in
+	// libhoop's dial; closing the agent below will tear it down.
+	drainDeadline := time.After(3 * time.Second)
+drain:
+	for {
+		select {
+		case <-demux.Channel(connSlow):
+		case <-demux.Channel(connFast):
+		case <-demux.SessionChannel():
+		case <-drainDeadline:
+			break drain
+		case <-time.After(200 * time.Millisecond):
+			break drain
+		}
+	}
+
+	shutdownAgent(t, agent, tr)
+}

--- a/agent/integration/testutil/goroutineleak.go
+++ b/agent/integration/testutil/goroutineleak.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package testutil
+
+import (
+	"runtime"
+	"time"
+)
+
+// GoroutineLeakChecker captures the goroutine count at construction time
+// and asserts at test end that the count returned within a tolerance.
+//
+// This is a coarse signal — it can't tell which goroutines leaked, only
+// that the total grew. False positives are possible because testcontainers,
+// the Docker SDK, and the Go runtime spawn background goroutines that
+// stick around between sub-tests. The tolerance absorbs that noise.
+//
+// Use it like:
+//
+//	leak := testutil.SnapshotGoroutines(t, 10)
+//	// ... run test ...
+//	leak.Assert(t)
+type GoroutineLeakChecker struct {
+	startCount int
+	tolerance  int
+}
+
+// SnapshotGoroutines captures the current goroutine count. Call Assert on
+// the returned checker after teardown to verify no significant leak.
+//
+// The tolerance is the maximum allowed delta. A value of 0 means strict
+// (no growth allowed); typical values for integration tests are 5–20
+// to absorb testcontainer / docker-client noise.
+//
+// The function settles briefly before capturing the baseline so that
+// goroutines from a just-completed setup step have time to exit.
+func SnapshotGoroutines(t T, tolerance int) *GoroutineLeakChecker {
+	t.Helper()
+	settle()
+	return &GoroutineLeakChecker{
+		startCount: runtime.NumGoroutine(),
+		tolerance:  tolerance,
+	}
+}
+
+// Assert checks that the goroutine count has not grown beyond tolerance.
+// It settles briefly first to allow in-flight teardown goroutines to exit.
+// On failure, it logs the start count, current count, and the goroutine
+// dump so the developer can see what's still running.
+func (g *GoroutineLeakChecker) Assert(t T) {
+	t.Helper()
+	settle()
+
+	end := runtime.NumGoroutine()
+	delta := end - g.startCount
+	if delta > g.tolerance {
+		buf := make([]byte, 1<<16)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("goroutine leak: started with %d, ended with %d (delta=%d, tolerance=%d)\n\n=== goroutine dump ===\n%s",
+			g.startCount, end, delta, g.tolerance, buf[:n])
+	}
+}
+
+// settle gives runtime goroutines a chance to schedule out before measuring.
+// 100ms is overkill for normal cleanup but cheap relative to test latency.
+func settle() {
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+}

--- a/agent/integration/testutil/pgstat.go
+++ b/agent/integration/testutil/pgstat.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// PGBackendCount opens a sidecar admin connection to the Postgres container
+// and returns the number of currently-active backend processes for the
+// given database, *excluding* the sidecar connection itself.
+//
+// Used by concurrency tests to assert "exactly one connection landed at
+// the upstream" — the sidecar's own connection is filtered out via
+// pg_backend_pid().
+//
+// Each call opens and closes its own admin connection so the count
+// snapshot is taken from a fresh session. Don't call this in a tight
+// loop; once-per-assertion is the intended use.
+func PGBackendCount(t T, pg *PGContainer) int {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("postgres", pg.ConnString())
+	if err != nil {
+		t.Fatalf("pgstat: failed to open admin connection: %v", err)
+	}
+	defer db.Close()
+
+	// Sanity: ensure the connection works before we count, otherwise a
+	// transient failure shows up as "0 backends" which is misleading.
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatalf("pgstat: admin ping failed: %v", err)
+	}
+
+	var count int
+	row := db.QueryRowContext(ctx, `
+		SELECT count(*) FROM pg_stat_activity
+		WHERE datname = $1 AND pid <> pg_backend_pid()
+	`, pg.Database)
+	if err := row.Scan(&count); err != nil {
+		t.Fatalf("pgstat: failed to count backends: %v", err)
+	}
+	return count
+}
+
+// WaitForPGBackendCount polls PGBackendCount until it equals want or the
+// timeout elapses. Useful for waiting out connection teardown (Postgres
+// reaps idle backends, but not instantly).
+func WaitForPGBackendCount(t T, pg *PGContainer, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last int
+	for time.Now().Before(deadline) {
+		last = PGBackendCount(t, pg)
+		if last == want {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("pgstat: expected %d backends after %v, last observed=%d", want, timeout, last)
+}
+
+

--- a/agent/integration/testutil/recvdemux.go
+++ b/agent/integration/testutil/recvdemux.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	pb "github.com/hoophq/hoop/common/proto"
+)
+
+// RecvDemux fans out the agent's outgoing packets from a MockTransport into
+// per-connection-ID channels so concurrent tests can drain responses
+// independently for each session/connection.
+//
+// The serial tests in postgres_test.go drain MockTransport.RecvCh() directly,
+// which is fine when only one in-flight query exists at a time. The
+// concurrency tests have multiple concurrent in-flight connections sharing
+// the same MockTransport; without demultiplexing they would race to read
+// each other's responses out of the shared channel.
+//
+// Demux is started once after the agent is up. From then on, callers must
+// use Demux.Channel(connID) to receive packets — direct reads from
+// MockTransport.RecvCh() will steal packets from the demux.
+type RecvDemux struct {
+	tr    *MockTransport
+	mu    sync.Mutex
+	conns map[string]chan *pb.Packet
+	// Packets without SpecClientConnectionID (session-level events like
+	// SessionOpenOK and SessionClose) are routed here.
+	sessionCh chan *pb.Packet
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+}
+
+// StartRecvDemux begins consuming from tr.RecvCh() in a background goroutine
+// and routes each packet to the channel registered for its
+// SpecClientConnectionID. Channels are created lazily on first reference.
+//
+// The demux runs until the test context is canceled (via Stop) or the
+// MockTransport is closed.
+func StartRecvDemux(t T, tr *MockTransport) *RecvDemux {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	d := &RecvDemux{
+		tr:        tr,
+		conns:     make(map[string]chan *pb.Packet),
+		sessionCh: make(chan *pb.Packet, 256),
+		ctx:       ctx,
+		cancel:    cancel,
+	}
+
+	d.wg.Add(1)
+	go d.loop()
+
+	t.Cleanup(func() {
+		d.Stop()
+	})
+	return d
+}
+
+func (d *RecvDemux) loop() {
+	defer d.wg.Done()
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case pkt, ok := <-d.tr.RecvCh():
+			if !ok {
+				return
+			}
+			connID := string(pkt.Spec[pb.SpecClientConnectionID])
+			if connID == "" {
+				select {
+				case d.sessionCh <- pkt:
+				case <-d.ctx.Done():
+					return
+				}
+				continue
+			}
+			ch := d.channelFor(connID)
+			select {
+			case ch <- pkt:
+			case <-d.ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (d *RecvDemux) channelFor(connID string) chan *pb.Packet {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	ch, ok := d.conns[connID]
+	if !ok {
+		// Buffer generously so a busy goroutine forwarding query results
+		// doesn't block the demux loop and stall siblings.
+		ch = make(chan *pb.Packet, 256)
+		d.conns[connID] = ch
+	}
+	return ch
+}
+
+// Channel returns the per-connection-ID receive channel. The channel is
+// created on first call and shared on subsequent calls for the same connID.
+//
+// Multiple receivers on the same channel are not supported — each connID
+// should be consumed by a single goroutine in the test.
+func (d *RecvDemux) Channel(connID string) <-chan *pb.Packet {
+	return d.channelFor(connID)
+}
+
+// SessionChannel returns packets that don't carry a SpecClientConnectionID
+// (SessionOpenOK, SessionClose, etc).
+func (d *RecvDemux) SessionChannel() <-chan *pb.Packet {
+	return d.sessionCh
+}
+
+// Stop cancels the demux loop and waits for it to exit.
+// Idempotent.
+func (d *RecvDemux) Stop() {
+	d.cancel()
+	d.wg.Wait()
+}
+
+// WaitForReadyOnConn drains the per-conn channel until a Postgres
+// ReadyForQuery ('Z') message is observed. Mirrors WaitForPGReady but
+// scoped to a specific connection.
+func WaitForReadyOnConn(t T, demux *RecvDemux, connID string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	ch := demux.Channel(connID)
+	for {
+		select {
+		case pkt, ok := <-ch:
+			if !ok {
+				t.Fatalf("recvdemux: channel closed before ready for conn=%s", connID)
+				return
+			}
+			msgs := ParsePGMessages(pkt.Payload)
+			for _, msg := range msgs {
+				if msg.Type == byte('Z') {
+					return
+				}
+			}
+		case <-deadline:
+			t.Fatalf("recvdemux: timed out waiting for ready on conn=%s after %v", connID, timeout)
+			return
+		}
+	}
+}
+
+// CollectResponsesOnConn drains the per-conn channel until ReadyForQuery
+// ('Z') is observed, returning all packets seen. Mirrors CollectPGResponses
+// but scoped to a specific connection.
+func CollectResponsesOnConn(t T, demux *RecvDemux, connID string, timeout time.Duration) []*pb.Packet {
+	t.Helper()
+	var pkts []*pb.Packet
+	deadline := time.After(timeout)
+	ch := demux.Channel(connID)
+	for {
+		select {
+		case pkt, ok := <-ch:
+			if !ok {
+				t.Fatalf("recvdemux: channel closed before ready for conn=%s after %d packets", connID, len(pkts))
+				return pkts
+			}
+			pkts = append(pkts, pkt)
+			msgs := ParsePGMessages(pkt.Payload)
+			for _, msg := range msgs {
+				if msg.Type == byte('Z') {
+					return pkts
+				}
+			}
+		case <-deadline:
+			t.Fatalf("recvdemux: timed out collecting responses on conn=%s after %v, got %d packets",
+				connID, timeout, len(pkts))
+			return pkts
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds three concurrency-focused PG integration tests plus three reusable testutil helpers:

| Test | What it asserts | Status on main |
|---|---|---|
| `TestPG_ConcurrentFirstPackets_SameConnID` | 50 concurrent first-packets for the same `(sid, connID)` → exactly 1 upstream backend | Passes (recv loop serializes today) |
| `TestPG_SessionCloseRace` | `SessionClose` during in-flight query → clean teardown, no orphan, no goroutine leak | Passes (recv loop serializes today) |
| `TestPG_ParallelSessions_OneHangs` | Two sessions, one with 10s dial timeout → fast session ready in <2s | **Skipped** (currently fails — see below) |

## Helpers added

- `testutil/recvdemux.go` — per-conn-ID packet demultiplexer so concurrent tests don't race over the shared `MockTransport.RecvCh()`.
- `testutil/pgstat.go` — sidecar admin connection that counts active PG backends via `pg_stat_activity` (excluding itself).
- `testutil/goroutineleak.go` — pre/post `runtime.NumGoroutine()` snapshot with tolerance.

## The skipped test

`TestPG_ParallelSessions_OneHangs` is the customer-symptom test (the SSH hangs reported by the stuck customer, ported to PG so we can demonstrate it against the mature harness). It points the slow session at `192.0.2.1` (RFC 5737 non-routable) so libhoop's 10s `net.DialTimeout` blocks the agent's recv loop, and asserts the fast session is unaffected.

On main today, the agent recv loop is synchronous (one `processPacket` at a time), so the fast session waits ~10s behind the slow one's dial. The test would fail.

It's skipped with a docstring explaining the condition. Unskip when the agent dispatch model supports per-session concurrency.

## Dependencies

- ENG-393 (PR #1439) provides the CI infrastructure that gives this job access to enterprise libhoop. Without it, all tests hit the OSS stub and fail at handshake. **Do not merge this until ENG-393 lands.**

## Linear

- ENG-394 (this PR, parent ENG-370)

## Out of scope

- The actual fix that would let test 3 pass (ENG-395)
- SSH and MySQL equivalent tests (ENG-391/392, ENG-387/388)

Automated by MisterMal