### PR TITLE
Adds an opt-in path that runs SQL hoop exec commands (Postgres, MySQL, MSSQL, Oracle) through in-process Go database drivers instead of spawning the vendor CLI (psql/mysql/sqlcmd/sqlplus)

### DIFF
--- a/_libhoop/agent/dbexec/dbexec.go
+++ b/_libhoop/agent/dbexec/dbexec.go
@@ -1,0 +1,31 @@
+// Package dbexec is the open-source stub for the enterprise driver-based SQL
+// exec surface. The real implementation (in-process pgx/mysql/mssql/oracle
+// drivers) lives in the private libhoop module; this stub exposes only the
+// constants the agent references so the OSS build compiles. The driver path is
+// unavailable in the OSS build: libhoop.NewAdHocDBExec returns a noop proxy
+// that reports the missing protocol library.
+package dbexec
+
+// Driver identifies the supported database engines for ad-hoc exec.
+type Driver string
+
+const (
+	DriverPostgres Driver = "postgres"
+	DriverMySQL    Driver = "mysql"
+	DriverMSSQL    Driver = "mssql"
+	DriverOracle   Driver = "oracledb"
+)
+
+// Option keys carry connection credentials through the libhoop opts map into
+// the driver-based exec path. They reuse the names the wire proxies use so the
+// agent populates one set of connection keys for either exec path.
+const (
+	OptKeyHost        = "hostname"
+	OptKeyPort        = "port"
+	OptKeyUser        = "username"
+	OptKeyPassword    = "password"
+	OptKeyDBName      = "dbname"
+	OptKeySSLMode     = "sslmode"
+	OptKeyInsecure    = "insecure"
+	OptKeyServiceName = "service_name"
+)

--- a/_libhoop/libhoop.go
+++ b/_libhoop/libhoop.go
@@ -37,6 +37,10 @@ func NewAdHocExec(rawEnvVarList map[string]any, args []string, payload []byte, s
 	return &noopProxy{connectionType: "terminal-exec"}, nil
 }
 
+func NewAdHocDBExec(driver string, payload []byte, stdout, stderr io.Writer, opts map[string]string) (Proxy, error) {
+	return &noopProxy{connectionType: "db-exec"}, nil
+}
+
 func NewConsole(rawEnvVarList map[string]any, args []string, stdout io.WriteCloser, opts map[string]string) (Proxy, error) {
 	return &noopProxy{connectionType: "terminal-console"}, nil
 }

