### PR TITLE
feat(agent+gateway): async SSH dispatch + upstream error UX + comprehensive tests [ENG-395, ENG-392, ENG-391, ENG-397]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,3 +226,13 @@ When merging `main` into a feature branch:
 | Dev run script         | `scripts/dev/run.sh`                                                   |
 | Env sample             | `.env.sample`                                                          |
 | Webapp entry           | `webapp/src/webapp/core.cljs`                                          |
+
+## Coding
+
+NO HACKS. The user is EXTREMELY concerted about code quality much more than immediate results. If they ask you to build something and, while doing so, you hit a wall, and realize that the only way to ship the requested feature is to introduce a local hack, workaround, monkey patch, duct tap - STOP IMMEDIATLY. Either fix the underlying flaw that blocked you ina ROBUST, WELL DESIGNED, PRODUCTION READY manner, or be honest that the prompt can't be completed without hacks.
+
+- DO NOT INTRODUCE HACKS IN THE CODE BASE
+- DO NOT COMMIT CODE THAT COULD BREAK THINGS LATER
+- DO NOT COMMIT PARTIAL SOLUTIONS OR WORKAROUNDS.
+
+The author appreciates honestly and he WILL be glad and thankful if you respond a request with "I couldn't complete your request because the repository lacked support for X". He will be even happier if you go ahead and update the repo to provide necessary support in a well designed and robust way. But he will be VERY ANGRY if, while attempting to implement a feature, you introduce a workaround that will potentially break things latter.

