### PR TITLE
fix: copying buffer max size, grpc pg connection

### DIFF
--- a/agent/controller/postgres.go
+++ b/agent/controller/postgres.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"io"
 	"libhoop"
+	"strconv"
 	"strings"
 
+	"github.com/hoophq/hoop/agent/controller/featureflagstate"
 	"github.com/hoophq/hoop/common/log"
+	pgtypes "github.com/hoophq/hoop/common/pgtypes"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
 )
@@ -80,6 +83,12 @@ func (a *Agent) processPGProtocol(pkt *pb.Packet) {
 		"dlp_experimental_redact_rows": connenv.experimentalRedactRows,
 		"guard_rail_rules":             guardRailRules,
 		"analyzer_metrics_rules":       analyzerMetricsRules,
+	}
+	// When the large-query flag is enabled, raise the Postgres packet cap so the
+	// libhoop proxy honors the same ceiling the client and gRPC transport use.
+	// libhoop falls back to its own default when this option is absent.
+	if featureflagstate.IsEnabled("experimental.pg_large_query") {
+		opts["max_packet_size"] = strconv.Itoa(pgtypes.LargeBufferSize)
 	}
 	serverWriter, err := libhoop.NewDBCore(context.Background(), streamClient, opts).Postgres()
 	if err != nil {

--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hoophq/hoop/common/grpc"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/common/memory"
+	pgtypes "github.com/hoophq/hoop/common/pgtypes"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbagent "github.com/hoophq/hoop/common/proto/agent"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
@@ -205,7 +206,11 @@ func runConnect(args []string, clientEnvVars map[string]string, durationFlagChan
 			}
 			switch connectionType {
 			case pb.ConnectionTypePostgres:
-				srv := proxy.NewPGServer(c.proxyPort, c.client)
+				pgMaxPacketSize := pgtypes.DefaultBufferSize
+				if clientconfig.IsFeatureEnabled(config, "experimental.pg_large_query") {
+					pgMaxPacketSize = pgtypes.LargeBufferSize
+				}
+				srv := proxy.NewPGServer(c.proxyPort, c.client, pgMaxPacketSize)
 				if err := srv.Serve(string(sessionID)); err != nil {
 					c.processGracefulExit(err)
 				}

--- a/client/cmd/proxymanager.go
+++ b/client/cmd/proxymanager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hoophq/hoop/common/grpc"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/common/memory"
+	pgtypes "github.com/hoophq/hoop/common/pgtypes"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbagent "github.com/hoophq/hoop/common/proto/agent"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
@@ -50,7 +51,7 @@ var (
 					return backoff.Error()
 				}
 				defer client.Close()
-				err = runAutoConnect(client)
+				err = runAutoConnect(client, config)
 				if status, ok := status.FromError(err); ok {
 					switch status.Code() {
 					case codes.Canceled:
@@ -79,7 +80,7 @@ var (
 
 func init() { rootCmd.AddCommand(proxyManagerCmd) }
 
-func runAutoConnect(client pb.ClientTransport) (err error) {
+func runAutoConnect(client pb.ClientTransport, config *clientconfig.Config) (err error) {
 	connStore := memory.New()
 	defer func() {
 		for _, obj := range connStore.List() {
@@ -122,7 +123,11 @@ func runAutoConnect(client pb.ClientTransport) (err error) {
 			client.StartKeepAlive()
 			switch connnectionType {
 			case pb.ConnectionTypePostgres:
-				srv := proxy.NewPGServer(proxyPort, client)
+				pgMaxPacketSize := pgtypes.DefaultBufferSize
+				if clientconfig.IsFeatureEnabled(config, "experimental.pg_large_query") {
+					pgMaxPacketSize = pgtypes.LargeBufferSize
+				}
+				srv := proxy.NewPGServer(proxyPort, client, pgMaxPacketSize)
 				if err := srv.Serve(sid); err != nil {
 					return err
 				}

--- a/client/proxy/pg.go
+++ b/client/proxy/pg.go
@@ -20,6 +20,7 @@ type PGServer struct {
 	client          pb.ClientTransport
 	connectionStore memory.Store
 	listener        net.Listener
+	maxPacketSize   int
 }
 
 type pgConnection struct {
@@ -28,15 +29,22 @@ type pgConnection struct {
 	backendKeyData *pgtypes.BackendKeyData
 }
 
-func NewPGServer(proxyPort string, client pb.ClientTransport) *PGServer {
+// NewPGServer creates a Postgres proxy server. maxPacketSize bounds the frame
+// size of a single decoded Postgres packet read from the local client; a
+// non-positive value falls back to pgtypes.DefaultBufferSize.
+func NewPGServer(proxyPort string, client pb.ClientTransport, maxPacketSize int) *PGServer {
 	listenAddr := defaultListenAddr(defaultPostgresPort)
 	if proxyPort != "" {
 		listenAddr = defaultListenAddr(proxyPort)
+	}
+	if maxPacketSize <= 0 {
+		maxPacketSize = pgtypes.DefaultBufferSize
 	}
 	return &PGServer{
 		listenAddr:      listenAddr,
 		client:          client,
 		connectionStore: memory.New(),
+		maxPacketSize:   maxPacketSize,
 	}
 }
 
@@ -155,7 +163,7 @@ func (p *PGServer) lookupConnectionByPid(pid uint32) *pgConnection {
 func (p *PGServer) copyPGBuffer(dst io.Writer, src *pgConnection) (written int64, err error) {
 	closedConn := false
 	for {
-		pkt, err := pgtypes.Decode(src.client)
+		pkt, err := pgtypes.DecodeWithMaxSize(src.client, p.maxPacketSize)
 		if err != nil {
 			if err == io.EOF || closedConn {
 				break

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -96,6 +96,13 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentAgent},
 	},
+	"experimental.pg_large_query": {
+		Name:        "experimental.pg_large_query",
+		Description: "Allow Postgres protocol messages larger than 16 MiB (up to 32 MiB) through hoop connect, e.g. a single very large SQL statement. Increases peak memory and session-recording size per large query across client, gateway and agent. All three components must run a build that registers this flag.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentClient, ComponentAgent},
+	},
 }
 
 // All returns every registered flag, sorted by name.

--- a/common/pgtypes/const.go
+++ b/common/pgtypes/const.go
@@ -1,6 +1,17 @@
 package pgtypes
 
-const DefaultBufferSize = 1 << 24
+const (
+	// DefaultBufferSize is the maximum frame size of a single decoded Postgres
+	// packet (16 MiB). This is the default cap applied when the
+	// experimental.pg_large_query feature flag is disabled.
+	DefaultBufferSize = 1 << 24
+	// LargeBufferSize is the maximum frame size of a single decoded Postgres
+	// packet (32 MiB) when the experimental.pg_large_query feature flag is
+	// enabled. It MUST stay below common/grpc.MaxRecvMsgSize so that an encoded
+	// packet still fits within a single gRPC message, leaving headroom for the
+	// packet envelope and spec metadata.
+	LargeBufferSize = 1 << 25
+)
 
 type PacketType byte
 

--- a/common/pgtypes/packet.go
+++ b/common/pgtypes/packet.go
@@ -67,7 +67,19 @@ func (p *Packet) IsFrontendSSLRequest() bool {
 	return false
 }
 
+// Decode reads a single typed Postgres packet using the default maximum frame
+// size (DefaultBufferSize).
 func Decode(data io.Reader) (*Packet, error) {
+	return DecodeWithMaxSize(data, DefaultBufferSize)
+}
+
+// DecodeWithMaxSize reads a single typed Postgres packet, rejecting any packet
+// whose frame length exceeds maxSize bytes. A non-positive maxSize falls back to
+// DefaultBufferSize so callers can never accidentally reject all packets.
+func DecodeWithMaxSize(data io.Reader, maxSize int) (*Packet, error) {
+	if maxSize <= 0 {
+		maxSize = DefaultBufferSize
+	}
 	typ := make([]byte, 1)
 	_, err := data.Read(typ)
 	if err != nil {
@@ -80,8 +92,8 @@ func Decode(data io.Reader) (*Packet, error) {
 			return nil, err
 		}
 		pktLen := pkt.HeaderLength() - 4 // length includes itself.
-		if pktLen > DefaultBufferSize || pktLen < 0 {
-			return nil, fmt.Errorf("max size (%v) reached", DefaultBufferSize)
+		if pktLen > maxSize || pktLen < 0 {
+			return nil, fmt.Errorf("max size (%v) reached", maxSize)
 		}
 		pkt.frame = make([]byte, pktLen)
 		_, err := io.ReadFull(data, pkt.frame)
@@ -95,8 +107,8 @@ func Decode(data io.Reader) (*Packet, error) {
 		return nil, err
 	}
 	pktLen := pkt.HeaderLength() - 4 // length includes itself.
-	if pktLen > DefaultBufferSize || pktLen < 0 {
-		return nil, fmt.Errorf("max size (%v) reached", DefaultBufferSize)
+	if pktLen > maxSize || pktLen < 0 {
+		return nil, fmt.Errorf("max size (%v) reached", maxSize)
 	}
 	pkt.frame = make([]byte, pktLen)
 	if _, err := io.ReadFull(data, pkt.frame); err != nil {


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

<!-- Suggested label: `minor` — adds a new opt-in capability (a feature flag); default behavior is unchanged. -->

## 📝 Description

`hoop connect` to a Postgres connection rejects any single wire message larger than 16 MiB with `fail to decode typed packet, err=max size (16777216) reached`. A large single statement (e.g. a generated `INSERT ... VALUES (...)`) is one Postgres message, so it never gets sent — while native `psql`/IDEs accept it.

This adds an opt-in feature flag, `experimental.pg_large_query`, that raises the Postgres packet cap from 16 MiB to 32 MiB across the client proxy and the agent. The flag is off by default, so existing behavior is unchanged unless an operator enables it.

## 🔗 Related Issue

Fixes #1496 

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Register `experimental.pg_large_query` feature flag (`common/featureflag/featureflag.go`), components Client + Agent, default `false`, experimental stability.
- `common/pgtypes`: add `LargeBufferSize` (32 MiB) alongside `DefaultBufferSize` (16 MiB); add `DecodeWithMaxSize(reader, maxSize)` and make `Decode` delegate to it with the default cap. A non-positive `maxSize` falls back to `DefaultBufferSize`.
- Client PG proxy (`client/proxy/pg.go`): `NewPGServer` now takes a `maxPacketSize`, stored on the server and applied via `DecodeWithMaxSize` in `copyPGBuffer`.
- Client wiring (`client/cmd/connect.go`, `client/cmd/proxymanager.go`): pass `LargeBufferSize` when `clientconfig.IsFeatureEnabled(config, "experimental.pg_large_query")` (flag is read from the gateway `/serverinfo` response), otherwise `DefaultBufferSize`. `runAutoConnect` now receives the client `config`.
- Agent (`agent/controller/postgres.go`): when `featureflagstate.IsEnabled("experimental.pg_large_query")`, pass `max_packet_size = LargeBufferSize` into the libhoop Postgres proxy opts so libhoop honors the same ceiling; libhoop uses its own default when the option is absent.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (CLI / agent path)
- **OS**:

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

Reproduction / manual verification:
1. Enable `experimental.pg_large_query` (client, gateway, and agent must all run a build that registers the flag).
2. `hoop connect <postgres-connection>`.
3. Execute a single statement between 16 MiB and the new cap (e.g. a generated multi-row `INSERT`).
4. With the flag off → request fails with `max size (16777216) reached`. With the flag on → packet is accepted by the client decoder.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- All three components (client, gateway, agent) must run a build that registers the flag and have it enabled; a mixed fleet leaves the lower cap in effect on whichever side is older.
- Trade-off: larger packets increase peak memory and session-recording size per large query on every hop.
- The end-to-end ceiling also depends on the proprietary `libhoop` Postgres proxy accepting `max_packet_size`; the OSS tree only carries a no-op stub, so this needs verifying against a real `libhoop` build.