### PR TITLE
Fix/download output

### DIFF
--- a/webapp/src/webapp/audit/views/results_container.cljs
+++ b/webapp/src/webapp/audit/views/results_container.cljs
@@ -20,7 +20,7 @@
   [{:keys [results-heads results-body log-view download-props]}
    {:keys [status results]}]
   [:div {:class "flex flex-col h-96 min-h-96"}
-   [:div {:class "flex justify-between items-end gap-4"}
+   [:div {:class "flex justify-between items-center gap-4"}
     [:div {:class "flex-1 min-w-0"}
      [tabs/tabs {:on-change #(reset! log-view %)
                  :tabs ["Plain text" "Table"]}]]

--- a/webapp/src/webapp/audit/views/results_container.cljs
+++ b/webapp/src/webapp/audit/views/results_container.cljs
@@ -1,5 +1,6 @@
 (ns webapp.audit.views.results-container
   (:require
+   ["@radix-ui/themes" :refer [Box Flex]]
    ["papaparse" :as papa]
    [clojure.string :as string]
    [reagent.core :as r]
@@ -19,13 +20,13 @@
 (defn tab-container
   [{:keys [results-heads results-body log-view download-props]}
    {:keys [status results]}]
-  [:div {:class "flex flex-col h-96 min-h-96"}
-   [:div {:class "flex justify-between items-center gap-4"}
-    [:div {:class "flex-1 min-w-0"}
+  [:> Flex {:direction "column" :class "h-96 min-h-96"}
+   [:> Flex {:justify "between" :align "center" :gap "4"}
+    [:> Box {:class "flex-1 min-w-0"}
      [tabs/tabs {:on-change #(reset! log-view %)
                  :tabs ["Plain text" "Table"]}]]
     (when download-props
-      [:div {:class "mb-large flex-shrink-0"}
+      [:> Box {:class "mb-large flex-shrink-0"}
        [download-menu/main download-props]])]
    (case @log-view
      "Plain text" [logs/virtualized-container {:status status :logs results}]
@@ -47,9 +48,9 @@
 
 (defmethod results-view :not-sql
   [_ {:keys [results status classes download-props]}]
-  [:div {:class "flex flex-col h-full"}
+  [:> Flex {:direction "column" :class "h-full"}
    (when download-props
-     [:div {:class "flex justify-end mb-small"}
+     [:> Flex {:justify "end" :class "mb-small"}
       [download-menu/main download-props]])
    [logs/virtualized-container {:status status :logs results :classes classes}]])
 

--- a/webapp/src/webapp/audit/views/results_container.cljs
+++ b/webapp/src/webapp/audit/views/results_container.cljs
@@ -5,6 +5,7 @@
    [reagent.core :as r]
    [webapp.components.ag-grid-table :as ag-grid-table]
    [webapp.components.logs-container :as logs]
+   [webapp.components.results-download-menu :as download-menu]
    [webapp.components.tabs :as tabs]))
 
 (defn- transform-results->matrix
@@ -16,11 +17,16 @@
       (get (js->clj (papa/parse res (clj->js {"delimiter" "\t"}))) "data"))))
 
 (defn tab-container
-  [{:keys [results-heads results-body log-view]}
+  [{:keys [results-heads results-body log-view download-props]}
    {:keys [status results]}]
   [:div {:class "flex flex-col h-96 min-h-96"}
-   [tabs/tabs {:on-change #(reset! log-view %)
-               :tabs ["Plain text" "Table"]}]
+   [:div {:class "flex justify-between items-end gap-4"}
+    [:div {:class "flex-1 min-w-0"}
+     [tabs/tabs {:on-change #(reset! log-view %)
+                 :tabs ["Plain text" "Table"]}]]
+    (when download-props
+      [:div {:class "mb-large flex-shrink-0"}
+       [download-menu/main download-props]])]
    (case @log-view
      "Plain text" [logs/virtualized-container {:status status :logs results}]
      "Table" [ag-grid-table/main results-heads results-body false true
@@ -31,42 +37,54 @@
 
 (defmulti results-view identity)
 (defmethod results-view :sql
-  [_ {:keys [results-heads results-body results status fixed-height? classes log-view]}]
+  [_ {:keys [results-heads results-body results status fixed-height? classes log-view download-props]}]
   [tab-container
    {:results-heads results-heads
     :results-body results-body
-    :log-view log-view}
+    :log-view log-view
+    :download-props download-props}
    {:status status :results results :fixed-height? fixed-height? :classes classes}])
 
 (defmethod results-view :not-sql
-  [_ {:keys [results status classes]}]
-  [logs/virtualized-container {:status status :logs results :classes classes}])
+  [_ {:keys [results status classes download-props]}]
+  [:div {:class "flex flex-col h-full"}
+   (when download-props
+     [:div {:class "flex justify-end mb-small"}
+      [download-menu/main download-props]])
+   [logs/virtualized-container {:status status :logs results :classes classes}]])
 
 (defn main []
   (let [log-view (r/atom "Plain text")]
 
-    (fn [connection-subtype {:keys [results results-status fixed-height? classes]}]
+    (fn [connection-subtype {:keys [results results-status fixed-height? classes
+                                    session-id connection-name has-large-payload?]}]
       (let [results-transformed (transform-results->matrix results connection-subtype)
             results-heads (first results-transformed)
             results-body (next results-transformed)
+            sql-subtypes #{"mysql-csv" "mysql" "postgres" "sql-server" "mssql"
+                           "postgres-csv" "sql-server-csv" "oracledb" "database"}
+            is-sql? (contains? sql-subtypes connection-subtype)
+            tabular? (and is-sql?
+                          (seq results-heads)
+                          (seq results-body))
+            download-props (when (= results-status :success)
+                             {:results results
+                              :matrix results-transformed
+                              :tabular? tabular?
+                              :session-id session-id
+                              :connection-name connection-name
+                              :has-large-payload? has-large-payload?})
             props-log-view {:results-heads results-heads
                             :results-body results-body
                             :fixed-height? fixed-height?
                             :status results-status
                             :results results
                             :classes classes
-                            :log-view log-view}]
+                            :log-view log-view
+                            :download-props download-props}]
 
         (if (= results-status :success)
-          (case connection-subtype
-            "mysql-csv" [results-view :sql props-log-view]
-            "mysql" [results-view :sql props-log-view]
-            "postgres" [results-view :sql props-log-view]
-            "sql-server" [results-view :sql props-log-view]
-            "mssql" [results-view :sql props-log-view]
-            "postgres-csv" [results-view :sql props-log-view]
-            "sql-server-csv" [results-view :sql props-log-view]
-            "oracledb" [results-view :sql props-log-view]
-            "database" [results-view :sql props-log-view]
+          (if is-sql?
+            [results-view :sql props-log-view]
             [results-view :not-sql props-log-view])
           [results-view :not-sql props-log-view])))))

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -43,23 +43,25 @@
 
 
 (defn large-input-warning [{:keys [session]}]
-  [:> Box {:class "w-full p-regular rounded-lg bg-[--gray-2]"}
-   [:> Callout.Root {:variant "surface"
-                     :size "2"
-                     :class "flex items-center mb-small justify-between"}
-    [:> Callout.Icon
-     [:> Info {:size 16}]]
-    [:> Callout.Text {:class "w-full"}
-     [:> Flex {:gap "4"
-               :class "items-center justify-between"}
-      [:> Text
-       "Input script is too large to display"]
-      [:> Button {:size "2"
-                  :variant "soft"
-                  :class "flex-shrink-0"
-                  :on-click #(rf/dispatch [:audit->session-input-download (:id session)])}
-       "Download"
-       [:> Download {:size 16}]]]]]])
+  (let [download-disabled? @(rf/subscribe [:gateway->sessions-download-disabled?])]
+    [:> Box {:class "w-full p-regular rounded-lg bg-[--gray-2]"}
+     [:> Callout.Root {:variant "surface"
+                       :size "2"
+                       :class "flex items-center mb-small justify-between"}
+      [:> Callout.Icon
+       [:> Info {:size 16}]]
+      [:> Callout.Text {:class "w-full"}
+       [:> Flex {:gap "4"
+                 :class "items-center justify-between"}
+        [:> Text
+         "Input script is too large to display"]
+        (when-not download-disabled?
+          [:> Button {:size "2"
+                      :variant "soft"
+                      :class "flex-shrink-0"
+                      :on-click #(rf/dispatch [:audit->session-input-download (:id session)])}
+           "Download"
+           [:> Download {:size 16}]])]]]]))
 
 (defmulti ^:private session-event-stream identity)
 (defmethod ^:private session-event-stream "command-line"

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -25,13 +25,6 @@
    [webapp.sessions.components.session-details :as session-details-component]
    [webapp.sessions.components.rejection-reason :as rejection-reason]))
 
-(def ^:private export-dictionary
-  {:postgres "csv"
-   :mysql "csv"
-   :database "csv"
-   :custom "txt"
-   :command-line "txt"})
-
 ;; TODO: Change it for send DB in the payload and not the response
 (defn- sanitize-response [response connection-type]
   (cond
@@ -238,11 +231,7 @@
            [session-header/main {:session session
                                  :user user
                                  :on-close #(rf/dispatch [:modal->close])
-                                 :clipboard-disabled? @clipboard-disabled?
-                                 :has-large-payload? has-large-payload?
-                                 :download-extension (get export-dictionary
-                                                          (keyword (:type session))
-                                                          "txt")}]
+                                 :clipboard-disabled? @clipboard-disabled?}]
 
            [:> Box {:class (str "space-y-radix-5 "
                                 (when is-dedicated-page? "pb-radix-6"))}
@@ -349,7 +338,10 @@
                             {:results        results
                              :results-status results-status
                              :fixed-height?  true
-                             :results-id     (:id session)}]])))
+                             :results-id     (:id session)
+                             :session-id     (:id session)
+                             :connection-name (:connection session)
+                             :has-large-payload? has-large-payload?}]])))
 
                     ;; connect: session-event-stream unchanged (video player, raw, etc.)
                     [session-event-stream (:type session) session])])])

