### PR TITLE
fix(auth): API-key authenticated gRPC sessions were being killed after 5 minutes by the IDP user-token poller.

### DIFF
--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -90,9 +90,10 @@ func (s *Server) subscribeClient(stream *streamclient.ProxyStream) (err error) {
 	// The stream will be closed when receiving a SessionClose packet
 	// from the agent or when the stream process manager closes it.
 	if clientOrigin == pb.ConnectionOriginClient {
-		// Machine-identity sessions reach this path with the same client origin
+		// Machine-identity and API-key sessions reach this path with the same client origin
 		// but have no IDP-issued user token to poll — skip polling for them.
-		if pctx.IdentityType != plugintypes.IdentityTypeMachine {
+		if pctx.IdentityType != plugintypes.IdentityTypeMachine &&
+			pctx.IdentityType != plugintypes.IdentityTypeAPIKey {
 			usertoken.PollingUserToken(pctx.Context, func(cause error) {
 				_ = stream.Close(cause)
 			}, tokenVerifier, pctx.UserID)

--- a/gateway/transport/interceptors/auth/auth.go
+++ b/gateway/transport/interceptors/auth/auth.go
@@ -162,7 +162,8 @@ func (i *interceptor) StreamServerInterceptor(srv any, ss grpc.ServerStream, inf
 			go models.UpdateAPIKeyLastUsed(ctx.UserID)
 			ctx.UserID = ctx.UserSubject
 			gwctx := &GatewayContext{
-				UserContext: *ctx,
+				UserContext:  *ctx,
+				IdentityType: plugintypes.IdentityTypeAPIKey,
 			}
 			connectionName := commongrpc.MetaGet(md, "connection-name")
 			conn, err := i.getConnection(connectionName, ctx)
@@ -203,7 +204,8 @@ func (i *interceptor) StreamServerInterceptor(srv any, ss grpc.ServerStream, inf
 				UserGroups:     []string{types.GroupAdmin},
 			}
 			gwctx := &GatewayContext{
-				UserContext: *ctx,
+				UserContext:  *ctx,
+				IdentityType: plugintypes.IdentityTypeAPIKey,
 			}
 			connectionName := commongrpc.MetaGet(md, "connection-name")
 			conn, err := i.getConnection(connectionName, ctx)

--- a/gateway/transport/plugins/types/types.go
+++ b/gateway/transport/plugins/types/types.go
@@ -15,6 +15,12 @@ import (
 // of redefining the literal string.
 const IdentityTypeMachine = "machine"
 
+// IdentityTypeAPIKey marks gRPC sessions authenticated via an hpk_ API key.
+// API keys are issued by the gateway itself — there is no IDP-backed user token
+// to poll, so the auth interceptor uses this type to opt out of user-token
+// verification (mirroring IdentityTypeMachine).
+const IdentityTypeAPIKey = "api_key"
+
 type GenericMap map[string]any
 
 type PacketErr struct {


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

API-key authenticated gRPC sessions were being killed after 5 minutes by the IDP user-token poller. The poller (`usertoken.PollingUserToken`) looks up a `user_tokens` row for the session's user UUID — but API keys are issued by the gateway itself and have no IDP-backed token, so the lookup always returned "access token not found" and closed the stream.

Machine Identity sessions already opted out of this poll via the `IdentityTypeMachine` marker. This PR mirrors that pattern for both API-key flavors (per-org `hpk_` keys and the static server-wide `API_KEY`) by introducing a dedicated `IdentityTypeAPIKey` marker that the polling loop now also recognizes.

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when this PR is merged -->

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `IdentityTypeAPIKey = "api_key"` constant in `gateway/transport/plugins/types/types.go` alongside the existing `IdentityTypeMachine`.
- Set `IdentityType: plugintypes.IdentityTypeAPIKey` on the `GatewayContext` for both API-key auth paths in `gateway/transport/interceptors/auth/auth.go` (the per-org `hpk_` path and the static server-wide `API_KEY` path).
- Extended the polling-skip condition in `gateway/transport/client.go` so `subscribeClient` skips `usertoken.PollingUserToken` for both `IdentityTypeMachine` and `IdentityTypeAPIKey` sessions; refreshed the inline comment to reflect both cases.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (gRPC transport change, no UI surface)
- **OS**: macOS (development), Linux (CI)

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

Manual verification:
- Connected with an `hpk_` API key and confirmed the gRPC stream stayed open past the 5-minute polling interval (previously closed with "access token not found for user subject").
- Confirmed the audit plugin still records API-key sessions as `identity_type = 'user'` in the `sessions` table — its existing `== identityTypeMachine` checks treat any other value (including the new `"api_key"`) as user, so session reporting is unchanged.
- Verified Machine Identity sessions continue to work unchanged.

## 📸 Screenshots (if applicable)

N/A — backend-only change.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**Suggested label**: `patch` (bug fix, no API surface or wire-format change, no migrations, no new env vars).

**Scope notes for reviewers**:
- The audit plugin was intentionally left untouched. API-key sessions continue to persist as `identity_type = 'user'` to preserve existing reporting/dashboards. If we later want a distinct `"api_key"` value in `sessions.identity_type`, that's a follow-up that also touches the OpenAPI enum (`api/openapi/types.go:788`) and any downstream consumers.
- Other call sites of `PollingUserToken` (if any) were not surveyed — only the `subscribeClient` path on the main gRPC connect flow was in scope, since that's the one API-key clients hit.
- No feature-flag gating: the change is a targeted bug fix that restores the expected behavior for API-key sessions; gating it would just defer the fix.