--- a/agent/controller/agent.go
+++ b/agent/controller/agent.go
@@ -86,6 +86,7 @@ type (
 		port               string
 		authorizedSSHKeys  string
 		dbname             string
+		serviceName        string
 		insecure           bool
 		options            string
 		postgresSSLMode    string
@@ -728,6 +729,7 @@ func parseConnectionEnvVars(envVars map[string]any, connType pb.ConnectionType) 
 		port:              envVarS.Getenv("PORT"),
 		authorizedSSHKeys: envVarS.Getenv("AUTHORIZED_SERVER_KEYS"),
 		dbname:            envVarS.Getenv("DB"),
+		serviceName:       envVarS.Getenv("SID"),
 		insecure:          envVarS.Getenv("INSECURE") == "true",
 		postgresSSLMode:   envVarS.Getenv("SSLMODE"),
 		options:           envVarS.Getenv("OPTIONS"),
@@ -771,6 +773,13 @@ func parseConnectionEnvVars(envVars map[string]any, connType pb.ConnectionType) 
 		}
 		if env.host == "" || env.pass == "" || env.user == "" {
 			return nil, errors.New("missing required secrets for mssql connection [HOST, USER, PASS]")
+		}
+	case pb.ConnectionTypeOracleDB:
+		if env.port == "" {
+			env.port = "1521"
+		}
+		if env.host == "" || env.pass == "" || env.user == "" || env.serviceName == "" {
+			return nil, errors.New("missing required secrets for oracledb connection [HOST, USER, PASS, SID]")
 		}
 	case pb.ConnectionTypeMongoDB:
 		if env.connectionString != "" {

--- a/agent/controller/terminal-exec.go
+++ b/agent/controller/terminal-exec.go
@@ -3,7 +3,9 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"io"
 	"libhoop"
+	"libhoop/agent/dbexec"
 	redactortypes "libhoop/redactor/types"
 	"strconv"
 	"strings"
@@ -13,6 +15,24 @@ import (
 	pb "github.com/hoophq/hoop/common/proto"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
 )
+
+// dbExecDriverFlag gates the driver-based SQL exec path. When off, SQL exec
+// connections fall back to spawning the vendor CLI.
+const dbExecDriverFlag = "experimental.db_exec_driver"
+
+// dbExecDriver maps a connection type to the in-process driver used by the
+// secure SQL exec path, reporting whether the type is supported.
+func dbExecDriver(connType string) (string, bool) {
+	switch pb.ConnectionType(connType) {
+	case pb.ConnectionTypePostgres:
+		return string(dbexec.DriverPostgres), true
+	case pb.ConnectionTypeMySQL:
+		return string(dbexec.DriverMySQL), true
+	case pb.ConnectionTypeMSSQL:
+		return string(dbexec.DriverMSSQL), true
+	}
+	return "", false
+}
 
 // execInputLogMaxBytes caps the size of the exec input snippet attached to
 // structured logs. Keeps memory usage and downstream log volume bounded when
@@ -73,8 +93,23 @@ func (a *Agent) doExec(pkt *pb.Packet) {
 		"guard_rail_rules":          guardRailRules,
 	}
 
-	args := append(connParams.CmdList, connParams.ClientArgs...)
-	cmd, err := libhoop.NewAdHocExec(connParams.EnvVars, args, pkt.Payload, stdoutw, stderrw, opts)
+	// SQL exec connections route through the in-process database driver when the
+	// flag is on, which removes the vendor CLI's meta-command escape surface
+	// (e.g. psql "\!") and keeps the credential out of any spawned process.
+	// Every other connection type, and the flag-off case, keeps the CLI path.
+	var (
+		cmd      libhoop.Proxy
+		err      error
+		execDesc string
+	)
+	if driver, ok := dbExecDriver(connParams.ConnectionType); ok && featureflagstate.IsEnabled(dbExecDriverFlag) {
+		cmd, err = a.newDBExecProxy(driver, connParams, pkt.Payload, stdoutw, stderrw, opts)
+		execDesc = "db-driver=" + driver
+	} else {
+		args := append(connParams.CmdList, connParams.ClientArgs...)
+		cmd, err = libhoop.NewAdHocExec(connParams.EnvVars, args, pkt.Payload, stdoutw, stderrw, opts)
+		execDesc = fmt.Sprintf("%v", args)
+	}
 	if err != nil {
 		log.With("sid", sid).Infof("failed configuring command, reason=%v", err)
 		// Write error to stderr so it's visible in the web UI output
@@ -103,7 +138,7 @@ func (a *Agent) doExec(pkt *pb.Packet) {
 			"input_size", size,
 		)
 	}
-	log.With(logFields...).Infof("tty=false, stdinsize=%v - executing command:%v", len(pkt.Payload), args)
+	log.With(logFields...).Infof("tty=false, stdinsize=%v - executing command:%v", len(pkt.Payload), execDesc)
 	sessionIDKey := fmt.Sprintf(execStoreKey, sid)
 	a.connStore.Set(sessionIDKey, cmd)
 
@@ -128,4 +163,25 @@ func (a *Agent) doExec(pkt *pb.Packet) {
 		cmd.FlushMetrics(newIoMetricFlush(a.client, sid))
 	})
 
+}
+
+// newDBExecProxy resolves the connection credentials and builds the
+// driver-based SQL exec proxy. Credentials are passed to libhoop through the
+// opts map (the same channel the wire proxies use) so libhoop stays free of
+// agent/common imports.
+func (a *Agent) newDBExecProxy(driver string, connParams *pb.AgentConnectionParams, payload []byte, stdoutw, stderrw io.Writer, opts map[string]string) (libhoop.Proxy, error) {
+	connenv, err := parseConnectionEnvVars(connParams.EnvVars, pb.ConnectionType(connParams.ConnectionType))
+	if err != nil {
+		return nil, err
+	}
+	opts[dbexec.OptKeyHost] = connenv.host
+	opts[dbexec.OptKeyPort] = connenv.port
+	opts[dbexec.OptKeyUser] = connenv.user
+	opts[dbexec.OptKeyPassword] = connenv.pass
+	opts[dbexec.OptKeyDBName] = connenv.dbname
+	opts[dbexec.OptKeySSLMode] = connenv.postgresSSLMode
+	if connenv.insecure {
+		opts[dbexec.OptKeyInsecure] = "true"
+	}
+	return libhoop.NewAdHocDBExec(driver, payload, stdoutw, stderrw, opts)
 }

--- a/agent/controller/terminal-exec.go
+++ b/agent/controller/terminal-exec.go
@@ -30,6 +30,8 @@ func dbExecDriver(connType string) (string, bool) {
 		return string(dbexec.DriverMySQL), true
 	case pb.ConnectionTypeMSSQL:
 		return string(dbexec.DriverMSSQL), true
+	case pb.ConnectionTypeOracleDB:
+		return string(dbexec.DriverOracle), true
 	}
 	return "", false
 }
@@ -180,6 +182,7 @@ func (a *Agent) newDBExecProxy(driver string, connParams *pb.AgentConnectionPara
 	opts[dbexec.OptKeyPassword] = connenv.pass
 	opts[dbexec.OptKeyDBName] = connenv.dbname
 	opts[dbexec.OptKeySSLMode] = connenv.postgresSSLMode
+	opts[dbexec.OptKeyServiceName] = connenv.serviceName
 	if connenv.insecure {
 		opts[dbexec.OptKeyInsecure] = "true"
 	}

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -89,6 +89,13 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentGateway},
 	},
+	"experimental.db_exec_driver": {
+		Name:        "experimental.db_exec_driver",
+		Description: "Run Postgres/MySQL/MSSQL exec commands through in-process Go database drivers instead of spawning the vendor CLI (psql/mysql/sqlcmd). Eliminates client meta-command shell escapes (e.g. psql \\!) and keeps the connection credential out of any user-reachable process.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentAgent},
+	},
 }
 
 // All returns every registered flag, sorted by name.

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -91,7 +91,7 @@ var catalog = map[string]Flag{
 	},
 	"experimental.db_exec_driver": {
 		Name:        "experimental.db_exec_driver",
-		Description: "Run Postgres/MySQL/MSSQL exec commands through in-process Go database drivers instead of spawning the vendor CLI (psql/mysql/sqlcmd). Eliminates client meta-command shell escapes (e.g. psql \\!) and keeps the connection credential out of any user-reachable process.",
+		Description: "Run Postgres/MySQL/MSSQL/Oracle exec commands through in-process Go database drivers instead of spawning the vendor CLI (psql/mysql/sqlcmd/sqlplus). Eliminates client meta-command shell escapes (e.g. psql \\!, sqlplus HOST) and keeps the connection credential out of any user-reachable process.",
 		Default:     false,
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentAgent},


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

<!-- Recommended label: `minor` (new opt-in functionality, gated behind a flag, default off) -->

## 📝 Description

Adds an opt-in path that runs SQL `hoop exec` commands (Postgres, MySQL, MSSQL, Oracle) through in-process Go database drivers instead of spawning the vendor CLI (`psql`/`mysql`/`sqlcmd`/`sqlplus`). The driver path removes the CLI meta-command shell-escape surface (e.g. `psql \!`, `sqlplus HOST`) that let a user run arbitrary OS commands on the agent host, and keeps the connection credential out of any spawned process.

The behavior is gated behind a new `experimental.db_exec_driver` flag (default off). When off, exec spawns the CLI as today. This PR registers the flag and wires the agent to the driver path; the `dbexec` executor implementation lives in the `_libhoop` repo (see Additional Notes).

## 🔗 Related Issue

<!-- Security report: `hoop exec` against a Postgres connection piped payload to psql, which interpreted `\!`/`! cmd` as a shell escape and ran arbitrary commands on the agent host, leaking its environment (cloud creds, DB passwords, API keys). The same pattern affected other interactive DB CLIs. -->

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Register the `experimental.db_exec_driver` feature flag in `common/featureflag/featureflag.go` (agent component, experimental, default `false`).
- Route SQL exec through the in-process driver in `agent/controller/terminal-exec.go`: add the `dbExecDriver` mapping (Postgres/MySQL/MSSQL/Oracle), add `newDBExecProxy`, and branch `doExec` to the driver path when the flag is on, falling back to the CLI for every other connection type and when the flag is off.
- Add Oracle connection parsing in `agent/controller/agent.go`: read the `SID` env var into a new `serviceName` field, default port `1521`, and require `HOST`/`USER`/`PASS`/`SID`.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (backend change in the Go agent)
- **OS**: macOS (dev), Linux (agent runtime)

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

Unit tests for the `dbexec` package (statement splitter, renderers, feedback, value formatting) pass. The docker golden harness (build tag `dbexec_golden`) diffs driver output against real `psql`/`mysql`/`sqlcmd`/`sqlplus` and includes shell-escape regression tests; it needs running databases and the CLIs installed. Manual: enable the flag and run `hoop exec` against each DB type from the web terminal and CLI.

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- Depends on the `_libhoop` changes that add the `dbexec` package (`Executor`, the per-engine drivers, `NewAdHocDBExec`, `OptKeyServiceName`, `DriverOracle`). This PR will not build without them, so the libhoop change must merge first or together.
- Default-off: no runtime behavior changes until an org enables `experimental.db_exec_driver`.
- No new gateway/agent config env vars. `SID` is an existing per-connection secret, so no helm or `.env.sample` updates are needed.
- Reviewer focus: the `doExec` branch in `terminal-exec.go` (flag gate + CLI fallback for unsupported types) and the new Oracle case in `parseConnectionEnvVars`.

---