### PR TITLE
change access request behavior in a single rule

### DIFF
--- a/gateway/api/accessrequests/rules.go
+++ b/gateway/api/accessrequests/rules.go
@@ -104,7 +104,7 @@ func CreateAccessRequestRule(c *gin.Context) {
 	}
 
 	if req.Attributes != nil {
-		found, err := models.GetRequestRulesByAttributes(models.DB, orgID, req.Attributes, req.AccessType)
+		found, err := models.GetRequestRuleByAttributesAndAccessType(models.DB, orgID, req.Attributes, req.AccessType)
 		if err != nil && err != gorm.ErrRecordNotFound {
 			httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed to get request rules by attributes")
 			return
@@ -316,7 +316,7 @@ func UpdateAccessRequestRule(c *gin.Context) {
 	}
 
 	if req.Attributes != nil {
-		found, err := models.GetRequestRulesByAttributes(models.DB, orgID, req.Attributes, req.AccessType)
+		found, err := models.GetRequestRuleByAttributesAndAccessType(models.DB, orgID, req.Attributes, req.AccessType)
 		if err != nil && err != gorm.ErrRecordNotFound {
 			httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed to get request rules by attributes")
 			return

--- a/gateway/api/mcpserver/tools_access_request_rules.go
+++ b/gateway/api/mcpserver/tools_access_request_rules.go
@@ -199,7 +199,7 @@ func accessRequestRulesCreateHandler(ctx context.Context, _ *mcp.CallToolRequest
 	}
 
 	if len(args.Attributes) > 0 {
-		found, err := models.GetRequestRulesByAttributes(models.DB, orgID, args.Attributes, args.AccessType)
+		found, err := models.GetRequestRuleByAttributesAndAccessType(models.DB, orgID, args.Attributes, args.AccessType)
 		if err != nil && err != gorm.ErrRecordNotFound {
 			return nil, nil, fmt.Errorf("failed to check existing attributes rule: %w", err)
 		}
@@ -281,7 +281,7 @@ func accessRequestRulesUpdateHandler(ctx context.Context, _ *mcp.CallToolRequest
 	}
 
 	if len(args.Attributes) > 0 {
-		found, err := models.GetRequestRulesByAttributes(models.DB, orgID, args.Attributes, args.AccessType)
+		found, err := models.GetRequestRuleByAttributesAndAccessType(models.DB, orgID, args.Attributes, args.AccessType)
 		if err != nil && err != gorm.ErrRecordNotFound {
 			return nil, nil, fmt.Errorf("failed to check existing attributes rule: %w", err)
 		}
@@ -396,12 +396,12 @@ func ensureStringArray(s []string) []string {
 
 func accessRequestRuleToMap(rule *models.AccessRequestRule) map[string]any {
 	m := map[string]any{
-		"id":                       rule.ID.String(),
-		"name":                     rule.Name,
-		"access_type":              rule.AccessType,
-		"all_groups_must_approve":  rule.AllGroupsMustApprove,
-		"created_at":               rule.CreatedAt,
-		"updated_at":               rule.UpdatedAt,
+		"id":                      rule.ID.String(),
+		"name":                    rule.Name,
+		"access_type":             rule.AccessType,
+		"all_groups_must_approve": rule.AllGroupsMustApprove,
+		"created_at":              rule.CreatedAt,
+		"updated_at":              rule.UpdatedAt,
 	}
 	if rule.Description != nil {
 		m["description"] = *rule.Description

--- a/gateway/models/access_request_rules.go
+++ b/gateway/models/access_request_rules.go
@@ -133,7 +133,7 @@ func DeleteAccessRequestRuleByName(db *gorm.DB, name string, orgID uuid.UUID) er
 	return nil
 }
 
-func GetRequestRulesByAttributes(db *gorm.DB, orgID uuid.UUID, attributes []string, accessType string) (*AccessRequestRule, error) {
+func GetRequestRuleByAttributesAndAccessType(db *gorm.DB, orgID uuid.UUID, attributes []string, accessType string) (*AccessRequestRule, error) {
 	var accessRequestRule AccessRequestRule
 
 	ruleNamesSubQuery := db.Model(&AccessRequestRuleAttribute{}).

--- a/gateway/models/access_request_rules.go
+++ b/gateway/models/access_request_rules.go
@@ -47,6 +47,18 @@ func GetAccessRequestRuleByResourceNameAndAccessType(db *gorm.DB, orgID uuid.UUI
 	return &accessRequestRule, nil
 }
 
+func GetAccessRequestRuleByResourceName(db *gorm.DB, orgID uuid.UUID, resourceName string) ([]AccessRequestRule, error) {
+	var accessRequestRules []AccessRequestRule
+	result := db.
+		Where("org_id = ? AND connection_names @> ?", orgID, pq.Array([]string{resourceName})).
+		Find(&accessRequestRules)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return accessRequestRules, nil
+}
+
 func GetAccessRequestRuleByResourceNamesAndAccessType(db *gorm.DB, orgID uuid.UUID, resourceName []string, accessType string) (*AccessRequestRule, error) {
 	var accessRequestRule AccessRequestRule
 	result := db.
@@ -149,4 +161,22 @@ func GetRequestRuleByAttributesAndAccessType(db *gorm.DB, orgID uuid.UUID, attri
 	}
 
 	return &accessRequestRule, nil
+}
+
+func GetRequestRulesByAttributes(db *gorm.DB, orgID uuid.UUID, attributes []string) ([]AccessRequestRule, error) {
+	var accessRequestRules []AccessRequestRule
+
+	ruleNamesSubQuery := db.Model(&AccessRequestRuleAttribute{}).
+		Distinct("access_rule_name").
+		Where("org_id = ? AND attribute_name IN (?)", orgID, attributes)
+
+	result := db.Model(&AccessRequestRule{}).
+		Where("org_id = ?", orgID).
+		Where("name IN (?)", ruleNamesSubQuery).
+		Find(&accessRequestRules)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return accessRequestRules, nil
 }

--- a/gateway/services/accessrequest.go
+++ b/gateway/services/accessrequest.go
@@ -16,7 +16,7 @@ func GetRuleForConnection(orgID uuid.UUID, connectionName, accessType string) (*
 	}
 
 	if len(connectionAttributes) > 0 {
-		rule, err := models.GetRequestRulesByAttributes(models.DB, orgID, connectionAttributes, accessType)
+		rule, err := models.GetRequestRuleByAttributesAndAccessType(models.DB, orgID, connectionAttributes, accessType)
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("failed fetching access request rules: %s", err)
 		}

--- a/gateway/services/accessrequest.go
+++ b/gateway/services/accessrequest.go
@@ -33,3 +33,28 @@ func GetRuleForConnection(orgID uuid.UUID, connectionName, accessType string) (*
 
 	return rule, nil
 }
+
+func GetRulesForConnection(orgID uuid.UUID, connectionName string) ([]models.AccessRequestRule, error) {
+	connectionAttributes, err := models.GetConnectionAttributes(models.DB, orgID, connectionName)
+	if err != nil {
+		return nil, fmt.Errorf("failed fetching connection attributes: %s", err)
+	}
+
+	if len(connectionAttributes) > 0 {
+		rules, err := models.GetRequestRulesByAttributes(models.DB, orgID, connectionAttributes)
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("failed fetching access request rules: %s", err)
+		}
+
+		if len(rules) > 0 {
+			return rules, nil
+		}
+	}
+
+	rules, err := models.GetAccessRequestRuleByResourceName(models.DB, orgID, connectionName)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("failed fetching access request rule: %s", err)
+	}
+
+	return rules, nil
+}

--- a/gateway/transport/interceptors/accessrequest/accessrequest.go
+++ b/gateway/transport/interceptors/accessrequest/accessrequest.go
@@ -194,15 +194,34 @@ func OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plugintypes.ConnectRe
 	}
 
 	orgID := uuid.MustParse(pctx.OrgID)
-	accessRule, err := services.GetRuleForConnection(orgID, pctx.ConnectionName, accessType)
+
+	var accessRule *models.AccessRequestRule
+	accessRules, err := services.GetRulesForConnection(orgID, pctx.ConnectionName)
 	if err != nil {
-		return nil, plugintypes.InternalErr("failed fetching access request rule", err)
+		return nil, plugintypes.InternalErr("failed fetching access request rules", err)
 	}
 
-	if accessRule == nil {
+	switch len(accessRules) {
+	case 0:
 		log.With("sid", pctx.SID, "orgid", pctx.OrgID, "user-id", pctx.UserID, "connection-id", pctx.ConnectionID,
-			"access-type", accessType).Infof("no access rule found for this resource and access type")
+			"access-type", accessType).Infof("no access rules found for this resource")
 		return nil, nil
+	case 1:
+		accessRule = &accessRules[0]
+		if accessRule.AccessType != accessType {
+			return nil, plugintypes.InvalidArgument("request denied due to access request rules")
+		}
+	default:
+		for _, ar := range accessRules {
+			if ar.AccessType == accessType {
+				accessRule = &ar
+				break
+			}
+		}
+
+		if accessRule == nil {
+			return nil, plugintypes.InvalidArgument("request denied due to access request rules")
+		}
 	}
 
 	if len(accessRule.ApprovalRequiredGroups) > 0 {

--- a/gateway/transport/interceptors/accessrequest/accessrequest.go
+++ b/gateway/transport/interceptors/accessrequest/accessrequest.go
@@ -209,7 +209,7 @@ func OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plugintypes.ConnectRe
 	case 1:
 		accessRule = &accessRules[0]
 		if accessRule.AccessType != accessType {
-			return nil, plugintypes.InvalidArgument("request denied due to access request rules")
+			return nil, plugintypes.InvalidArgument("request denied due to access request rules, name=%v", accessRule.Name)
 		}
 	default:
 		for _, ar := range accessRules {
@@ -220,7 +220,7 @@ func OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plugintypes.ConnectRe
 		}
 
 		if accessRule == nil {
-			return nil, plugintypes.InvalidArgument("request denied due to access request rules")
+			return nil, plugintypes.InvalidArgument("request denied due to access request rules, rule with access type %v not found", accessType)
 		}
 	}
 


### PR DESCRIPTION
> [!WARNING]
> This is a break change, it changes the access request behavior.

## 📝 Description

Enhances the access request rule retrieval logic to support multiple rules per connection. Previously, only a single rule was fetched and matched against the requested access type. Now, all applicable rules (by connection name or by connection attributes) are retrieved and evaluated, allowing connections that have multiple rules defined to be handled correctly.

## 🔗 Related Issue

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `GetAccessRequestRuleByResourceName` model function to fetch all access request rules matching a connection name (regardless of access type)
- Added `GetRequestRulesByAttributes` model function to fetch all access request rules matching a set of connection attributes (regardless of access type)
- Added `GetRulesForConnection` service function that returns all applicable rules for a connection, checking attributes first and falling back to resource name lookup
- Renamed `GetRequestRulesByAttributes` → `GetRequestRuleByAttributesAndAccessType` for semantic clarity and updated all call sites
- Updated the `accessrequest` gRPC interceptor (`OnReceive`) to use `GetRulesForConnection` and handle the multi-rule result: deny if no rule matches the requested access type, proceed if exactly one matching rule is found

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

The interceptor now returns `InvalidArgument` (request denied) when rules exist for a connection but none match the requested access type, rather than silently passing through. This ensures that connections with rules configured are always evaluated strictly.