### PR TITLE
fix: use MustSyncGroups flag to control group synchronization

### DIFF
--- a/gateway/api/mcpauth/verifier.go
+++ b/gateway/api/mcpauth/verifier.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hoophq/hoop/common/proto"
 	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/idp"
-	idptypes "github.com/hoophq/hoop/gateway/idp/types"
 	oidcprovider "github.com/hoophq/hoop/gateway/idp/oidc"
+	idptypes "github.com/hoophq/hoop/gateway/idp/types"
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/hoophq/hoop/gateway/storagev2"
 	"github.com/hoophq/hoop/gateway/storagev2/types"
@@ -197,7 +197,7 @@ func syncMcpUser(orgID string, uinfo idptypes.ProviderUserInfo) (*models.Context
 	if err := models.CreateUser(newUser); err != nil {
 		return nil, fmt.Errorf("failed creating mcp user: %w", err)
 	}
-	if len(uinfo.Groups) > 0 {
+	if uinfo.MustSyncGroups && len(uinfo.Groups) > 0 {
 		groupRows := make([]models.UserGroup, 0, len(uinfo.Groups))
 		for _, g := range uinfo.Groups {
 			groupRows = append(groupRows, models.UserGroup{
@@ -224,14 +224,21 @@ func refreshExistingUser(ctx *models.Context, uinfo idptypes.ProviderUserInfo) e
 		Status:   string(types.UserStatusActive),
 		SlackID:  ctx.UserSlackID,
 	}
-	groupRows := make([]models.UserGroup, 0, len(uinfo.Groups))
-	for _, g := range mergeAdmin(uinfo.Groups, ctx) {
+
+	existingGroups := ctx.UserGroups
+	if uinfo.MustSyncGroups {
+		existingGroups = mergeAdmin(uinfo.Groups, ctx)
+	}
+
+	var groupRows []models.UserGroup
+	for _, g := range existingGroups {
 		groupRows = append(groupRows, models.UserGroup{
 			OrgID:  ctx.OrgID,
 			UserID: ctx.UserID,
 			Name:   g,
 		})
 	}
+
 	if err := models.UpdateUserAndUserGroups(&updatedUser, groupRows); err != nil {
 		return fmt.Errorf("failed updating mcp user: %w", err)
 	}

--- a/gateway/idp/oidc/oidc.go
+++ b/gateway/idp/oidc/oidc.go
@@ -291,12 +291,6 @@ func (p *Provider) VerifyIDTokenForCode(code string) (token *oauth2.Token, uinfo
 	log.With("issuer", idToken.Issuer, "subject", uinfo.Subject, "email", uinfo.Email, "email-verified", uinfo.EmailVerified).
 		Infof("token exchanged (oauth2) and id_token verified")
 
-	// overwrite the groups and indicate it should sync groups
-	if syncGsuiteGroups {
-		uinfo.Groups = groups
-		uinfo.MustSyncGroups = true
-		uinfo.MustSyncGsuiteGroups = true
-	}
 	return token, uinfo, err
 }
 
@@ -414,6 +408,19 @@ func (p *Provider) VerifyAccessTokenForResource(accessToken, expectedResource st
 			uinfo.Profile = name
 		}
 	}
+
+	groups, syncGsuiteGroups, err := p.fetchGsuiteGroups(accessToken, uinfo.Email)
+	if err != nil {
+		log.Errorf("unable to synchronize groups from Google: %v", err)
+	}
+
+	// overwrite the groups and indicate it should sync groups
+	if syncGsuiteGroups {
+		uinfo.Groups = groups
+		uinfo.MustSyncGroups = true
+		uinfo.MustSyncGsuiteGroups = true
+	}
+
 	return uinfo, claims, nil
 }
 


### PR DESCRIPTION
## 📝 Description

Fixes a bug in the MCP authentication flow where user group synchronization was happening unconditionally. The `MustSyncGroups` flag was being set only in `VerifyIDTokenForCode` (OAuth2 code flow), but MCP auth uses `VerifyAccessTokenForResource` (access token flow). This caused groups to never be synced for MCP users, or conversely, to be overwritten with an empty list when no groups were present.

The fix moves the G Suite groups fetch logic into `VerifyAccessTokenForResource` and gates all group sync operations on the `MustSyncGroups` flag.

## 🔗 Related Issue

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- Moved G Suite group fetching (`fetchGsuiteGroups`) from `VerifyIDTokenForCode` to `VerifyAccessTokenForResource` so groups are correctly resolved during MCP (access token) authentication
- Gated group sync in `syncMcpUser` behind `uinfo.MustSyncGroups && len(uinfo.Groups) > 0` to prevent empty group lists from overwriting existing memberships
- Gated group sync in `refreshExistingUser` behind `uinfo.MustSyncGroups` for the same reason

## 🧪 Testing

### Test Configuration:
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed — verified MCP authentication correctly syncs G Suite groups when using an access token, and does not clear groups when `MustSyncGroups` is false

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes