### PR TITLE
feat: enhance rules table with Enter key handling for pattern input

### DIFF
--- a/webapp/src/webapp/guardrails/rules_table.cljs
+++ b/webapp/src/webapp/guardrails/rules_table.cljs
@@ -69,6 +69,9 @@
        :not-margin-bottom? true
        :on-change #(on-pattern-change pattern-state idx (-> % .-target .-value))
        :on-blur #(on-rule-field-change state idx :pattern_regex (get @pattern-state idx ""))
+       :on-keyDown (fn [e]
+                     (when (= (.-key e) "Enter")
+                       (.preventDefault e)))
        :value (get @pattern-state idx "")}]
      [:> Tooltip {:content "Use Go regex syntax."}
       [:> CircleHelp {:size 16}]]]
@@ -140,7 +143,7 @@
 
            [:> Table.Cell {:p "4" :width "220px"}
             (when-not (empty? (:type rule))
-              [:div {:class (str " text-sm w-full")}
+              [:div {:class "text-sm w-full"}
                [:div {:class "flex items-center gap-2"}
                 [:> Select.Root
                  {:size "2"


### PR DESCRIPTION
## 📝 Description

Fixes a bug in the guardrails form where pressing Enter while typing a custom regex pattern (Pattern Match rule) would submit the entire form before the pattern value was committed to state, resulting in the pattern being lost and the user being navigated away from the form.

## 🔗 Related Issue

Fixes ENG-417

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- Added `on-key-down` handler to the pattern regex input that calls `.preventDefault` when Enter is pressed, preventing the form from submitting while the user is typing a regex pattern

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome, Firefox
- **OS**: Linux / macOS

### Tests performed:
- [x] Manual testing completed

**Steps to reproduce the original bug:**
1. Open a guardrail (create or edit)
2. Add an Input or Output rule, select type "Pattern Match", then "Create custom rule"
3. Type a regex in the details input and press Enter
4. Observe: form saves immediately with an empty `pattern_regex`

**After fix:**
- Pressing Enter inside the regex input no longer submits the form
- The value is correctly saved when clicking the Save button (blur fires before submit, committing the value)

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings