### PR TITLE
fix(httpproxy): chunk large responses to avoid gRPC ResourceExhausted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test-enterprise: libhoop-map generate-wasm
 test-integration: libhoop-map generate-wasm
 	env CGO_ENABLED=0 go test -tags integration -v -timeout 10m -count=1 ./agent/integration/...
 
-generate-openapi-docs:
+generate-openapi-docs: libhoop-map
 	cd ./gateway/ && go run github.com/swaggo/swag/cmd/swag@v1.16.3 init -g api/server.go -o api/openapi/autogen --outputTypes go --markdownFiles api/openapi/docs/ --parseDependency
 	go run gateway/cmd/openapi-gen/main.go
 

--- a/agent/controller/httpproxy.go
+++ b/agent/controller/httpproxy.go
@@ -14,6 +14,14 @@ import (
 	pbclient "github.com/hoophq/hoop/common/proto/client"
 )
 
+// httpProxyResponseChunkSize bounds the size of each gRPC packet emitted for an
+// HTTP proxy response. libhoop fully buffers a response and writes it to the
+// client stream in a single Write; without chunking, a large response (e.g. a
+// big ClickHouse result) becomes one oversized gRPC message and is rejected with
+// a ResourceExhausted error. The value must stay safely below
+// common/grpc.MaxRecvMsgSize.
+const httpProxyResponseChunkSize = 1024 * 1024 * 4 // 4 MiB
+
 func (a *Agent) processHttpProxyWriteServer(pkt *pb.Packet) {
 	sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
 	clientConnectionID := string(pkt.Spec[pb.SpecClientConnectionID])
@@ -95,7 +103,11 @@ func (a *Agent) processHttpProxyWriteServer(pkt *pb.Packet) {
 		connenv.httpProxyHeaders["insecure"] = fmt.Sprintf("%v", connenv.kubernetesInsecureSkipVerify)
 	}
 
-	httpProxy, err := libhoop.NewHttpProxy(context.Background(), httpStreamClient, connenv.httpProxyHeaders)
+	// Wrap the stream writer so an oversized buffered response is split into
+	// multiple sub-limit gRPC packets instead of a single message that exceeds
+	// MaxRecvMsgSize. The client reassembles the byte stream in order.
+	chunkedClient := pb.NewChunkedWriter(httpStreamClient, httpProxyResponseChunkSize)
+	httpProxy, err := libhoop.NewHttpProxy(context.Background(), chunkedClient, connenv.httpProxyHeaders)
 	if err != nil {
 		log.Infof("failed connecting to %v, err=%v", connenv.host, err)
 		a.sendClientSessionClose(sessionID, fmt.Sprintf("failed connecting to internal service, reason=%v", err))

--- a/common/proto/types.go
+++ b/common/proto/types.go
@@ -169,6 +169,72 @@ func (s *streamWriter) SendSessionClose(errMsg string) error {
 	})
 }
 
