### PR TITLE
fix(cli): isolate dev binary from `hoop versions` symlink + clearer conflict error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Protocol-specific proxy servers configured via `server_misc_config`:
 | Start Postgres | `make run-dev-postgres` | Uses `scripts/dev/run-postgres.sh`; skip if you have your own PG |
 | Start Presidio (DLP) | `make run-dev-presidio` | Optional, for data masking dev |
 | Run gateway + agent | `make run-dev` | Uses `scripts/dev/run.sh`; reads `.env` (copy `.env.sample` first) |
-| Build dev CLI | `make build-dev-client` | Output: `$HOME/.hoop/bin/hoop` (plaintext-friendly) |
+| Build dev CLI | `make build-dev-client` | Output: `$HOME/.hoop/dev/hoop` (plaintext-friendly; the `bin/` sibling is reserved for `hoop versions`' active symlink) |
 | Build webapp into gateway | `make build-dev-webapp` | Then rerun `make run-dev` |
 | Run frontend dev (both) | `cd webapp_v2 && npm run dev:full` | Starts Vite (:5173) + shadow-cljs (:8280) together. CLJS edits require a browser hard-reload — Vite proxies the bundle and can't HMR it. |
 | Run React dev only | `cd webapp_v2 && npm run dev` | Vite on :5173. CLJS routes are blank until shadow-cljs is started separately. |

--- a/DEV.md
+++ b/DEV.md
@@ -50,11 +50,13 @@ make build-dev-webapp
 By default versioned clients are builded to strict connect via TLS. In order to build a client that permits connecting to remote hosts without TLS, execute the instruction below:
 
 ```sh
-# generate binary at $HOME/.hoop/bin/hoop
+# generate binary at $HOME/.hoop/dev/hoop
 make build-dev-client
 ```
 
-> Append `$HOME/.hoop/bin` to your `$PATH` in your profile to find commands when typing in your shell
+> Append `$HOME/.hoop/dev` to your `$PATH` in your profile to find commands when typing in your shell.
+>
+> Note: `$HOME/.hoop/bin/hoop` is reserved as the active symlink managed by `hoop versions`; the dev binary lives in `$HOME/.hoop/dev/hoop` so the two workflows don't collide. Put `$HOME/.hoop/dev` first on `PATH` if you want your dev build to take precedence; put `$HOME/.hoop/bin` first if you want whatever `hoop versions sync` / `hoop versions upgrade` last installed.
 
 ### Data Masking Setup
 
@@ -108,7 +110,7 @@ make run-dev-spiffe-agent
 
 This script:
 
-- rebuilds `$HOME/.hoop/bin/hoop` if source files under `agent/` or `common/clientconfig/` are newer than the binary
+- rebuilds `$HOME/.hoop/dev/hoop` if source files under `agent/` or `common/clientconfig/` are newer than the binary
 - reads `POSTGRES_DB_URI` from `hoopdev`'s env and seeds two rows in `hoopdevpg` (idempotent):
   - `private.agents` → a `spiffe-agent` row
   - `private.agent_spiffe_mappings` → maps `spiffe://local.test/agent/local-dev` to that agent

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ run-dev-spiffe-agent:
 run-dev-spiffe: run-dev-spiffe-agent
 
 build-dev-client:
-	go build -ldflags "-s -w -X github.com/hoophq/hoop/client/proxy.defaultListenAddrValue=0.0.0.0" -o ${HOME}/.hoop/bin/hoop github.com/hoophq/hoop/client
+	mkdir -p ${HOME}/.hoop/dev
+	go build -ldflags "-s -w -X github.com/hoophq/hoop/client/proxy.defaultListenAddrValue=0.0.0.0" -o ${HOME}/.hoop/dev/hoop github.com/hoophq/hoop/client
 
 build-dev-webapp:
 	./scripts/dev/build-webapp.sh

--- a/client/upgrade/symlink.go
+++ b/client/upgrade/symlink.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 )
 
-// ErrBinLinkConflict is returned when $HOME/.hoop/bin/hoop already exists
-// but is a regular file or a symlink pointing outside of
-// $HOME/.hoop/versions. We refuse to overwrite it because it may belong to
-// the user.
-var ErrBinLinkConflict = errors.New("hoop bin symlink is owned by something else; refusing to overwrite")
+// ErrBinLinkConflict is returned when $HOME/.hoop/bin/hoop already
+// exists but is a regular file or a symlink pointing outside of
+// $HOME/.hoop/versions. We refuse to overwrite it because it may
+// belong to the user — most often a stale `make build-dev-client`
+// output from before the dev binary moved to $HOME/.hoop/dev/hoop.
+var ErrBinLinkConflict = errors.New("hoop bin path is owned by something else; refusing to overwrite")
 
 // SetActive atomically updates the active symlink at $HOME/.hoop/bin/hoop
 // to point at the installed version's binary and updates the store's
@@ -82,7 +83,20 @@ func assertOwnedSymlink(l Layout, binLink string) error {
 		return fmt.Errorf("failed stat %s: %w", binLink, err)
 	}
 	if info.Mode()&os.ModeSymlink == 0 {
-		return fmt.Errorf("%w: %s exists and is not a symlink", ErrBinLinkConflict, binLink)
+		return fmt.Errorf(`%w:
+
+%s exists as a regular file, not the symlink the version manager creates.
+
+The most common cause is an older `+"`make build-dev-client`"+` run that
+wrote the dev binary at this exact path. The dev binary now lives at
+$HOME/.hoop/dev/hoop, and $HOME/.hoop/bin/hoop is reserved as the
+symlink updated by `+"`hoop versions sync` / `hoop versions upgrade`"+`.
+
+To recover, do one of the following and re-run the same hoop versions
+command:
+  - keep the dev build: mv "%s" "$HOME/.hoop/dev/hoop"
+  - discard it:         rm "%s"`,
+			ErrBinLinkConflict, binLink, binLink, binLink)
 	}
 	cur, err := os.Readlink(binLink)
 	if err != nil {

--- a/scripts/dev/run-spiffe-agent.sh
+++ b/scripts/dev/run-spiffe-agent.sh
@@ -6,7 +6,7 @@
 #   1. `make run-dev-spiffe-prep` has been run at least once to mint
 #      the JWT and update .env.
 #   2. `make run-dev` is running in another terminal and healthy.
-#   3. `make build-dev-client` has produced $HOME/.hoop/bin/hoop.
+#   3. `make build-dev-client` has produced $HOME/.hoop/dev/hoop.
 #
 # On each invocation this script idempotently seeds the dev DB with a
 # `spiffe-agent` row and a matching `agent_spiffe_mappings` row, then
@@ -21,7 +21,7 @@ AGENT_NAME="${HOOP_SPIFFE_AGENT_NAME:-spiffe-agent}"
 AGENT_ID="${HOOP_SPIFFE_AGENT_ID:-11111111-2222-3333-4444-555555555555}"
 APP_CONTAINER="${HOOPDEV_APP_CONTAINER:-hoopdev}"
 DB_CONTAINER="${HOOPDEV_DB_CONTAINER:-hoopdevpg}"
-HOOP_BIN="${HOOP_BIN:-$HOME/.hoop/bin/hoop}"
+HOOP_BIN="${HOOP_BIN:-$HOME/.hoop/dev/hoop}"
 
 if [[ ! -f "$SPIFFE_DIR/agent.jwt" || ! -f "$SPIFFE_DIR/bundle.jwks" ]]; then
   echo "missing SPIFFE artifacts in $SPIFFE_DIR — run 'make run-dev-spiffe-prep' first"

--- a/scripts/local-spiffe-agent.sh
+++ b/scripts/local-spiffe-agent.sh
@@ -25,7 +25,7 @@ AUDIENCE="${AUDIENCE:-http://localhost:8009}"
 AGENT_IMAGE_TAG="${AGENT_IMAGE_TAG:-1403.0.0-5a9bd6f}"
 
 # Path to the hoop CLI; HOOP_BIN can be overridden if installed elsewhere.
-HOOP_BIN="${HOOP_BIN:-$HOME/.hoop/bin/hoop}"
+HOOP_BIN="${HOOP_BIN:-$HOME/.hoop/dev/hoop}"
 command -v "$HOOP_BIN" >/dev/null 2>&1 || [ -x "$HOOP_BIN" ] \
   || { echo "hoop CLI not found at $HOOP_BIN — set HOOP_BIN or 'make build-dev-client'"; exit 1; }
 


### PR DESCRIPTION

This PR fixes the collision in two complementary ways:

1. **Moves the dev binary off the contested path.** `make build-dev-client` now writes to `$HOME/.hoop/dev/hoop`, leaving `$HOME/.hoop/bin/` reserved as the active-symlink directory owned by `hoop versions`. `DEV.md`, `CLAUDE.md`, and the two SPIFFE-agent scripts that read the dev binary track the new path.
2. **Rewrites the `ErrBinLinkConflict` error** so contributors who already have a stale dev binary at the old location see a multi-line message naming the most common cause and giving two copy-paste recovery commands (`mv` to preserve the dev build at the new path, or `rm` to discard it).

After this PR a fresh `make build-dev-client && hoop versions sync` cycle works without intervention, and existing contributors recover with a single command from the error message itself.

## 🔗 Related Issue

<!-- No tracking issue; this is a follow-up to #1465 -->

Related to #1465

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- **`Makefile`** — `build-dev-client` now writes to `$HOME/.hoop/dev/hoop` (with `mkdir -p`). The Rust agent (`hoop_rs`) stays at `$HOME/.hoop/bin/hoop_rs` since it doesn't conflict with the symlink at `$HOME/.hoop/bin/hoop`.
- **`scripts/dev/run-spiffe-agent.sh`** and **`scripts/local-spiffe-agent.sh`** — the `HOOP_BIN` default points at `$HOME/.hoop/dev/hoop`. The header comment in `run-spiffe-agent.sh` references the new path too.
- **`DEV.md`** — `make build-dev-client` instructions reflect the new path, and a Note explains the `dev/` vs `bin/` split: put `$HOME/.hoop/dev` first on PATH if you want your dev build to take precedence, or `$HOME/.hoop/bin` first if you want whatever `hoop versions` last installed.
- **`CLAUDE.md`** — the dev-CLI table entry tracks the new path and notes the reservation.
- **`client/upgrade/symlink.go`** — `assertOwnedSymlink` returns a multi-line error when a regular file occupies the bin path, calling out the most common cause (an older `make build-dev-client` run from before the path split) and printing two ready-to-paste recovery commands with the actual path quoted in:
  - `mv "<path>" "$HOME/.hoop/dev/hoop"` — keep the dev build at the new location
  - `rm "<path>"` — discard it

  `ErrBinLinkConflict` is still wrapped underneath, so `errors.Is(err, ErrBinLinkConflict)` keeps working for callers.

No code changes in `client/cmd/`, no changes to gateway / agent / migrations / plugins. The diff is six files, ~31 lines.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (CLI feature)
- **OS**: macOS (Darwin/arm64)

### Tests performed:
- [x] Unit tests pass — `go test ./client/upgrade/... -count=1`. The existing `TestSetActiveRefusesUserManagedFile` and `TestSetActiveRefusesSymlinkOutsideVersionsDir` still pass (they use `errors.Is(err, ErrBinLinkConflict)`, not message-text matching).
- [x] `go build ./...` clean across the client module.
- [x] Smoke-tested the new error path: parked a regular file at `~/.hoop/bin/hoop` in a tempdir layout and called `SetActive` against it. The rendered message reads as:
- [x] Verified `make build-dev-client` writes to `~/.hoop/dev/hoop`, and `hoop versions sync` then proceeds without ever touching the dev binary.

## 📸 Screenshots (if applicable)

N/A — CLI feature; error output reproduced verbatim in the testing notes above.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- **Migration for existing contributors.** Anyone with a leftover regular file at `$HOME/.hoop/bin/hoop` from a pre-#1465 `make build-dev-client` will see the new error the first time they run `hoop versions sync` / `upgrade` / `use`. They paste one of the two commands from the error message and they're done — no manual investigation required. No automated migration was added: trying to detect "is this an old dev binary?" by hashing or string-matching the file would be exactly the kind of workaround `CLAUDE.md`'s coding section warns against, and the recovery is genuinely one command.
- **No public docs changes needed.** The `clients/cli-versions.mdx` page describes `$HOME/.hoop/bin/hoop` as the symlink path — which is still correct. The dev-path split is a contributor concern documented in `DEV.md` and `CLAUDE.md`, both shipped in this PR.
- **`hoop_rs` (Rust agent) intentionally stays at `$HOME/.hoop/bin/hoop_rs`.** It doesn't share a filename with the symlink and `make build-dev-rust` doesn't touch `hoop`, so there's no collision to fix there.

---
