### PR TITLE
fix(httpproxy): remove negative auth cache

### DIFF
--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -36,34 +35,11 @@ const (
 	// and it uses Authorization header so using the same for consistency
 	// we will be able to get kubernetes connections in our database
 	// NOTE in the future we might want to support custom headers as well
-	proxyTokenHeader     = "Authorization"
-	proxyTokenCookie     = "hoop_proxy_token"
-	negativeAuthCacheTTL = 24 * time.Hour // Invalid auth keys will never be valid, so we will clean this up after hours
+	proxyTokenHeader = "Authorization"
+	proxyTokenCookie = "hoop_proxy_token"
 )
 
 var instanceStore sync.Map
-
-// negativeAuthEntry stores a cached authentication failure with timestamp
-type negativeAuthEntry struct {
-	err       error
-	timestamp time.Time
-}
-
-// credentialError wraps errors related to invalid or expired credentials.
-// Only these errors should be stored in the negative auth cache.
-type credentialError struct {
-	err error
-}
-
-func (e *credentialError) Error() string { return e.err.Error() }
-func (e *credentialError) Unwrap() error { return e.err }
-
-func newCredentialError(format string, a ...any) error {
-	return &credentialError{err: fmt.Errorf(format, a...)}
-}
-
-// negativeAuthCache caches failed authentication attempts to avoid repeated database queries
-var negativeAuthCache sync.Map // map[string]*negativeAuthEntry
 
 type HttpProxyServer struct {
 	sessionStore sync.Map // map[string]*httpProxySession
@@ -265,22 +241,6 @@ func (s *HttpProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid proxy token", http.StatusUnauthorized)
 		return
 	}
-	// check if the key is in the negative auth cache
-	// avoid hammering the database with invalid requests
-	// avoid goroutine for each request
-	if cached, ok := negativeAuthCache.Load(secretKeyHash); ok {
-		log.Debugf("negative auth cache hit for secret key hash: %s", secretKeyHash)
-		entry := cached.(*negativeAuthEntry)
-		// Check if cache entry is still valid (not expired)
-		// we will clean this after 1 day just to clean the memory
-		if time.Since(entry.timestamp) < negativeAuthCacheTTL {
-			http.Error(w, entry.err.Error(), http.StatusUnauthorized)
-			return
-		}
-		// Cache expired, remove it
-		negativeAuthCache.Delete(secretKeyHash)
-	}
-
 	// The correlation ID is session-scoped: it is only honored on the request that
 	// creates the long-lived hoop session for this credential. Later requests reusing
 	// the session will have their X-Hoop-Correlation-Id header ignored.
@@ -296,13 +256,6 @@ func (s *HttpProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	session, err := s.getOrCreateSession(secretKeyHash, correlationID)
 	if err != nil {
-		var credErr *credentialError
-		if errors.As(err, &credErr) {
-			negativeAuthCache.Store(secretKeyHash, &negativeAuthEntry{
-				err:       err,
-				timestamp: time.Now(),
-			})
-		}
 		log.Warnf("failed to get/create session: %v", err)
 		http.SetCookie(w, &http.Cookie{
 			Name:   proxyTokenCookie,
@@ -327,13 +280,13 @@ func getValidConnectionCredentials(secretKeyHash string) (*models.ConnectionCred
 
 	if err != nil {
 		if err == models.ErrNotFound {
-			return nil, newCredentialError("http proxy invalid proxy token credentials")
+			return nil, fmt.Errorf("http proxy invalid proxy token credentials")
 		}
 		return nil, fmt.Errorf("http proxy failed obtaining credentials: %v", err)
 	}
 
 	if dba.ExpireAt.Before(time.Now().UTC()) {
-		return nil, newCredentialError("http proxy token credentials expired")
+		return nil, fmt.Errorf("http proxy token credentials expired")
 	}
 
 	return dba, nil


### PR DESCRIPTION
## Problem

The negative auth cache was originally added to avoid hammering the DB when Kubernetes tokens expired and triggered a flood of requests. It cached failed auth attempts for 24h.

However, httpproxy tokens are now **infinite-lived credentials**. When a user's OIDC token (behind the proxy) expires, the proxy gets a 401, catches it as a `credentialError`, and stores the proxy token hash in `negativeAuthCache` for 24h. Even after the user renews their OIDC session, the proxy continues rejecting their requests until the cache TTL expires or the gateway restarts.

## Fix

Remove the negative auth cache entirely. The protection it provided is no longer needed because:
- httpproxy tokens are infinite — they don't expire on a regular basis
- Sessions are cached in `sessionStore` — the DB is only hit on session creation, not every request
- The flood-of-requests scenario it guarded against no longer applies

Fixes the issue where users get permanently locked out of the HTTP proxy after their OIDC token rotates.

cc @chico 

Automated by MisterMal