### PR TITLE
fix: hide flag-gated entries in collapsed sidebar

### DIFF
--- a/webapp_v2/src/layout/Sidebar/SidebarCollapsed.jsx
+++ b/webapp_v2/src/layout/Sidebar/SidebarCollapsed.jsx
@@ -10,6 +10,7 @@ import classes from './Sidebar.module.css'
 export function SidebarCollapsed({ skipLink }) {
   const { toggleSidebarCollapsed, setPendingOpenSection } = useUIStore()
   const { user, isAdmin, isSelfHosted } = useUserStore()
+  const isFeatureFlagEnabled = useUserStore((s) => s.isFeatureFlagEnabled)
 
   return (
     <Stack
@@ -38,7 +39,7 @@ export function SidebarCollapsed({ skipLink }) {
         classNames={{ root: classes.collapsedScrollArea }}
       >
         <Stack gap={2} align="center" role="list" aria-label="Main navigation">
-          {MAIN_ITEMS.filter((i) => !shouldHide(i, isAdmin, isSelfHosted)).map((item) => (
+          {MAIN_ITEMS.filter((i) => !shouldHide(i, isAdmin, isSelfHosted, isFeatureFlagEnabled)).map((item) => (
             <Box component="li" key={item.path || item.label} className={classes.listItem}>
               <IconBtn {...item} />
             </Box>
@@ -49,7 +50,7 @@ export function SidebarCollapsed({ skipLink }) {
           <Box mt="xxl" w="100%">
             <Text size="xs" fw={600} mb="xs" className={classes.sectionHidden}>Discover</Text>
             <Stack gap="xsAlt" align="center" role="list" aria-label="Discover">
-              {DISCOVER_ITEMS.filter((i) => !shouldHide(i, isAdmin, isSelfHosted)).map((item) => (
+              {DISCOVER_ITEMS.filter((i) => !shouldHide(i, isAdmin, isSelfHosted, isFeatureFlagEnabled)).map((item) => (
                 <Box component="li" key={item.path} className={classes.listItem}>
                   <IconBtn {...item} />
                 </Box>
@@ -62,7 +63,7 @@ export function SidebarCollapsed({ skipLink }) {
           <Box mt="xxl" w="100%">
             <Text size="xs" fw={600} mb="xs" className={classes.sectionHidden}>Organization</Text>
             <Stack gap="xsAlt" align="center" role="list" aria-label="Organization">
-              {ORGANIZATION_ITEMS.filter((i) => !shouldHide(i, isAdmin, isSelfHosted)).map((item) =>
+              {ORGANIZATION_ITEMS.filter((i) => !shouldHide(i, isAdmin, isSelfHosted, isFeatureFlagEnabled)).map((item) =>
                 item.children ? (
                   <Box component="li" key={item.label} className={classes.listItem}>
                     <IconBtn

--- a/webapp_v2/src/layout/Sidebar/constants.js
+++ b/webapp_v2/src/layout/Sidebar/constants.js
@@ -88,7 +88,7 @@ export const ORGANIZATION_ITEMS = [
       { label: 'API Keys', path: '/settings/api-keys', adminOnly: true, badge: { text: 'NEW', color: 'green' } },
       { label: 'Attributes', path: '/settings/attributes', adminOnly: true, badge: { text: 'NEW', color: 'green' } },
       { label: 'Infrastructure', path: '/settings/infrastructure', adminOnly: true, selfhostedOnly: true },
-      { label: 'Experimental', path: '/settings/experimental', adminOnly: true, badge: { text: 'BETA', color: 'indigo' } },
+      { label: 'Experimental', path: '/settings/experimental', adminOnly: true },
       { label: 'License', path: '/settings/license', adminOnly: true },
       { label: 'Internal Audit Logs', path: '/settings/audit-logs', adminOnly: true },
       { label: 'Users', path: '/organization/users', adminOnly: true }


### PR DESCRIPTION
## 📝 Description

- Fix: `SidebarCollapsed` wasn't checking feature flags, so Event Routing showed up in the collapsed sidebar even when the flag was off. Now passes `isFeatureFlagEnabled` to `shouldHide`, matching the expanded sidebar.
- Drop the BETA badge from the Experimental settings entry.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 🧪 Testing

### Test Configuration:
- **Browser(s)**:  Chrome
- **OS**: MacOs

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

