### PR TITLE
fix(analytics): identify users from webapp to collapse Segment MTU

### DIFF
--- a/gateway/api/login/oidc/login.go
+++ b/gateway/api/login/oidc/login.go
@@ -502,7 +502,7 @@ func (h *handler) analyticsTrack(isNewUser bool, userAgent string, ctx *models.C
 	trackClient := analytics.New()
 	defer trackClient.Close()
 	if !isNewUser {
-		trackClient.Track(ctx.UserID, analytics.EventLogin, map[string]any{
+		trackClient.Track(ctx.UserSubject, analytics.EventLogin, map[string]any{
 			"org-id":       ctx.OrgID,
 			"auth-method":  appconfig.Get().AuthMethod(),
 			"user-agent":   userAgent,
@@ -513,14 +513,14 @@ func (h *handler) analyticsTrack(isNewUser bool, userAgent string, ctx *models.C
 	trackClient.Identify(&types.APIContext{
 		OrgID:          ctx.OrgID,
 		OrgLicenseData: &ctx.OrgLicenseData,
-		UserID:         ctx.UserID,
+		UserID:         ctx.UserSubject,
 		UserEmail:      ctx.UserEmail,
 		UserName:       ctx.UserName,
 	})
 	go func() {
 		// wait some time until the identify call get times to reach to intercom
 		time.Sleep(time.Second * 10)
-		trackClient.Track(ctx.UserID, analytics.EventSignup, map[string]any{
+		trackClient.Track(ctx.UserSubject, analytics.EventSignup, map[string]any{
 			"org-id":       ctx.OrgID,
 			"auth-method":  appconfig.Get().AuthMethod(),
 			"user-agent":   userAgent,

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -221,7 +221,7 @@ func Update(c *gin.Context) {
 	trackClient.Identify(&types.APIContext{
 		OrgID:          ctx.OrgID,
 		OrgLicenseData: ctx.OrgLicenseData,
-		UserID:         existingUser.ID,
+		UserID:         existingUser.Subject,
 		UserEmail:      existingUser.Email,
 		UserName:       existingUser.Name,
 		UserStatus:     existingUser.Status,

--- a/webapp_v2/CLAUDE.md
+++ b/webapp_v2/CLAUDE.md
@@ -140,6 +140,7 @@ Authentication follows the same logic as the original webapp (ClojureScript):
 
 ### Environment Variables
 - `VITE_API_URL` (optional): Custom API endpoint. Defaults to `/api` (relative to current domain)
+- `SEGMENT_WRITE_KEY` (optional, build-time): Segment write key baked into the bundle at `npm run build`. Same env var as the CLJS bundle, so a single setting controls both webapps. Defaults to the hoop.dev production key — override only when pointing a build at a different Segment workspace.
 
 ## Re-frame Interop (CLJS ↔ React)
 

--- a/webapp_v2/package-lock.json
+++ b/webapp_v2/package-lock.json
@@ -13,6 +13,7 @@
         "@mantine/hooks": "^8.3.18",
         "@mantine/notifications": "^8.3.18",
         "@mantine/spotlight": "^8.3.18",
+        "@segment/analytics-next": "^1.64.0",
         "axios": "^1.13.5",
         "dayjs": "^1.11.20",
         "lucide-react": "^0.577.0",
@@ -1082,6 +1083,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@mantine/core": {
       "version": "8.3.18",
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.18.tgz",
@@ -1522,6 +1544,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@segment/analytics-core": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.3.tgz",
+      "integrity": "sha512-63X8e2DWb2ZnJ9S3H8iSOFnbeDXMkTGhA8kZG4eFAO07QBwBVyWo5BCpv6vmuOMEkv2le6t2FMg1p6ZeJQA/4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-next": {
+      "version": "1.84.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.84.0.tgz",
+      "integrity": "sha512-V5scoCrhiTpRPOuBwNVpvE4KvHwrjgQ5fs282R72KiAZ0HoxmjLgReZYjZogBf7qq/c6VmQG3nidwh8PQGcY1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.8.3",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "@segment/analytics-page-tools": "1.0.0",
+        "@segment/analytics.js-video-plugins": "^0.2.1",
+        "@segment/facade": "^3.4.9",
+        "dset": "^3.1.4",
+        "js-cookie": "3.0.1",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1",
+        "unfetch": "^4.1.0"
+      }
+    },
+    "node_modules/@segment/analytics-page-tools": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-page-tools/-/analytics-page-tools-1.0.0.tgz",
+      "integrity": "sha512-o9OVB91qLB9qb0Bw1HfjmWm5AnrMNULRjx++4lBqLt8InKRX1urrRBparVlpj+yJA0sckN5ZcsfazRLuPgBYDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics.js-video-plugins": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz",
+      "integrity": "sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==",
+      "license": "ISC",
+      "dependencies": {
+        "unfetch": "^3.1.1"
+      }
+    },
+    "node_modules/@segment/analytics.js-video-plugins/node_modules/unfetch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.1.2.tgz",
+      "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==",
+      "license": "MIT"
+    },
+    "node_modules/@segment/facade": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@segment/facade/-/facade-3.4.10.tgz",
+      "integrity": "sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@segment/isodate-traverse": "^1.1.1",
+        "inherits": "^2.0.4",
+        "new-date": "^1.0.3",
+        "obj-case": "0.2.1"
+      }
+    },
+    "node_modules/@segment/isodate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.3.tgz",
+      "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==",
+      "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@segment/isodate-traverse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz",
+      "integrity": "sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@segment/isodate": "^1.0.3"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2183,6 +2296,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {
@@ -3092,6 +3214,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -3510,6 +3638,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3762,12 +3899,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/new-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/new-date/-/new-date-1.0.3.tgz",
+      "integrity": "sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@segment/isodate": "1.0.3"
+      }
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -3975,6 +4141,12 @@
       "bin": {
         "which": "bin/which"
       }
+    },
+    "node_modules/obj-case": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
+      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5206,6 +5378,12 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5333,6 +5511,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -5554,6 +5738,22 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/webapp_v2/package.json
+++ b/webapp_v2/package.json
@@ -17,6 +17,7 @@
     "@mantine/hooks": "^8.3.18",
     "@mantine/notifications": "^8.3.18",
     "@mantine/spotlight": "^8.3.18",
+    "@segment/analytics-next": "^1.64.0",
     "axios": "^1.13.5",
     "dayjs": "^1.11.20",
     "lucide-react": "^0.577.0",

--- a/webapp_v2/src/components/ProtectedRoute.jsx
+++ b/webapp_v2/src/components/ProtectedRoute.jsx
@@ -9,7 +9,7 @@ import PageLoader from '@/components/PageLoader'
 function ProtectedRoute({ children, adminOnly = false }) {
   const location = useLocation()
   const { isAuthenticated, saveRedirectUrl, logout } = useAuthStore()
-  const { user, isAdmin, setUser, setLoading, setServerInfo, initIntercom } = useUserStore()
+  const { user, isAdmin, setUser, setLoading, setServerInfo, initIntercom, initAnalytics } = useUserStore()
   const [initializing, setInitializing] = useState(true)
   const [redirectTo, setRedirectTo] = useState(null)
   const initialized = useRef(false)
@@ -52,6 +52,7 @@ function ProtectedRoute({ children, adminOnly = false }) {
           if (serverInfo) {
             setServerInfo(serverInfo)
             initIntercom(userData)
+            initAnalytics(userData)
           }
           currentUser = userData
         }

--- a/webapp_v2/src/services/analytics.js
+++ b/webapp_v2/src/services/analytics.js
@@ -1,0 +1,50 @@
+/* global __SEGMENT_WRITE_KEY__ */
+import { AnalyticsBrowser } from '@segment/analytics-next'
+
+const SEGMENT_WRITE_KEY = __SEGMENT_WRITE_KEY__
+
+let analytics = null
+
+function load() {
+  if (analytics) return analytics
+  analytics = AnalyticsBrowser.load({ writeKey: SEGMENT_WRITE_KEY })
+  return analytics
+}
+
+async function sha256Hex(input) {
+  const bytes = new TextEncoder().encode(input)
+  const buf = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function buildTraits(user, mode, hashedId) {
+  const traits = {
+    'org-id': user.org_id,
+    'user-id': hashedId,
+    'is-admin': !!user.is_admin,
+    status: user.status,
+  }
+  if (mode === 'identified') {
+    traits.email = user.email
+    traits.name = user.name
+  }
+  return traits
+}
+
+// Identifies the current user in Segment so the browser's anonymous_id is
+// linked to the same user_id the gateway uses (SHA-256 of the OIDC subject).
+// Without this, every browser session is counted as a separate MTU. See ENG-407.
+export async function identify(user, mode) {
+  if (!user?.id || mode === 'disabled') return
+  const instance = load()
+  const hashedId = await sha256Hex(user.id)
+  // analytics-next persists traits to localStorage and merges them into every
+  // subsequent identify() call. Without resetting, email/name from a prior
+  // 'identified' session would leak into anonymous-mode payloads. Replacing
+  // the cache here guarantees the wire payload matches buildTraits() exactly.
+  const userObj = await instance.user()
+  userObj.traits({})
+  await instance.identify(hashedId, buildTraits(user, mode, hashedId))
+}

--- a/webapp_v2/src/stores/useUserStore.js
+++ b/webapp_v2/src/stores/useUserStore.js
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { identify as analyticsIdentify } from '@/services/analytics'
 
 const INTERCOM_APP_ID = 'ryuapdmp'
 
@@ -21,6 +22,7 @@ export const useUserStore = create((set, get) => ({
   isSelfHosted: false,
   isFreeLicense: true,
   analyticsTracking: false,
+  analyticsMode: 'anonymous',
   disableClipboard: false,
   gatewayVersion: null,
   featureFlags: {},
@@ -31,15 +33,16 @@ export const useUserStore = create((set, get) => ({
     const license = serverInfo?.license_info
     const isFreeLicense = !(license?.is_valid && license?.type === 'enterprise')
     const analyticsTracking = serverInfo?.analytics_tracking === 'enabled'
+    const analyticsMode = serverInfo?.analytics_mode || 'anonymous'
     const disableClipboard = !!serverInfo?.disable_clipboard_copy_cut
     const featureFlags = serverInfo?.feature_flags || {}
-    set({ isFreeLicense, gatewayVersion: serverInfo?.version || null, analyticsTracking, disableClipboard, featureFlags })
+    set({ isFreeLicense, gatewayVersion: serverInfo?.version || null, analyticsTracking, analyticsMode, disableClipboard, featureFlags })
   },
   isFeatureFlagEnabled: (name) => !!get().featureFlags?.[name],
   setLoading: (loading) => set({ loading }),
   clear: () => {
     if (window.Intercom) window.Intercom('shutdown')
-    set({ user: null, isAdmin: false, isSelfHosted: false, isFreeLicense: true, analyticsTracking: false, disableClipboard: false, gatewayVersion: null, featureFlags: {} })
+    set({ user: null, isAdmin: false, isSelfHosted: false, isFreeLicense: true, analyticsTracking: false, analyticsMode: 'anonymous', disableClipboard: false, gatewayVersion: null, featureFlags: {} })
   },
 
   initIntercom: (user) => {
@@ -64,5 +67,13 @@ export const useUserStore = create((set, get) => ({
 
     // Script creates a stub immediately — safe to call boot right away
     window.Intercom('boot', config)
+  },
+
+  initAnalytics: (user) => {
+    const { analyticsTracking, analyticsMode } = get()
+    if (!analyticsTracking) return
+    analyticsIdentify(user, analyticsMode).catch((err) => {
+      console.warn('[analytics] identify failed:', err)
+    })
   },
 }))

--- a/webapp_v2/vite.config.js
+++ b/webapp_v2/vite.config.js
@@ -4,7 +4,8 @@ import path from 'path';
 
 export default defineConfig({
   define: {
-    __BUILD_ID__: JSON.stringify(Date.now().toString())
+    __BUILD_ID__: JSON.stringify(Date.now().toString()),
+    __SEGMENT_WRITE_KEY__: JSON.stringify(process.env.SEGMENT_WRITE_KEY || '043Lv52mAcoGOHWVq7n3bxZAVvocyqx0')
   },
   plugins: [react()],
   resolve: {


### PR DESCRIPTION
## 📝 Description

Fixes the Segment MTU inflation reported in **ENG-407**, where the `hoophq` workspace was showing ~14k tracked users while PostHog/Mixpanel reported only ~6k. Root cause: the browser's Segment SDK assigns a random `anonymous_id` to every visitor, and the webapp was never calling `analytics.identify()` after login, so every browser session counted as a separate MTU and never collapsed into the gateway-identified user.

This PR adds the missing `identify()` call on the React shell (which wraps every authenticated route) so Segment links the browser's `anonymous_id` to the same hashed user-id the gateway already uses server-side. The hashing matches `gateway/analytics/segment.go:getUserIDHash` exactly (SHA-256 of the OIDC subject, lowercase hex), so browser and server identify into the **same** Segment profile.

A small backend fix is bundled in: two `Track`/`Identify` call sites in `gateway/api/login/oidc/login.go` and `gateway/api/user/user.go` were passing `ctx.UserID` (the DB row UUID) instead of `ctx.UserSubject` (the stable OIDC subject), which could cause the same human to register as multiple Segment profiles across user-record re-creations.

## 🔗 Related Issue

ENG-407

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

**Backend (gateway)**
- `gateway/api/login/oidc/login.go` — `Track`/`Identify` now pass `ctx.UserSubject` instead of `ctx.UserID` (DB UUID).
- `gateway/api/user/user.go` — same fix on `Identify` in the user-update path.

**React shell (webapp_v2)**
- New `src/services/analytics.js` — owns the `AnalyticsBrowser` singleton, computes `sha256(user.id)` to match the gateway's hashed user-id, builds the trait set, and resets cached traits before each identify so `localStorage`-persisted PII can't leak into an `anonymous`-mode payload.
- `src/stores/useUserStore.js` — adds `analyticsMode` to state (from `serverInfo.analytics_mode`) and `initAnalytics(user)` mirroring `initIntercom(user)`.
- `src/components/ProtectedRoute.jsx` — calls `initAnalytics(userData)` right after `initIntercom(userData)` when user + serverInfo land.
- `vite.config.js` — injects `SEGMENT_WRITE_KEY` (env var) into the bundle at build time. Same env var name as the CLJS bundle, with the same hardcoded default. No CI/helm/Dockerfile changes needed.
- `package.json` — adds `@segment/analytics-next ^1.64.0` (same version as the CLJS bundle).
- `CLAUDE.md` — documents `SEGMENT_WRITE_KEY`.

**CLJS webapp**
- `src/webapp/events/segment.cljs` — makes `:segment->load` idempotent so the SDK can't be loaded twice (which previously doubled all destination scripts: Intercom, ProfitWell, etc.).

**Per-mode behavior (mirrors the gateway):**

| `analytics_mode` | identify fires? | Traits sent |
|---|---|---|
| `disabled` | no | — |
| `anonymous` | yes | `org-id`, `user-id` (hashed), `is-admin`, `status` |
| `identified` | yes | adds `email`, `name` |

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome, Brave (Brave's tracker blocker amplifies retries — verified the fix doesn't cause runaway request volume)
- **OS**: macOS

### Tests performed:
- [x] Manual testing completed
- [x] Verified the hashed user-id in the browser's identify request payload matches the gateway's `getUserIDHash(ctx.UserSubject)` output.
- [x] Toggled the org's `analytics_mode` between `identified`, `anonymous`, `disabled` and verified the identify payload changes accordingly (no `email`/`name` in `anonymous` mode, no identify at all in `disabled`).
- [x] Confirmed the `anonymousId` field in the identify payload — this is the Segment SDK's auto-generated browser session ID and is the merge instruction Segment needs to collapse anonymous events into the identified user.
- [x] Verified CLJS bundle compiles (`shadow-cljs release hoop-ui` — 0 warnings) and `webapp_v2` builds (`npm run build`) and lints clean for the touched files.

## 📄 Additional Notes

**Why frontend-only `identify()` (no CLJS counterpart)?** Earlier iterations added an identify dispatch on the CLJS side too, but the React shell wraps every route (per `webapp_v2/CONTEXT_MIGRATION.md`), so its identify already covers all authenticated sessions. A second CLJS identify would just be redundant and double the per-page request volume.

**Why the trait-cache reset?** `analytics-next` persists user traits to `localStorage` and **merges** them into every subsequent `identify()` call. Without an explicit reset, `email`/`name` from a previous `identified`-mode session would leak into a later `anonymous`-mode payload. Resetting before each identify guarantees the wire payload matches `buildTraits()` exactly.

**Out of scope, flagged for follow-up:**
- `gateway/api/serverinfo/serverinfo.go` uses a package-level singleton `serverInfoData` that mutates per request — fields like `AnalyticsMode`, `FeatureFlags`, `LicenseInfo` can leak across concurrent org responses.
