### PR TITLE
fix(resources): inject command from connection metadata catalog, bq and fix python version ENG-409

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.out
 
 # IDE related
+.cursor/
 agent/.idea/*
 agentrs/.idea/*
 client/.idea/*

--- a/rootfs/usr/local/bin/bq
+++ b/rootfs/usr/local/bin/bq
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 : "${GOOGLE_APPLICATION_CREDENTIALS:? Required environment variable not set}"
-export CLOUDSDK_PYTHON=${CLOUDSDK_PYTHON:-"/usr/bin/python3.9"}
+export CLOUDSDK_PYTHON=${CLOUDSDK_PYTHON:-"/usr/bin/python3.12"}
 
 gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS 2> /dev/null
 touch $HOME/.bigqueryrc

--- a/webapp/src/webapp/resources/add_role/events.cljs
+++ b/webapp/src/webapp/resources/add_role/events.cljs
@@ -43,10 +43,9 @@
        {:db (assoc-in db [:resource-setup :submitting?] true)
         :fx (vec (map-indexed
                   (fn [idx role]
-                    (let [metadata (->> resource-metadata
-                                        (filter #(= (get-in % [:resourceConfiguration :subtype])
-                                                    (:subtype role)))
-                                        first)
+                    (let [metadata (process-form/find-connection-metadata
+                                    resource-metadata
+                                    (:subtype role))
                           command-role (get-in metadata [:resourceConfiguration :command])
                           processed-role (process-form/process-role role agent-id command-role)
                           body (assoc processed-role :resource_name resource-name)]

--- a/webapp/src/webapp/resources/setup/events/process_form.cljs
+++ b/webapp/src/webapp/resources/setup/events/process_form.cljs
@@ -98,6 +98,17 @@
     (clj->js
      (merge envvar-result filesystem-result))))
 
+(defn find-connection-metadata
+  "Returns the resourceConfiguration metadata entry that matches the given
+  subtype, or nil if no match. `resource-metadata` is the list under
+  `[:connections :metadata :data :connections]` in app-db (loaded from
+  `/data/connections-metadata.json`)."
+  [resource-metadata subtype]
+  (when (and resource-metadata subtype)
+    (->> resource-metadata
+         (filter #(= (get-in % [:resourceConfiguration :subtype]) subtype))
+         first)))
+
 (defn process-role
   "Process a single role into the format expected by the API"
   [role agent-id & [command-role]]
@@ -180,12 +191,27 @@
         resource-subtype (get-in db [:resource-setup :subtype])
         agent-id (get-in db [:resource-setup :agent-id])
         raw-roles (get-in db [:resource-setup :roles] [])
+        ;; The connections metadata catalog (loaded from
+        ;; /data/connections-metadata.json) is the source of truth for each
+        ;; subtype's runtime command (e.g. BigQuery's
+        ;; `bq query ... --project_id=$CLOUDSDK_CORE_PROJECT`). The setup
+        ;; form only collects credentials; the command itself is never
+        ;; surfaced to the user, so we have to inject it here. Without
+        ;; this, the agent receives an empty CmdList and exec fails.
+        resource-metadata (get-in db [:connections :metadata :data :connections] [])
 
         ;; Finalize roles by adding any uncommitted current values
         roles (mapv finalize-role-current-values raw-roles)
 
-        ;; Process all roles
-        processed-roles (mapv #(process-role % agent-id) roles)]
+        ;; Process all roles, injecting the command from the metadata
+        ;; catalog for each role's subtype.
+        processed-roles (mapv (fn [role]
+                                (let [metadata (find-connection-metadata
+                                                resource-metadata
+                                                (:subtype role))
+                                      command-role (get-in metadata [:resourceConfiguration :command])]
+                                  (process-role role agent-id command-role)))
+                              roles)]
 
     {:name resource-name
      :type resource-type


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Fix: metadata catalog command not injected on resource create.

When creating a new resource through the Resources flow, the runtime command from the connection metadata catalog (`/data/connections-metadata.json`, sourced from `documentation/store/connections/*.yml`) was not being injected into the role payload. The agent therefore received an empty `command` list and `exec` failed before reaching the configured binary.

Symptom we hit in the wild: creating a BigQuery resource saved `command = []`, so the agent had nothing to run for `bq query …`. The same latent bug affected **every `type: custom` subtype that ships a command in its metadata YAML** — DynamoDB, AWS CloudWatch, AWS ECS, AWS CLI, Redis, Cassandra, Django, Ruby on Rails, Node.js, Clojure, Elixir, PHP Artisan, Python scripts, etc. — and would have surfaced as soon as anyone tried any of them through the new Resources flow.

Root cause: in `webapp/src/webapp/resources/setup/events/process_form.cljs`, `process-payload` was calling `process-role` without the optional `command-role` argument, relying solely on the role's local `:command` to round-trip through the wizard state. PR #1184 had already fixed the equivalent issue for the **add-role** flow by reading the command directly from `[:connections :metadata :data :connections]`; the **create-resource** flow was never updated to match.

This PR brings the create-resource flow in line with the add-role flow by reading the canonical command from the metadata catalog at the final processing step, and extracts the shared lookup into a `find-connection-metadata` helper used by both flows.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `find-connection-metadata` helper in `webapp/src/webapp/resources/setup/events/process_form.cljs` that resolves the catalog entry for a given subtype from `[:connections :metadata :data :connections]`.
- Updated `process-payload` in the same file to look up `[:resourceConfiguration :command]` per role's subtype and pass it as `command-role` to `process-role`, mirroring the behavior that PR #1184 introduced for the add-role flow.
- Refactored `webapp/src/webapp/resources/add_role/events.cljs` to use the new shared `find-connection-metadata` helper instead of an inline `(filter …)` over the metadata list, so both flows have a single source of truth.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome (latest)
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

Manual verification:

1. **BigQuery (regression case)** — Create a new BigQuery resource via the Resources catalog, provide `GOOGLE_APPLICATION_CREDENTIALS` and `CLOUDSDK_CORE_PROJECT`, add at least one role, and submit. Verify in the DB that `connections.command = {bq,query,--use_legacy_sql=false,--format=prettyjson,--project_id=$CLOUDSDK_CORE_PROJECT}`. Open the web terminal for the connection and run `SELECT 1;` — the agent now receives a non-empty argv and exec proceeds (any remaining failure is a credentials/project-id concern, not an empty-command one).
2. **Other custom-with-command subtypes** — Spot-check Redis and AWS CLI: create via Resources flow, confirm `connections.command` matches the YAML in `documentation/store/connections/<subtype>.yml`.
3. **Database subtypes (no regression)** — Create a Postgres resource; `connections.command` remains `[]` and the gateway's `GetConnectionDefaults` still injects `psql …` at runtime as before.
4. **`linux-vm` (no regression)** — Create a linux-vm resource with a custom `command-args` value; verify the saved `command` matches the form input and is not overridden by metadata.
5. **add-role flow (no regression)** — Add a new role to an existing BigQuery resource via the add-role wizard; confirm the new connection is saved with the same command as the resource. This exercises the refactored helper without changing behavior.

## 📸 Screenshots (if applicable)

<img width="1058" height="960" alt="image" src="https://github.com/user-attachments/assets/2111e0bb-0313-4746-8258-037d009508a0" />
## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- **Scope is intentionally limited to the new Resources flow.** The legacy single-connection flow in `webapp/src/webapp/connections/views/setup/events/process_form.cljs` has its own `process-payload` with a separate (and currently dead) `:metadata-command-args` code path — it is **not** touched by this PR. If editing an existing connection via the legacy Configure tab ever needs the same metadata-driven injection, that should be a follow-up PR.
- **Label suggestion: `patch`.** This is a non-breaking bug fix; no public API, wire format, or schema changes.
- **Reviewer focus:** the contract between `find-connection-metadata` ↔ `process-role` ↔ `:resource-setup->add-role`. In particular, confirm that for `type: database` / `type: application` / empty-`command:` custom subtypes the resolved `command-role` is `nil` so we still fall back to `(:command role)` and end up at `[]` (which is what the backend expects so it can inject its default command).

---