### PR TITLE
ci: deduplicate API changelog PR comment + Doc auto-regen on commit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -61,7 +61,6 @@ Fixes #
 
 <!-- Please check off the following items by replacing [ ] with [x] -->
 
-- [ ] I have run `make generate-openapi-docs` to update the OpenAPI docs
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas

--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -1,45 +1,100 @@
-name: API Changelog
+name: OpenAPI Docs
 
 on:
   pull_request:
     paths:
+      - 'gateway/**/*.go'
+      - 'gateway/api/openapi/docs/**'
       - 'gateway/api/openapi/openapiv3.json'
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: write
+  pull-requests: write
+
+# Cancel superseded runs on the same PR so two near-simultaneous pushes
+# don't race on `git push` and leave a misleading stale-docs comment.
+concurrency:
+  group: openapi-docs-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  generate:
+  regen-and-diff:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: checkout PR head
         uses: actions/checkout@v6
         with:
+          # PAT so the regen commit pushed later fires downstream workflows
+          # (pullrequest.yml, pullrequest-release.yml). Same precedent as
+          # auto-release.yml — pushes made with GITHUB_TOKEN do not trigger
+          # other workflows.
+          token: ${{ secrets.GH_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
-      - name: find base spec
+      - name: setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.26.0'
+          cache-dependency-path: '**/go.sum'
+
+      - name: regenerate OpenAPI docs
+        run: make generate-openapi-docs
+
+      - name: detect diff
+        id: diff
         run: |
-          git show origin/${{ github.base_ref }}:gateway/api/openapi/openapiv3.json > base-openapiv3.json
+          set -euo pipefail
+          if git diff --quiet -- gateway/api/openapi/autogen gateway/api/openapi/openapiv3.json; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "Stale files:"
+            git diff --name-only -- gateway/api/openapi/autogen gateway/api/openapi/openapiv3.json
+          fi
+
+      - name: commit and push regenerated docs
+        if: steps.diff.outputs.stale == 'true' && github.event.pull_request.head.repo.fork == false
+        id: push
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add gateway/api/openapi/autogen gateway/api/openapi/openapiv3.json
+          git commit -m 'chore: regenerate OpenAPI docs'
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+      - name: find base spec
+        if: always()
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          git show origin/${{ github.base_ref }}:gateway/api/openapi/openapiv3.json > /tmp/base-openapiv3.json
 
       - name: generate changelog
+        if: always()
         uses: oasdiff/oasdiff-action/changelog@v0.0.39
         id: changelog
         with:
-          base: 'base-openapiv3.json'
+          base: '/tmp/base-openapiv3.json'
           revision: 'gateway/api/openapi/openapiv3.json'
           format: 'markup'
 
-      - name: post changelog as PR comment
+      - name: update PR comments
         if: always()
         uses: actions/github-script@v8
         env:
           CHANGELOG_OUTPUT: ${{ steps.changelog.outputs.changelog }}
+          STALE: ${{ steps.diff.outputs.stale }}
+          PUSHED: ${{ steps.push.outcome == 'success' }}
         with:
           script: |
-            const marker = '<!-- api-changelog-comment -->';
-            const output = process.env.CHANGELOG_OUTPUT;
-            const hasChanges = output && output.trim().length > 0;
-            const body = hasChanges ? `${marker}\n## 📋 API Changelog\n\n${output}` : null;
+            const changelogMarker = '<!-- api-changelog-comment -->';
+            const staleMarker = '<!-- api-docs-stale-comment -->';
 
-            const existing = await github.paginate(
+            const findMarked = async (marker) => github.paginate(
               github.rest.issues.listComments,
               {
                 owner: context.repo.owner,
@@ -50,36 +105,54 @@ jobs:
               (response) => response.data.filter((c) => c.body && c.body.includes(marker))
             );
 
-            if (hasChanges) {
-              if (existing.length > 0) {
-                const [keep, ...stale] = existing;
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: keep.id,
-                  body,
-                });
-                for (const c of stale) {
+            const upsertOrDelete = async (marker, body) => {
+              const existing = await findMarked(marker);
+              if (body) {
+                if (existing.length > 0) {
+                  const [keep, ...stale] = existing;
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: keep.id,
+                    body,
+                  });
+                  for (const c of stale) {
+                    await github.rest.issues.deleteComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: c.id,
+                    });
+                  }
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    body,
+                  });
+                }
+              } else {
+                for (const c of existing) {
                   await github.rest.issues.deleteComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     comment_id: c.id,
                   });
                 }
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body,
-                });
               }
-            } else {
-              for (const c of existing) {
-                await github.rest.issues.deleteComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: c.id,
-                });
-              }
-            }
+            };
+
+            const changelogOutput = process.env.CHANGELOG_OUTPUT;
+            const hasChangelog = changelogOutput && changelogOutput.trim().length > 0;
+            const changelogBody = hasChangelog
+              ? `${changelogMarker}\n## 📋 API Changelog\n\n${changelogOutput}`
+              : null;
+            await upsertOrDelete(changelogMarker, changelogBody);
+
+            const stale = process.env.STALE === 'true';
+            const pushed = process.env.PUSHED === 'true';
+            const needsStaleNotice = stale && !pushed;
+            const staleBody = needsStaleNotice
+              ? `${staleMarker}\n## ⚠️ OpenAPI docs are out of date\n\nThe generated spec in this PR doesn't match what \`make generate-openapi-docs\` produces from the current Go sources. Please run:\n\n\`\`\`sh\nmake generate-openapi-docs\n\`\`\`\n\nand commit the updated \`gateway/api/openapi/autogen/\` and \`gateway/api/openapi/openapiv3.json\` files.`
+              : null;
+            await upsertOrDelete(staleMarker, staleBody);