--- a/agent/controller/agent.go
+++ b/agent/controller/agent.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -34,9 +35,20 @@ import (
 	pbgateway "github.com/hoophq/hoop/common/proto/gateway"
 	pbsystem "github.com/hoophq/hoop/common/proto/system"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
+	"golang.org/x/sync/singleflight"
 )
 
 type (
+	// sessionState carries a per-session RW lock and a closed sentinel.
+	// Packet handlers take RLock for the duration of their work; SessionClose
+	// takes Lock, which drains any in-flight handlers before cleanup runs.
+	// The closed flag, read under RLock, lets handlers drop packets that
+	// arrive after cleanup has begun.
+	sessionState struct {
+		mu     sync.RWMutex
+		closed atomic.Bool
+	}
+
 	Agent struct {
 		client           pb.ClientTransport
 		connStore        memory.Store
@@ -44,10 +56,24 @@ type (
 		runtimeEnvs      map[string]string
 		shutdownCtx      context.Context
 		shutdownCancelFn context.CancelCauseFunc
-		// Using sync.Map is more complex here due untyped nature, so we use a mutex + typed map
-		connMtx         map[string]*sync.Mutex
-		connMtxStoreMtx sync.Mutex
-		closedSessions  sync.Map
+
+		// sessionStates is keyed by gateway session ID. Entries are created
+		// lazily on first access and live for the duration of the agent
+		// process; never deleting them is what lets late packets find
+		// closed=true under RLock instead of racing through a fresh state.
+		sessionStates sync.Map
+
+		// connWriteLocks serializes writes per (sessionID, connectionID).
+		// Required when packet dispatch is async (see Run) so that two
+		// goroutines handling consecutive packets for the same connection
+		// don't reorder writes to the upstream proxy.
+		connWriteLocks sync.Map
+
+		// sshFlightGroup deduplicates concurrent first-packet handling for
+		// the same (sessionID, connectionID) in processSSHProtocol. Without
+		// it, async-dispatched goroutines could each miss the connStore
+		// cache and dial duplicate upstream SSH connections.
+		sshFlightGroup singleflight.Group
 	}
 	connEnv struct {
 		scheme             string
@@ -123,8 +149,33 @@ func New(client pb.ClientTransport, cfg *config.Config, runtimeEnvs map[string]s
 		runtimeEnvs:      runtimeEnvs,
 		shutdownCtx:      shutdownCtx,
 		shutdownCancelFn: cancelFn,
-		connMtx:          make(map[string]*sync.Mutex),
 	}
+}
+
+// sessionStateFor returns the per-session lock-and-state record, creating
+// it on first reference. Entries persist for the lifetime of the agent
+// process so that a late packet for a closed session always finds
+// closed=true rather than racing through a freshly-allocated state.
+func (a *Agent) sessionStateFor(sessionID string) *sessionState {
+	if v, ok := a.sessionStates.Load(sessionID); ok {
+		return v.(*sessionState)
+	}
+	state := &sessionState{}
+	actual, _ := a.sessionStates.LoadOrStore(sessionID, state)
+	return actual.(*sessionState)
+}
+
+// connWriteLockFor returns the per-connection write mutex. It serializes
+// writes to a single upstream proxy when packet dispatch is async, so
+// consecutive packets for the same (sessionID, connectionID) do not
+// reorder at the libhoop layer.
+func (a *Agent) connWriteLockFor(key string) *sync.Mutex {
+	if v, ok := a.connWriteLocks.Load(key); ok {
+		return v.(*sync.Mutex)
+	}
+	mu := &sync.Mutex{}
+	actual, _ := a.connWriteLocks.LoadOrStore(key, mu)
+	return actual.(*sync.Mutex)
 }
 
 func (a *Agent) Close(cause error) {
@@ -218,6 +269,22 @@ func (a *Agent) Run() error {
 		case <-a.shutdownCtx.Done():
 			return context.Cause(a.shutdownCtx)
 		default:
+		}
+
+		// SSH connection writes and the SessionClose that ends them can be
+		// dispatched concurrently when the async flag is enabled, so a
+		// slow upstream on one session does not stall packet processing
+		// for other sessions on this agent. processSSHProtocol uses the
+		// session RW lock, per-connection write mutex, and singleflight
+		// group on the Agent to keep concurrent handlers correct.
+		//
+		// SessionClose is included so the recv loop is not blocked when
+		// it has to wait for an in-flight SSH handler to drain before
+		// running session cleanup.
+		if featureflagstate.IsEnabled("experimental.agent_async_ssh") &&
+			(pkt.Type == pbagent.SSHConnectionWrite || pkt.Type == pbagent.SessionClose) {
+			go a.processPacket(pkt)
+			continue
 		}
 
 		a.processPacket(pkt)
@@ -327,7 +394,17 @@ func (a *Agent) processSessionClose(pkt *pb.Packet) {
 
 func (a *Agent) sessionCleanup(sessionID string) {
 	log.With("sid", sessionID).Infof("cleaning up session")
-	a.closedSessions.Store(sessionID, true)
+
+	// Acquire the session's write lock and mark it closed before iterating
+	// the connStore. RLock holders (in-flight packet handlers) drain here,
+	// guaranteeing that no handler is mid-build when we start tearing down
+	// proxies. Late packets arriving after Unlock find closed=true under
+	// their own RLock and return without touching the store.
+	state := a.sessionStateFor(sessionID)
+	state.mu.Lock()
+	state.closed.Store(true)
+	defer state.mu.Unlock()
+
 	filterFn := func(k string) bool { return strings.Contains(k, sessionID) }
 	for key, obj := range a.connStore.Filter(filterFn) {
 		if p, ok := obj.(libhoop.Proxy); ok {
@@ -345,6 +422,7 @@ func (a *Agent) sessionCleanup(sessionID string) {
 			}()
 		}
 		a.connStore.Del(key)
+		a.connWriteLocks.Delete(key)
 	}
 }
 

--- a/agent/controller/featureflagstate/featureflagstate_test.go
+++ b/agent/controller/featureflagstate/featureflagstate_test.go
@@ -1,0 +1,117 @@
+package featureflagstate
+
+import (
+	"encoding/json"
+	"testing"
+
+	pb "github.com/hoophq/hoop/common/proto"
+)
+
+// reset clears the package-level flag state so each test starts from a
+// known baseline. The package keeps its state in a process-global map by
+// design (matching the gateway's per-process cache), so test isolation
+// has to happen at the test layer.
+func reset(t *testing.T) {
+	t.Helper()
+	mu.Lock()
+	flags = map[string]bool{}
+	mu.Unlock()
+}
+
+func TestUpdateAndIsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		flags    map[string]bool
+		query    string
+		expected bool
+	}{
+		{
+			name:     "enabled flag returns true",
+			flags:    map[string]bool{"experimental.example": true},
+			query:    "experimental.example",
+			expected: true,
+		},
+		{
+			name:     "disabled flag returns false",
+			flags:    map[string]bool{"experimental.example": false},
+			query:    "experimental.example",
+			expected: false,
+		},
+		{
+			name:     "unknown flag returns false",
+			flags:    map[string]bool{"experimental.other": true},
+			query:    "experimental.example",
+			expected: false,
+		},
+		{
+			name:     "empty state returns false",
+			flags:    map[string]bool{},
+			query:    "experimental.example",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reset(t)
+			raw, err := json.Marshal(tc.flags)
+			if err != nil {
+				t.Fatalf("failed to marshal flags: %v", err)
+			}
+			Update(map[string][]byte{pb.SpecFeatureFlagsKey: raw})
+
+			got := IsEnabled(tc.query)
+			if got != tc.expected {
+				t.Errorf("IsEnabled(%q) = %v, want %v", tc.query, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestUpdateReplacesEntireState(t *testing.T) {
+	reset(t)
+	first, _ := json.Marshal(map[string]bool{"flag_a": true, "flag_b": true})
+	Update(map[string][]byte{pb.SpecFeatureFlagsKey: first})
+
+	second, _ := json.Marshal(map[string]bool{"flag_a": true})
+	Update(map[string][]byte{pb.SpecFeatureFlagsKey: second})
+
+	if IsEnabled("flag_b") {
+		t.Error("flag_b should have been removed by the second Update")
+	}
+	if !IsEnabled("flag_a") {
+		t.Error("flag_a should still be enabled after the second Update")
+	}
+}
+
+func TestUpdateIgnoresMissingKey(t *testing.T) {
+	reset(t)
+	initial, _ := json.Marshal(map[string]bool{"sticky_flag": true})
+	Update(map[string][]byte{pb.SpecFeatureFlagsKey: initial})
+
+	// An Update call with no flags key should leave existing state intact —
+	// the gateway sometimes sends partial packets and we don't want to
+	// silently wipe the agent's flag snapshot.
+	Update(map[string][]byte{})
+
+	if !IsEnabled("sticky_flag") {
+		t.Error("sticky_flag should not have been cleared by an Update without the flags key")
+	}
+}
+
+func TestSnapshotReturnsCopy(t *testing.T) {
+	reset(t)
+	raw, _ := json.Marshal(map[string]bool{"copy_test": true})
+	Update(map[string][]byte{pb.SpecFeatureFlagsKey: raw})
+
+	snap := Snapshot()
+	snap["copy_test"] = false
+	snap["added_in_caller"] = true
+
+	if !IsEnabled("copy_test") {
+		t.Error("Snapshot must return an independent copy; mutation leaked back into the package state")
+	}
+	if IsEnabled("added_in_caller") {
+		t.Error("Snapshot must return an independent copy; new key leaked back into the package state")
+	}
+}

--- a/agent/controller/ssh.go
+++ b/agent/controller/ssh.go
@@ -13,10 +13,19 @@ import (
 
 func (a *Agent) processSSHProtocol(pkt *pb.Packet) {
 	sid := string(pkt.Spec[pb.SpecGatewaySessionID])
-	if _, closed := a.closedSessions.Load(sid); closed {
+
+	// Hold the session RLock for the duration of the handler. SessionClose
+	// takes the Lock side, which drains in-flight handlers before tearing
+	// down state; any packet that arrives after cleanup has begun finds
+	// closed=true here and returns without touching the store.
+	state := a.sessionStateFor(sid)
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.closed.Load() {
 		log.With("sid", sid).Debugf("session already closed, dropping late SSH packet")
 		return
 	}
+
 	streamClient := pb.NewStreamWriter(a.client, pbclient.SSHConnectionWrite, pkt.Spec)
 	connParams := a.connectionParams(sid)
 	if connParams == nil {
@@ -31,10 +40,17 @@ func (a *Agent) processSSHProtocol(pkt *pb.Packet) {
 		a.sendClientSessionClose(sid, "connection id not found, contact the administrator")
 		return
 	}
-	clientConnectionIDKey := fmt.Sprintf("%s:%s", sid, string(clientConnectionID))
-	clientObj := a.connStore.Get(clientConnectionIDKey)
-	if serverWriter, ok := clientObj.(io.WriteCloser); ok {
-		if _, err := serverWriter.Write(pkt.Payload); err != nil {
+	clientConnectionIDKey := fmt.Sprintf("%s:%s", sid, clientConnectionID)
+
+	// Fast path: a proxy already exists for this connection. Serialize the
+	// write under the per-connection mutex so concurrent handlers for the
+	// same (sid, connID) cannot reorder writes to libhoop's upstream.
+	if serverWriter, ok := a.connStore.Get(clientConnectionIDKey).(io.WriteCloser); ok {
+		writeMu := a.connWriteLockFor(clientConnectionIDKey)
+		writeMu.Lock()
+		_, err := serverWriter.Write(pkt.Payload)
+		writeMu.Unlock()
+		if err != nil {
 			log.With("sid", sid).Errorf("failed sending packet, err=%v", err)
 			a.sendClientSessionClose(sid, fmt.Sprintf("unable to write packet: %v", err))
 			_ = serverWriter.Close()
@@ -42,55 +58,70 @@ func (a *Agent) processSSHProtocol(pkt *pb.Packet) {
 		return
 	}
 
-	// SessionClose runs on a different mutex and may have already cleaned up
-	// this session. The closedSessions flag is set atomically before cleanup,
-	// so checking it here prevents creating a spurious SSH connection from a
-	// late-arriving packet.
-	if _, closed := a.closedSessions.Load(sid); closed {
+	// Slow path: this is the first packet for the connection. Build the
+	// libhoop proxy under singleflight so concurrent first-packets for
+	// the same (sid, connID) result in exactly one upstream dial.
+	result, err, _ := a.sshFlightGroup.Do(clientConnectionIDKey, func() (any, error) {
+		if existing, ok := a.connStore.Get(clientConnectionIDKey).(io.WriteCloser); ok {
+			return existing, nil
+		}
+
+		connenv, parseErr := parseConnectionEnvVars(connParams.EnvVars, pb.ConnectionTypeSSH)
+		if parseErr != nil {
+			return nil, fmt.Errorf("SSH credentials not found in memory: %v", parseErr)
+		}
+
 		log.With("sid", sid, "conn", clientConnectionID).
-			Debugf("session already closed, dropping late SSH packet")
-		return
-	}
+			Infof("starting SSH proxy connection at %v", connenv.Address())
 
-	connenv, err := parseConnectionEnvVars(connParams.EnvVars, pb.ConnectionTypeSSH)
-	if err != nil {
-		log.With("sid", sid).Error("SSH credentials not found in memory, err=%v", err)
-		a.sendClientSessionClose(sid, "credentials are empty, contact the administrator")
-		return
-	}
+		opts := map[string]string{
+			"sid":                    sid,
+			"hostname":               connenv.host,
+			"port":                   connenv.port,
+			"username":               connenv.user,
+			"password":               connenv.pass,
+			"authorized_server_keys": connenv.authorizedSSHKeys,
+			"connection_id":          clientConnectionID,
+		}
+		proxy, proxyErr := libhoop.NewSSHProxy(context.Background(), streamClient, opts)
+		if proxyErr != nil {
+			return nil, fmt.Errorf("failed initializing SSH proxy connection: %v", proxyErr)
+		}
 
-	log.With("sid", sid, "conn", clientConnectionID).
-		Infof("starting SSH proxy connection at %v", connenv.Address())
+		proxy.Run(func(_ int, errMsg string) {
+			a.connStore.Del(clientConnectionIDKey)
+			a.connWriteLocks.Delete(clientConnectionIDKey)
+			a.sendClientSessionClose(sid, errMsg)
+		})
 
-	opts := map[string]string{
-		"sid":                    sid,
-		"hostname":               connenv.host,
-		"port":                   connenv.port,
-		"username":               connenv.user,
-		"password":               connenv.pass,
-		"authorized_server_keys": connenv.authorizedSSHKeys,
-		"connection_id":          clientConnectionID,
-	}
-	serverWriter, err := libhoop.NewSSHProxy(context.Background(), streamClient, opts)
-	if err != nil {
-		errMsg := fmt.Sprintf("failed initializing SSH proxy connection, err=%v", err)
-		log.With("sid", sid, "conn", clientConnectionID).Errorf(errMsg)
-		a.sendClientSessionClose(sid, errMsg)
-		return
-	}
-
-	serverWriter.Run(func(_ int, errMsg string) {
-		a.connStore.Del(clientConnectionIDKey)
-		a.sendClientSessionClose(sid, errMsg)
+		a.connStore.Set(clientConnectionIDKey, proxy)
+		return proxy, nil
 	})
-
-	// write the first packet when establishing the connection
-	if _, err = serverWriter.Write(pkt.Payload); err != nil {
-		errMsg := fmt.Sprintf("unable to connect with remote SSH server, err=%v", err)
-		log.With("sid", sid, "conn", clientConnectionID).Errorf(errMsg)
-		a.sendClientSessionClose(sid, errMsg)
+	if err != nil {
+		log.With("sid", sid, "conn", clientConnectionID).Errorf("%v", err)
+		a.sendClientSessionClose(sid, err.Error())
 		return
 	}
 
-	a.connStore.Set(clientConnectionIDKey, serverWriter)
+	serverWriter, ok := result.(io.WriteCloser)
+	if !ok {
+		// Unreachable: the singleflight closure always returns an
+		// io.WriteCloser or an error. A type mismatch would mean a bug in
+		// libhoop's Proxy interface, which we can't continue past.
+		log.With("sid", sid, "conn", clientConnectionID).
+			Errorf("singleflight returned unexpected type %T", result)
+		a.sendClientSessionClose(sid, "internal error: proxy type mismatch")
+		return
+	}
+
+	// Write the first packet's payload, serialized like the fast path.
+	writeMu := a.connWriteLockFor(clientConnectionIDKey)
+	writeMu.Lock()
+	_, writeErr := serverWriter.Write(pkt.Payload)
+	writeMu.Unlock()
+	if writeErr != nil {
+		errMsg := fmt.Sprintf("unable to connect with remote SSH server, err=%v", writeErr)
+		log.With("sid", sid, "conn", clientConnectionID).Errorf(errMsg)
+		a.sendClientSessionClose(sid, errMsg)
+	}
 }

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	go.mongodb.org/mongo-driver v1.17.9
+	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	libhoop v0.0.0-00010101000000-000000000000
 )
@@ -134,7 +135,6 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/api v0.275.0 // indirect
 	google.golang.org/genproto v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/agent/integration/ssh_base_test.go
+++ b/agent/integration/ssh_base_test.go
@@ -1,0 +1,517 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/agent/integration/testutil"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// waitForUpstreamReady gives libhoop's async SSH dial+handshake time
+// to settle before the test issues real channel work. Without this,
+// NewSession returns instantly (the bridge accepts session channels
+// locally) but the upstream sshd may not yet be reachable through
+// libhoop's pending ssh.Dial, and the subsequent exec/shell request
+// races the dial.
+const waitForUpstreamReady = 500 * time.Millisecond
+
+// Base SSH protocol scenarios driven through the PipedSSHClient
+// bridge. These exercise processSSHProtocol end-to-end: the test
+// stands up a real x/crypto/ssh.Client, the bridge translates SSH
+// channel/request events into sshtypes envelopes, the agent forwards
+// them through libhoop's SSH proxy, and the real sshd container in
+// testcontainers does the actual work.
+//
+// These tests give us first-time coverage of the SSH happy paths
+// (auth, exec, pty, multi-channel, port-forward) that processSSHProtocol
+// has carried for years without an integration test.
+
+// passwordClientConfig builds an SSH client config that authenticates
+// the test against the linuxserver/openssh-server container using the
+// fixed test credentials.
+func passwordClientConfig(user, pass string) *ssh.ClientConfig {
+	return &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{ssh.Password(pass)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+}
+
+// TestSSH_PasswordAuth_Connect verifies the end-to-end SSH handshake
+// with password authentication: PipedSSHClient → net.Pipe →
+// sshtypes envelopes → MockTransport → controller.Agent →
+// libhoop.SSHProxy → upstream sshd. The assertion is "the
+// ssh.Client constructed successfully" — under the hood that
+// required KEX, password auth, and the global-request loop to all
+// complete cleanly.
+func TestSSH_PasswordAuth_Connect(t *testing.T) {
+	ssh := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sid := testutil.OpenSSHSession(t, tr, ssh.Host, ssh.Port, ssh.User, ssh.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	pc, err := testutil.DialPipedSSH(t, tr, demux, sid, "piped-1",
+		passwordClientConfig(ssh.User, ssh.Password), nil)
+	if err != nil {
+		t.Fatalf("piped ssh dial: %v", err)
+	}
+	if pc.Client == nil {
+		t.Fatalf("expected non-nil SSH client after successful dial")
+	}
+}
+
+// TestSSH_PubkeyAuth_Connect verifies the end-to-end SSH handshake
+// with public-key authentication. The test generates an RSA keypair,
+// installs the public key as the upstream sshd's authorized_keys for
+// the test user, and configures the agent's libhoop with the private
+// key via the AUTHORIZED_SERVER_KEYS env var. A successful Client.NewSession
+// proves the key-based auth path works end-to-end.
+func TestSSH_PubkeyAuth_Connect(t *testing.T) {
+	key := testutil.GenerateSSHKey(t)
+	sshC := testutil.StartSSHWithPublicKey(t, key.AuthorizedKey)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sid := testutil.OpenSSHSessionWithKey(t, tr, sshC.Host, sshC.Port, sshC.User, key.PrivateKeyPEM)
+	demux := testutil.StartRecvDemux(t, tr)
+
+	// Use the same key for the local bridge handshake — the bridge
+	// accepts anything, but this keeps the test plumbing honest.
+	clientCfg := &ssh.ClientConfig{
+		User:            sshC.User,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(key.Signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+	pc, err := testutil.DialPipedSSH(t, tr, demux, sid, "piped-pubkey", clientCfg, nil)
+	if err != nil {
+		t.Fatalf("piped ssh dial: %v", err)
+	}
+
+	// NewSession will trigger libhoop's pubkey-based dial against
+	// the upstream sshd. If the upstream rejects the key, the agent
+	// emits SessionClose; if it accepts, NewSession completes.
+	session, err := pc.Client.NewSession()
+	if err != nil {
+		t.Fatalf("new session over pubkey auth: %v", err)
+	}
+	defer session.Close()
+
+	time.Sleep(waitForUpstreamReady)
+
+	out, err := session.Output("echo pubkey-ok")
+	if err != nil {
+		t.Fatalf("exec over pubkey-authed session: %v", err)
+	}
+	got := strings.TrimSpace(string(out))
+	if got != "pubkey-ok" {
+		t.Errorf("expected 'pubkey-ok', got %q", got)
+	}
+}
+
+// TestSSH_BadCredentials configures the agent with a bad upstream
+// password and asserts the session closes cleanly when libhoop's
+// dial fails authentication.
+//
+// The test's local SSH handshake (between PipedSSHClient and the
+// in-process bridge) always succeeds because the bridge accepts any
+// auth — the real upstream authentication happens inside libhoop's
+// ssh.Dial when the first channel-open packet triggers proxy
+// creation. So the assertion is "the agent surfaces auth failure as
+// SessionClose", not "the SSH client handshake errors out."
+func TestSSH_BadCredentials(t *testing.T) {
+	sshC := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	// Open the session with a bad password baked into env vars. The
+	// agent stores these in connection params and replays them to
+	// libhoop's ssh.Dial.
+	sid := testutil.OpenSSHSession(t, tr, sshC.Host, sshC.Port, sshC.User, "definitely-not-the-password")
+	demux := testutil.StartRecvDemux(t, tr)
+
+	pc, err := testutil.DialPipedSSH(t, tr, demux, sid, "piped-bad",
+		passwordClientConfig(sshC.User, sshC.Password), nil)
+	if err != nil {
+		t.Fatalf("local piped ssh handshake should not have failed: %v", err)
+	}
+
+	// Trigger a channel open so the agent invokes libhoop, which
+	// dials the upstream with the bad credentials and fails auth.
+	// NewSession returns when the bridge accepts the channel locally,
+	// not when the upstream confirms — so we explicitly wait for the
+	// SessionClose response that surfaces libhoop's auth failure.
+	go func() {
+		session, err := pc.Client.NewSession()
+		if err == nil {
+			_ = session.Close()
+		}
+	}()
+
+	closePkt := waitForAgentSessionClose(t, demux, sid, 10*time.Second)
+	body := string(closePkt.Payload)
+	if !strings.Contains(strings.ToLower(body), "auth") &&
+		!strings.Contains(strings.ToLower(body), "unable") {
+		t.Errorf("expected SessionClose body to mention auth failure, got: %q", body)
+	}
+}
+
+// waitForAgentSessionClose drains demux.SessionChannel() until a
+// SessionClose for the given session ID arrives, or fails the test
+// on timeout. Used by tests that expect the agent to emit a clean
+// SessionClose response (e.g. on auth failure or upstream errors).
+func waitForAgentSessionClose(t *testing.T, demux *testutil.RecvDemux, sid string, timeout time.Duration) *pb.Packet {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case pkt, ok := <-demux.SessionChannel():
+			if !ok {
+				t.Fatalf("session channel closed before SessionClose for sid=%s", sid)
+			}
+			if string(pkt.Spec[pb.SpecGatewaySessionID]) == sid &&
+				pkt.Type == pbclient.SessionClose {
+				return pkt
+			}
+		case <-deadline:
+			t.Fatalf("timed out after %v waiting for SessionClose on sid=%s", timeout, sid)
+			return nil
+		}
+	}
+}
+
+// TestSSH_ExecCommand runs `echo hello` over the established
+// connection and asserts the stdout output matches. This exercises
+// channel-open + exec request + data forwarding + exit-status path
+// end-to-end.
+func TestSSH_ExecCommand(t *testing.T) {
+	sshC := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sid := testutil.OpenSSHSession(t, tr, sshC.Host, sshC.Port, sshC.User, sshC.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	pc, err := testutil.DialPipedSSH(t, tr, demux, sid, "piped-exec",
+		passwordClientConfig(sshC.User, sshC.Password), nil)
+	if err != nil {
+		t.Fatalf("piped ssh dial: %v", err)
+	}
+
+	session, err := pc.Client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer session.Close()
+
+	time.Sleep(waitForUpstreamReady)
+
+	out, err := session.Output("echo hello")
+	if err != nil {
+		t.Fatalf("exec echo hello: %v", err)
+	}
+	got := strings.TrimSpace(string(out))
+	if got != "hello" {
+		t.Errorf("expected 'hello', got %q", got)
+	}
+}
+
+// TestSSH_ExitStatus_Forwarding runs a command with a non-zero exit
+// (`false`) and asserts the SSH library surfaces the exit code. This
+// proves the ServerSSHRequest with type "exit-status" is forwarded
+// from the upstream sshd back through libhoop and the bridge to the
+// test's ssh.Session.
+func TestSSH_ExitStatus_Forwarding(t *testing.T) {
+	sshC := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sid := testutil.OpenSSHSession(t, tr, sshC.Host, sshC.Port, sshC.User, sshC.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	pc, err := testutil.DialPipedSSH(t, tr, demux, sid, "piped-exit",
+		passwordClientConfig(sshC.User, sshC.Password), nil)
+	if err != nil {
+		t.Fatalf("piped ssh dial: %v", err)
+	}
+
+	session, err := pc.Client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer session.Close()
+
+	err = session.Run("false")
+	if err == nil {
+		t.Fatalf("expected non-nil error for `false` command, got nil")
+	}
+	var exitErr *ssh.ExitError
+	if !asExitError(err, &exitErr) {
+		t.Fatalf("expected *ssh.ExitError, got %T: %v", err, err)
+	}
+	if exitErr.ExitStatus() != 1 {
+		t.Errorf("expected exit status 1, got %d", exitErr.ExitStatus())
+	}
+}
+
+// TestSSH_InteractiveShell_PTY opens an interactive shell with a
+// pty-req, writes a command to stdin, reads output from stdout, and
+// closes cleanly. Exercises pty allocation and bidirectional data
+// flow on the same channel.
+func TestSSH_InteractiveShell_PTY(t *testing.T) {
+	sshC := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sid := testutil.OpenSSHSession(t, tr, sshC.Host, sshC.Port, sshC.User, sshC.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	pc, err := testutil.DialPipedSSH(t, tr, demux, sid, "piped-pty",
+		passwordClientConfig(sshC.User, sshC.Password), nil)
+	if err != nil {
+		t.Fatalf("piped ssh dial: %v", err)
+	}
+
+	session, err := pc.Client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer session.Close()
+
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          0,
+		ssh.TTY_OP_ISPEED: 14400,
+		ssh.TTY_OP_OSPEED: 14400,
+	}
+	if err := session.RequestPty("xterm", 24, 80, modes); err != nil {
+		t.Fatalf("request pty: %v", err)
+	}
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdoutBuf := &bytes.Buffer{}
+	session.Stdout = stdoutBuf
+
+	if err := session.Shell(); err != nil {
+		t.Fatalf("start shell: %v", err)
+	}
+
+	// Write a command that produces a known marker, then exit. The
+	// pty echoes input (with ECHO=0 above this is supposed to be off
+	// but busybox sh still produces predictable output).
+	if _, err := io.WriteString(stdin, "echo PIPED_OK; exit\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+
+	// The shell exits when it sees `exit`; session.Wait returns the
+	// exit code. We don't care about the code here, just that the
+	// output contains our marker.
+	_ = session.Wait()
+	got := stdoutBuf.String()
+	if !strings.Contains(got, "PIPED_OK") {
+		t.Errorf("expected PTY shell output to contain PIPED_OK marker, got %q", got)
+	}
+}
+
+// TestSSH_MultipleChannels opens two exec channels on the same SSH
+// connection and runs commands on each. Both must complete cleanly.
+// This proves the bridge correctly multiplexes channels by ChannelID
+// (no cross-talk in the inbound packet pump).
+func TestSSH_MultipleChannels(t *testing.T) {
+	sshC := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sid := testutil.OpenSSHSession(t, tr, sshC.Host, sshC.Port, sshC.User, sshC.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	pc, err := testutil.DialPipedSSH(t, tr, demux, sid, "piped-multi",
+		passwordClientConfig(sshC.User, sshC.Password), nil)
+	if err != nil {
+		t.Fatalf("piped ssh dial: %v", err)
+	}
+
+	runOnce := func(label, cmd, want string) {
+		t.Helper()
+		session, err := pc.Client.NewSession()
+		if err != nil {
+			t.Fatalf("[%s] new session: %v", label, err)
+		}
+		defer session.Close()
+		out, err := session.Output(cmd)
+		if err != nil {
+			t.Fatalf("[%s] run %q: %v", label, cmd, err)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != want {
+			t.Errorf("[%s] expected %q, got %q", label, want, got)
+		}
+	}
+
+	// Two sequential channels (not concurrent — that's covered by
+	// the concurrency tests). The point here is that the bridge
+	// correctly handles a second channel after the first closes.
+	runOnce("ch-1", "echo one", "one")
+	runOnce("ch-2", "echo two", "two")
+}
+
+// TestSSH_SessionClose_CleanShutdown opens a session, runs a
+// command, then injects a SessionClose packet and asserts the
+// upstream connection drops cleanly. The session RW lock guarantees
+// no orphan proxies remain.
+func TestSSH_SessionClose_CleanShutdown(t *testing.T) {
+	sshC := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sid := testutil.OpenSSHSession(t, tr, sshC.Host, sshC.Port, sshC.User, sshC.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	pc, err := testutil.DialPipedSSH(t, tr, demux, sid, "piped-close",
+		passwordClientConfig(sshC.User, sshC.Password), nil)
+	if err != nil {
+		t.Fatalf("piped ssh dial: %v", err)
+	}
+
+	session, err := pc.Client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	if _, err := session.Output("echo ready"); err != nil {
+		t.Fatalf("warm-up exec: %v", err)
+	}
+	_ = session.Close()
+
+	// Inject SessionClose for this connection and verify the
+	// upstream connection count drops to zero within a reasonable
+	// window.
+	closePkt := testutil.BuildSessionClosePacket(pc.SessionID(), "0")
+	tr.Inject(closePkt)
+	sshC.WaitForEstablishedSSHConnections(t, 0, 10*time.Second)
+}
+
+// TestSSH_DirectTCPIP_PortForward opens a port-forward channel
+// through the established SSH connection, dials nginx via the
+// forward, sends an HTTP GET, and asserts the 200 response makes
+// the round trip. Exercises the direct-tcpip channel type and
+// bidirectional data flow on a non-session channel.
+func TestSSH_DirectTCPIP_PortForward(t *testing.T) {
+	// linuxserver/openssh-server defaults AllowTcpForwarding=no, so
+	// we explicitly need the variant that flips it on after the
+	// container starts.
+	sshC := testutil.StartSSHWithForwarding(t)
+	httpTarget := testutil.StartHTTPTarget(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sid := testutil.OpenSSHSession(t, tr, sshC.Host, sshC.Port, sshC.User, sshC.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	pc, err := testutil.DialPipedSSH(t, tr, demux, sid, "piped-fwd",
+		passwordClientConfig(sshC.User, sshC.Password), nil)
+	if err != nil {
+		t.Fatalf("piped ssh dial: %v", err)
+	}
+
+	// Give libhoop time to finish the async upstream SSH handshake
+	// before we ask it to open a forward channel. The forward dial
+	// (and HTTP roundtrip) happen inside the upstream SSH container,
+	// so they need the SSH channel to be fully established first.
+	time.Sleep(waitForUpstreamReady)
+
+	// Dial nginx through the SSH connection. ssh.Client.Dial opens a
+	// direct-tcpip channel against the configured destination; the
+	// agent forwards it through libhoop, which connects to nginx
+	// from inside the upstream SSH container.
+	target := httpTarget.ContainerIP + ":" + httpTarget.ContainerPort
+	conn, err := pc.Client.Dial("tcp", target)
+	if err != nil {
+		t.Fatalf("ssh dial through forward to %s: %v", target, err)
+	}
+	defer conn.Close()
+
+	if _, err := io.WriteString(conn, "GET / HTTP/1.0\r\nHost: nginx\r\n\r\n"); err != nil {
+		t.Fatalf("http write through forward: %v", err)
+	}
+
+	// SSH channels (x/crypto/ssh.chanConn) don't honor
+	// SetReadDeadline — SetReadDeadline returns "deadline not
+	// supported" and io.Copy blocks until the channel closes.
+	// Instead of waiting for the channel to close (libhoop holds
+	// the close until upstream requests-done fires, which never
+	// happens for direct-tcpip — that's a libhoop limitation
+	// tracked in ENG-396's sibling cleanups), read with a soft
+	// completion signal: once we see the HTTP status line and
+	// 200 bytes of body, we know nginx answered.
+	readDone := make(chan readResult, 1)
+	go func() {
+		buf := &bytes.Buffer{}
+		tmp := make([]byte, 4096)
+		for {
+			n, err := conn.Read(tmp)
+			if n > 0 {
+				buf.Write(tmp[:n])
+				// Once we have the status line and a chunk of
+				// body we've proven the forward works. The
+				// SSH channel won't close cleanly until the
+				// session ends, so don't wait for io.EOF.
+				if bytes.Contains(buf.Bytes(), []byte("HTTP/")) &&
+					buf.Len() >= 500 {
+					break
+				}
+			}
+			if err != nil {
+				break
+			}
+		}
+		readDone <- readResult{body: buf.String()}
+	}()
+
+	var resp string
+	select {
+	case r := <-readDone:
+		resp = r.body
+	case <-time.After(15 * time.Second):
+		t.Fatalf("http read through forward timed out after 15s")
+	}
+
+	if !strings.HasPrefix(resp, "HTTP/1.0 200") && !strings.HasPrefix(resp, "HTTP/1.1 200") {
+		t.Errorf("expected 200 OK from nginx via port-forward, got first line: %q",
+			strings.SplitN(resp, "\n", 2)[0])
+	}
+}
+
+type readResult struct {
+	body string
+	err  error
+}
+
+// asExitError unwraps an SSH command error into a *ssh.ExitError.
+// The go.crypto library returns *ExitError for non-zero command
+// exits; callers test on it to read the status code.
+func asExitError(err error, target **ssh.ExitError) bool {
+	if err == nil {
+		return false
+	}
+	if e, ok := err.(*ssh.ExitError); ok {
+		*target = e
+		return true
+	}
+	return false
+}

--- a/agent/integration/ssh_test.go
+++ b/agent/integration/ssh_test.go
@@ -1,0 +1,196 @@
+//go:build integration
+
+package integration
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/agent/integration/testutil"
+)
+
+// asyncSSHFlag is the experimental flag introduced by ENG-395 that gates
+// per-packet goroutine dispatch for SSHConnectionWrite and SessionClose.
+// When false, packets process synchronously on the recv loop; when true,
+// each packet runs in its own goroutine guarded by the per-session RW
+// lock and per-connection write mutex.
+const asyncSSHFlag = "experimental.agent_async_ssh"
+
+const sshTestTimeout = 30 * time.Second
+
+// TestSSH_BaseSmoke_FlagOff verifies that with async-SSH dispatch off,
+// opening an SSH session and asking libhoop to open a "session" channel
+// against the upstream sshd produces an observable upstream connection.
+// This is the regression contract: the flag-off path must continue to
+// behave exactly as main does today.
+func TestSSH_BaseSmoke_FlagOff(t *testing.T) {
+	ssh := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	// Reset flag state explicitly. featureflagstate is process-global
+	// and other tests in the suite may have left it on.
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: false})
+
+	sessionID := testutil.OpenSSHSession(t, tr, ssh.Host, ssh.Port, ssh.User, ssh.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	const connID = "conn-smoke"
+
+	// First packet: OpenChannel("session"). Triggers libhoop.NewSSHProxy
+	// + proxy.Run() inside the agent's singleflight closure, then the
+	// payload is forwarded to libhoop which dials the upstream sshd and
+	// opens an SSH session channel.
+	testutil.SendSSHWrite(t, tr, sessionID, connID, testutil.SSHOpenChannelPayload(1))
+
+	// Upstream connection should appear after the async dial finishes.
+	// 10s is generous against CI cold-start scheduling.
+	ssh.WaitForEstablishedSSHConnections(t, 1, 10*time.Second)
+	_ = demux // demux exists to drain any libhoop responses cleanly during shutdown
+}
+
+// TestSSH_BaseSmoke_FlagOn is the flag-on twin of the smoke test.
+// Asserts that the async dispatch path doesn't break the happy case.
+func TestSSH_BaseSmoke_FlagOn(t *testing.T) {
+	ssh := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sessionID := testutil.OpenSSHSession(t, tr, ssh.Host, ssh.Port, ssh.User, ssh.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	const connID = "conn-smoke-async"
+
+	testutil.SendSSHWrite(t, tr, sessionID, connID, testutil.SSHOpenChannelPayload(1))
+	ssh.WaitForEstablishedSSHConnections(t, 1, 10*time.Second)
+	_ = demux
+}
+
+// TestSSH_ConcurrentFirstPackets_SameConnID_FlagOn is the singleflight
+// regression contract. Fires 50 goroutines that each send the first SSH
+// packet for the same (sessionID, connID), then asserts that exactly
+// one upstream SSH connection was created — proving that
+// singleflight.Group correctly dedups concurrent proxy construction.
+//
+// Without singleflight, this scenario would race: each goroutine sees
+// connStore.Get return nil, each calls libhoop.NewSSHProxy + proxy.Run,
+// each dials the upstream. The connStore.Set is last-write-wins so
+// orphan proxies remain pumping bytes into the gRPC stream.
+//
+// This test only runs under flag-on because async dispatch is what
+// puts multiple goroutines into the same code path concurrently. With
+// sync dispatch the recv loop processes packets serially and the race
+// can't fire — but that's a behavioral coincidence, not a fix.
+func TestSSH_ConcurrentFirstPackets_SameConnID_FlagOn(t *testing.T) {
+	ssh := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	sessionID := testutil.OpenSSHSession(t, tr, ssh.Host, ssh.Port, ssh.User, ssh.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	const connID = "conn-shared"
+	const numGoroutines = 50
+
+	payload := testutil.SSHOpenChannelPayload(1)
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	startGate := make(chan struct{})
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-startGate
+			testutil.SendSSHWrite(t, tr, sessionID, connID, payload)
+		}()
+	}
+	close(startGate)
+	wg.Wait()
+
+	// Wait until the singleflight winner's dial completes and registers
+	// in the container. WaitForEstablishedSSHConnections fails if the
+	// count is anything other than 1 within the deadline — both 0
+	// (nothing happened) and >1 (race fired) are failures.
+	ssh.WaitForEstablishedSSHConnections(t, 1, 15*time.Second)
+
+	// Re-check once after a brief settle delay. If the race fired but
+	// race losers' duplicate connections close quickly (e.g., libhoop
+	// errors out on duplicate session attempts), a single point-in-time
+	// check could miss the spike. The second observation catches any
+	// late arrivals.
+	time.Sleep(500 * time.Millisecond)
+	got := ssh.EstablishedSSHConnections(t)
+	if got != 1 {
+		t.Errorf("expected exactly 1 upstream SSH connection after burst, got %d "+
+			"(singleflight should have deduped 50 concurrent first-packets to 1 dial)", got)
+	}
+	_ = demux
+}
+
+// TestSSH_SessionCloseRace_FlagOn verifies the per-session RW lock
+// introduced in ENG-395. Opens an SSH session, fires a burst of writes,
+// then injects SessionClose while writes may still be in flight on
+// their per-packet goroutines.
+//
+// The invariant: SessionClose's Lock() must drain all in-flight RLock
+// holders (the per-packet goroutines) before tearing down the
+// connStore entries. A torn-down proxy mid-Write would manifest as a
+// libhoop error sent back to the client; we don't assert that exactly,
+// but we assert clean teardown: no goroutine leak and an observable
+// SessionClose response.
+//
+// With -race enabled (when libhoop's pre-existing races are resolved in
+// ENG-396), this test would also catch any concurrent access to torn-
+// down state. We don't depend on -race here so this test is informative
+// even on the default integration runner.
+func TestSSH_SessionCloseRace_FlagOn(t *testing.T) {
+	ssh := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	leak := testutil.SnapshotGoroutines(t, 30)
+
+	sessionID := testutil.OpenSSHSession(t, tr, ssh.Host, ssh.Port, ssh.User, ssh.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	const connID = "conn-1"
+
+	// Open the channel first so subsequent writes hit the cache-hit
+	// fast path. This isolates the race we're testing (SessionClose
+	// vs cached-proxy writes) from the singleflight slow path.
+	testutil.SendSSHWrite(t, tr, sessionID, connID, testutil.SSHOpenChannelPayload(1))
+	ssh.WaitForEstablishedSSHConnections(t, 1, 10*time.Second)
+
+	// Burst Data packets. With async dispatch, each runs in its own
+	// goroutine holding the session RLock briefly. The goal is to
+	// have several handlers in flight when SessionClose arrives.
+	for i := 0; i < 20; i++ {
+		testutil.SendSSHWrite(t, tr, sessionID, connID,
+			testutil.SSHDataPayload(1, []byte("noise-data-for-libhoop\r\n")))
+	}
+
+	// Fire SessionClose immediately after the burst. With async
+	// dispatch, SessionClose is also goroutine-dispatched and must
+	// wait for the RLock holders to drain before sessionCleanup runs.
+	// SessionClose from client→agent is one-way; the agent does not
+	// emit a SessionClose back, so we observe cleanup via the upstream
+	// connection drop instead.
+	closePkt := testutil.BuildSessionClosePacket(sessionID, "0")
+	tr.Inject(closePkt)
+
+	// Upstream connection should drop once libhoop's proxy.Close()
+	// runs (kicked off in a goroutine inside sessionCleanup). If the
+	// session RW lock didn't drain in-flight handlers, sessionCleanup
+	// would race against the handlers, possibly orphaning the proxy
+	// and leaving the connection alive.
+	ssh.WaitForEstablishedSSHConnections(t, 0, 10*time.Second)
+	_ = demux
+
+	// Give libhoop's proxy goroutines a moment to fully exit after
+	// the underlying SSH client closes. SnapshotGoroutines's
+	// tolerance absorbs noise but flags a real leak.
+	time.Sleep(1 * time.Second)
+	leak.Assert(t)
+}

--- a/agent/integration/ssh_test.go
+++ b/agent/integration/ssh_test.go
@@ -19,6 +19,19 @@ const asyncSSHFlag = "experimental.agent_async_ssh"
 
 const sshTestTimeout = 30 * time.Second
 
+// stallFillBytes is the payload size used by the parallel-stall test to
+// saturate libhoop's writerQueueCh and the kernel TCP buffers between
+// agent and the (paused) slow proxy. SSH's default channel window is
+// 2 MiB; ~4 MiB of data ensures we push past it, fill the agent-side
+// kernel send buffer, fill libhoop's per-channel send loop, and back
+// pressure into the writerQueueCh buffer (capacity 100).
+const stallFillBytes = 4 * 1024 * 1024
+
+// stallChunkSize is the per-Data packet size. Smaller chunks send more
+// packets through libhoop's writerQueueCh, which makes the buffer fill
+// the dominant blocking point rather than the SSH window.
+const stallChunkSize = 16 * 1024
+
 // TestSSH_BaseSmoke_FlagOff verifies that with async-SSH dispatch off,
 // opening an SSH session and asking libhoop to open a "session" channel
 // against the upstream sshd produces an observable upstream connection.
@@ -193,4 +206,248 @@ func TestSSH_SessionCloseRace_FlagOn(t *testing.T) {
 	// tolerance absorbs noise but flags a real leak.
 	time.Sleep(1 * time.Second)
 	leak.Assert(t)
+}
+
+// TestSSH_ParallelSessions_OneStalled_FlagOff is the customer-symptom
+// reproduction in its "bug present" form. It sets up two SSH sessions
+// on the same agent:
+//
+//   - Session A goes through a SlowTCPProxy that we pause mid-stream.
+//     Once paused, agent → libhoop → proxy bytes pile up: kernel TCP
+//     send buffer (~64KB) fills, SSH channel window (2MB default) fills,
+//     libhoop's ch.Write blocks, dataChannel (unbuffered) blocks,
+//     writerQueueCh (100-slot buffer) fills, and finally the agent's
+//     serverWriter.Write blocks. This is the production hang triggered
+//     by SCP transfers against a slow remote.
+//
+//   - Session B is a normal SSH connection to the same sshd directly
+//     (no slow proxy). With sync packet dispatch (flag off), the recv
+//     loop is wedged inside Session A's blocking Write, so Session B's
+//     OpenChannel packet cannot be processed — Session B never sees
+//     its upstream connection appear.
+//
+// Asserts: Session B's upstream connection appears within 5 seconds.
+// With the flag off, this assertion fails because the agent's recv
+// loop is stuck on Session A. Under flag-on (the next test), it
+// succeeds because Session A's blocking Write runs in its own
+// goroutine and the recv loop continues dispatching Session B.
+//
+// This test pairs with TestSSH_ParallelSessions_OneStalled_FlagOn:
+// together they form the regression contract for the customer's bug.
+func TestSSH_ParallelSessions_OneStalled_FlagOff(t *testing.T) {
+	ssh := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: false})
+
+	// The slow proxy points at the real sshd. SessionA dials the
+	// proxy; SessionB dials the sshd directly so we can isolate the
+	// stall to SessionA's path.
+	slowProxy := testutil.StartSlowTCPProxy(t, ssh.ConnString())
+	slowHost, slowPort := slowProxy.Addr()
+
+	sidA := testutil.OpenSSHSession(t, tr, slowHost, slowPort, ssh.User, ssh.Password)
+	sidB := testutil.OpenSSHSession(t, tr, ssh.Host, ssh.Port, ssh.User, ssh.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	const connA = "conn-a"
+	const connB = "conn-b"
+
+	// Open a channel on session A. This completes the SSH handshake
+	// and gives us a channel we can pump data into. The proxy is not
+	// yet paused, so the handshake finishes normally.
+	testutil.SendSSHWrite(t, tr, sidA, connA, testutil.SSHOpenChannelPayload(1))
+	ssh.WaitForEstablishedSSHConnections(t, 1, 10*time.Second)
+
+	// Pause the proxy. Subsequent writes from the agent will reach
+	// the proxy but not the sshd; the proxy holds them in its kernel
+	// receive buffer until Resume.
+	slowProxy.Pause()
+
+	// Pump enough data through session A to saturate every buffer in
+	// the chain (kernel send + SSH window + libhoop's queues). Once
+	// any of these is full, the next agent Write blocks the recv
+	// loop. We fire-and-forget — the test does not wait for these
+	// goroutines.
+	fillCtx := newFillContext(t)
+	go fillSessionA(fillCtx, tr, sidA, connA)
+
+	// Give the fill loop a moment to actually push bytes and trigger
+	// the saturation. 1 second is a generous lower bound — typical
+	// saturation occurs within tens of milliseconds with 16 KiB
+	// chunks but CI scheduling can stretch it.
+	time.Sleep(1 * time.Second)
+
+	// Now try to open a channel on session B. With the recv loop
+	// blocked on session A's stalled Write, this packet cannot be
+	// processed — no second upstream SSH connection appears.
+	testutil.SendSSHWrite(t, tr, sidB, connB, testutil.SSHOpenChannelPayload(1))
+
+	// We expect the connection count to stay at 1 (only session A's
+	// proxy connection). Wait up to 5 seconds; if session B somehow
+	// got through (the bug is gone), this fails.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		got := ssh.EstablishedSSHConnections(t)
+		if got >= 2 {
+			t.Errorf("flag-off: session B opened an SSH connection (count=%d) "+
+				"despite session A stalling — the recv loop is no longer "+
+				"synchronously blocked on Write. Regression contract violated.",
+				got)
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Logf("flag-off: confirmed session B is blocked behind session A's stalled Write")
+	_ = demux
+
+	// Drain order matters: stop the fill goroutine, resume the proxy
+	// so libhoop can drain in-flight writes, send SessionClose for
+	// both sessions so libhoop's proxies close their writerQueueCh
+	// cleanly (their consumer-side loops exit on EOF rather than
+	// racing with concurrent Write calls), then shut down the agent.
+	//
+	// This dance works around two pre-existing libhoop races where
+	// concurrent Write calls during teardown can either send on a
+	// closed channel or double-close it. See ENG-396 for the libhoop
+	// fix needed to make this dance unnecessary.
+	fillCtx.cancel()
+	slowProxy.Resume()
+	teardownStalledSessions(t, tr, sidA, sidB)
+	shutdownAgent(t, agent, tr)
+}
+
+// TestSSH_ParallelSessions_OneStalled_FlagOn is the "fix verified" twin
+// of the customer-symptom test. Same setup as the flag-off variant; the
+// difference is that SSHConnectionWrite packets are now dispatched on
+// per-packet goroutines, so session A's blocking Write doesn't hold up
+// the recv loop. Session B's OpenChannel packet reaches its handler
+// promptly and the upstream SSH connection is established within a few
+// seconds.
+func TestSSH_ParallelSessions_OneStalled_FlagOn(t *testing.T) {
+	ssh := testutil.StartSSH(t)
+	agent, tr := startAgent(t)
+
+	testutil.SetAgentFeatureFlags(t, tr, map[string]bool{asyncSSHFlag: true})
+
+	slowProxy := testutil.StartSlowTCPProxy(t, ssh.ConnString())
+	slowHost, slowPort := slowProxy.Addr()
+
+	sidA := testutil.OpenSSHSession(t, tr, slowHost, slowPort, ssh.User, ssh.Password)
+	sidB := testutil.OpenSSHSession(t, tr, ssh.Host, ssh.Port, ssh.User, ssh.Password)
+	demux := testutil.StartRecvDemux(t, tr)
+	const connA = "conn-a"
+	const connB = "conn-b"
+
+	testutil.SendSSHWrite(t, tr, sidA, connA, testutil.SSHOpenChannelPayload(1))
+	ssh.WaitForEstablishedSSHConnections(t, 1, 10*time.Second)
+
+	slowProxy.Pause()
+
+	fillCtx := newFillContext(t)
+	go fillSessionA(fillCtx, tr, sidA, connA)
+
+	time.Sleep(1 * time.Second)
+
+	// Session B should open promptly because its packet is dispatched
+	// on its own goroutine; session A's stalled handler can't block
+	// the recv loop.
+	start := time.Now()
+	testutil.SendSSHWrite(t, tr, sidB, connB, testutil.SSHOpenChannelPayload(1))
+	ssh.WaitForEstablishedSSHConnections(t, 2, 10*time.Second)
+	elapsed := time.Since(start)
+	t.Logf("flag-on: session B established in %v", elapsed)
+
+	if elapsed > 5*time.Second {
+		t.Errorf("flag-on: session B took %v to establish; expected <5s. "+
+			"Session A's stall appears to still be blocking session B.", elapsed)
+	}
+	_ = demux
+
+	// Same drain dance as the flag-off twin — see comment there.
+	fillCtx.cancel()
+	slowProxy.Resume()
+	teardownStalledSessions(t, tr, sidA, sidB)
+	shutdownAgent(t, agent, tr)
+}
+
+// teardownStalledSessions sends SessionClose for both sessions and
+// waits briefly so libhoop's SSH proxies can wind down cleanly. This
+// avoids two pre-existing libhoop races (close-of-closed-channel and
+// send-on-closed-channel in Proxy.Write) that fire when many writes
+// are blocked in writerQueueCh at the moment of agent shutdown.
+//
+// The libhoop fix tracked in ENG-396 will make this helper redundant.
+func teardownStalledSessions(t *testing.T, tr *testutil.MockTransport, sids ...string) {
+	t.Helper()
+	for _, sid := range sids {
+		tr.Inject(testutil.BuildSessionClosePacket(sid, "0"))
+	}
+	// Give the SessionClose packets time to be processed and for
+	// libhoop's Proxy.Close to drain its queue. 2 seconds is enough
+	// for thousands of small in-flight packets on a local CI runner.
+	time.Sleep(2 * time.Second)
+}
+
+// fillContext encapsulates the lifecycle of the background goroutine
+// that pumps data into session A. The cancel function is invoked by
+// the test at teardown so the goroutine exits promptly.
+type fillContext struct {
+	t      *testing.T
+	done   chan struct{}
+	cancel func()
+}
+
+func newFillContext(t *testing.T) *fillContext {
+	done := make(chan struct{})
+	return &fillContext{
+		t:    t,
+		done: done,
+		cancel: sync.OnceFunc(func() {
+			close(done)
+		}),
+	}
+}
+
+// fillSessionA pushes Data packets into session A's channel to
+// saturate libhoop's writerQueueCh (100-slot buffer). It sends a
+// bounded burst then stops; the goal is to put libhoop's Write into
+// the blocking state, not to exhaust MockTransport's recvCh — the
+// test needs recvCh to retain room for session B's OpenChannel
+// packet.
+//
+// The burst size of writerQueueCap-ish packets fills the libhoop
+// queue. The few packets after that block the agent's Write (flag
+// off) or spawn blocked goroutines (flag on). Either way, the test's
+// next injection (session B) goes into recvCh with room to spare.
+//
+// Includes a small inter-packet delay so the burst is observable
+// rather than instantaneous — easier to reason about timing in CI
+// where scheduling jitter is higher.
+func fillSessionA(fc *fillContext, tr *testutil.MockTransport, sid, connID string) {
+	defer func() {
+		// SendSSHWrite calls tr.Inject which panics after 10s of
+		// blocking. Recover to keep the test process alive.
+		_ = recover()
+	}()
+
+	payload := make([]byte, stallChunkSize)
+	for i := range payload {
+		payload[i] = byte(i & 0xff)
+	}
+	dataPkt := testutil.SSHDataPayload(1, payload)
+
+	// libhoop's writerQueueCh capacity is 100. We send ~120 packets
+	// so the queue saturates and the agent's Write is blocked on
+	// packet 101+, but we leave recvCh (also 100 slots) mostly empty
+	// so the test's session B injection has room.
+	const burst = 120
+	for sent := 0; sent < burst; sent++ {
+		select {
+		case <-fc.done:
+			return
+		default:
+		}
+		testutil.SendSSHWrite(fc.t, tr, sid, connID, dataPkt)
+		time.Sleep(5 * time.Millisecond)
+	}
 }

--- a/agent/integration/testutil/featureflag.go
+++ b/agent/integration/testutil/featureflag.go
@@ -1,0 +1,38 @@
+//go:build integration
+
+package testutil
+
+import (
+	"encoding/json"
+	"time"
+
+	pb "github.com/hoophq/hoop/common/proto"
+	pbgateway "github.com/hoophq/hoop/common/proto/gateway"
+)
+
+// SetAgentFeatureFlags pushes a FeatureFlagUpdate packet at the agent so
+// subsequent IsEnabled checks for the listed flags return true. The agent
+// processes the packet on the recv loop; a brief sleep gives the loop
+// time to apply the snapshot before the test proceeds.
+//
+// Pass an empty map to clear all flags (the agent treats Update with an
+// empty snapshot as "reset everything to disabled").
+func SetAgentFeatureFlags(t T, tr *MockTransport, flags map[string]bool) {
+	t.Helper()
+	raw, err := json.Marshal(flags)
+	if err != nil {
+		t.Fatalf("featureflag: failed marshaling flags: %v", err)
+	}
+	pkt := &pb.Packet{
+		Type: pbgateway.FeatureFlagUpdate,
+		Spec: map[string][]byte{
+			pb.SpecFeatureFlagsKey: raw,
+		},
+	}
+	tr.Inject(pkt)
+
+	// The recv loop is async; give it a moment to land. 50ms is well past
+	// any realistic delay between Inject() returning and the agent
+	// observing the packet, but short enough to keep tests snappy.
+	time.Sleep(50 * time.Millisecond)
+}

--- a/agent/integration/testutil/slow_tcp_proxy.go
+++ b/agent/integration/testutil/slow_tcp_proxy.go
@@ -1,0 +1,214 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// SlowTCPProxy is a TCP forwarder that can be paused on demand. It sits
+// between the agent (as the SSH client) and the real sshd container,
+// transparently bidirectional in the normal state.
+//
+// When Pause() is called, the proxy stops draining bytes from the
+// agent-side connection to the upstream-side connection. Bytes pile up
+// in the agent → libhoop → libhoop's writerQueueCh path; once that
+// 100-message buffer fills, the agent's serverWriter.Write blocks. With
+// synchronous packet dispatch (feature flag off), that blocks the
+// entire recv loop and any other session on the agent stalls — which is
+// exactly the customer's reported symptom.
+//
+// Resume() releases the buffered bytes back to the upstream.
+//
+// SlowTCPProxy is goroutine-safe. Stop() closes the listener and any
+// active connections; the test's t.Cleanup hook calls it automatically.
+type SlowTCPProxy struct {
+	listener   net.Listener
+	upstream   string // host:port
+	paused     atomic.Bool
+	resumeCh   chan struct{} // closed and replaced under mu on each Pause()
+	mu         sync.Mutex
+	activeConn []net.Conn
+	wg         sync.WaitGroup
+	stopped    atomic.Bool
+}
+
+// StartSlowTCPProxy starts a TCP forwarder on an ephemeral port and
+// returns its host:port plus the proxy handle. Connections accepted on
+// the proxy are forwarded bidirectionally to upstreamAddr. Use Pause/
+// Resume to control whether agent→upstream bytes drain.
+func StartSlowTCPProxy(t T, upstreamAddr string) *SlowTCPProxy {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("slow-tcp-proxy: failed to listen: %v", err)
+	}
+
+	p := &SlowTCPProxy{
+		listener: ln,
+		upstream: upstreamAddr,
+		resumeCh: make(chan struct{}),
+	}
+
+	p.wg.Add(1)
+	go p.acceptLoop()
+
+	t.Cleanup(func() {
+		p.Stop()
+	})
+	return p
+}
+
+// Addr returns the listener address as host, port strings ready to be
+// passed to BuildSSHEnvVars.
+func (p *SlowTCPProxy) Addr() (host, port string) {
+	addr := p.listener.Addr().(*net.TCPAddr)
+	return addr.IP.String(), fmt.Sprintf("%d", addr.Port)
+}
+
+// Pause stops draining agent→upstream bytes. Already-buffered bytes in
+// the kernel's TCP receive buffer stay there; bytes the agent writes
+// after Pause arrive at the proxy but are held until Resume.
+//
+// Idempotent; calling Pause while already paused is a no-op.
+func (p *SlowTCPProxy) Pause() {
+	p.paused.Store(true)
+}
+
+// Resume releases the proxy from a paused state. Any goroutines that
+// were waiting on the resume channel wake up and drain the bytes that
+// piled up during the pause.
+//
+// Idempotent.
+func (p *SlowTCPProxy) Resume() {
+	p.mu.Lock()
+	if !p.paused.Swap(false) {
+		p.mu.Unlock()
+		return
+	}
+	old := p.resumeCh
+	p.resumeCh = make(chan struct{})
+	p.mu.Unlock()
+	close(old)
+}
+
+// Stop terminates the proxy: closes the listener and every active
+// connection it forwarded. Safe to call multiple times.
+func (p *SlowTCPProxy) Stop() {
+	if !p.stopped.CompareAndSwap(false, true) {
+		return
+	}
+	_ = p.listener.Close()
+	p.mu.Lock()
+	conns := append([]net.Conn(nil), p.activeConn...)
+	p.activeConn = nil
+	p.mu.Unlock()
+	for _, c := range conns {
+		_ = c.Close()
+	}
+	// Unblock any goroutines currently parked on resumeCh.
+	p.Resume()
+	p.wg.Wait()
+}
+
+func (p *SlowTCPProxy) acceptLoop() {
+	defer p.wg.Done()
+	for {
+		downstream, err := p.listener.Accept()
+		if err != nil {
+			return
+		}
+		p.trackConn(downstream)
+		p.wg.Add(1)
+		go p.handleConn(downstream)
+	}
+}
+
+func (p *SlowTCPProxy) trackConn(c net.Conn) {
+	p.mu.Lock()
+	p.activeConn = append(p.activeConn, c)
+	p.mu.Unlock()
+}
+
+func (p *SlowTCPProxy) handleConn(downstream net.Conn) {
+	defer p.wg.Done()
+	defer downstream.Close()
+
+	dialCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	d := net.Dialer{}
+	upstream, err := d.DialContext(dialCtx, "tcp", p.upstream)
+	if err != nil {
+		return
+	}
+	p.trackConn(upstream)
+	defer upstream.Close()
+
+	// Two unidirectional pumps. Upstream → downstream never pauses so
+	// SSH replies can reach the agent during a paused state (the SSH
+	// handshake itself must complete before a Pause() makes sense).
+	// Downstream → upstream respects the pause and is where buffers
+	// accumulate.
+	//
+	// Use a WaitGroup local to this connection so handleConn doesn't
+	// return (and trigger the deferred Close) until both pumps finish.
+	// Without this, the two goroutines outlive their connections and
+	// the deferred Close fires immediately, resetting the SSH
+	// handshake before any bytes flow.
+	var pumpWg sync.WaitGroup
+	pumpWg.Add(2)
+	p.wg.Add(2)
+	go func() {
+		defer pumpWg.Done()
+		p.copyOneWay(upstream, downstream, false /* respectPause */)
+	}()
+	go func() {
+		defer pumpWg.Done()
+		p.copyOneWay(downstream, upstream, true /* respectPause */)
+	}()
+	pumpWg.Wait()
+}
+
+// copyOneWay forwards bytes from src to dst. If respectPause is true,
+// the loop waits on the proxy's resumeCh whenever paused is set before
+// performing the dst.Write. This is the direction (agent → upstream)
+// where we want backpressure to accumulate.
+func (p *SlowTCPProxy) copyOneWay(src, dst net.Conn, respectPause bool) {
+	defer p.wg.Done()
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			if respectPause {
+				for p.paused.Load() && !p.stopped.Load() {
+					p.mu.Lock()
+					ch := p.resumeCh
+					p.mu.Unlock()
+					<-ch
+				}
+				if p.stopped.Load() {
+					return
+				}
+			}
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				return
+			}
+		}
+		if err != nil {
+			// Half-close the write side so the peer sees EOF instead of
+			// the connection abruptly resetting. SSH treats RST as a
+			// protocol error during teardown.
+			if tc, ok := dst.(*net.TCPConn); ok {
+				_ = tc.CloseWrite()
+			}
+			return
+		}
+	}
+}
+
+

--- a/agent/integration/testutil/ssh_client.go
+++ b/agent/integration/testutil/ssh_client.go
@@ -1,0 +1,458 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pb "github.com/hoophq/hoop/common/proto"
+	sshtypes "libhoop/proxy/ssh/types"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// PipedSSHClient runs an x/crypto/ssh.Client whose underlying transport
+// is bridged to a MockTransport via net.Pipe and a sshtypes envelope
+// translator. From the test's perspective it's a regular SSH client:
+// New a session, run Exec or Shell, get output back.
+//
+// Why this exists
+//
+// libhoop's SSH proxy speaks hoop's custom envelope on the agent ←→
+// gateway wire, not raw SSH. So tests can't simply wrap MockTransport
+// in a net.Conn and call ssh.NewClient — the agent would receive raw
+// SSH bytes and reject them with "unknown packet type". The
+// PipedSSHClient mirrors the client/proxy/ssh.go pattern from the
+// real hoop CLI: it stands up an ssh.ServerConn on a net.Pipe, the
+// test's SSH client connects to it as if it were any other SSH
+// server, and the bridging layer translates SSH channel/request/data
+// events into sshtypes envelopes shipped over the MockTransport.
+//
+// Wire flow
+//
+//	test                  PipedSSHClient                MockTransport / Agent
+//	──────                ──────────────                 ────────────────────
+//	ssh.NewSession()      SSH server-side translator     sshtypes.OpenChannel
+//	  → channel open  ──► net.Pipe ──► ssh.ServerConn ──► encode ──► Inject()
+//	                                                      │
+//	  ← channel data   ◄── net.Pipe ◄── ssh.ServerConn ◄── decode ◄── Recv (demux)
+//
+// PipedSSHClient is not safe for use by multiple goroutines other
+// than the parallelism naturally provided by *ssh.Session and *ssh.Channel
+// (each test should drive one PipedSSHClient and use the SSH library's
+// own multiplexing for concurrent channels).
+type PipedSSHClient struct {
+	// Client is the configured ssh.Client. Tests call Client.NewSession(),
+	// Client.Dial(), etc. directly.
+	Client *ssh.Client
+
+	sessionID string
+	connID    string
+	tr        *MockTransport
+	demux     *RecvDemux
+
+	// pipe sides
+	clientConn net.Conn // the test's SSH client side
+	serverConn net.Conn // the translator's SSH server side
+
+	// SSH server-side state
+	srvConn *ssh.ServerConn
+
+	// Bridge: maps hoop channel IDs ↔ ssh.Channel on the server side so
+	// inbound Data packets can find the channel to write to.
+	chanMu     sync.Mutex
+	channels   map[uint16]*serverChannelState
+	nextChanID atomic.Uint32
+
+	cancel    context.CancelFunc
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+// serverChannelState tracks the SSH channel we accepted on the server
+// side plus any pending request replies indexed by request type.
+type serverChannelState struct {
+	ch        ssh.Channel
+	chType    string
+	closeOnce sync.Once
+}
+
+// DialPipedSSH builds the net.Pipe-bridged SSH server/translator and
+// returns a PipedSSHClient with a connected ssh.Client ready for the
+// test to drive. The session must already be open at the agent (call
+// OpenSSHSession before StartRecvDemux + DialPipedSSH).
+//
+// clientCfg drives the test's local SSH client (auth method, host-key
+// callback). sshSrvCfg drives the translator's SSH server side (host
+// key, auth callbacks); it can be nil for sensible defaults that
+// accept any auth.
+//
+// Cleanup is automatic via t.Cleanup; tests don't need to defer Close.
+func DialPipedSSH(t *testing.T, tr *MockTransport, demux *RecvDemux,
+	sid, connID string,
+	clientCfg *ssh.ClientConfig, sshSrvCfg *ssh.ServerConfig) (*PipedSSHClient, error) {
+	t.Helper()
+
+	// We use a real TCP loopback listener instead of net.Pipe because
+	// net.Pipe is synchronous (Write blocks until the other side
+	// Reads), which deadlocks SSH's exchangeVersions step: both sides
+	// do Write(banner) then Read(banner) serially and neither
+	// completes its Write because the other isn't yet Reading. A real
+	// TCP socket has kernel-level send buffers that absorb the small
+	// banner write without blocking.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("piped ssh listen: %w", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &PipedSSHClient{
+		sessionID: sid,
+		connID:    connID,
+		tr:        tr,
+		demux:     demux,
+		channels:  make(map[uint16]*serverChannelState),
+		cancel:    cancel,
+		done:      make(chan struct{}),
+	}
+
+	if sshSrvCfg == nil {
+		sshSrvCfg = defaultSSHServerConfig(t)
+	}
+
+	// Server-side handshake runs in a goroutine because both sides of
+	// an SSH handshake need to be reading/writing concurrently;
+	// ssh.NewServerConn and ssh.NewClientConn each block until the
+	// handshake completes.
+	srvErrCh := make(chan error, 1)
+	srvReadyCh := make(chan struct{})
+	go func() {
+		defer listener.Close()
+		conn, err := listener.Accept()
+		if err != nil {
+			srvErrCh <- err
+			close(srvReadyCh)
+			return
+		}
+		p.serverConn = conn
+		srvConn, newChans, reqs, err := ssh.NewServerConn(conn, sshSrvCfg)
+		if err != nil {
+			srvErrCh <- err
+			close(srvReadyCh)
+			return
+		}
+		p.srvConn = srvConn
+		close(srvReadyCh)
+		go ssh.DiscardRequests(reqs)
+		p.serveNewChannels(ctx, newChans)
+	}()
+
+	clientConn, err := net.DialTimeout("tcp", listener.Addr().String(), 5*time.Second)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("piped ssh dial loopback: %w", err)
+	}
+	p.clientConn = clientConn
+
+	// The inbound-packet pump runs concurrently with the handshake so
+	// the agent's SSHConnectionWrite responses (e.g. SSHRequestReply
+	// after the client sends a request) reach the translator. The
+	// handshake itself is in raw-SSH bytes over net.Pipe, not over
+	// MockTransport, so the inbound pump matters only after the first
+	// channel opens.
+	go p.inboundPump(ctx)
+
+	// Run the test's SSH client handshake. ssh.NewClientConn returns
+	// after KEX + auth completes successfully (or fails).
+	cConn, cChans, cReqs, err := ssh.NewClientConn(p.clientConn, "piped", clientCfg)
+	if err != nil {
+		p.Close()
+		return nil, fmt.Errorf("ssh client handshake: %w", err)
+	}
+
+	// Wait briefly for the server-side handshake to also complete so
+	// p.srvConn is set before we return.
+	select {
+	case err := <-srvErrCh:
+		p.Close()
+		return nil, fmt.Errorf("ssh server-side handshake: %w", err)
+	case <-srvReadyCh:
+	case <-time.After(10 * time.Second):
+		p.Close()
+		return nil, fmt.Errorf("ssh server-side handshake: timed out")
+	}
+
+	p.Client = ssh.NewClient(cConn, cChans, cReqs)
+
+	t.Cleanup(func() {
+		p.Close()
+	})
+	return p, nil
+}
+
+// Close tears down both sides of the pipe and the inbound pump. Safe
+// to call multiple times.
+func (p *PipedSSHClient) Close() {
+	p.closeOnce.Do(func() {
+		p.cancel()
+		if p.Client != nil {
+			_ = p.Client.Close()
+		}
+		if p.srvConn != nil {
+			_ = p.srvConn.Close()
+		}
+		_ = p.clientConn.Close()
+		_ = p.serverConn.Close()
+		close(p.done)
+	})
+}
+
+// SessionID returns the agent-side session ID, useful for sending
+// SessionClose packets in teardown tests.
+func (p *PipedSSHClient) SessionID() string { return p.sessionID }
+
+// ConnID returns the gateway-side connection ID this client occupies.
+func (p *PipedSSHClient) ConnID() string { return p.connID }
+
+// serveNewChannels handles each new channel request from the test's
+// SSH client by accepting it on the server side, allocating a hoop
+// channel ID, and forwarding it to the agent as sshtypes.OpenChannel.
+// Once accepted, the channel's I/O is bridged to sshtypes.Data /
+// sshtypes.SSHRequest packets in dedicated goroutines.
+func (p *PipedSSHClient) serveNewChannels(ctx context.Context, newChans <-chan ssh.NewChannel) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case newCh, ok := <-newChans:
+			if !ok {
+				return
+			}
+			p.handleNewChannel(ctx, newCh)
+		}
+	}
+}
+
+func (p *PipedSSHClient) handleNewChannel(ctx context.Context, newCh ssh.NewChannel) {
+	chID := uint16(p.nextChanID.Add(1))
+	chType := newCh.ChannelType()
+	chExtra := newCh.ExtraData()
+
+	srvCh, reqs, err := newCh.Accept()
+	if err != nil {
+		return
+	}
+
+	p.chanMu.Lock()
+	p.channels[chID] = &serverChannelState{ch: srvCh, chType: chType}
+	p.chanMu.Unlock()
+
+	// Tell the agent to open the same channel against the upstream sshd.
+	p.sendPacket((sshtypes.OpenChannel{
+		ChannelID:        chID,
+		ChannelType:      chType,
+		ChannelExtraData: chExtra,
+	}).Encode())
+
+	// Pump channel data from the test's SSH client → sshtypes.Data
+	// packets bound for the agent. We do NOT close srvCh on Read
+	// returning EOF — closing the local channel would tear down the
+	// channel on the test's side, and many tests open a channel and
+	// only read from it (exec, port-forward) without writing any
+	// stdin. EOF here just means "no more outbound stdin from the
+	// test," which we signal to the upstream so commands see stdin
+	// closed.
+	go func() {
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := srvCh.Read(buf)
+			if n > 0 {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				p.sendPacket((sshtypes.Data{
+					ChannelID: chID,
+					Payload:   append([]byte(nil), buf[:n]...),
+				}).Encode())
+			}
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					p.sendPacket((sshtypes.EOF{ChannelID: chID}).Encode())
+				}
+				return
+			}
+		}
+	}()
+
+	// Pump channel requests (pty-req, shell, exec, signal, etc.) as
+	// sshtypes.SSHRequest packets bound for the agent.
+	go func() {
+		for req := range reqs {
+			p.sendPacket((sshtypes.SSHRequest{
+				ChannelID:   chID,
+				RequestType: req.Type,
+				WantReply:   req.WantReply,
+				Payload:     req.Payload,
+			}).Encode())
+			// We reply locally with success because the real
+			// reply will arrive asynchronously from the agent
+			// as sshtypes.SSHRequestReply (which the inbound
+			// pump consumes); x/crypto/ssh requires reply by
+			// the time the request handler returns, so we
+			// can't wait for the real one. This matches the
+			// pattern in client/proxy/ssh.go.
+			if req.WantReply {
+				_ = req.Reply(true, nil)
+			}
+		}
+	}()
+}
+
+// inboundPump consumes SSHConnectionWrite packets the agent emits on
+// behalf of this connection and dispatches them to the right local
+// SSH channel.
+func (p *PipedSSHClient) inboundPump(ctx context.Context) {
+	if p.demux == nil {
+		return
+	}
+	ch := p.demux.Channel(p.connID)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case pkt, ok := <-ch:
+			if !ok {
+				return
+			}
+			p.handleInboundPacket(pkt)
+		}
+	}
+}
+
+func (p *PipedSSHClient) handleInboundPacket(pkt *pb.Packet) {
+	if len(pkt.Payload) == 0 {
+		return
+	}
+	switch sshtypes.DecodeType(pkt.Payload) {
+	case sshtypes.DataType:
+		var d sshtypes.Data
+		if err := sshtypes.Decode(pkt.Payload, &d); err != nil {
+			return
+		}
+		if state := p.lookupChannel(d.ChannelID); state != nil {
+			_, _ = state.ch.Write(d.Payload)
+		}
+	case sshtypes.CloseChannelType:
+		var cc sshtypes.CloseChannel
+		if err := sshtypes.Decode(pkt.Payload, &cc); err != nil {
+			return
+		}
+		p.chanMu.Lock()
+		state := p.channels[cc.ID]
+		delete(p.channels, cc.ID)
+		p.chanMu.Unlock()
+		if state != nil {
+			state.closeOnce.Do(func() { _ = state.ch.Close() })
+		}
+	case sshtypes.EOFType:
+		var eof sshtypes.EOF
+		if err := sshtypes.Decode(pkt.Payload, &eof); err != nil {
+			return
+		}
+		if state := p.lookupChannel(eof.ChannelID); state != nil {
+			_ = state.ch.CloseWrite()
+		}
+	case sshtypes.ServerSSHRequestType:
+		var sreq sshtypes.ServerSSHRequest
+		if err := sshtypes.Decode(pkt.Payload, &sreq); err != nil {
+			return
+		}
+		state := p.lookupChannel(sreq.ChannelID)
+		if state == nil {
+			return
+		}
+		// Forward the server's request (e.g. exit-status) to the
+		// test's local SSH client side as a channel request.
+		_, _ = state.ch.SendRequest(sreq.RequestType, sreq.WantReply, sreq.Payload)
+	case sshtypes.SSHRequestReplyType:
+		// We replied locally to wantReply=true when forwarding the
+		// outbound request; the upstream's reply is informational
+		// here. Dropping it is fine for tests that don't need to
+		// distinguish ok=true vs ok=false on requests.
+		return
+	}
+}
+
+func (p *PipedSSHClient) lookupChannel(chID uint16) *serverChannelState {
+	p.chanMu.Lock()
+	defer p.chanMu.Unlock()
+	return p.channels[chID]
+}
+
+// sendPacket injects an SSHConnectionWrite packet at the agent on
+// behalf of the bridged SSH client. Guards against the test having
+// already canceled the bridge (the agent shut down, MockTransport's
+// recvCh is closed) — in that case, packets that would have been
+// queued by a goroutine still mid-flight are silently dropped. The
+// alternative is a process panic from "send on closed channel" inside
+// tr.Inject during teardown.
+func (p *PipedSSHClient) sendPacket(payload []byte) {
+	select {
+	case <-p.done:
+		return
+	default:
+	}
+	defer func() {
+		// Last-ditch defense against the narrow window where Inject
+		// races a transport Close that happens between the select
+		// above and the channel send inside Inject.
+		_ = recover()
+	}()
+	SendSSHWrite(noopT{}, p.tr, p.sessionID, p.connID, payload)
+}
+
+// defaultSSHServerConfig returns a minimal SSH server config suitable
+// for the translator side of the pipe: any password / pubkey / none
+// auth is accepted because the actual auth happens out at the real
+// sshd container; the in-pipe handshake just needs to complete.
+func defaultSSHServerConfig(t *testing.T) *ssh.ServerConfig {
+	t.Helper()
+	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("piped-ssh: failed to generate host key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(hostKey)
+	if err != nil {
+		t.Fatalf("piped-ssh: failed to build host key signer: %v", err)
+	}
+	cfg := &ssh.ServerConfig{
+		NoClientAuth: true,
+	}
+	cfg.AddHostKey(signer)
+	return cfg
+}
+
+// noopT is a minimal T implementation used internally by the bridge
+// goroutines that call testutil helpers (which expect a T for
+// Helper(), Fatalf(), and Cleanup()). The bridge is best-effort
+// during teardown — if a packet inject fails we don't want to fail
+// the test from a goroutine the test no longer owns.
+type noopT struct{}
+
+func (noopT) Helper()                           {}
+func (noopT) Fatalf(format string, args ...any) {}
+func (noopT) Cleanup(func())                    {}
+
+// Compile-time assertion that noopT satisfies the T interface.
+var _ T = noopT{}

--- a/agent/integration/testutil/ssh_container.go
+++ b/agent/integration/testutil/ssh_container.go
@@ -26,6 +26,17 @@ type SSHContainer struct {
 	Container testcontainers.Container
 }
 
+// StartSSHWithForwarding boots an OpenSSH server with TCP forwarding
+// enabled. linuxserver/openssh-server defaults `AllowTcpForwarding no`,
+// which blocks the direct-tcpip channels exercised by port-forward
+// tests. This variant runs an exec inside the container after start
+// to flip the config and reload sshd.
+func StartSSHWithForwarding(t T) *SSHContainer {
+	c := startSSHContainer(t, "")
+	c.enableTCPForwarding(t)
+	return c
+}
+
 // StartSSH boots an OpenSSH server in a container. Password auth is enabled
 // for the test user so password-based credentials match what
 // parseConnectionEnvVars expects.
@@ -33,26 +44,47 @@ type SSHContainer struct {
 // linuxserver/openssh-server takes a few seconds to provision the user; the
 // wait strategy polls the TCP port until it accepts connections rather than
 // scraping logs, which is more reliable across image versions.
+//
+// Use StartSSHWithPublicKey for tests that need pubkey auth.
 func StartSSH(t T) *SSHContainer {
+	return startSSHContainer(t, "")
+}
+
+// StartSSHWithPublicKey boots an OpenSSH server with the given public key
+// installed in the test user's authorized_keys, plus password auth still
+// enabled as a fallback. Pass the public key in OpenSSH authorized-keys
+// format (e.g. "ssh-rsa AAAAB3..."). Used by pubkey-auth tests.
+func StartSSHWithPublicKey(t T, publicKey string) *SSHContainer {
+	return startSSHContainer(t, publicKey)
+}
+
+func startSSHContainer(t T, publicKey string) *SSHContainer {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	const user = "testuser"
 	const password = "testpass"
 
+	env := map[string]string{
+		"PUID":            "1000",
+		"PGID":            "1000",
+		"TZ":              "Etc/UTC",
+		"USER_NAME":       user,
+		"USER_PASSWORD":   password,
+		"PASSWORD_ACCESS": "true",
+		"SUDO_ACCESS":     "false",
+	}
+	if publicKey != "" {
+		// linuxserver/openssh-server's entrypoint reads PUBLIC_KEY
+		// and appends it to the user's authorized_keys file.
+		env["PUBLIC_KEY"] = publicKey
+	}
+
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        "lscr.io/linuxserver/openssh-server:latest",
 			ExposedPorts: []string{"2222/tcp"},
-			Env: map[string]string{
-				"PUID":            "1000",
-				"PGID":            "1000",
-				"TZ":              "Etc/UTC",
-				"USER_NAME":       user,
-				"USER_PASSWORD":   password,
-				"PASSWORD_ACCESS": "true",
-				"SUDO_ACCESS":     "false",
-			},
+			Env:          env,
 			WaitingFor: wait.ForListeningPort("2222/tcp").
 				WithStartupTimeout(60 * time.Second),
 		},
@@ -120,6 +152,113 @@ func (c *SSHContainer) waitForBanner(t T) {
 // ConnString returns a host:port string suitable for direct TCP dialing.
 func (c *SSHContainer) ConnString() string {
 	return fmt.Sprintf("%s:%s", c.Host, c.Port)
+}
+
+// enableTCPForwarding edits the sshd_config inside the container so
+// direct-tcpip channels work, then sends a HUP to sshd to pick up
+// the change. linuxserver/openssh-server ships with
+// `AllowTcpForwarding no` and there's no env var to override it.
+//
+// Idempotent — calling twice does no harm.
+func (c *SSHContainer) enableTCPForwarding(t T) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Patch the running sshd config, then reload via SIGHUP. The
+	// process pidfile lives at the standard /config/sshd/sshd.pid in
+	// linuxserver, but pkill is simpler and works across versions.
+	_, _, err := c.Container.Exec(ctx, []string{
+		"sh", "-c",
+		"sed -i 's/^AllowTcpForwarding no/AllowTcpForwarding yes/' /config/sshd/sshd_config && " +
+			"pkill -HUP sshd || true",
+	}, tcexec.Multiplexed())
+	if err != nil {
+		t.Fatalf("ssh-container: enableTCPForwarding exec: %v", err)
+	}
+
+	// Settle delay so sshd's HUP reload completes before tests
+	// drive port-forward traffic. SIGHUP causes sshd to re-exec
+	// itself; a few hundred ms is enough.
+	time.Sleep(500 * time.Millisecond)
+}
+
+// HTTPTarget represents a small HTTP server container intended as the
+// destination for SSH direct-tcpip port-forward tests. The
+// ContainerIP and ContainerPort fields point at the in-network
+// address reachable from other containers on the docker bridge
+// network (which is what the SSH container needs); HostPort exposes
+// the same service on the host for sanity-check fetches from the
+// test process.
+type HTTPTarget struct {
+	ContainerIP   string
+	ContainerPort string
+	HostPort      string
+	Container     testcontainers.Container
+}
+
+// StartHTTPTarget boots a minimal nginx container that serves a fixed
+// response. Used by the port-forward test as the target the SSH
+// channel is forwarded to.
+func StartHTTPTarget(t T) *HTTPTarget {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "nginx:alpine",
+			ExposedPorts: []string{"80/tcp"},
+			WaitingFor: wait.ForListeningPort("80/tcp").
+				WithStartupTimeout(30 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to start nginx container: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = container.Terminate(context.Background())
+	})
+
+	port, err := container.MappedPort(ctx, "80/tcp")
+	if err != nil {
+		t.Fatalf("nginx port: %v", err)
+	}
+
+	// Inspect the container to find its IP on the default docker
+	// bridge. We need this address — not the host-mapped one — to
+	// reach nginx from inside the SSH container (which is the
+	// destination of the direct-tcpip forward).
+	state, err := container.Inspect(ctx)
+	if err != nil {
+		t.Fatalf("nginx inspect: %v", err)
+	}
+	var ip string
+	if state != nil && state.NetworkSettings != nil {
+		for _, network := range state.NetworkSettings.Networks {
+			if network != nil && network.IPAddress.IsValid() {
+				ip = network.IPAddress.String()
+				break
+			}
+		}
+	}
+	if ip == "" {
+		t.Fatalf("nginx container has no IP address on any network")
+	}
+
+	return &HTTPTarget{
+		ContainerIP:   ip,
+		ContainerPort: "80",
+		HostPort:      port.Port(),
+		Container:     container,
+	}
+}
+
+// HostURL returns the http://host:port the test process can hit
+// directly (used to verify nginx is actually running before
+// exercising the port-forward path).
+func (h *HTTPTarget) HostURL() string {
+	return fmt.Sprintf("http://127.0.0.1:%s/", h.HostPort)
 }
 
 // EstablishedSSHConnections returns the number of established TCP

--- a/agent/integration/testutil/ssh_container.go
+++ b/agent/integration/testutil/ssh_container.go
@@ -1,0 +1,192 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// SSHContainer wraps a linuxserver/openssh-server container for integration
+// tests. Credentials are fixed so test code can reference them directly:
+// user "testuser" / password "testpass".
+type SSHContainer struct {
+	Host      string
+	Port      string
+	User      string
+	Password  string
+	Container testcontainers.Container
+}
+
+// StartSSH boots an OpenSSH server in a container. Password auth is enabled
+// for the test user so password-based credentials match what
+// parseConnectionEnvVars expects.
+//
+// linuxserver/openssh-server takes a few seconds to provision the user; the
+// wait strategy polls the TCP port until it accepts connections rather than
+// scraping logs, which is more reliable across image versions.
+func StartSSH(t T) *SSHContainer {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	const user = "testuser"
+	const password = "testpass"
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "lscr.io/linuxserver/openssh-server:latest",
+			ExposedPorts: []string{"2222/tcp"},
+			Env: map[string]string{
+				"PUID":            "1000",
+				"PGID":            "1000",
+				"TZ":              "Etc/UTC",
+				"USER_NAME":       user,
+				"USER_PASSWORD":   password,
+				"PASSWORD_ACCESS": "true",
+				"SUDO_ACCESS":     "false",
+			},
+			WaitingFor: wait.ForListeningPort("2222/tcp").
+				WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to start openssh container: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = container.Terminate(context.Background())
+	})
+
+	mappedPort, err := container.MappedPort(ctx, "2222/tcp")
+	if err != nil {
+		t.Fatalf("failed to get mapped ssh port: %v", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("failed to get ssh container host: %v", err)
+	}
+
+	c := &SSHContainer{
+		Host:      host,
+		Port:      mappedPort.Port(),
+		User:      user,
+		Password:  password,
+		Container: container,
+	}
+
+	// linuxserver/openssh-server briefly accepts TCP before sshd is fully
+	// initialized — the port is up while user provisioning still runs in
+	// the entrypoint. Probe the banner to make sure sshd is actually
+	// speaking SSH before returning.
+	c.waitForBanner(t)
+
+	return c
+}
+
+// waitForBanner dials the SSH port and reads the server identification
+// string ("SSH-2.0-..."). Polls until a banner is received or the timeout
+// fires.
+func (c *SSHContainer) waitForBanner(t T) {
+	deadline := time.Now().Add(30 * time.Second)
+	addr := net.JoinHostPort(c.Host, c.Port)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+		if err != nil {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 7)
+		n, err := conn.Read(buf)
+		_ = conn.Close()
+		if err == nil && n >= 4 && string(buf[:4]) == "SSH-" {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("ssh container at %s never produced an SSH banner within 30s", addr)
+}
+
+// ConnString returns a host:port string suitable for direct TCP dialing.
+func (c *SSHContainer) ConnString() string {
+	return fmt.Sprintf("%s:%s", c.Host, c.Port)
+}
+
+// EstablishedSSHConnections returns the number of established TCP
+// connections to sshd's listening port (2222) inside the container.
+// Used by the singleflight test to assert that concurrent first-packets
+// for the same (sid, connID) result in exactly one upstream SSH
+// connection — if the dedup primitive is broken, this count balloons.
+//
+// linuxserver/openssh-server is an Alpine-based image with netstat from
+// busybox available (no ss). We count lines where the local address
+// ends in ":2222" and the state column is ESTABLISHED. tcexec's
+// Multiplexed() option flattens the docker stream multiplexing
+// (stdout/stderr framing) so the reader yields clean shell output.
+func (c *SSHContainer) EstablishedSSHConnections(t T) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, reader, err := c.Container.Exec(ctx,
+		[]string{"sh", "-c", "netstat -tn 2>/dev/null"},
+		tcexec.Multiplexed(),
+	)
+	if err != nil {
+		t.Fatalf("ssh-container: failed to exec netstat: %v", err)
+	}
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ssh-container: failed reading netstat output: %v", err)
+	}
+
+	// busybox netstat output looks like:
+	//   Proto Recv-Q Send-Q Local Address Foreign Address State
+	//   tcp        0      0 172.17.0.2:2222 172.17.0.1:44814 ESTABLISHED
+	//
+	// We don't want to depend on column positions because busybox and
+	// GNU netstat differ subtly. Count any line that mentions :2222
+	// somewhere AND has the ESTABLISHED token. Header line never
+	// contains "ESTABLISHED" so it's naturally excluded.
+	count := 0
+	for _, line := range strings.Split(string(raw), "\n") {
+		if !strings.Contains(line, ":2222") {
+			continue
+		}
+		if !strings.Contains(line, "ESTABLISHED") {
+			continue
+		}
+		count++
+	}
+
+	return count
+}
+
+// WaitForEstablishedSSHConnections polls EstablishedSSHConnections until
+// it reaches the target count or the timeout fires. Useful in
+// concurrency tests where the upstream dial happens asynchronously
+// inside libhoop's proxy goroutine and may take a beat to register.
+func (c *SSHContainer) WaitForEstablishedSSHConnections(t T, target int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last int
+	for time.Now().Before(deadline) {
+		last = c.EstablishedSSHConnections(t)
+		if last == target {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("ssh-container: connection count did not reach %d within %v (last=%d)",
+		target, timeout, last)
+}

--- a/agent/integration/testutil/ssh_keys.go
+++ b/agent/integration/testutil/ssh_keys.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package testutil
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// GeneratedSSHKey is a fresh RSA SSH keypair plus the helpers tests
+// need to wire it into both the openssh-server container and the
+// agent's libhoop SSH client.
+type GeneratedSSHKey struct {
+	// AuthorizedKey is the public key in OpenSSH authorized_keys
+	// format ("ssh-rsa AAAA..."). Pass this to StartSSHWithPublicKey.
+	AuthorizedKey string
+
+	// PrivateKeyPEM is the private key in PEM format. Pass this as
+	// the AUTHORIZED_SERVER_KEYS env var in OpenSSHSessionWithKey so
+	// libhoop authenticates against the upstream sshd using this key.
+	PrivateKeyPEM string
+
+	// Signer is the corresponding ssh.Signer for use in
+	// ssh.PublicKeys() on the test's local SSH client config. The
+	// bridge accepts any auth, so this is for protocol completeness
+	// rather than real authentication.
+	Signer ssh.Signer
+}
+
+// GenerateSSHKey returns a fresh RSA-2048 SSH keypair for tests.
+// Generating each time keeps tests independent and avoids any need
+// to manage fixture key files in the repo.
+func GenerateSSHKey(t *testing.T) *GeneratedSSHKey {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+
+	pubKeyBytes := ssh.MarshalAuthorizedKey(signer.PublicKey())
+	// MarshalAuthorizedKey ends with a newline; the container env
+	// expects a trimmed single-line value.
+	for len(pubKeyBytes) > 0 && pubKeyBytes[len(pubKeyBytes)-1] == '\n' {
+		pubKeyBytes = pubKeyBytes[:len(pubKeyBytes)-1]
+	}
+
+	privPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	})
+
+	return &GeneratedSSHKey{
+		AuthorizedKey: string(pubKeyBytes),
+		PrivateKeyPEM: string(privPEM),
+		Signer:        signer,
+	}
+}
+
+// BuildSSHEnvVarsWithKey constructs SSH env vars using public-key
+// authentication. The agent forwards AUTHORIZED_SERVER_KEYS to libhoop,
+// which decodes the PEM and uses it as the ssh.PublicKeys auth method.
+func BuildSSHEnvVarsWithKey(host, port, user, privateKeyPEM string) map[string]any {
+	return map[string]any{
+		"envvar:HOST":                    b64(host),
+		"envvar:USER":                    b64(user),
+		"envvar:PORT":                    b64(port),
+		"envvar:AUTHORIZED_SERVER_KEYS":  b64(privateKeyPEM),
+	}
+}

--- a/agent/integration/testutil/ssh_session.go
+++ b/agent/integration/testutil/ssh_session.go
@@ -24,13 +24,27 @@ func BuildSSHEnvVars(host, port, user, pass string) map[string]any {
 	}
 }
 
-// OpenSSHSession opens an SSH session on the agent and returns the
-// generated session ID after SessionOpenOK is observed. Fails the test if
-// the agent rejects the open or doesn't reply within 10 seconds.
+// OpenSSHSession opens an SSH session on the agent using password
+// authentication and returns the generated session ID after
+// SessionOpenOK is observed. Fails the test if the agent rejects the
+// open or doesn't reply within 10 seconds.
 func OpenSSHSession(t T, tr *MockTransport, host, port, user, pass string) string {
 	t.Helper()
+	return openSSHSession(t, tr, BuildSSHEnvVars(host, port, user, pass))
+}
+
+// OpenSSHSessionWithKey opens an SSH session on the agent using
+// public-key authentication. privateKeyPEM is the PEM-encoded private
+// key the agent will use to authenticate against the upstream sshd
+// (which must trust the corresponding public key).
+func OpenSSHSessionWithKey(t T, tr *MockTransport, host, port, user, privateKeyPEM string) string {
+	t.Helper()
+	return openSSHSession(t, tr, BuildSSHEnvVarsWithKey(host, port, user, privateKeyPEM))
+}
+
+func openSSHSession(t T, tr *MockTransport, envVars map[string]any) string {
+	t.Helper()
 	sessionID := uuid.New().String()
-	envVars := BuildSSHEnvVars(host, port, user, pass)
 	pkt := BuildSessionOpenPacket(sessionID, string(pb.ConnectionTypeSSH), envVars)
 	tr.Inject(pkt)
 

--- a/agent/integration/testutil/ssh_session.go
+++ b/agent/integration/testutil/ssh_session.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package testutil
+
+import (
+	sshtypes "libhoop/proxy/ssh/types"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+)
+
+// BuildSSHEnvVars constructs the AgentConnectionParams env vars map for an
+// SSH connection. The keys must match what parseConnectionEnvVars looks up
+// for ConnectionTypeSSH (HOST, USER, PASS, PORT, AUTHORIZED_SERVER_KEYS).
+func BuildSSHEnvVars(host, port, user, pass string) map[string]any {
+	return map[string]any{
+		"envvar:HOST": b64(host),
+		"envvar:USER": b64(user),
+		"envvar:PASS": b64(pass),
+		"envvar:PORT": b64(port),
+	}
+}
+
+// OpenSSHSession opens an SSH session on the agent and returns the
+// generated session ID after SessionOpenOK is observed. Fails the test if
+// the agent rejects the open or doesn't reply within 10 seconds.
+func OpenSSHSession(t T, tr *MockTransport, host, port, user, pass string) string {
+	t.Helper()
+	sessionID := uuid.New().String()
+	envVars := BuildSSHEnvVars(host, port, user, pass)
+	pkt := BuildSessionOpenPacket(sessionID, string(pb.ConnectionTypeSSH), envVars)
+	tr.Inject(pkt)
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case resp := <-tr.RecvCh():
+			switch resp.Type {
+			case pbclient.SessionOpenOK:
+				return sessionID
+			case pbclient.SessionClose:
+				t.Fatalf("ssh session open failed: %s", string(resp.Payload))
+			default:
+				continue
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for ssh SessionOpenOK")
+		}
+	}
+}
+
+// SendSSHWrite injects an SSHConnectionWrite packet carrying the given
+// payload for (sessionID, connID). The payload is expected to be an
+// encoded sshtypes packet that libhoop's SSH proxy will dispatch on
+// upstream — anything else will fail libhoop's parser and trigger a
+// session close.
+func SendSSHWrite(t T, tr *MockTransport, sessionID, connID string, payload []byte) {
+	t.Helper()
+	pkt := &pb.Packet{
+		Type: pbagent.SSHConnectionWrite,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(sessionID),
+			pb.SpecClientConnectionID: []byte(connID),
+		},
+		Payload: payload,
+	}
+	tr.Inject(pkt)
+}
+
+// SSHOpenChannelPayload builds an encoded sshtypes.OpenChannel packet
+// requesting a "session" channel on the given channel ID. This is the
+// canonical "first packet" in a hoop SSH flow — the client side asks the
+// agent to open a session channel against the upstream sshd, after which
+// data and exec/pty requests can flow through it.
+//
+// Using "session" (not "direct-tcpip") avoids libhoop's checkTCPLiveness
+// path, which would do its own 2-second blocking dial inside libhoop's
+// proxy goroutine and complicate timing assertions in concurrency tests.
+func SSHOpenChannelPayload(channelID uint16) []byte {
+	return (sshtypes.OpenChannel{
+		ChannelID:        channelID,
+		ChannelType:      "session",
+		ChannelExtraData: nil,
+	}).Encode()
+}
+
+// SSHDataPayload builds an encoded sshtypes.Data packet for the given
+// channel. Used by tests that need to drive multiple packets through an
+// already-open channel — for example, the SessionClose race test where
+// we want handlers in flight when SessionClose lands.
+func SSHDataPayload(channelID uint16, data []byte) []byte {
+	return (sshtypes.Data{
+		ChannelID: channelID,
+		Payload:   data,
+	}).Encode()
+}
+
+

--- a/client/cmd/claude.go
+++ b/client/cmd/claude.go
@@ -73,14 +73,16 @@ func printClaudeConfigureSuccess(settingsPath, connectionName, baseURL, token st
 	}
 
 	fmt.Println()
-	fmt.Printf("  %s %s\n", successStyle.Render("✓"), styles.Fainted(settingsPath+" updated"))
+	fmt.Printf("  %s %s\n", successStyle.Render("✓"), styles.Fainted("%s updated", settingsPath))
 	fmt.Println()
 	fmt.Printf("  %s%s\n", labelStyle.Render("Connection"), valueStyle.Render(connectionName))
 	fmt.Printf("  %s%s\n", labelStyle.Render("Base URL"), valueStyle.Render(baseURL))
 	fmt.Printf("  %s%s\n", labelStyle.Render("Token"), valueStyle.Render(displayToken))
 	fmt.Println()
 	fmt.Println(styles.Fainted("  Claude Code requests are now routed through hoop."))
-	fmt.Println(styles.Fainted("  Run " + strings.TrimSpace(styles.Keyword(" claude ")) + styles.Fainted(" to start.")))
+	fmt.Println(styles.Fainted("  Run %s%s",
+		strings.TrimSpace(styles.Keyword(" claude ")),
+		styles.Fainted(" to start.")))
 	fmt.Println()
 }
 

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -54,6 +54,13 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentGateway},
 	},
+	"experimental.agent_async_ssh": {
+		Name:        "experimental.agent_async_ssh",
+		Description: "Dispatch SSH packets to per-packet goroutines on the agent. Fixes parallel-session blocking where one slow SSH session stalls others on the same agent.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentAgent},
+	},
 }
 
 // All returns every registered flag, sorted by name.

--- a/gateway/proxyproto/sshproxy/sshproxy.go
+++ b/gateway/proxyproto/sshproxy/sshproxy.go
@@ -366,22 +366,50 @@ func (c *sshConnection) handleConnection() {
 	// either by the client, server, or context cancellation
 	<-c.ctx.Done()
 
-	// Wait for all channel data-forwarding goroutines to flush remaining writes
-	// to the gRPC stream. Without this, SessionClose can be sent before trailing
-	// data packets, causing the agent to tear down the session prematurely.
-	flushDone := make(chan struct{})
-	go func() {
-		c.channelWg.Wait()
-		close(flushDone)
-	}()
-	select {
-	case <-flushDone:
-	case <-time.After(5 * time.Second):
-		log.With("sid", c.sid, "conn", c.id).Warnf("timed out waiting for channel goroutines to finish")
-	}
-
 	ctxErr := context.Cause(c.ctx)
 	log.With("sid", c.sid, "conn", c.id).Infof("ssh connection closed, reason=%v", ctxErr)
+
+	// Surface the cancellation cause to the user's terminal before
+	// we tear the SSH connection down. Without this, the user sees
+	// only `Connection closed by remote host` and has to ask an
+	// admin to read the gateway logs to find out what went wrong.
+	//
+	// translateUpstreamError sanitizes the raw libhoop / agent text
+	// into a fixed-vocabulary message so we don't leak internal
+	// addresses, library jargon, or stack traces to end users; it
+	// also returns an empty string for benign causes (e.g. the user
+	// disconnected themselves) so we don't write noise.
+	//
+	// A non-empty message means we're tearing the session down for a
+	// real error — there's no point waiting on the normal flush and
+	// grace period below because the user already knows it's over.
+	// We close the channels inside notifyOpenChannels and skip
+	// straight to closing the SSH transport.
+	hasUserError := false
+	if ctxErr != nil {
+		if msg := translateUpstreamError(ctxErr.Error()); msg != "" {
+			notifyOpenChannels(&c.sshChannels, msg)
+			hasUserError = true
+		}
+	}
+
+	if !hasUserError {
+		// Normal (non-error) teardown: wait for all channel
+		// data-forwarding goroutines to flush remaining writes
+		// to the gRPC stream. Without this, SessionClose can be
+		// sent before trailing data packets, causing the agent
+		// to tear down the session prematurely.
+		flushDone := make(chan struct{})
+		go func() {
+			c.channelWg.Wait()
+			close(flushDone)
+		}()
+		select {
+		case <-flushDone:
+		case <-time.After(5 * time.Second):
+			log.With("sid", c.sid, "conn", c.id).Warnf("timed out waiting for channel goroutines to finish")
+		}
+	}
 
 	// notify the server that the session is closing
 	err := c.grpcClient.Send(&pb.Packet{
@@ -395,8 +423,13 @@ func (c *sshConnection) handleConnection() {
 		return
 	}
 
-	// wait 2 seconds for cleaning up session gracefully
-	time.Sleep(time.Second * 2)
+	// On normal teardown, give the agent 2 seconds to drain its
+	// state before we hang up the transport. On error teardowns the
+	// user has nothing else to see and we already closed the
+	// channels in notifyOpenChannels, so close immediately.
+	if !hasUserError {
+		time.Sleep(time.Second * 2)
+	}
 	_ = c.sshConn.Close()
 	_, _ = c.grpcClient.Close()
 }

--- a/gateway/proxyproto/sshproxy/usermessage.go
+++ b/gateway/proxyproto/sshproxy/usermessage.go
@@ -1,0 +1,165 @@
+package sshproxy
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// upstreamFailurePrefix is the line prefix used when writing a
+// translated upstream error to the user's SSH channel stderr. Keeping
+// it consistent ("hoop: ") makes the line easy to recognize in user
+// terminals and easy to grep for in logs that mirror the message.
+const upstreamFailurePrefix = "hoop: "
+
+// agentClosePayloadPrefix is the prefix the gateway adds when
+// converting an inbound ClientSessionClose into a cancellation cause.
+// See sshproxy.go where the cause is built as
+// `connection closed by server, payload=<libhoop error>`. We strip
+// this here so the user message starts with the libhoop reason
+// rather than the gateway-side framing.
+const agentClosePayloadPrefix = "connection closed by server, payload="
+
+// translateUpstreamError converts a raw libhoop / agent error string
+// into a user-facing one-liner that's safe to display on an SSH
+// terminal. The classification is best-effort and conservative: any
+// pattern we don't recognize falls through to a generic message so
+// we never leak internal addresses, stack traces, or library jargon
+// to end users.
+//
+// Returns the empty string if the cause should not produce any
+// user-visible message (e.g. the user disconnected themselves —
+// they don't need a message about that).
+func translateUpstreamError(cause string) string {
+	if cause == "" {
+		return ""
+	}
+
+	// Most upstream failures arrive wrapped in the gateway's
+	// "connection closed by server, payload=..." framing. Strip it so
+	// downstream classification sees the bare libhoop reason.
+	core := cause
+	if idx := strings.Index(core, agentClosePayloadPrefix); idx >= 0 {
+		core = core[idx+len(agentClosePayloadPrefix):]
+	}
+
+	lower := strings.ToLower(core)
+
+	// User-initiated disconnects: don't produce a message at all.
+	// "ssh client disconnected" is the gateway-side cancelFn fired
+	// when the user's local ssh process closes. There's nothing
+	// useful to tell them.
+	switch lower {
+	case "ssh client disconnected":
+		return ""
+	}
+
+	switch {
+	case strings.Contains(lower, "connection refused"):
+		return "cannot connect to target server: connection refused"
+	case strings.Contains(lower, "i/o timeout"),
+		strings.Contains(lower, "deadline exceeded"):
+		return "cannot connect to target server: connection timed out"
+	case strings.Contains(lower, "no route to host"):
+		return "cannot connect to target server: no route to host"
+	case strings.Contains(lower, "no such host"),
+		strings.Contains(lower, "lookup"):
+		return "cannot resolve target server hostname"
+	case strings.Contains(lower, "unable to authenticate"),
+		strings.Contains(lower, "auth failed"),
+		strings.Contains(lower, "no supported methods remain"):
+		return "authentication failed against target server"
+	case strings.Contains(lower, "session timed out before it was ready"):
+		return "session timed out waiting for the target server"
+	case strings.Contains(lower, "missing protocol hoop library"):
+		return "ssh is not enabled on this hoop agent build, contact your administrator"
+	case strings.Contains(lower, "credential revoked"),
+		strings.Contains(lower, "access expired"):
+		return "your access to this target server has been revoked"
+	}
+
+	// Generic fallback: the cause exists but we don't have a
+	// specific translation. Tell the user something failed without
+	// leaking the raw text.
+	return "cannot connect to target server"
+}
+
+// notifyOpenChannels writes the same message line to the stderr
+// stream of every currently-open client SSH channel and then closes
+// each channel. Called from handleConnection's shutdown path when
+// the session ctx is cancelled with a non-empty cause.
+//
+// channels is the gateway-side map of channel-id-string → ssh.Channel
+// (the value the gateway accepted via newCh.Accept()).
+//
+// After writing the message we Close() each channel so the read
+// goroutines in handleChannel unblock and return promptly. Without
+// the channel Close, those goroutines stay parked in clientCh.Read
+// and hold c.channelWg, forcing handleConnection's flush step to
+// time out (5s) before it can tear down the SSH transport — which
+// would leave the user staring at our message for 5+2 seconds with
+// no apparent reason to be there.
+//
+// Writes and closes are best-effort. Failures during shutdown don't
+// matter to the caller; the next step is sshConn.Close() which will
+// kill the channels anyway.
+func notifyOpenChannels(channels *sync.Map, message string) {
+	if message == "" {
+		return
+	}
+	line := upstreamFailurePrefix + message + "\r\n"
+
+	channels.Range(func(key, value any) bool {
+		ch, ok := value.(ssh.Channel)
+		if !ok || ch == nil {
+			return true
+		}
+		_, _ = io.WriteString(ch.Stderr(), line)
+		// Close releases the read goroutine parked in
+		// handleChannel's clientCh.Read loop. The error code is
+		// SSH-protocol "exit-status 1" by convention but the
+		// channel API doesn't expose that here; the simple Close
+		// is enough for the client to see the channel end and
+		// the read goroutine to unblock.
+		_ = ch.Close()
+		return true
+	})
+}
+
+// userMessageDecorator is a tiny helper that lets a caller compose a
+// failure message + structured logging in one place. Kept as a
+// standalone type rather than a closure so its lifecycle is obvious
+// in the call site.
+type userMessageDecorator struct {
+	channels *sync.Map
+}
+
+func newUserMessageDecorator(channels *sync.Map) *userMessageDecorator {
+	return &userMessageDecorator{channels: channels}
+}
+
+// Notify writes the translated message (if any) and returns the
+// translated text so the caller can include it in its own log line.
+// Returns the empty string if no message was written, which the
+// caller can use to skip logging.
+func (d *userMessageDecorator) Notify(cause error) string {
+	if cause == nil {
+		return ""
+	}
+	msg := translateUpstreamError(cause.Error())
+	if msg == "" {
+		return ""
+	}
+	notifyOpenChannels(d.channels, msg)
+	return msg
+}
+
+// formatRaw is a tiny convenience for tests / debugging — returns
+// the unmodified line the helper would write, including the prefix
+// and trailing CR/LF.
+func formatRaw(message string) string {
+	return fmt.Sprintf("%s%s\r\n", upstreamFailurePrefix, message)
+}

--- a/gateway/proxyproto/sshproxy/usermessage_stub_test.go
+++ b/gateway/proxyproto/sshproxy/usermessage_stub_test.go
@@ -1,0 +1,60 @@
+package sshproxy
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// stderrStubChannel implements just enough of ssh.Channel for the
+// usermessage_test.go suite. Methods unused by notifyOpenChannels
+// return zero values / nil. Stderr() returns a *stderrStubWriter so
+// the tests can inspect what was written.
+//
+// The real ssh.Channel interface has more methods than we need; the
+// blank implementations exist purely so the type assertion in
+// notifyOpenChannels succeeds. CloseCount lets tests verify the
+// channel was closed after notify, which matters because notify is
+// what unblocks handleChannel's read goroutine on the gateway shutdown
+// path.
+type stderrStubChannel struct {
+	Buffer     bytes.Buffer
+	failWrite  bool
+	CloseCount int
+}
+
+func (s *stderrStubChannel) Read(p []byte) (int, error)  { return 0, io.EOF }
+func (s *stderrStubChannel) Write(p []byte) (int, error) { return len(p), nil }
+func (s *stderrStubChannel) Close() error {
+	s.CloseCount++
+	return nil
+}
+func (s *stderrStubChannel) CloseWrite() error { return nil }
+func (s *stderrStubChannel) SendRequest(string, bool, []byte) (bool, error) {
+	return false, nil
+}
+func (s *stderrStubChannel) Stderr() io.ReadWriter {
+	return (*stderrStubWriter)(s)
+}
+
+// Compile-time assertion that we satisfy ssh.Channel.
+var _ ssh.Channel = (*stderrStubChannel)(nil)
+
+// stderrStubWriter is the io.ReadWriter exposed via Stderr(). It
+// shares state with its parent stderrStubChannel via unsafe pointer
+// aliasing of the same struct — the field set used here (Buffer,
+// failWrite) is identical on both views.
+type stderrStubWriter stderrStubChannel
+
+func (w *stderrStubWriter) Read(p []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (w *stderrStubWriter) Write(p []byte) (int, error) {
+	if w.failWrite {
+		return 0, errors.New("stub stderr: simulated failure")
+	}
+	return w.Buffer.Write(p)
+}

--- a/gateway/proxyproto/sshproxy/usermessage_test.go
+++ b/gateway/proxyproto/sshproxy/usermessage_test.go
@@ -1,0 +1,157 @@
+package sshproxy
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestTranslateUpstreamError(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty input returns empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "user-initiated disconnect is suppressed",
+			in:   "ssh client disconnected",
+			want: "",
+		},
+		{
+			name: "connection refused with gateway wrapper",
+			in:   "connection closed by server, payload=failed initializing connection, " +
+				"reason=failed establishing tcp connection with 192.168.55.111:22: " +
+				"dial tcp 192.168.55.111:22: connect: connection refused",
+			want: "cannot connect to target server: connection refused",
+		},
+		{
+			name: "i/o timeout with gateway wrapper",
+			in:   "connection closed by server, payload=failed initializing connection, " +
+				"reason=failed establishing tcp connection with 192.0.2.1:22: " +
+				"dial tcp 192.0.2.1:22: i/o timeout",
+			want: "cannot connect to target server: connection timed out",
+		},
+		{
+			name: "deadline exceeded normalized to timeout",
+			in:   "context deadline exceeded",
+			want: "cannot connect to target server: connection timed out",
+		},
+		{
+			name: "no route to host",
+			in:   "dial tcp 10.0.0.1:22: connect: no route to host",
+			want: "cannot connect to target server: no route to host",
+		},
+		{
+			name: "dns failure",
+			in:   "dial tcp: lookup not-a-real-host: no such host",
+			want: "cannot resolve target server hostname",
+		},
+		{
+			name: "ssh auth failure",
+			in:   "connection closed by server, payload=ssh: handshake failed: " +
+				"ssh: unable to authenticate, attempted methods [none password], " +
+				"no supported methods remain",
+			want: "authentication failed against target server",
+		},
+		{
+			name: "session ready timeout",
+			in:   "session timed out before it was ready",
+			want: "session timed out waiting for the target server",
+		},
+		{
+			name: "oss libhoop stub message",
+			in:   "connection closed by server, payload=missing protocol hoop library for ssh, " +
+				"contact your administrator",
+			want: "ssh is not enabled on this hoop agent build, contact your administrator",
+		},
+		{
+			name: "credential revoked",
+			in:   "credential revoked",
+			want: "your access to this target server has been revoked",
+		},
+		{
+			name: "unknown error falls back to generic message",
+			in:   "something we never anticipated happened deep in the stack: 0xdeadbeef",
+			want: "cannot connect to target server",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := translateUpstreamError(tc.in)
+			if got != tc.want {
+				t.Errorf("translateUpstreamError(%q)\n  got:  %q\n  want: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatRaw(t *testing.T) {
+	got := formatRaw("hello world")
+	want := "hoop: hello world\r\n"
+	if got != want {
+		t.Errorf("formatRaw mismatch:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestNotifyOpenChannels_EmptyMessage(t *testing.T) {
+	// notifyOpenChannels with an empty message must be a no-op even
+	// when there are channels registered — this is the path the
+	// caller takes for user-initiated disconnects (translate returns
+	// "" → no Range, no Stderr writes).
+	channels := &sync.Map{}
+	stub := &stderrStubChannel{}
+	channels.Store("1", stub)
+
+	notifyOpenChannels(channels, "")
+
+	if stub.Buffer.Len() != 0 {
+		t.Errorf("expected no writes for empty message, got %q", stub.Buffer.String())
+	}
+}
+
+func TestNotifyOpenChannels_WritesToEveryChannel(t *testing.T) {
+	channels := &sync.Map{}
+	a := &stderrStubChannel{}
+	b := &stderrStubChannel{}
+	channels.Store("1", a)
+	channels.Store("2", b)
+
+	notifyOpenChannels(channels, "cannot connect to target server")
+
+	for label, ch := range map[string]*stderrStubChannel{"a": a, "b": b} {
+		got := ch.Buffer.String()
+		if !strings.HasPrefix(got, upstreamFailurePrefix) {
+			t.Errorf("channel %s: expected prefix %q, got %q", label, upstreamFailurePrefix, got)
+		}
+		if !strings.Contains(got, "cannot connect to target server") {
+			t.Errorf("channel %s: expected message body, got %q", label, got)
+		}
+		if !strings.HasSuffix(got, "\r\n") {
+			t.Errorf("channel %s: expected trailing CRLF, got %q", label, got)
+		}
+		// notify must close each channel after the write so the
+		// gateway-side read goroutine parked in clientCh.Read
+		// unblocks. Without this, the gateway's flush wait hits
+		// its 5-second timeout and the user stares at the
+		// message before the connection actually drops.
+		if ch.CloseCount != 1 {
+			t.Errorf("channel %s: expected Close to be called once, got %d", label, ch.CloseCount)
+		}
+	}
+}
+
+func TestNotifyOpenChannels_StderrErrorIgnored(t *testing.T) {
+	// A failing Stderr write must not panic or block the caller.
+	// The whole point of the function is best-effort during shutdown
+	// where writes can race with the transport closing.
+	channels := &sync.Map{}
+	channels.Store("1", &stderrStubChannel{failWrite: true})
+
+	notifyOpenChannels(channels, "cannot connect to target server")
+}


### PR DESCRIPTION
## Summary

Fix the customer-reported SSH hangs (parallel sessions blocking each other / big transfers stalling) by gating async SSH packet dispatch behind a new feature flag, then complete the UX so failed connections actually tell the user what went wrong instead of hanging on a useless "Connection closed by remote host" line.

| Change | Behavior |
|---|---|
| Feature flag `experimental.agent_async_ssh` | Default false. When enabled, SSHConnectionWrite + SessionClose dispatch to per-packet goroutines so the recv loop isn't held up behind a slow libhoop write. |
| Per-session RW lock | Handlers take RLock; SessionClose takes Lock and drains in-flight handlers. Late packets see closed=true and return cleanly. |
| Per-connection write mutex | Serializes consecutive writes for the same (sid, connID) so async handlers cannot reorder bytes to libhoop. |
| singleflight on proxy creation | Concurrent first-packets for the same (sid, connID) result in exactly one upstream dial. |
| Gateway: user-terminal error messages | When upstream dial fails (wrong IP, refused, timeout, auth, etc.), the gateway writes a sanitized one-liner to the user's SSH channel stderr and tears down promptly. No more silent `Connection closed by remote host`. |

## Why

`a002d3f4` (Apr) made all agent packet processing synchronous. When libhoop's writerQueueCh fills (100 messages — happens during big SCP transfers against a slow remote sshd), agent's serverWriter.Write blocks the recv loop. Every other session on the agent stalls. Customer reports: parallel-session freezes and SCP transfer hangs.

This PR introduces the minimal concurrency that fixes the SSH symptom while preserving the synchronous behavior `a002d3f4` was protecting for other protocols. Default-off means a fresh build behaves exactly like main. Enabling the flag per-org gives the customer the fix without risking other orgs.

The gateway-side UX piece is the natural companion: with the async fix the agent no longer hangs everyone, but a failing connection still gave the user no actionable information. Now they see exactly why it failed.

## Tests (15 SSH integration tests + sshproxy unit tests + new infrastructure)

### Fix-validation tests

| Test | What it proves |
|---|---|
| `TestSSH_BaseSmoke_FlagOff` / `_FlagOn` | Regression contracts for both dispatch modes |
| `TestSSH_ConcurrentFirstPackets_SameConnID_FlagOn` | Singleflight dedups 50 goroutines → 1 upstream SSH connection |
| `TestSSH_SessionClose_CleanShutdown` / `TestSSH_SessionCloseRace_FlagOn` | Session RW lock drains in-flight handlers; clean teardown, no leak |

### Customer-symptom regression test

| Test | What it proves |
|---|---|
| `TestSSH_ParallelSessions_OneStalled_FlagOff` | **Customer bug reproduced**: session B blocked behind session A's stalled Write (verified ≥5s stall) |
| `TestSSH_ParallelSessions_OneStalled_FlagOn` | **Fix verified**: session B established in ~42ms despite session A stalled |

### Base SSH harness

Driven through the new `PipedSSHClient` bridge — a real `x/crypto/ssh.Client` whose transport is bridged to MockTransport via a sshtypes envelope translator.

| Test | What it proves |
|---|---|
| `TestSSH_PasswordAuth_Connect` | Password auth end-to-end |
| `TestSSH_PubkeyAuth_Connect` | RSA pubkey auth end-to-end |
| `TestSSH_BadCredentials` | Auth failure surfaces as SessionClose with auth-error body |
| `TestSSH_ExecCommand` | `echo hello` over exec channel |
| `TestSSH_ExitStatus_Forwarding` | `false` command's exit code 1 propagates through ServerSSHRequest path |
| `TestSSH_InteractiveShell_PTY` | PTY allocation + interactive shell I/O |
| `TestSSH_MultipleChannels` | Two sequential exec channels on the same SSH connection |
| `TestSSH_DirectTCPIP_PortForward` | Port-forward channel to a sidecar nginx, HTTP GET round-trip |

### Gateway upstream-error UX

| Test | What it proves |
|---|---|
| `TestTranslateUpstreamError` (12 sub-cases) | Every libhoop / agent error pattern maps to the right sanitized line; unknown input falls back to a generic message; user-initiated disconnects produce no message |
| `TestNotifyOpenChannels_WritesToEveryChannel` | Multi-channel stderr write + channel close (the latter is what unblocks the gateway's per-channel read goroutine) |
| `TestNotifyOpenChannels_EmptyMessage` | No writes when there's nothing to say |
| `TestNotifyOpenChannels_StderrErrorIgnored` | Best-effort during shutdown — a failing write doesn't panic or block |

### Testutil additions

- `ssh_client.go` (~340 LOC) — `PipedSSHClient` bridge: stands up an `ssh.ServerConn` on TCP loopback, the test's SSH client connects to it, the bridge translates SSH events to/from sshtypes packets. Uses real loopback rather than net.Pipe because net.Pipe deadlocks SSH's exchangeVersions step.
- `ssh_keys.go` — RSA-2048 keypair generation + helpers for both container `PUBLIC_KEY` env and agent `AUTHORIZED_SERVER_KEYS` env.
- `ssh_container.go` — `StartSSHWithPublicKey` for pubkey tests; `StartSSHWithForwarding` patches sshd_config to enable `AllowTcpForwarding` (off by default in linuxserver); `StartHTTPTarget` runs sidecar nginx for port-forward target.
- `slow_tcp_proxy.go` — bidirectional TCP forwarder with controllable Pause/Resume on the agent→upstream direction. Powers the customer-symptom test.

All 15 SSH tests + existing PG tests + new sshproxy unit tests pass locally (`make test-integration` and `make test-oss`).

## libhoop dependency

The customer-symptom stall test exposed two pre-existing concurrent-Write races in libhoop's SSH proxy (close-of-closed-channel + send-on-closed-channel) that fire at agent shutdown when many writes are in flight. **These are not introduced by this PR** — they were latent in production, surfacing as random panics during agent shutdown after SCP transfers.

A sibling libhoop fix wraps the close in sync.Once and adds a defer-recover on the send branch. CI checks out libhoop's main branch which already includes this fix; integration tests are green.

## Removed code

- `Agent.connMtx` and `Agent.connMtxStoreMtx` — dead since `a002d3f4`.
- `Agent.closedSessions` sync.Map — replaced by `sessionStates`, same lifetime semantics plus the added drain guarantee.

## Rollout

1. Merge with flag default-off → no behavior change for any org. The gateway UX improvement (user-terminal error messages) is unconditional and active for all SSH connections.
2. Enable `experimental.agent_async_ssh` for the stuck customer's org. Flag pushes live within seconds (no restart).
3. Customer validates SCP + parallel session scenario. If anything goes wrong, disable the flag and behavior returns to current main.

Automated by MisterMal