--- a/webapp/src/webapp/components/results_download_menu.cljs
+++ b/webapp/src/webapp/components/results_download_menu.cljs
@@ -93,26 +93,29 @@
    When the content exceeds the client-side threshold and a :session-id is
    available, downloads are delegated to the existing backend token flow."
   [{:keys [results tabular?] :as props}]
-  (when (and results (not (cs/blank? results)))
-    [:> DropdownMenu.Root
-     [:> DropdownMenu.Trigger
-      [:> IconButton {:variant "ghost"
-                      :color "gray"
-                      :size "1"
-                      :aria-label "Download options"}
-       [:> MoreHorizontal {:size 16}]]]
-     [:> DropdownMenu.Content {:align "end"}
-      [:> DropdownMenu.Item {:on-select #(handle-download props :txt)}
-       [:> Flex {:align "center" :gap "2"}
-        [:> FileText {:size 16}]
-        [:> Text {:size "2"} "Download as TXT"]]]
-      (when tabular?
-        [:<>
-         [:> DropdownMenu.Item {:on-select #(handle-download props :csv)}
-          [:> Flex {:align "center" :gap "2"}
-           [:> Sheet {:size 16}]
-           [:> Text {:size "2"} "Download as CSV"]]]
-         [:> DropdownMenu.Item {:on-select #(handle-download props :json)}
-          [:> Flex {:align "center" :gap "2"}
-           [:> Braces {:size 16}]
-           [:> Text {:size "2"} "Download as JSON"]]]])]]))
+  (let [download-disabled? @(rf/subscribe [:gateway->sessions-download-disabled?])]
+    (when (and results
+               (not (cs/blank? results))
+               (not download-disabled?))
+      [:> DropdownMenu.Root
+       [:> DropdownMenu.Trigger
+        [:> IconButton {:variant "ghost"
+                        :color "gray"
+                        :size "1"
+                        :aria-label "Download options"}
+         [:> MoreHorizontal {:size 16}]]]
+       [:> DropdownMenu.Content {:align "end"}
+        [:> DropdownMenu.Item {:on-select #(handle-download props :txt)}
+         [:> Flex {:align "center" :gap "2"}
+          [:> FileText {:size 16}]
+          [:> Text {:size "2"} "Download as TXT"]]]
+        (when tabular?
+          [:<>
+           [:> DropdownMenu.Item {:on-select #(handle-download props :csv)}
+            [:> Flex {:align "center" :gap "2"}
+             [:> Sheet {:size 16}]
+             [:> Text {:size "2"} "Download as CSV"]]]
+           [:> DropdownMenu.Item {:on-select #(handle-download props :json)}
+            [:> Flex {:align "center" :gap "2"}
+             [:> Braces {:size 16}]
+             [:> Text {:size "2"} "Download as JSON"]]]])]])))

--- a/webapp/src/webapp/components/results_download_menu.cljs
+++ b/webapp/src/webapp/components/results_download_menu.cljs
@@ -1,6 +1,6 @@
 (ns webapp.components.results-download-menu
   (:require
-   ["@radix-ui/themes" :refer [DropdownMenu IconButton]]
+   ["@radix-ui/themes" :refer [DropdownMenu Flex IconButton Text]]
    ["lucide-react" :refer [MoreHorizontal FileText Sheet Braces]]
    ["papaparse" :as papa]
    [clojure.string :as cs]
@@ -102,20 +102,17 @@
                       :aria-label "Download options"}
        [:> MoreHorizontal {:size 16}]]]
      [:> DropdownMenu.Content {:align "end"}
-      [:> DropdownMenu.Item
-       {:class "flex justify-between gap-4 group cursor-pointer hover:bg-gray-2"
-        :on-click #(handle-download props :txt)}
-       "Download as TXT"
-       [:> FileText {:size 16 :class "text-gray-10"}]]
+      [:> DropdownMenu.Item {:on-select #(handle-download props :txt)}
+       [:> Flex {:align "center" :gap "2"}
+        [:> FileText {:size 16}]
+        [:> Text {:size "2"} "Download as TXT"]]]
       (when tabular?
         [:<>
-         [:> DropdownMenu.Item
-          {:class "flex justify-between gap-4 group cursor-pointer hover:bg-gray-2"
-           :on-click #(handle-download props :csv)}
-          "Download as CSV"
-          [:> Sheet {:size 16 :class "text-gray-10"}]]
-         [:> DropdownMenu.Item
-          {:class "flex justify-between gap-4 group cursor-pointer hover:bg-gray-2"
-           :on-click #(handle-download props :json)}
-          "Download as JSON"
-          [:> Braces {:size 16 :class "text-gray-10"}]]])]]))
+         [:> DropdownMenu.Item {:on-select #(handle-download props :csv)}
+          [:> Flex {:align "center" :gap "2"}
+           [:> Sheet {:size 16}]
+           [:> Text {:size "2"} "Download as CSV"]]]
+         [:> DropdownMenu.Item {:on-select #(handle-download props :json)}
+          [:> Flex {:align "center" :gap "2"}
+           [:> Braces {:size 16}]
+           [:> Text {:size "2"} "Download as JSON"]]]])]]))