--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -34,12 +34,52 @@ jobs:
           CHANGELOG_OUTPUT: ${{ steps.changelog.outputs.changelog }}
         with:
           script: |
+            const marker = '<!-- api-changelog-comment -->';
             const output = process.env.CHANGELOG_OUTPUT;
-            if (output && output.trim().length > 0) {
-              await github.rest.issues.createComment({
+            const hasChanges = output && output.trim().length > 0;
+            const body = hasChanges ? `${marker}\n## 📋 API Changelog\n\n${output}` : null;
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: `## 📋 API Changelog\n\n${output}`
-              });
+                per_page: 100,
+              },
+              (response) => response.data.filter((c) => c.body && c.body.includes(marker))
+            );
+
+            if (hasChanges) {
+              if (existing.length > 0) {
+                const [keep, ...stale] = existing;
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: keep.id,
+                  body,
+                });
+                for (const c of stale) {
+                  await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: c.id,
+                  });
+                }
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } else {
+              for (const c of existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
             }

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test-enterprise: libhoop-map generate-wasm
 test-integration: libhoop-map generate-wasm
 	env CGO_ENABLED=0 go test -tags integration -v -timeout 10m -count=1 ./agent/integration/...
 
-generate-openapi-docs:
+generate-openapi-docs: libhoop-map
 	cd ./gateway/ && go run github.com/swaggo/swag/cmd/swag@v1.16.3 init -g api/server.go -o api/openapi/autogen --outputTypes go --markdownFiles api/openapi/docs/ --parseDependency
 	go run gateway/cmd/openapi-gen/main.go
 


### PR DESCRIPTION
## 📝 Description

Makes the OpenAPI docs CI 100% automatic and eliminates duplicate changelog comments.

**Problem 1 — comment spam:** the `API Changelog` workflow re-runs on every push that includes `gateway/api/openapi/openapiv3.json` in the PR diff (the `paths:` filter compares PR head vs base, not commit-to-commit). Each run unconditionally creates a new comment, so PRs that iterate on the OpenAPI spec end up with a long stack of near-identical "📋 API Changelog" comments — see #1449, which has 13 of them.

**Problem 2 — manual regen step:** contributors have to remember to run `make generate-openapi-docs` and push the result. The PR template even lists it as a checklist item. Missed regens lead to stale `autogen/docs.go` / `openapiv3.json` on `main`.

This PR fixes both.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] 🔧 Build configuration change

## 📋 Changes Made

**Workflow (`.github/workflows/breaking-change-check.yml`, renamed to `OpenAPI Docs`):**
- Triggers on `gateway/**/*.go`, `gateway/api/openapi/docs/**`, or `openapiv3.json` changes.
- Runs `make generate-openapi-docs` and diffs `gateway/api/openapi/autogen` + `openapiv3.json`.
- If stale and the PR is from the same repo → commits as `github-actions[bot]` and pushes with `secrets.GH_TOKEN` so downstream test/build workflows re-fire on the auto-commit (same precedent as `auto-release.yml`). Bounded recursion: the re-fired run finds docs in sync and exits.
- If stale and the PR is from a fork → posts an actionable comment asking the contributor to regenerate locally (using a separate `<!-- api-docs-stale-comment -->` marker).
- Concurrency group cancels superseded runs to avoid push races.
- Changelog comment uses a hidden `<!-- api-changelog-comment -->` marker, is updated in place, and is deleted if the diff goes empty mid-PR. Cleans up any leftover duplicates from before this change.

**Makefile:**
- `generate-openapi-docs` now declares `libhoop-map` as a prereq (matching `test-oss`, `test-enterprise`, `test-integration`, `generate-wasm`), so the workflow doesn't need to call it explicitly.

**PR template (`.github/PULL_REQUEST_TEMPLATE.md`):**
- Drop the now-automated `"I have run make generate-openapi-docs"` checklist item.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a
- **OS**: n/a (GitHub Actions, `ubuntu-latest`)

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

Since this PR doesn't touch `gateway/**/*.go` or the OpenAPI spec, the new workflow won't run on this PR itself — the first real exercise will be the next PR that modifies gateway Go code. The dedup logic on the changelog comment will also retroactively clean up duplicates the first time it runs on PRs like #1449.

## 📸 Screenshots (if applicable)

n/a

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Alternatives considered and rejected:
- **`pull_request_target` for fork-PR auto-commit**: would let us push to forks, but it runs `go run` on fork code with secret access — a real RCE risk.
- **Splitting regen and oasdiff into two workflows**: needs `workflow_run` chaining or a synchronize re-fire. Combined workflow is simpler and keeps regen + oasdiff atomically aligned against the same spec.
- **`GITHUB_TOKEN` for the push**: would not re-trigger downstream test/build workflows, so the auto-committed code would land untested.