### PR TITLE
fix(ci): write oasdiff base spec inside workspace, not /tmp

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -70,15 +70,17 @@ jobs:
       - name: find base spec
         if: always()
         run: |
+          # Write into the workspace (not /tmp) because the oasdiff action below
+          # runs inside a Docker container that only mounts $GITHUB_WORKSPACE.
           git fetch origin ${{ github.base_ref }} --depth=1
-          git show origin/${{ github.base_ref }}:gateway/api/openapi/openapiv3.json > /tmp/base-openapiv3.json
+          git show origin/${{ github.base_ref }}:gateway/api/openapi/openapiv3.json > base-openapiv3.json
 
       - name: generate changelog
         if: always()
         uses: oasdiff/oasdiff-action/changelog@v0.0.39
         id: changelog
         with:
-          base: '/tmp/base-openapiv3.json'
+          base: 'base-openapiv3.json'
           revision: 'gateway/api/openapi/openapiv3.json'
           format: 'markup'
 


### PR DESCRIPTION
## 📝 Description

Fix the OpenAPI Docs workflow introduced in #1452. It currently fails on every PR with:

```
Error: failed to load base spec from "/tmp/base-openapiv3.json": no such file or directory
```

The `oasdiff/oasdiff-action/changelog` action runs inside a Docker container that only mounts `$GITHUB_WORKSPACE` — so `/tmp/base-openapiv3.json` written on the runner host is invisible to the container.

This restores the original behavior of writing the base spec into the workspace root (the approach used before #1452), where it's reachable from inside the container.

## 🔗 Related Issue

Failing run on PR #1450: https://github.com/hoophq/hoop/actions/runs/26115400230/job/76803232897

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- Write `base-openapiv3.json` into the workspace root instead of `/tmp/`, so the oasdiff Docker container can read it.

## 🧪 Testing

- [x] CI will re-run this workflow on this PR and verify the `generate changelog` step succeeds.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings