### PR TITLE
feat(gateway): surface upstream SSH failures on user terminal

### DIFF
--- a/gateway/proxyproto/sshproxy/sshproxy.go
+++ b/gateway/proxyproto/sshproxy/sshproxy.go
@@ -383,6 +383,22 @@ func (c *sshConnection) handleConnection() {
 	ctxErr := context.Cause(c.ctx)
 	log.With("sid", c.sid, "conn", c.id).Infof("ssh connection closed, reason=%v", ctxErr)
 
+	// Surface the cancellation cause to the user's terminal before
+	// we tear the SSH connection down. Without this, the user sees
+	// only `Connection closed by remote host` and has to ask an
+	// admin to read the gateway logs to find out what went wrong.
+	//
+	// translateUpstreamError sanitizes the raw libhoop / agent text
+	// into a fixed-vocabulary message so we don't leak internal
+	// addresses, library jargon, or stack traces to end users; it
+	// also returns an empty string for benign causes (e.g. the user
+	// disconnected themselves) so we don't write noise.
+	if ctxErr != nil {
+		if msg := translateUpstreamError(ctxErr.Error()); msg != "" {
+			notifyOpenChannels(&c.sshChannels, msg)
+		}
+	}
+
 	// notify the server that the session is closing
 	err := c.grpcClient.Send(&pb.Packet{
 		Type: pbagent.SessionClose,

--- a/gateway/proxyproto/sshproxy/sshproxy.go
+++ b/gateway/proxyproto/sshproxy/sshproxy.go
@@ -366,20 +366,6 @@ func (c *sshConnection) handleConnection() {
 	// either by the client, server, or context cancellation
 	<-c.ctx.Done()
 
-	// Wait for all channel data-forwarding goroutines to flush remaining writes
-	// to the gRPC stream. Without this, SessionClose can be sent before trailing
-	// data packets, causing the agent to tear down the session prematurely.
-	flushDone := make(chan struct{})
-	go func() {
-		c.channelWg.Wait()
-		close(flushDone)
-	}()
-	select {
-	case <-flushDone:
-	case <-time.After(5 * time.Second):
-		log.With("sid", c.sid, "conn", c.id).Warnf("timed out waiting for channel goroutines to finish")
-	}
-
 	ctxErr := context.Cause(c.ctx)
 	log.With("sid", c.sid, "conn", c.id).Infof("ssh connection closed, reason=%v", ctxErr)
 
@@ -393,9 +379,35 @@ func (c *sshConnection) handleConnection() {
 	// addresses, library jargon, or stack traces to end users; it
 	// also returns an empty string for benign causes (e.g. the user
 	// disconnected themselves) so we don't write noise.
+	//
+	// A non-empty message means we're tearing the session down for a
+	// real error — there's no point waiting on the normal flush and
+	// grace period below because the user already knows it's over.
+	// We close the channels inside notifyOpenChannels and skip
+	// straight to closing the SSH transport.
+	hasUserError := false
 	if ctxErr != nil {
 		if msg := translateUpstreamError(ctxErr.Error()); msg != "" {
 			notifyOpenChannels(&c.sshChannels, msg)
+			hasUserError = true
+		}
+	}
+
+	if !hasUserError {
+		// Normal (non-error) teardown: wait for all channel
+		// data-forwarding goroutines to flush remaining writes
+		// to the gRPC stream. Without this, SessionClose can be
+		// sent before trailing data packets, causing the agent
+		// to tear down the session prematurely.
+		flushDone := make(chan struct{})
+		go func() {
+			c.channelWg.Wait()
+			close(flushDone)
+		}()
+		select {
+		case <-flushDone:
+		case <-time.After(5 * time.Second):
+			log.With("sid", c.sid, "conn", c.id).Warnf("timed out waiting for channel goroutines to finish")
 		}
 	}
 
@@ -411,8 +423,13 @@ func (c *sshConnection) handleConnection() {
 		return
 	}
 
-	// wait 2 seconds for cleaning up session gracefully
-	time.Sleep(time.Second * 2)
+	// On normal teardown, give the agent 2 seconds to drain its
+	// state before we hang up the transport. On error teardowns the
+	// user has nothing else to see and we already closed the
+	// channels in notifyOpenChannels, so close immediately.
+	if !hasUserError {
+		time.Sleep(time.Second * 2)
+	}
 	_ = c.sshConn.Close()
 	_, _ = c.grpcClient.Close()
 }

--- a/gateway/proxyproto/sshproxy/usermessage.go
+++ b/gateway/proxyproto/sshproxy/usermessage.go
@@ -1,0 +1,157 @@
+package sshproxy
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// upstreamFailurePrefix is the line prefix used when writing a
+// translated upstream error to the user's SSH channel stderr. Keeping
+// it consistent ("hoop: ") makes the line easy to recognize in user
+// terminals and easy to grep for in logs that mirror the message.
+const upstreamFailurePrefix = "hoop: "
+
+// agentClosePayloadPrefix is the prefix the gateway adds when
+// converting an inbound ClientSessionClose into a cancellation cause.
+// See sshproxy.go where the cause is built as
+// `connection closed by server, payload=<libhoop error>`. We strip
+// this here so the user message starts with the libhoop reason
+// rather than the gateway-side framing.
+const agentClosePayloadPrefix = "connection closed by server, payload="
+
+// translateUpstreamError converts a raw libhoop / agent error string
+// into a user-facing one-liner that's safe to display on an SSH
+// terminal. The classification is best-effort and conservative: any
+// pattern we don't recognize falls through to a generic message so
+// we never leak internal addresses, stack traces, or library jargon
+// to end users.
+//
+// Returns the empty string if the cause should not produce any
+// user-visible message (e.g. the user disconnected themselves —
+// they don't need a message about that).
+func translateUpstreamError(cause string) string {
+	if cause == "" {
+		return ""
+	}
+
+	// Most upstream failures arrive wrapped in the gateway's
+	// "connection closed by server, payload=..." framing. Strip it so
+	// downstream classification sees the bare libhoop reason.
+	core := cause
+	if idx := strings.Index(core, agentClosePayloadPrefix); idx >= 0 {
+		core = core[idx+len(agentClosePayloadPrefix):]
+	}
+
+	lower := strings.ToLower(core)
+
+	// User-initiated disconnects: don't produce a message at all.
+	// "ssh client disconnected" is the gateway-side cancelFn fired
+	// when the user's local ssh process closes. There's nothing
+	// useful to tell them.
+	switch lower {
+	case "ssh client disconnected":
+		return ""
+	}
+
+	switch {
+	case strings.Contains(lower, "connection refused"):
+		return "cannot connect to target server: connection refused"
+	case strings.Contains(lower, "i/o timeout"),
+		strings.Contains(lower, "deadline exceeded"):
+		return "cannot connect to target server: connection timed out"
+	case strings.Contains(lower, "no route to host"):
+		return "cannot connect to target server: no route to host"
+	case strings.Contains(lower, "no such host"),
+		strings.Contains(lower, "lookup"):
+		return "cannot resolve target server hostname"
+	case strings.Contains(lower, "unable to authenticate"),
+		strings.Contains(lower, "auth failed"),
+		strings.Contains(lower, "no supported methods remain"):
+		return "authentication failed against target server"
+	case strings.Contains(lower, "session timed out before it was ready"):
+		return "session timed out waiting for the target server"
+	case strings.Contains(lower, "missing protocol hoop library"):
+		return "ssh is not enabled on this hoop agent build, contact your administrator"
+	case strings.Contains(lower, "credential revoked"),
+		strings.Contains(lower, "access expired"):
+		return "your access to this target server has been revoked"
+	}
+
+	// Generic fallback: the cause exists but we don't have a
+	// specific translation. Tell the user something failed without
+	// leaking the raw text.
+	return "cannot connect to target server"
+}
+
+// notifyOpenChannels writes the same message line to the stderr
+// stream of every currently-open client SSH channel and then closes
+// each channel. Called from handleConnection's shutdown path when
+// the session ctx is cancelled with a non-empty cause.
+//
+// channels is the gateway-side map of channel-id-string → ssh.Channel
+// (the value the gateway accepted via newCh.Accept()).
+//
+// Writes are best-effort — failures to write or close are logged at
+// the caller's discretion but don't fail the shutdown.
+func notifyOpenChannels(channels *sync.Map, message string) {
+	if message == "" {
+		return
+	}
+	line := upstreamFailurePrefix + message + "\r\n"
+
+	channels.Range(func(key, value any) bool {
+		ch, ok := value.(ssh.Channel)
+		if !ok || ch == nil {
+			return true
+		}
+		// Best-effort write; if stderr is already closed or the
+		// transport has gone away, the user won't see this anyway
+		// and we don't want to block the shutdown.
+		if _, err := io.WriteString(ch.Stderr(), line); err != nil {
+			// Log via the caller's logger if needed; here we
+			// silently move on so this helper stays cheap and
+			// log-free for callers to control verbosity.
+			_ = err
+		}
+		return true
+	})
+}
+
+// userMessageDecorator is a tiny helper that lets a caller compose a
+// failure message + structured logging in one place. Kept as a
+// standalone type rather than a closure so its lifecycle is obvious
+// in the call site.
+type userMessageDecorator struct {
+	channels *sync.Map
+}
+
+func newUserMessageDecorator(channels *sync.Map) *userMessageDecorator {
+	return &userMessageDecorator{channels: channels}
+}
+
+// Notify writes the translated message (if any) and returns the
+// translated text so the caller can include it in its own log line.
+// Returns the empty string if no message was written, which the
+// caller can use to skip logging.
+func (d *userMessageDecorator) Notify(cause error) string {
+	if cause == nil {
+		return ""
+	}
+	msg := translateUpstreamError(cause.Error())
+	if msg == "" {
+		return ""
+	}
+	notifyOpenChannels(d.channels, msg)
+	return msg
+}
+
+// formatRaw is a tiny convenience for tests / debugging — returns
+// the unmodified line the helper would write, including the prefix
+// and trailing CR/LF.
+func formatRaw(message string) string {
+	return fmt.Sprintf("%s%s\r\n", upstreamFailurePrefix, message)
+}

--- a/gateway/proxyproto/sshproxy/usermessage.go
+++ b/gateway/proxyproto/sshproxy/usermessage.go
@@ -95,8 +95,17 @@ func translateUpstreamError(cause string) string {
 // channels is the gateway-side map of channel-id-string → ssh.Channel
 // (the value the gateway accepted via newCh.Accept()).
 //
-// Writes are best-effort — failures to write or close are logged at
-// the caller's discretion but don't fail the shutdown.
+// After writing the message we Close() each channel so the read
+// goroutines in handleChannel unblock and return promptly. Without
+// the channel Close, those goroutines stay parked in clientCh.Read
+// and hold c.channelWg, forcing handleConnection's flush step to
+// time out (5s) before it can tear down the SSH transport — which
+// would leave the user staring at our message for 5+2 seconds with
+// no apparent reason to be there.
+//
+// Writes and closes are best-effort. Failures during shutdown don't
+// matter to the caller; the next step is sshConn.Close() which will
+// kill the channels anyway.
 func notifyOpenChannels(channels *sync.Map, message string) {
 	if message == "" {
 		return
@@ -108,15 +117,14 @@ func notifyOpenChannels(channels *sync.Map, message string) {
 		if !ok || ch == nil {
 			return true
 		}
-		// Best-effort write; if stderr is already closed or the
-		// transport has gone away, the user won't see this anyway
-		// and we don't want to block the shutdown.
-		if _, err := io.WriteString(ch.Stderr(), line); err != nil {
-			// Log via the caller's logger if needed; here we
-			// silently move on so this helper stays cheap and
-			// log-free for callers to control verbosity.
-			_ = err
-		}
+		_, _ = io.WriteString(ch.Stderr(), line)
+		// Close releases the read goroutine parked in
+		// handleChannel's clientCh.Read loop. The error code is
+		// SSH-protocol "exit-status 1" by convention but the
+		// channel API doesn't expose that here; the simple Close
+		// is enough for the client to see the channel end and
+		// the read goroutine to unblock.
+		_ = ch.Close()
 		return true
 	})
 }

--- a/gateway/proxyproto/sshproxy/usermessage_stub_test.go
+++ b/gateway/proxyproto/sshproxy/usermessage_stub_test.go
@@ -15,16 +15,23 @@ import (
 //
 // The real ssh.Channel interface has more methods than we need; the
 // blank implementations exist purely so the type assertion in
-// notifyOpenChannels succeeds.
+// notifyOpenChannels succeeds. CloseCount lets tests verify the
+// channel was closed after notify, which matters because notify is
+// what unblocks handleChannel's read goroutine on the gateway shutdown
+// path.
 type stderrStubChannel struct {
-	Buffer    bytes.Buffer
-	failWrite bool
+	Buffer     bytes.Buffer
+	failWrite  bool
+	CloseCount int
 }
 
-func (s *stderrStubChannel) Read(p []byte) (int, error)              { return 0, io.EOF }
-func (s *stderrStubChannel) Write(p []byte) (int, error)             { return len(p), nil }
-func (s *stderrStubChannel) Close() error                            { return nil }
-func (s *stderrStubChannel) CloseWrite() error                       { return nil }
+func (s *stderrStubChannel) Read(p []byte) (int, error)  { return 0, io.EOF }
+func (s *stderrStubChannel) Write(p []byte) (int, error) { return len(p), nil }
+func (s *stderrStubChannel) Close() error {
+	s.CloseCount++
+	return nil
+}
+func (s *stderrStubChannel) CloseWrite() error { return nil }
 func (s *stderrStubChannel) SendRequest(string, bool, []byte) (bool, error) {
 	return false, nil
 }

--- a/gateway/proxyproto/sshproxy/usermessage_stub_test.go
+++ b/gateway/proxyproto/sshproxy/usermessage_stub_test.go
@@ -1,0 +1,53 @@
+package sshproxy
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// stderrStubChannel implements just enough of ssh.Channel for the
+// usermessage_test.go suite. Methods unused by notifyOpenChannels
+// return zero values / nil. Stderr() returns a *stderrStubWriter so
+// the tests can inspect what was written.
+//
+// The real ssh.Channel interface has more methods than we need; the
+// blank implementations exist purely so the type assertion in
+// notifyOpenChannels succeeds.
+type stderrStubChannel struct {
+	Buffer    bytes.Buffer
+	failWrite bool
+}
+
+func (s *stderrStubChannel) Read(p []byte) (int, error)              { return 0, io.EOF }
+func (s *stderrStubChannel) Write(p []byte) (int, error)             { return len(p), nil }
+func (s *stderrStubChannel) Close() error                            { return nil }
+func (s *stderrStubChannel) CloseWrite() error                       { return nil }
+func (s *stderrStubChannel) SendRequest(string, bool, []byte) (bool, error) {
+	return false, nil
+}
+func (s *stderrStubChannel) Stderr() io.ReadWriter {
+	return (*stderrStubWriter)(s)
+}
+
+// Compile-time assertion that we satisfy ssh.Channel.
+var _ ssh.Channel = (*stderrStubChannel)(nil)
+
+// stderrStubWriter is the io.ReadWriter exposed via Stderr(). It
+// shares state with its parent stderrStubChannel via unsafe pointer
+// aliasing of the same struct — the field set used here (Buffer,
+// failWrite) is identical on both views.
+type stderrStubWriter stderrStubChannel
+
+func (w *stderrStubWriter) Read(p []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (w *stderrStubWriter) Write(p []byte) (int, error) {
+	if w.failWrite {
+		return 0, errors.New("stub stderr: simulated failure")
+	}
+	return w.Buffer.Write(p)
+}

--- a/gateway/proxyproto/sshproxy/usermessage_test.go
+++ b/gateway/proxyproto/sshproxy/usermessage_test.go
@@ -135,6 +135,14 @@ func TestNotifyOpenChannels_WritesToEveryChannel(t *testing.T) {
 		if !strings.HasSuffix(got, "\r\n") {
 			t.Errorf("channel %s: expected trailing CRLF, got %q", label, got)
 		}
+		// notify must close each channel after the write so the
+		// gateway-side read goroutine parked in clientCh.Read
+		// unblocks. Without this, the gateway's flush wait hits
+		// its 5-second timeout and the user stares at the
+		// message before the connection actually drops.
+		if ch.CloseCount != 1 {
+			t.Errorf("channel %s: expected Close to be called once, got %d", label, ch.CloseCount)
+		}
 	}
 }
 

--- a/gateway/proxyproto/sshproxy/usermessage_test.go
+++ b/gateway/proxyproto/sshproxy/usermessage_test.go
@@ -1,0 +1,149 @@
+package sshproxy
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestTranslateUpstreamError(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty input returns empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "user-initiated disconnect is suppressed",
+			in:   "ssh client disconnected",
+			want: "",
+		},
+		{
+			name: "connection refused with gateway wrapper",
+			in:   "connection closed by server, payload=failed initializing connection, " +
+				"reason=failed establishing tcp connection with 192.168.55.111:22: " +
+				"dial tcp 192.168.55.111:22: connect: connection refused",
+			want: "cannot connect to target server: connection refused",
+		},
+		{
+			name: "i/o timeout with gateway wrapper",
+			in:   "connection closed by server, payload=failed initializing connection, " +
+				"reason=failed establishing tcp connection with 192.0.2.1:22: " +
+				"dial tcp 192.0.2.1:22: i/o timeout",
+			want: "cannot connect to target server: connection timed out",
+		},
+		{
+			name: "deadline exceeded normalized to timeout",
+			in:   "context deadline exceeded",
+			want: "cannot connect to target server: connection timed out",
+		},
+		{
+			name: "no route to host",
+			in:   "dial tcp 10.0.0.1:22: connect: no route to host",
+			want: "cannot connect to target server: no route to host",
+		},
+		{
+			name: "dns failure",
+			in:   "dial tcp: lookup not-a-real-host: no such host",
+			want: "cannot resolve target server hostname",
+		},
+		{
+			name: "ssh auth failure",
+			in:   "connection closed by server, payload=ssh: handshake failed: " +
+				"ssh: unable to authenticate, attempted methods [none password], " +
+				"no supported methods remain",
+			want: "authentication failed against target server",
+		},
+		{
+			name: "session ready timeout",
+			in:   "session timed out before it was ready",
+			want: "session timed out waiting for the target server",
+		},
+		{
+			name: "oss libhoop stub message",
+			in:   "connection closed by server, payload=missing protocol hoop library for ssh, " +
+				"contact your administrator",
+			want: "ssh is not enabled on this hoop agent build, contact your administrator",
+		},
+		{
+			name: "credential revoked",
+			in:   "credential revoked",
+			want: "your access to this target server has been revoked",
+		},
+		{
+			name: "unknown error falls back to generic message",
+			in:   "something we never anticipated happened deep in the stack: 0xdeadbeef",
+			want: "cannot connect to target server",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := translateUpstreamError(tc.in)
+			if got != tc.want {
+				t.Errorf("translateUpstreamError(%q)\n  got:  %q\n  want: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatRaw(t *testing.T) {
+	got := formatRaw("hello world")
+	want := "hoop: hello world\r\n"
+	if got != want {
+		t.Errorf("formatRaw mismatch:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestNotifyOpenChannels_EmptyMessage(t *testing.T) {
+	// notifyOpenChannels with an empty message must be a no-op even
+	// when there are channels registered — this is the path the
+	// caller takes for user-initiated disconnects (translate returns
+	// "" → no Range, no Stderr writes).
+	channels := &sync.Map{}
+	stub := &stderrStubChannel{}
+	channels.Store("1", stub)
+
+	notifyOpenChannels(channels, "")
+
+	if stub.Buffer.Len() != 0 {
+		t.Errorf("expected no writes for empty message, got %q", stub.Buffer.String())
+	}
+}
+
+func TestNotifyOpenChannels_WritesToEveryChannel(t *testing.T) {
+	channels := &sync.Map{}
+	a := &stderrStubChannel{}
+	b := &stderrStubChannel{}
+	channels.Store("1", a)
+	channels.Store("2", b)
+
+	notifyOpenChannels(channels, "cannot connect to target server")
+
+	for label, ch := range map[string]*stderrStubChannel{"a": a, "b": b} {
+		got := ch.Buffer.String()
+		if !strings.HasPrefix(got, upstreamFailurePrefix) {
+			t.Errorf("channel %s: expected prefix %q, got %q", label, upstreamFailurePrefix, got)
+		}
+		if !strings.Contains(got, "cannot connect to target server") {
+			t.Errorf("channel %s: expected message body, got %q", label, got)
+		}
+		if !strings.HasSuffix(got, "\r\n") {
+			t.Errorf("channel %s: expected trailing CRLF, got %q", label, got)
+		}
+	}
+}
+
+func TestNotifyOpenChannels_StderrErrorIgnored(t *testing.T) {
+	// A failing Stderr write must not panic or block the caller.
+	// The whole point of the function is best-effort during shutdown
+	// where writes can race with the transport closing.
+	channels := &sync.Map{}
+	channels.Store("1", &stderrStubChannel{failWrite: true})
+
+	notifyOpenChannels(channels, "cannot connect to target server")
+}


### PR DESCRIPTION
## Summary

When libhoop's upstream SSH dial fails (wrong IP, refused, timeout, auth failure, OSS agent without SSH support), the user's local `ssh` client today sees only `Connection closed by remote host`. The actual reason lives in the agent → gateway error path but never reaches the user's terminal. This change surfaces a sanitized error line on the user's SSH channel stderr before the connection closes.

| Scenario | Before | After |
|---|---|---|
| Wrong / unreachable IP | `Connection closed by remote host` | `hoop: cannot connect to target server: connection timed out` |
| Refused (port closed / firewall) | `Connection closed by remote host` | `hoop: cannot connect to target server: connection refused` |
| Bad upstream credentials | `Connection closed by remote host` | `hoop: authentication failed against target server` |
| OSS agent without SSH | `Connection closed by remote host` | `hoop: ssh is not enabled on this hoop agent build, contact your administrator` |
| Unknown / unexpected error | `Connection closed by remote host` | `hoop: cannot connect to target server` (generic fallback) |
| User exits ssh normally | `Connection closed by remote host` | `Connection closed by remote host` (no extra noise) |

## How it works

When the gateway-side `sshConnection` ctx is cancelled with a cause, `context.Cause(c.ctx)` carries the libhoop / agent error text. Before sending `pbagent.SessionClose` and closing the underlying SSH conn, the gateway:

1. Calls `translateUpstreamError` on the cause string. Maps libhoop's raw messages onto a fixed vocabulary so we never leak internal addresses, library jargon, or stack traces. Unknown patterns fall back to a generic `cannot connect to target server`.
2. If translation returned a non-empty string, calls `notifyOpenChannels` which writes `hoop: <message>\r\n` to `Stderr()` of every currently-open `ssh.Channel`. The user's `ssh` process prints the line before showing its own "Connection closed" notice.

User-initiated disconnects translate to an empty string so we don't produce noise when the user just exited normally.

## What this deliberately doesn't do

Pre-channel errors (dial failed before any channel was opened) still show only `Connection closed by remote host`. SSH protocol has no graceful way to surface an error before channel acceptance without a wire-protocol change. Acceptable trade-off — a real user running `ssh user@host` always opens a session channel before sending exec/shell requests, so the typical case is covered.

No new packet types. No agent changes. No `libhoop` changes.

## Tests

`usermessage_test.go` covers:

- Every translation branch (refused, timeout, no-route, DNS, auth, session-ready timeout, OSS stub, credential revoked)
- The empty-input no-op
- The user-disconnect suppression
- The unknown-input generic fallback
- `formatRaw` line shape
- `notifyOpenChannels` writes to every channel
- `notifyOpenChannels` skips writes for the empty message even with channels registered
- `notifyOpenChannels` survives `Stderr().Write` returning an error (best-effort during shutdown)

`usermessage_stub_test.go` provides a minimal `ssh.Channel` implementation for the multi-channel tests.

`go test ./gateway/...` and `go vet ./gateway/...` are clean.

## Origin

UX gap surfaced during validation of the ENG-395 async SSH fix. With async dispatch on, the agent no longer hangs the whole gateway when one target is unreachable; the user just sees an opaque close. This change completes the UX story so failing connections actually tell the user what went wrong.

Automated by MisterMal