--- a/webapp/src/webapp/components/results_download_menu.cljs
+++ b/webapp/src/webapp/components/results_download_menu.cljs
@@ -1,0 +1,121 @@
+(ns webapp.components.results-download-menu
+  (:require
+   ["@radix-ui/themes" :refer [DropdownMenu IconButton]]
+   ["lucide-react" :refer [MoreHorizontal FileText Sheet Braces]]
+   ["papaparse" :as papa]
+   [clojure.string :as cs]
+   [re-frame.core :as rf]))
+
+(def ^:private client-side-threshold (* 2 1024 1024))
+
+(defn- pad2 [n] (if (< n 10) (str "0" n) (str n)))
+
+(defn- filename-timestamp []
+  (let [d (js/Date.)]
+    (str (.getUTCFullYear d)
+         (pad2 (inc (.getUTCMonth d)))
+         (pad2 (.getUTCDate d))
+         "-"
+         (pad2 (.getUTCHours d))
+         (pad2 (.getUTCMinutes d))
+         (pad2 (.getUTCSeconds d)))))
+
+(defn- build-filename [{:keys [connection-name session-id]} ext]
+  (let [parts (cond-> []
+                (and connection-name (not (cs/blank? connection-name))) (conj connection-name)
+                (and session-id (not (cs/blank? session-id))) (conj session-id)
+                true (conj (filename-timestamp)))]
+    (str (cs/join "-" parts) "." ext)))
+
+(defn- trigger-download! [filename mime-type content]
+  (let [blob (js/Blob. #js [content] #js {:type mime-type})
+        url (js/URL.createObjectURL blob)
+        a (.createElement js/document "a")]
+    (set! (.-href a) url)
+    (set! (.-download a) filename)
+    (.appendChild js/document.body a)
+    (.click a)
+    (.removeChild js/document.body a)
+    (js/setTimeout #(js/URL.revokeObjectURL url) 0)))
+
+(defn- matrix->csv [matrix]
+  (papa/unparse (clj->js matrix)))
+
+(defn- matrix->json [heads body]
+  (let [head-keys (vec (map-indexed
+                        (fn [idx h]
+                          (if (or (nil? h) (cs/blank? h))
+                            (str "column_" (inc idx))
+                            h))
+                        heads))
+        rows (mapv (fn [row]
+                     (into {}
+                           (map vector head-keys row)))
+                   body)]
+    (.stringify js/JSON (clj->js rows) nil 2)))
+
+(defn- use-backend? [{:keys [has-large-payload? results session-id]}]
+  (and session-id
+       (or has-large-payload?
+           (and results (> (count results) client-side-threshold)))))
+
+(defn- handle-client-download [{:keys [results matrix tabular?] :as props} format]
+  (let [filename-meta (select-keys props [:connection-name :session-id])]
+    (case format
+      :txt (trigger-download! (build-filename filename-meta "txt") "text/plain" results)
+      :csv (let [content (if (and tabular? matrix)
+                           (matrix->csv matrix)
+                           results)]
+             (trigger-download! (build-filename filename-meta "csv") "text/csv" content))
+      :json (let [heads (first matrix)
+                  body (next matrix)
+                  content (matrix->json heads body)]
+              (trigger-download! (build-filename filename-meta "json") "application/json" content)))))
+
+(defn- handle-download [{:keys [session-id] :as props} format]
+  (if (use-backend? props)
+    (rf/dispatch [:audit->session-file-generate session-id (name format)])
+    (handle-client-download props format)))
+
+(defn main
+  "Dropdown menu offering txt/csv/json downloads of the rendered output.
+
+   Required props:
+     :results          Raw output string already rendered to the user.
+
+   Optional props:
+     :tabular?         When true, CSV/JSON entries are offered.
+     :matrix           Parsed [[heads] [row] ...] used by CSV/JSON. Required when tabular?.
+     :session-id       Used as filename hint and as the target for backend downloads.
+     :connection-name  Used as filename hint.
+     :has-large-payload? When true, forces the backend download flow.
+
+   When the content exceeds the client-side threshold and a :session-id is
+   available, downloads are delegated to the existing backend token flow."
+  [{:keys [results tabular?] :as props}]
+  (when (and results (not (cs/blank? results)))
+    [:> DropdownMenu.Root
+     [:> DropdownMenu.Trigger
+      [:> IconButton {:variant "ghost"
+                      :color "gray"
+                      :size "1"
+                      :aria-label "Download options"}
+       [:> MoreHorizontal {:size 16}]]]
+     [:> DropdownMenu.Content {:align "end"}
+      [:> DropdownMenu.Item
+       {:class "flex justify-between gap-4 group cursor-pointer hover:bg-gray-2"
+        :on-click #(handle-download props :txt)}
+       "Download as TXT"
+       [:> FileText {:size 16 :class "text-gray-10"}]]
+      (when tabular?
+        [:<>
+         [:> DropdownMenu.Item
+          {:class "flex justify-between gap-4 group cursor-pointer hover:bg-gray-2"
+           :on-click #(handle-download props :csv)}
+          "Download as CSV"
+          [:> Sheet {:size 16 :class "text-gray-10"}]]
+         [:> DropdownMenu.Item
+          {:class "flex justify-between gap-4 group cursor-pointer hover:bg-gray-2"
+           :on-click #(handle-download props :json)}
+          "Download as JSON"
+          [:> Braces {:size 16 :class "text-gray-10"}]]])]]))

--- a/webapp/src/webapp/components/results_download_menu.cljs
+++ b/webapp/src/webapp/components/results_download_menu.cljs
@@ -97,7 +97,7 @@
     (when (and results
                (not (cs/blank? results))
                (not download-disabled?))
-      [:> DropdownMenu.Root
+      [:> DropdownMenu.Root {:modal false}
        [:> DropdownMenu.Trigger
         [:> IconButton {:variant "ghost"
                         :color "gray"
@@ -105,17 +105,20 @@
                         :aria-label "Download options"}
          [:> MoreHorizontal {:size 16}]]]
        [:> DropdownMenu.Content {:align "end"}
-        [:> DropdownMenu.Item {:on-select #(handle-download props :txt)}
+        [:> DropdownMenu.Item {:class "cursor-pointer hover:bg-gray-2"
+                               :on-select #(handle-download props :txt)}
          [:> Flex {:align "center" :gap "2"}
           [:> FileText {:size 16}]
           [:> Text {:size "2"} "Download as TXT"]]]
         (when tabular?
           [:<>
-           [:> DropdownMenu.Item {:on-select #(handle-download props :csv)}
+           [:> DropdownMenu.Item {:class "cursor-pointer hover:bg-gray-2"
+                                  :on-select #(handle-download props :csv)}
             [:> Flex {:align "center" :gap "2"}
              [:> Sheet {:size 16}]
              [:> Text {:size "2"} "Download as CSV"]]]
-           [:> DropdownMenu.Item {:on-select #(handle-download props :json)}
+           [:> DropdownMenu.Item {:class "cursor-pointer hover:bg-gray-2"
+                                  :on-select #(handle-download props :json)}
             [:> Flex {:align "center" :gap "2"}
              [:> Braces {:size 16}]
              [:> Text {:size "2"} "Download as JSON"]]]])]])))

--- a/webapp/src/webapp/components/results_download_menu.cljs
+++ b/webapp/src/webapp/components/results_download_menu.cljs
@@ -97,7 +97,7 @@
     (when (and results
                (not (cs/blank? results))
                (not download-disabled?))
-      [:> DropdownMenu.Root {:modal false}
+      [:> DropdownMenu.Root
        [:> DropdownMenu.Trigger
         [:> IconButton {:variant "ghost"
                         :color "gray"
@@ -105,19 +105,19 @@
                         :aria-label "Download options"}
          [:> MoreHorizontal {:size 16}]]]
        [:> DropdownMenu.Content {:align "end"}
-        [:> DropdownMenu.Item {:class "cursor-pointer hover:bg-gray-2"
+        [:> DropdownMenu.Item {:class "cursor-pointer hover:bg-gray-2 text-gray-12"
                                :on-select #(handle-download props :txt)}
          [:> Flex {:align "center" :gap "2"}
           [:> FileText {:size 16}]
           [:> Text {:size "2"} "Download as TXT"]]]
         (when tabular?
           [:<>
-           [:> DropdownMenu.Item {:class "cursor-pointer hover:bg-gray-2"
+           [:> DropdownMenu.Item {:class "cursor-pointer hover:bg-gray-2 text-gray-12"
                                   :on-select #(handle-download props :csv)}
             [:> Flex {:align "center" :gap "2"}
              [:> Sheet {:size 16}]
              [:> Text {:size "2"} "Download as CSV"]]]
-           [:> DropdownMenu.Item {:class "cursor-pointer hover:bg-gray-2"
+           [:> DropdownMenu.Item {:class "cursor-pointer hover:bg-gray-2 text-gray-12"
                                   :on-select #(handle-download props :json)}
             [:> Flex {:align "center" :gap "2"}
              [:> Braces {:size 16}]

--- a/webapp/src/webapp/events/gateway_info.cljs
+++ b/webapp/src/webapp/events/gateway_info.cljs
@@ -74,3 +74,8 @@
  :gateway->clipboard-disabled?
  (fn [db _]
    (get-in db [:gateway->info :data :disable_clipboard_copy_cut] false)))
+
+(rf/reg-sub
+ :gateway->sessions-download-disabled?
+ (fn [db _]
+   (get-in db [:gateway->info :data :disable_sessions_download] false)))

--- a/webapp/src/webapp/sessions/components/session_header.cljs
+++ b/webapp/src/webapp/sessions/components/session_header.cljs
@@ -1,7 +1,7 @@
 (ns webapp.sessions.components.session-header
   (:require
    ["@radix-ui/themes" :refer [Box Button IconButton Flex Heading]]
-   ["lucide-react" :refer [Link2 Square RotateCw X Download Workflow]]
+   ["lucide-react" :refer [Link2 Square RotateCw X Workflow]]
    [clojure.string :as cs]
    [re-frame.core :as rf]
    [reagent.core :as r]
@@ -40,7 +40,7 @@
   (reset! killing-status :loading)
   (rf/dispatch [:audit->kill-session session killing-status]))
 
-(defn main [{:keys [session user on-close clipboard-disabled? has-large-payload? download-extension]}]
+(defn main [{:keys [session user on-close clipboard-disabled?]}]
   (let [admin? (:admin? user)
         current-user-id (:id user)
         session-user-id (:user_id session)
@@ -112,18 +112,6 @@
            :color "gray"}
           [:> RotateCw {:size 20 :class "text-gray-11"}]
           "Re-run"])
-
-       ;; Download button (shown only for large payloads)
-       (when has-large-payload?
-         [:> Button
-          {:on-click #(rf/dispatch [:audit->session-file-generate
-                                    (:id session)
-                                    download-extension])
-           :variant "soft"
-           :size "2"
-           :color "gray"}
-          [:> Download {:size 20 :class "text-gray-11"}]
-          "Download"])
 
        ;; Share button (copy link)
        (when-not clipboard-disabled?

--- a/webapp/src/webapp/webclient/log_area/main.cljs
+++ b/webapp/src/webapp/webclient/log_area/main.cljs
@@ -96,7 +96,7 @@
                    :tabs available-tabs
                    :selected-tab @selected-tab}]]
            (when download-props
-             [:> Box {:class "mb-regular flex-shrink-0"}
+             [:> Box {:class "mb-regular pt-small flex-shrink-0"}
               [download-menu/main download-props]])]
           [:> Box {:role "tabpanel"
                    :id (str "tabpanel-" (case @selected-tab

--- a/webapp/src/webapp/webclient/log_area/main.cljs
+++ b/webapp/src/webapp/webclient/log_area/main.cljs
@@ -1,10 +1,11 @@
 (ns webapp.webclient.log-area.main
   (:require ["papaparse" :as papa]
-            ["@radix-ui/themes" :refer [Box]]
+            ["@radix-ui/themes" :refer [Box Flex]]
             [clojure.string :as cs]
             [re-frame.core :as rf]
             [reagent.core :as r]
             [webapp.components.ag-grid-table :as ag-grid-table]
+            [webapp.components.results-download-menu :as download-menu]
             [webapp.webclient.log-area.output-tabs :refer [tabs]]
             [webapp.webclient.log-area.logs :as logs]))
 
@@ -68,7 +69,18 @@
                             {:logs "Logs"}
                             (when (and connection-type-database?
                                        (not parallel-mode-active?))
-                              {:tabular "Tabular"}))]
+                              {:tabular "Tabular"}))
+            tabular-data? (and connection-type-database?
+                               (seq results-heads)
+                               (seq results-body))
+            download-props (when (and response (not (cs/blank? response))
+                                      (= tabular-status :success))
+                             {:results response
+                              :matrix results-transformed
+                              :tabular? (boolean tabular-data?)
+                              :session-id (:session_id (:data @script-response))
+                              :connection-name nil
+                              :has-large-payload? false})]
 
         (when-not (some #(= @selected-tab %) (vals available-tabs))
           (.setItem js/localStorage "webclient-selected-tab" (first (vals available-tabs)))
@@ -76,11 +88,16 @@
 
         [:> Box {:class "flex-1 min-h-0 flex flex-col overflow-hidden"}
          [:> Box {:class "h-full flex flex-col bg-gray-1 border-b border-gray-3"}
-          [tabs {:on-click (fn [_ value]
-                             (.setItem js/localStorage "webclient-selected-tab" value)
-                             (reset! selected-tab value))
-                 :tabs available-tabs
-                 :selected-tab @selected-tab}]
+          [:> Flex {:justify "between" :align "end" :gap "4" :class "pr-small"}
+           [:> Box {:class "flex-1 min-w-0"}
+            [tabs {:on-click (fn [_ value]
+                               (.setItem js/localStorage "webclient-selected-tab" value)
+                               (reset! selected-tab value))
+                   :tabs available-tabs
+                   :selected-tab @selected-tab}]]
+           (when download-props
+             [:> Box {:class "mb-regular flex-shrink-0"}
+              [download-menu/main download-props]])]
           [:> Box {:role "tabpanel"
                    :id (str "tabpanel-" (case @selected-tab
                                           "Tabular" :tabular

--- a/webapp/src/webapp/webclient/log_area/main.cljs
+++ b/webapp/src/webapp/webclient/log_area/main.cljs
@@ -88,7 +88,7 @@
 
         [:> Box {:class "flex-1 min-h-0 flex flex-col overflow-hidden"}
          [:> Box {:class "h-full flex flex-col bg-gray-1 border-b border-gray-3"}
-          [:> Flex {:justify "between" :align "end" :gap "4" :class "pr-small"}
+          [:> Flex {:justify "between" :align "center" :gap "4" :class "pr-small"}
            [:> Box {:class "flex-1 min-w-0"}
             [tabs {:on-click (fn [_ value]
                                (.setItem js/localStorage "webclient-selected-tab" value)


### PR DESCRIPTION
## 📝 Description

The ellipsis menu for downloading session results had disappeared from the frontend. This PR restores it and unifies all download entry points into a single, reusable component used by Audit session details, the Webclient log area, and the Runbooks runner.

The menu offers **TXT** for any output and additionally **CSV** / **JSON** when the connection produces tabular output. Downloads under 2MB are generated client-side from the already-loaded payload; larger payloads (or sessions flagged with `has-large-payload?`) fall back to the existing backend token flow, keeping the 4MB threshold behavior intact.

The standalone "Download" button that previously lived in the session header for >4MB payloads has been removed, so users now see a single predictable entry point on every results surface.

It also honors the existing `DISABLE_SESSIONS_DOWNLOAD` server policy: the menu (and the input-script download button in the large-input warning) are hidden when the policy is on, preventing the client-side path from bypassing the rule that the backend enforces at `session.go:493`.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added a new reusable `webapp.components.results-download-menu` component built on Radix `DropdownMenu`, offering TXT (always) and CSV/JSON (for tabular outputs). Uses a 2MB threshold to decide between client-side blob generation (via `papaparse`'s `unparse` for CSV) and the existing backend token flow (`:audit->session-file-generate`).
- Wired the menu into `webapp.audit.views.results-container` so it appears next to the Plain text / Table tabs on session details.
- Wired the same menu into `webapp.webclient.log-area.main`, which automatically covers both the Webclient editor output and the Runbooks runner.
- Removed the duplicate "Download" button from `webapp.sessions.components.session-header` and dropped the now-unused `:has-large-payload?` / `:download-extension` props at the call site, unifying every download entry point into the ellipsis menu.
- Added a new re-frame subscription `:gateway->sessions-download-disabled?` in `webapp.events.gateway-info` that reads `disable_sessions_download` from `/serverinfo`, and used it to hide the menu and the `large-input-warning` download button when `DISABLE_SESSIONS_DOWNLOAD=true`.
- Aligned the menu trigger vertically with the tabs (space-between / items-center) and removed custom `hover:bg-gray-2` classes on `DropdownMenu.Item` so each entry inherits the default Radix hover styling, matching `webapp.webclient.log-area.logs`.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome (latest)
- **OS**: macOS / Linux

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

Manual scenarios to validate:
- SQL session with small result (<2MB): TXT, CSV, JSON entries appear; each downloads client-side with filename `{connection}-{sid}-{timestamp}.{ext}`.
- SQL session with `has-large-payload?` (>4MB): menu falls back to the backend token endpoint and opens the temporary download URL.
- Exec / command-line session: only TXT is offered.
- Runbook executed from the Webclient: menu appears next to the Logs/Tabular tabs and downloads the rendered output.
- With `DISABLE_SESSIONS_DOWNLOAD=true` on the gateway: the ellipsis menu no longer renders, and the input-script "Download" button in the large-input warning is hidden.
- With `DISABLE_CLIPBOARD_COPY_CUT=true`: download menu is unaffected (separate policy, by design).

## 📸 Screenshots (if applicable)

<img width="1947" height="1066" alt="Screenshot 2026-05-13 at 20 50 35" src="https://github.com/user-attachments/assets/f662f37e-84bf-4d62-ae8f-4dbde7b49fd8" />
<img width="1945" height="1073" alt="Screenshot 2026-05-13 at 20 51 56" src="https://github.com/user-attachments/assets/8ef90e42-3121-472d-9052-bf5caecd57f2" />


## ✅ Checklist

- [ ] I have run `make generate-openapi-docs` to update the OpenAPI docs (not applicable — frontend-only change, no API surface modified)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- **Build verification gap**: the sandbox running this branch blocks access to `repo.clojars.org`, so `npx shadow-cljs compile hoop-ui` could not download `thheller:shadow-cljs:2.28.14` and the build was not executed end-to-end. Manual review confirmed every JS/Radix/lucide symbol used (`DropdownMenu`, `IconButton`, `Flex`, `Text`, `MoreHorizontal`, `FileText`, `Sheet`, `Braces`, `papa/unparse`) is exported by the locked versions in `package.json`. Please run `npm run dev:hoop-ui` locally to confirm.
- **Reviewer focus**: behavior parity between the client-side CSV path (`papa.unparse` of the matrix already shown in the Table tab) and the backend CSV path (`parseBlobStream` with `withCsvFmt: true`) — they use different parsers, so a >2MB SQL session may produce a slightly different CSV than a small one. If exact parity is required we should consider routing all CSV through the backend.
- The two policies (`DISABLE_CLIPBOARD_COPY_CUT` and `DISABLE_SESSIONS_DOWNLOAD`) are kept independent on purpose, matching the existing codebase convention.