+// chunkedWriter wraps an io.Writer and splits each Write call into sub-writes no
+// larger than maxChunkSize. It lets byte-stream protocols (e.g. the HTTP proxy)
+// emit arbitrarily large payloads without producing a single gRPC message that
+// exceeds the transport receive limit (common/grpc.MaxRecvMsgSize), which would
+// otherwise be rejected with a ResourceExhausted error.
+//
+// It must NOT be used for message-framed protocols (Postgres, MySQL, MongoDB,
+// MSSQL): splitting one protocol message across packets would corrupt the
+// gateway's per-message audit recording, query parsing and DLP/guardrails, all
+// of which assume one packet equals one complete protocol message.
+//
+// The wrapper transparently forwards the underlying writer's Close and
+// SendSessionClose behaviors so wrapping a streamWriter does not disable the
+// session-close error reporting libhoop relies on for guardrail violations.
+type chunkedWriter struct {
+	w            io.Writer
+	maxChunkSize int
+}
+
+// NewChunkedWriter returns an io.WriteCloser that caps each underlying Write at
+// maxChunkSize bytes. A non-positive maxChunkSize disables chunking (writes pass
+// through unchanged).
+func NewChunkedWriter(w io.Writer, maxChunkSize int) io.WriteCloser {
+	return &chunkedWriter{w: w, maxChunkSize: maxChunkSize}
+}
+
+func (c *chunkedWriter) Write(p []byte) (int, error) {
+	if c.maxChunkSize <= 0 || len(p) <= c.maxChunkSize {
+		return c.w.Write(p)
+	}
+	written := 0
+	for len(p) > 0 {
+		n := len(p)
+		if n > c.maxChunkSize {
+			n = c.maxChunkSize
+		}
+		nw, err := c.w.Write(p[:n])
+		written += nw
+		if err != nil {
+			return written, err
+		}
+		if nw < n {
+			return written, io.ErrShortWrite
+		}
+		p = p[n:]
+	}
+	return written, nil
+}
+
+func (c *chunkedWriter) Close() error {
+	if wc, ok := c.w.(io.Closer); ok {
+		return wc.Close()
+	}
+	return nil
+}
+
+// SendSessionClose forwards to the underlying writer when it implements the
+// SessionCloser contract, preserving libhoop's ability to report guardrail
+// errors (e.g. on WebSocket streams) through the stream.
+func (c *chunkedWriter) SendSessionClose(errMsg string) error {
+	if sc, ok := c.w.(SessionCloser); ok {
+		return sc.SendSessionClose(errMsg)
+	}
+	return nil
+}
+
 func GobEncode(data any) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	err := gob.NewEncoder(buf).Encode(data)

--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -627,13 +627,102 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		for key, values := range resp.Header {
-			for _, value := range values {
-				w.Header().Add(key, value)
-			}
+		sess.writeBufferedResponse(w, resp, responseChan, connectionID)
+	}
+}
+
+// writeBufferedResponse forwards a regular (non-SSE, non-WebSocket) HTTP response
+// to the client.
+//
+// The agent may split a large response across multiple HttpProxyConnectionWrite
+// packets (each capped below the gRPC max message size), so the body is not
+// guaranteed to arrive whole in the first packet. The agent writes the response
+// as a single contiguous byte stream, so every packet after the first is raw
+// body continuation. libhoop always sets Content-Length to the exact body size
+// for buffered responses, so we use it to know when the body is complete.
+//
+// A response that fits in one packet completes immediately (the first packet
+// holds the whole body), preserving the previous single-packet behavior.
+func (sess *httpProxySession) writeBufferedResponse(
+	w http.ResponseWriter,
+	resp *http.Response,
+	responseChan chan []byte,
+	connectionID string,
+) {
+	log := log.With("sid", sess.sid, "conn", connectionID)
+
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
 		}
-		w.WriteHeader(resp.StatusCode)
-		_, _ = io.Copy(w, resp.Body)
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	flusher, _ := w.(http.Flusher)
+
+	// Body bytes carried by the first packet (resp.Body reads it after the
+	// headers). A premature EOF here is expected when Content-Length is larger
+	// than what arrived in the first packet, so the error is ignored and the
+	// remainder is reassembled from responseChan below.
+	firstBody, _ := io.ReadAll(resp.Body)
+	bodyWritten := int64(len(firstBody))
+	if len(firstBody) > 0 {
+		if _, err := w.Write(firstBody); err != nil {
+			log.Warnf("failed writing response body: %v", err)
+			return
+		}
+	}
+	if flusher != nil {
+		flusher.Flush()
+	}
+
+	// Unknown length (Content-Length absent) or body already complete: nothing
+	// more to reassemble. The unknown-length case mirrors the prior single-packet
+	// behavior and avoids blocking on a stream that has no completion signal.
+	if resp.ContentLength < 0 || bodyWritten >= resp.ContentLength {
+		return
+	}
+
+	// Reassemble the remaining body from subsequent packets until Content-Length
+	// is satisfied. The agent does not send a per-response close for keep-alive
+	// connections, so Content-Length (not channel closure) is the authoritative
+	// completion signal; channel closure and the idle timeout are safety nets.
+	const idleTimeout = 60 * time.Second
+	idleTimer := time.NewTimer(idleTimeout)
+	defer idleTimer.Stop()
+
+	for bodyWritten < resp.ContentLength {
+		select {
+		case <-sess.ctx.Done():
+			return
+		case <-idleTimer.C:
+			log.Warnf("response reassembly aborted: idle timeout (%v) exceeded, written=%d/%d",
+				idleTimeout, bodyWritten, resp.ContentLength)
+			return
+		case data, ok := <-responseChan:
+			if !ok {
+				log.Warnf("response reassembly ended early: channel closed, written=%d/%d",
+					bodyWritten, resp.ContentLength)
+				return
+			}
+			if len(data) > 0 {
+				if _, err := w.Write(data); err != nil {
+					log.Warnf("failed writing response body chunk: %v", err)
+					return
+				}
+				bodyWritten += int64(len(data))
+				if flusher != nil {
+					flusher.Flush()
+				}
+			}
+			if !idleTimer.Stop() {
+				select {
+				case <-idleTimer.C:
+				default:
+				}
+			}
+			idleTimer.Reset(idleTimeout)
+		}
 	}
 }
 


### PR DESCRIPTION
**Release label:** `patch`

## 📝 Description

HTTP Proxy connections fail whenever the upstream returns a response larger than the gRPC max receive size (~17 MiB), with:

`rpc error: code = ResourceExhausted desc = grpc: received message larger than max (… vs. 17825792)`

This reproduces with any service proxied via HTTP Proxy that returns large payloads (reported against ClickHouse accessed through the 0.6.3 JDBC driver in DataGrip/DBeaver, where analyst queries return large result sets).

**Root cause:** the agent's HTTP proxy (libhoop) fully buffers each response and writes it to the gRPC stream in a single `Write`, so a large response becomes one oversized gRPC message and is rejected before it ever reaches the client.

This PR makes the HTTP-proxy response path stream in bounded chunks instead of a single oversized message.

## 🔗 Related Issue

Fixes #1488 

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- **`common/proto/types.go`** — add `NewChunkedWriter`, an `io.WriteCloser` that caps each underlying write at `maxChunkSize` and transparently forwards `Close`/`SendSessionClose` to the wrapped writer.
- **`agent/controller/httpproxy.go`** — wrap the HTTP-proxy stream writer with `NewChunkedWriter` (4 MiB cap) before handing it to libhoop, so a large buffered response is split into multiple sub-limit gRPC packets instead of one message that exceeds `MaxRecvMsgSize`.
- **`gateway/proxyproto/httpproxy/httpproxy.go`** — the gateway-native HTTP proxy previously assumed a regular response arrives in exactly one packet, which chunking would have truncated. Add `writeBufferedResponse`, which reassembles the body across packets using the `Content-Length` libhoop sets for buffered responses. SSE and WebSocket handling are unchanged; single-packet responses keep their previous behavior.

## 🧪 Testing

Stand up a simple upstream that returns large bodies with `Content-Length` and route it through an HTTP Proxy connection, then verify byte-for-byte integrity (size + sha256) of the downloaded payloads.

- **`hoop connect <conn>`** (client-relay path) — exercises agent chunking + client byte-stream reassembly.
- **Gateway HTTP-proxy port + `Authorization: <proxy-token>`** — exercises agent chunking + the new `writeBufferedResponse` reassembly.

Sizes exercised: 1 MiB (single packet), 10 MiB (multi-packet, under the old limit), 50/100 MiB (previously `ResourceExhausted`). All should download intact.

### Test Configuration:
- **Browser(s)**: N/A (curl + JDBC driver)
- **OS**: macOS / Linux

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- This fixes the **transport limit**, not peak memory: the agent still buffers the full response in memory for guardrails/redaction (libhoop), so very large responses remain bounded by agent RAM. Chunking only governs gRPC message framing.
- The gateway reassembly relies on the `Content-Length` libhoop always sets for buffered (non-SSE/WebSocket) responses; if it is ever absent, the code falls back to the prior single-packet behavior rather than blocking.
- No change to `MaxRecvMsgSize` is needed — every HTTP-proxy gRPC message now stays ≤ 4 MiB, well under the existing 17 MiB ceiling.