### PR TITLE
fix(analytics): prevent nil-pointer crash in TrackSessionUsageData

### DIFF
--- a/gateway/analytics/segment.go
+++ b/gateway/analytics/segment.go
@@ -225,14 +225,87 @@ func (s *Segment) Track(userID, eventName string, properties map[string]any) {
 	}
 }
 
-func sessionUsageProperties(
-	s *models.Session,
-	c *models.Connection,
-	agent *models.Agent,
-	guardrails *models.ConnectionGuardRailRules,
-	dataMasking json.RawMessage,
-	accessRequestList []*models.AccessRequestRule,
-) map[string]any {
+type sessionUsageData struct {
+	session              *models.Session
+	connection           *models.Connection
+	agent                *models.Agent
+	guardrails           *models.ConnectionGuardRailRules
+	dataMasking          json.RawMessage
+	jitAccessRequest     *models.AccessRequestRule
+	commandAccessRequest *models.AccessRequestRule
+}
+
+func loadSessionUsageData(orgID, sessionID string) (*sessionUsageData, error) {
+	session, err := models.GetSessionByID(orgID, sessionID)
+	if err != nil {
+		log.Warnf("failed getting session by ID, reason=%v", err)
+		return nil, err
+	}
+
+	connection, err := models.GetConnectionByName(models.DB, session.Connection)
+	if err != nil {
+		log.Warnf("failed getting connection features by name, reason=%v", err)
+		return nil, err
+	}
+
+	data := &sessionUsageData{session: session, connection: connection}
+	orgUUID := uuid.MustParse(orgID)
+
+	group, _ := errgroup.WithContext(context.Background())
+	group.Go(func() error {
+		agent, err := models.GetAgentByNameOrID(orgID, connection.AgentID.String)
+		if err != nil {
+			log.Warnf("failed getting agent by name, reason=%v", err)
+			return err
+		}
+		data.agent = agent
+		return nil
+	})
+	group.Go(func() error {
+		guardrails, err := services.GetGuardRailRulesForConnection(orgID, session.Connection)
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Warnf("failed getting guardrails for connection, reason=%v", err)
+			return err
+		}
+		data.guardrails = guardrails
+		return nil
+	})
+	group.Go(func() error {
+		dataMasking, err := services.GetDataMaskingRulesForConnection(orgID, session.Connection)
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Warnf("failed getting data masking rules for connection, reason=%v", err)
+			return err
+		}
+		data.dataMasking = dataMasking
+		return nil
+	})
+	group.Go(func() error {
+		rule, err := services.GetRuleForConnection(orgUUID, session.Connection, "jit")
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Warnf("failed getting jit rule for connection, reason=%v", err)
+			return err
+		}
+		data.jitAccessRequest = rule
+		return nil
+	})
+	group.Go(func() error {
+		rule, err := services.GetRuleForConnection(orgUUID, session.Connection, "command")
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Warnf("failed getting command rule for connection, reason=%v", err)
+			return err
+		}
+		data.commandAccessRequest = rule
+		return nil
+	})
+
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func sessionUsageProperties(d *sessionUsageData) map[string]any {
+	s, c := d.session, d.connection
 
 	props := map[string]any{
 		"org-id":                           s.OrgID,
@@ -242,14 +315,14 @@ func sessionUsageProperties(
 		"status":                           s.Status,
 		"created-at":                       s.CreatedAt.String(),
 		"ai-session-analyzer-activated":    false,
-		"agent-version":                    agent.GetMeta("version"),
-		"agent-platform":                   agent.GetMeta("platform"),
-		"mandatory-metadata-activated":     c.MandatoryMetadataFields != nil && len(c.MandatoryMetadataFields) > 0,
+		"agent-version":                    d.agent.GetMeta("version"),
+		"agent-platform":                   d.agent.GetMeta("platform"),
+		"mandatory-metadata-activated":     len(c.MandatoryMetadataFields) > 0,
 		"jira-template-activated":          c.JiraIssueTemplateID.Valid && c.JiraIssueTemplateID.String != "",
 		"jit-access-request-activated":     false,
 		"command-access-request-activated": false,
-		"guardrails-activated":             guardrails != nil && !guardrails.HasEmptyRules(),
-		"data-masking-activated":           string(dataMasking) != "[]",
+		"guardrails-activated":             d.guardrails != nil && !d.guardrails.HasEmptyRules(),
+		"data-masking-activated":           string(d.dataMasking) != "[]",
 	}
 
 	if s.EndSession != nil {
@@ -262,15 +335,15 @@ func sessionUsageProperties(
 		props["ai-session-analyzer-action"] = s.AIAnalysis.Action
 	}
 
-	for _, rule := range accessRequestList {
-		if rule != nil {
-			props[fmt.Sprintf("%s-access-request-activated", rule.AccessType)] = true
-			props[fmt.Sprintf("%s-access-request-force-approval", rule.AccessType)] = len(rule.ForceApprovalGroups) > 0
-			props[fmt.Sprintf("%s-access-request-all-groups-must-approve", rule.AccessType)] = rule.AllGroupsMustApprove
-
-			if rule.MinApprovals != nil {
-				props[fmt.Sprintf("%s-access-request-minimum-approval", rule.AccessType)] = *rule.MinApprovals
-			}
+	for _, rule := range []*models.AccessRequestRule{d.jitAccessRequest, d.commandAccessRequest} {
+		if rule == nil {
+			continue
+		}
+		props[fmt.Sprintf("%s-access-request-activated", rule.AccessType)] = true
+		props[fmt.Sprintf("%s-access-request-force-approval", rule.AccessType)] = len(rule.ForceApprovalGroups) > 0
+		props[fmt.Sprintf("%s-access-request-all-groups-must-approve", rule.AccessType)] = rule.AllGroupsMustApprove
+		if rule.MinApprovals != nil {
+			props[fmt.Sprintf("%s-access-request-minimum-approval", rule.AccessType)] = *rule.MinApprovals
 		}
 	}
 
@@ -278,80 +351,12 @@ func sessionUsageProperties(
 }
 
 func (s *Segment) TrackSessionUsageData(eventName string, orgID string, userID string, sessionID string) {
-	var (
-		err                  error
-		session              *models.Session
-		connection           *models.Connection
-		agent                *models.Agent
-		guardrails           *models.ConnectionGuardRailRules
-		jitAccessRequest     *models.AccessRequestRule
-		commandAccessRequest *models.AccessRequestRule
-		dataMasking          json.RawMessage
-	)
-
-	if session, err = models.GetSessionByID(orgID, sessionID); err != nil {
-		log.Warnf("failed getting session by ID, reason=%v", err)
+	data, err := loadSessionUsageData(orgID, sessionID)
+	if err != nil {
 		return
 	}
-
-	if connection, err = models.GetConnectionByName(models.DB, session.Connection); err != nil {
-		log.Warnf("failed getting connection features by name, reason=%v", err)
-		return
-	}
-
-	group, _ := errgroup.WithContext(context.Background())
-	group.Go(func() error {
-		if agent, err = models.GetAgentByNameOrID(orgID, connection.AgentID.String); err != nil {
-			log.Warnf("failed getting agent by name, reason=%v", err)
-			return err
-		}
-		return nil
-	})
-
-	group.Go(func() error {
-		if guardrails, err = services.GetGuardRailRulesForConnection(orgID, session.Connection); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			log.Warnf("failed getting guardrails for connection, reason=%v", err)
-			return err
-		}
-
-		return nil
-	})
-
-	group.Go(func() error {
-		if dataMasking, err = services.GetDataMaskingRulesForConnection(orgID, session.Connection); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			log.Warnf("failed getting data masking rules for connection, reason=%v", err)
-			return err
-		}
-
-		return nil
-	})
-
-	group.Go(func() error {
-		if jitAccessRequest, err = services.GetRuleForConnection(uuid.MustParse(orgID), session.Connection, "jit"); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			log.Warnf("failed getting jit rule for connection, reason=%v", err)
-			return err
-		}
-
-		return nil
-	})
-
-	group.Go(func() error {
-		if commandAccessRequest, err = services.GetRuleForConnection(uuid.MustParse(orgID), session.Connection, "command"); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			log.Warnf("failed getting command rule for connection, reason=%v", err)
-			return err
-		}
-
-		return nil
-	})
-
-	if err := group.Wait(); err != nil {
-		return
-	}
-
-	props := sessionUsageProperties(session, connection, agent, guardrails, dataMasking, []*models.AccessRequestRule{jitAccessRequest, commandAccessRequest})
 	log.With("sid", sessionID).Infof("tracking session usage data, event=%s", eventName)
-
-	s.Track(userID, eventName, props)
+	s.Track(userID, eventName, sessionUsageProperties(data))
 }
 
 // CreateConnectionEvent is the canonical input for the hoop-create-connection

--- a/gateway/analytics/segment_test.go
+++ b/gateway/analytics/segment_test.go
@@ -101,15 +101,21 @@ func TestSessionUsageProperties(t *testing.T) {
 		},
 	}
 
+	usageData := func(opts ...func(*sessionUsageData)) *sessionUsageData {
+		d := &sessionUsageData{
+			session:     baseSession,
+			connection:  baseConnection,
+			agent:       baseAgent,
+			dataMasking: json.RawMessage("[]"),
+		}
+		for _, opt := range opts {
+			opt(d)
+		}
+		return d
+	}
+
 	t.Run("basic properties with no optional features", func(t *testing.T) {
-		props := sessionUsageProperties(
-			baseSession,
-			baseConnection,
-			baseAgent,
-			nil,                   // no guardrails
-			json.RawMessage("[]"), // empty data masking
-			nil,                   // no access request rules
-		)
+		props := sessionUsageProperties(usageData())
 
 		assertProp(t, props, "org-id", "org-456")
 		assertProp(t, props, "session-id", "sess-123")
@@ -136,7 +142,7 @@ func TestSessionUsageProperties(t *testing.T) {
 		s := *baseSession
 		s.EndSession = &endTime
 
-		props := sessionUsageProperties(&s, baseConnection, baseAgent, nil, json.RawMessage("[]"), nil)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) { d.session = &s }))
 
 		assertProp(t, props, "finished-at", endTime.String())
 	})
@@ -148,7 +154,7 @@ func TestSessionUsageProperties(t *testing.T) {
 			Action:    "block",
 		}
 
-		props := sessionUsageProperties(&s, baseConnection, baseAgent, nil, json.RawMessage("[]"), nil)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) { d.session = &s }))
 
 		assertProp(t, props, "ai-session-analyzer-activated", true)
 		assertProp(t, props, "ai-session-analyzer-identified-risk", "high")
@@ -159,7 +165,7 @@ func TestSessionUsageProperties(t *testing.T) {
 		c := *baseConnection
 		c.MandatoryMetadataFields = pq.StringArray{"field1", "field2"}
 
-		props := sessionUsageProperties(baseSession, &c, baseAgent, nil, json.RawMessage("[]"), nil)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) { d.connection = &c }))
 
 		assertProp(t, props, "mandatory-metadata-activated", true)
 	})
@@ -168,7 +174,7 @@ func TestSessionUsageProperties(t *testing.T) {
 		c := *baseConnection
 		c.JiraIssueTemplateID = sql.NullString{String: "TMPL-001", Valid: true}
 
-		props := sessionUsageProperties(baseSession, &c, baseAgent, nil, json.RawMessage("[]"), nil)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) { d.connection = &c }))
 
 		assertProp(t, props, "jira-template-activated", true)
 	})
@@ -177,7 +183,7 @@ func TestSessionUsageProperties(t *testing.T) {
 		c := *baseConnection
 		c.JiraIssueTemplateID = sql.NullString{String: "", Valid: true}
 
-		props := sessionUsageProperties(baseSession, &c, baseAgent, nil, json.RawMessage("[]"), nil)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) { d.connection = &c }))
 
 		assertProp(t, props, "jira-template-activated", false)
 	})
@@ -188,7 +194,7 @@ func TestSessionUsageProperties(t *testing.T) {
 			GuardRailOutputRules: []byte(`[{"rule":"mask-ssn"}]`),
 		}
 
-		props := sessionUsageProperties(baseSession, baseConnection, baseAgent, gr, json.RawMessage("[]"), nil)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) { d.guardrails = gr }))
 
 		assertProp(t, props, "guardrails-activated", true)
 	})
@@ -199,7 +205,7 @@ func TestSessionUsageProperties(t *testing.T) {
 			GuardRailOutputRules: []byte(`[]`),
 		}
 
-		props := sessionUsageProperties(baseSession, baseConnection, baseAgent, gr, json.RawMessage("[]"), nil)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) { d.guardrails = gr }))
 
 		assertProp(t, props, "guardrails-activated", false)
 	})
@@ -207,29 +213,30 @@ func TestSessionUsageProperties(t *testing.T) {
 	t.Run("data masking activated", func(t *testing.T) {
 		dm := json.RawMessage(`[{"type":"email"}]`)
 
-		props := sessionUsageProperties(baseSession, baseConnection, baseAgent, nil, dm, nil)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) { d.dataMasking = dm }))
 
 		assertProp(t, props, "data-masking-activated", true)
 	})
 
 	t.Run("access request rules with jit and command", func(t *testing.T) {
-		rules := []*models.AccessRequestRule{
-			{
-				ID:                   uuid.New(),
-				AccessType:           "jit",
-				ForceApprovalGroups:  pq.StringArray{"admins"},
-				AllGroupsMustApprove: true,
-				MinApprovals:         &minApprovals,
-			},
-			{
-				ID:                   uuid.New(),
-				AccessType:           "command",
-				ForceApprovalGroups:  pq.StringArray{},
-				AllGroupsMustApprove: false,
-			},
+		jit := &models.AccessRequestRule{
+			ID:                   uuid.New(),
+			AccessType:           "jit",
+			ForceApprovalGroups:  pq.StringArray{"admins"},
+			AllGroupsMustApprove: true,
+			MinApprovals:         &minApprovals,
+		}
+		command := &models.AccessRequestRule{
+			ID:                   uuid.New(),
+			AccessType:           "command",
+			ForceApprovalGroups:  pq.StringArray{},
+			AllGroupsMustApprove: false,
 		}
 
-		props := sessionUsageProperties(baseSession, baseConnection, baseAgent, nil, json.RawMessage("[]"), rules)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) {
+			d.jitAccessRequest = jit
+			d.commandAccessRequest = command
+		}))
 
 		assertProp(t, props, "jit-access-request-activated", true)
 		assertProp(t, props, "jit-access-request-force-approval", true)
@@ -246,9 +253,7 @@ func TestSessionUsageProperties(t *testing.T) {
 	})
 
 	t.Run("access request rules with nil entries are skipped", func(t *testing.T) {
-		rules := []*models.AccessRequestRule{nil, nil}
-
-		props := sessionUsageProperties(baseSession, baseConnection, baseAgent, nil, json.RawMessage("[]"), rules)
+		props := sessionUsageProperties(usageData())
 
 		assertProp(t, props, "jit-access-request-activated", false)
 		assertProp(t, props, "command-access-request-activated", false)
@@ -257,7 +262,7 @@ func TestSessionUsageProperties(t *testing.T) {
 	t.Run("nil agent returns empty metadata", func(t *testing.T) {
 		nilAgent := &models.Agent{}
 
-		props := sessionUsageProperties(baseSession, baseConnection, nilAgent, nil, json.RawMessage("[]"), nil)
+		props := sessionUsageProperties(usageData(func(d *sessionUsageData) { d.agent = nilAgent }))
 
 		assertProp(t, props, "agent-version", "")
 		assertProp(t, props, "agent-platform", "")


### PR DESCRIPTION
## 📝 Description

`TrackSessionUsageData` was crashing intermittently with a nil-pointer dereference. The root cause was a data race in the previous `errgroup` block: all goroutines shared a single `err` variable in the enclosing scope, so a late-assigning goroutine could clobber an earlier error and let downstream code consume a `nil` model.

This PR fixes the race and takes the opportunity to clean up the function shape, which had grown awkward (5 stacked `var err error` blocks plus a 6-arg property builder).

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Code refactor

## 📋 Changes Made

- Extracted a `sessionUsageData` struct that holds all models the analytics event needs (session, connection, agent, guardrails, data masking, JIT and command access request rules).
- Introduced `loadSessionUsageData(orgID, sessionID)` which owns the parallel fetch orchestration. Each goroutine now writes directly to its own struct field, eliminating the shared-`err` race that produced the nil-pointer crash.
- Collapsed `sessionUsageProperties` from 6 positional args to a single `*sessionUsageData` argument.
- Slimmed `TrackSessionUsageData` down to a handful of lines — orchestration, logging, and `Track` — with no leaked intermediate state.
- Updated unit tests to use a small functional-options builder so each subtest expresses only the field it cares about.

## 🧪 Testing

### Test Configuration:
- **OS**: macOS (darwin)

### Tests performed:
- [x] Unit tests pass (`go test ./gateway/analytics/...`)
- [ ] Integration tests pass
- [x] Manual testing completed

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

The behavior of the analytics event is unchanged — same properties are emitted, the function still degrades gracefully when the session or related models cannot be loaded. The fix is purely structural.