### PR TITLE
test(agent): MySQL integration suite [ENG-387, ENG-388]

### DIFF
--- a/agent/integration/mysql_concurrency_test.go
+++ b/agent/integration/mysql_concurrency_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/agent/integration/testutil"
+)
+
+// TestMySQL_ParallelSessions runs two independent MySQL sessions on the
+// same agent concurrently and asserts both complete their work. Each
+// session has its own bridged connection, its own (sid, connID), and its
+// own upstream MariaDB backend.
+//
+// The invariant: independent sessions on the same agent must not corrupt
+// each other's state. With the blockingReader race fixed (ENG-396) this
+// runs clean under -race; before the fix, concurrent Read/Write on each
+// proxy's bytes.Buffer would trip the detector.
+func TestMySQL_ParallelSessions(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	const numSessions = 4
+
+	// Open all sessions *before* starting the demux. OpenMySQLSession
+	// reads SessionOpenOK directly off MockTransport.RecvCh(); once the
+	// demux is draining that same channel it would steal the replies, and
+	// two direct readers would steal from each other. So we serialize the
+	// opens up front, then start the demux, then dial the bridges (which
+	// need the demux running for their inbound pumps).
+	sessionIDs := make([]string, numSessions)
+	for i := 0; i < numSessions; i++ {
+		sessionIDs[i] = testutil.OpenMySQLSession(t, tr, mc)
+	}
+
+	demux := testutil.StartRecvDemux(t, tr)
+
+	clients := make([]*testutil.PipedMySQLClient, numSessions)
+	for i := 0; i < numSessions; i++ {
+		clients[i] = testutil.DialPipedMySQL(t, tr, demux, mc, sessionIDs[i], fmt.Sprintf("conn-parallel-%d", i))
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, numSessions)
+	for i := 0; i < numSessions; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			client := clients[i]
+			if err := client.PingWithTimeout(mysqlTestTimeout); err != nil {
+				errCh <- fmt.Errorf("session %d ping: %w", i, err)
+				return
+			}
+			var n int
+			if err := client.DB.QueryRow("SELECT ? + ?", i, 100).Scan(&n); err != nil {
+				errCh <- fmt.Errorf("session %d query: %w", i, err)
+				return
+			}
+			if n != i+100 {
+				errCh <- fmt.Errorf("session %d: expected %d, got %d", i, i+100, n)
+				return
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+// TestMySQL_SessionCloseRace opens a connection, fires a slow query, then
+// sends SessionClose while the query is in flight. Asserts teardown is
+// clean: the upstream backend exits and no goroutines leak.
+//
+// The invariant: a SessionClose arriving while a packet handler is still
+// running for that session must not leave the system with orphaned
+// upstream connections or leaked goroutines.
+func TestMySQL_SessionCloseRace(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	leak := testutil.SnapshotGoroutines(t, 25)
+
+	sessionID := testutil.OpenMySQLSession(t, tr, mc)
+	demux := testutil.StartRecvDemux(t, tr)
+	connID := "conn-close-race"
+	client := testutil.DialPipedMySQL(t, tr, demux, mc, sessionID, connID)
+
+	// Establish the connection up front so the SessionClose races a
+	// cached-proxy query path, not the initial handshake.
+	if err := client.PingWithTimeout(mysqlTestTimeout); err != nil {
+		t.Fatalf("initial ping: %v", err)
+	}
+
+	// Fire a ~2s query in the background. SLEEP runs on the upstream;
+	// the agent's recv loop returns after queuing the query bytes into
+	// libhoop's blockingReader, so SessionClose can land while the
+	// query is still executing server-side.
+	queryDone := make(chan struct{})
+	go func() {
+		defer close(queryDone)
+		var slept int
+		_ = client.DB.QueryRow("SELECT SLEEP(2)").Scan(&slept)
+	}()
+
+	// Let the query reach the server, then close the session underneath it.
+	time.Sleep(200 * time.Millisecond)
+	tr.Inject(testutil.BuildSessionClosePacket(sessionID, "0"))
+
+	// The query goroutine should unblock (with or without error) rather
+	// than hang forever.
+	select {
+	case <-queryDone:
+	case <-time.After(mysqlTestTimeout):
+		t.Fatal("query did not return after SessionClose — possible wedge")
+	}
+
+	// Upstream backend should fully disconnect within a few seconds.
+	mc.WaitForProcessCount(t, 0, 10*time.Second)
+
+	shutdownAgent(t, agent, tr)
+
+	// No significant goroutine leak after teardown. Tolerance absorbs
+	// docker-client / testcontainer background noise.
+	leak.Assert(t)
+}
+
+// TestMySQL_ParallelSessions_OneHangs is the MySQL analogue of the SSH
+// customer-symptom test: two sessions, one pointed at a non-routable
+// address so its first upstream dial blocks, the other at a real MariaDB.
+// It asserts the fast session is unaffected by the slow one.
+//
+// Skipped: the agent's async-dispatch flag (experimental.agent_async_ssh)
+// only covers SSH packets — MySQL packets are still processed
+// synchronously, so the slow session's blocking dial holds up the recv
+// loop and the fast session queues behind it. Unskip when async dispatch
+// is extended to MySQL.
+func TestMySQL_ParallelSessions_OneHangs(t *testing.T) {
+	t.Skip("MySQL packets are dispatched synchronously (async flag is SSH-only); " +
+		"a slow upstream dial blocks the recv loop. Unskip when async dispatch covers MySQL.")
+}

--- a/agent/integration/mysql_test.go
+++ b/agent/integration/mysql_test.go
@@ -1,0 +1,333 @@
+//go:build integration
+
+package integration
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/hoophq/hoop/agent/integration/testutil"
+)
+
+const mysqlTestTimeout = 30 * time.Second
+
+// dialMySQL wires up the common per-test scaffolding: start the agent,
+// open a MySQL session, start the demux, and build the bridged client.
+// Returns the client plus a teardown that shuts the agent down. The
+// ordering (OpenMySQLSession before StartRecvDemux before DialPipedMySQL)
+// matters — see the helper docs.
+func dialMySQL(t *testing.T, mc *testutil.MySQLContainer) (*testutil.PipedMySQLClient, func()) {
+	t.Helper()
+	agent, tr := startAgent(t)
+	sessionID := testutil.OpenMySQLSession(t, tr, mc)
+	demux := testutil.StartRecvDemux(t, tr)
+	connID := "conn-1"
+	client := testutil.DialPipedMySQL(t, tr, demux, mc, sessionID, connID)
+	return client, func() { shutdownAgent(t, agent, tr) }
+}
+
+// TestMySQL_Ping is the end-to-end smoke test: a successful ping forces
+// the full bridged handshake (server greeting → client handshake response
+// → libhoop-driven upstream auth → OK) through processMySQLProtocol and
+// libhoop's MySQL proxy.
+func TestMySQL_Ping(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	client, teardown := dialMySQL(t, mc)
+	defer teardown()
+
+	if err := client.PingWithTimeout(mysqlTestTimeout); err != nil {
+		t.Fatalf("mysql ping through agent failed: %v", err)
+	}
+}
+
+// TestMySQL_SimpleQuery runs a trivial SELECT and verifies the scalar
+// result round-trips through the proxy.
+func TestMySQL_SimpleQuery(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	client, teardown := dialMySQL(t, mc)
+	defer teardown()
+
+	var n int
+	if err := client.DB.QueryRow("SELECT 1 AS num").Scan(&n); err != nil {
+		t.Fatalf("SELECT 1 failed: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1, got %d", n)
+	}
+}
+
+// TestMySQL_CreateInsertSelectUpdateDelete exercises the full DML/DDL
+// lifecycle over a single bridged connection.
+func TestMySQL_CreateInsertSelectUpdateDelete(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	client, teardown := dialMySQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	table := fmt.Sprintf("test_crud_%d", time.Now().UnixNano())
+
+	exec := func(t *testing.T, query string, args ...any) sql.Result {
+		t.Helper()
+		res, err := db.Exec(query, args...)
+		if err != nil {
+			t.Fatalf("exec %q failed: %v", query, err)
+		}
+		return res
+	}
+
+	t.Run("CreateTable", func(t *testing.T) {
+		exec(t, fmt.Sprintf("CREATE TABLE %s (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL)", table))
+	})
+
+	t.Run("Insert", func(t *testing.T) {
+		res := exec(t, fmt.Sprintf("INSERT INTO %s (name) VALUES (?)", table), "alice")
+		affected, err := res.RowsAffected()
+		if err != nil {
+			t.Fatalf("RowsAffected: %v", err)
+		}
+		if affected != 1 {
+			t.Errorf("expected 1 row affected, got %d", affected)
+		}
+	})
+
+	t.Run("Select", func(t *testing.T) {
+		var name string
+		if err := db.QueryRow(fmt.Sprintf("SELECT name FROM %s WHERE name = ?", table), "alice").Scan(&name); err != nil {
+			t.Fatalf("select failed: %v", err)
+		}
+		if name != "alice" {
+			t.Errorf("expected 'alice', got %q", name)
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		res := exec(t, fmt.Sprintf("UPDATE %s SET name = ? WHERE name = ?", table), "bob", "alice")
+		affected, _ := res.RowsAffected()
+		if affected != 1 {
+			t.Errorf("expected 1 row updated, got %d", affected)
+		}
+	})
+
+	t.Run("SelectAfterUpdate", func(t *testing.T) {
+		var name string
+		if err := db.QueryRow(fmt.Sprintf("SELECT name FROM %s", table)).Scan(&name); err != nil {
+			t.Fatalf("select failed: %v", err)
+		}
+		if name != "bob" {
+			t.Errorf("expected 'bob', got %q", name)
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		res := exec(t, fmt.Sprintf("DELETE FROM %s", table))
+		affected, _ := res.RowsAffected()
+		if affected != 1 {
+			t.Errorf("expected 1 row deleted, got %d", affected)
+		}
+	})
+
+	t.Run("SelectAfterDelete", func(t *testing.T) {
+		var count int
+		if err := db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s", table)).Scan(&count); err != nil {
+			t.Fatalf("count failed: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected count 0, got %d", count)
+		}
+	})
+
+	t.Run("DropTable", func(t *testing.T) {
+		exec(t, fmt.Sprintf("DROP TABLE %s", table))
+	})
+}
+
+// TestMySQL_MultiRowResultSet verifies a result set spanning multiple
+// rows decodes correctly end-to-end (column metadata + row packets +
+// EOF/OK terminator all flow through the proxy).
+func TestMySQL_MultiRowResultSet(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	client, teardown := dialMySQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	table := fmt.Sprintf("test_multirow_%d", time.Now().UnixNano())
+	if _, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, val VARCHAR(32))", table)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer db.Exec(fmt.Sprintf("DROP TABLE %s", table))
+
+	for i := 1; i <= 5; i++ {
+		if _, err := db.Exec(fmt.Sprintf("INSERT INTO %s (id, val) VALUES (?, ?)", table), i, fmt.Sprintf("v%d", i)); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	rows, err := db.Query(fmt.Sprintf("SELECT id, val FROM %s ORDER BY id", table))
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	got := 0
+	for rows.Next() {
+		var id int
+		var val string
+		if err := rows.Scan(&id, &val); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got++
+		if id != got || val != fmt.Sprintf("v%d", got) {
+			t.Errorf("row %d: got (id=%d, val=%q)", got, id, val)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("expected 5 rows, got %d", got)
+	}
+}
+
+// TestMySQL_TransactionCommit verifies a committed transaction persists
+// across the proxy.
+func TestMySQL_TransactionCommit(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	client, teardown := dialMySQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	table := fmt.Sprintf("test_tx_commit_%d", time.Now().UnixNano())
+	if _, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (id INT AUTO_INCREMENT PRIMARY KEY, val VARCHAR(32)) ENGINE=InnoDB", table)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer db.Exec(fmt.Sprintf("DROP TABLE %s", table))
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf("INSERT INTO %s (val) VALUES (?)", table), "committed"); err != nil {
+		t.Fatalf("tx insert: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s WHERE val = ?", table), "committed").Scan(&count); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected committed row to persist, count=%d", count)
+	}
+}
+
+// TestMySQL_TransactionRollback verifies a rolled-back transaction leaves
+// no trace.
+func TestMySQL_TransactionRollback(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	client, teardown := dialMySQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	table := fmt.Sprintf("test_tx_rollback_%d", time.Now().UnixNano())
+	if _, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (id INT AUTO_INCREMENT PRIMARY KEY, val VARCHAR(32)) ENGINE=InnoDB", table)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer db.Exec(fmt.Sprintf("DROP TABLE %s", table))
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf("INSERT INTO %s (val) VALUES (?)", table), "rolled_back"); err != nil {
+		t.Fatalf("tx insert: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s WHERE val = ?", table), "rolled_back").Scan(&count); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 rows after rollback, got %d", count)
+	}
+}
+
+// TestMySQL_ErrorBadQuery verifies a server-side SQL error surfaces to the
+// client as a *mysql.MySQLError (proving the error packet round-trips) and
+// that the connection survives for a follow-up query.
+func TestMySQL_ErrorBadQuery(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	client, teardown := dialMySQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	_, err := db.Exec("SELECT * FROM nonexistent_table_xyz")
+	if err == nil {
+		t.Fatal("expected error for nonexistent table, got nil")
+	}
+	var myErr *mysql.MySQLError
+	if !asMySQLError(err, &myErr) {
+		t.Fatalf("expected *mysql.MySQLError, got %T: %v", err, err)
+	}
+	// 1146 = ER_NO_SUCH_TABLE
+	if myErr.Number != 1146 {
+		t.Errorf("expected error 1146 (no such table), got %d (%s)", myErr.Number, myErr.Message)
+	}
+	if !strings.Contains(strings.ToLower(myErr.Message), "nonexistent_table_xyz") {
+		t.Errorf("error message should reference the table, got: %s", myErr.Message)
+	}
+
+	// Connection must survive the error.
+	var n int
+	if err := db.QueryRow("SELECT 1").Scan(&n); err != nil {
+		t.Fatalf("connection did not survive query error: %v", err)
+	}
+}
+
+// TestMySQL_BadCredentials verifies that a session whose upstream password
+// is wrong fails to establish — libhoop authenticates against the upstream
+// itself, so the bad password manifests as a failed ping/connection.
+func TestMySQL_BadCredentials(t *testing.T) {
+	mc := testutil.StartMySQL(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	// Open a session whose env vars carry the wrong password. libhoop
+	// will fail the upstream handshake; the client never reaches a
+	// usable state.
+	badMC := *mc
+	badMC.Password = "wrongpassword"
+	sessionID := testutil.OpenMySQLSession(t, tr, &badMC)
+	demux := testutil.StartRecvDemux(t, tr)
+	client := testutil.DialPipedMySQL(t, tr, demux, &badMC, sessionID, "conn-bad")
+
+	if err := client.PingWithTimeout(15 * time.Second); err == nil {
+		t.Fatal("expected ping to fail with bad upstream credentials, got nil")
+	}
+}
+
+// asMySQLError is errors.As specialized for *mysql.MySQLError, kept local
+// to avoid an extra import in the test body.
+func asMySQLError(err error, target **mysql.MySQLError) bool {
+	for err != nil {
+		if me, ok := err.(*mysql.MySQLError); ok {
+			*target = me
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/agent/integration/testutil/mysql_client.go
+++ b/agent/integration/testutil/mysql_client.go
@@ -1,0 +1,272 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+)
+
+// PipedMySQLClient drives a real go-sql-driver/mysql connection whose
+// underlying transport is bridged to a MockTransport. From the test's
+// perspective it's a regular *sql.DB: call Exec/Query and get results.
+//
+// Why a real driver instead of hand-rolled wire bytes
+//
+// Unlike libhoop's Postgres proxy (a transparent byte pump), libhoop's
+// MySQL proxy is a man-in-the-middle that speaks the full handshake with
+// the client: it forwards the upstream server greeting to the client,
+// reads the client's handshake response (auth plugin negotiation,
+// scramble, capability flags), then completes auth with the upstream
+// itself. Reproducing that handshake by hand — caching_sha2_password /
+// mysql_native_password scramble, capability flag math, packet
+// sequencing — would be hundreds of lines of fragile protocol code.
+// Driving the actual go-sql-driver client gives us a correct client for
+// free; the bridge only shuttles raw bytes.
+//
+// Wire flow
+//
+//	test            PipedMySQLClient            MockTransport / Agent
+//	────            ────────────────            ─────────────────────
+//	db.Query()      go-sql-driver               MySQLConnectionWrite
+//	  → bytes  ───► net.Pipe ───► outbound pump ───► Inject()
+//	                                              │
+//	  ← bytes  ◄─── net.Pipe ◄─── inbound pump ◄── RecvCh (demux)
+//
+// The bridge is purely byte-oriented: MySQL is a single full-duplex
+// stream per connection (no channel multiplexing like SSH), so each
+// direction is a straight copy between the driver's net.Conn and a
+// MySQLConnectionWrite packet.
+type PipedMySQLClient struct {
+	// DB is the configured *sql.DB backed by the bridged connection.
+	// Tests call DB.Exec, DB.Query, DB.Ping directly.
+	DB *sql.DB
+
+	sessionID string
+	connID    string
+	tr        *MockTransport
+	demux     *RecvDemux
+
+	driverConn net.Conn // the go-sql-driver side of the pipe
+	bridgeConn net.Conn // the bridge side of the pipe
+
+	cancel    context.CancelFunc
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+// registry tracks live bridges by a unique DSN host token so the
+// registered dial func can hand the driver the right pipe. go-sql-driver
+// dials lazily (on first use of the *sql.DB), and RegisterDialContext is
+// process-global, so we route by an opaque per-client key embedded in the
+// DSN rather than by address.
+var (
+	mysqlBridgeRegistry   sync.Map // map[string]net.Conn
+	mysqlDialerRegistered atomic.Bool
+)
+
+func registerMySQLDialer() {
+	if mysqlDialerRegistered.CompareAndSwap(false, true) {
+		mysql.RegisterDialContext("hoopbridge", func(ctx context.Context, addr string) (net.Conn, error) {
+			v, ok := mysqlBridgeRegistry.LoadAndDelete(addr)
+			if !ok {
+				return nil, fmt.Errorf("hoopbridge: no bridge registered for %q", addr)
+			}
+			return v.(net.Conn), nil
+		})
+	}
+}
+
+// DialPipedMySQL builds the net.Pipe bridge for an already-open MySQL
+// session and returns a PipedMySQLClient with a ready *sql.DB. The DB is
+// configured to a single connection so test assertions about upstream
+// connection counts are deterministic.
+//
+// The session must already be open at the agent (call OpenMySQLSession)
+// and the demux must already be running (call StartRecvDemux) before
+// dialing — the inbound pump reads the server greeting off the demux as
+// soon as the driver's first write triggers libhoop's upstream dial.
+//
+// Cleanup is automatic via t.Cleanup; tests don't need to defer Close.
+func DialPipedMySQL(t *testing.T, tr *MockTransport, demux *RecvDemux, mc *MySQLContainer, sessionID, connID string) *PipedMySQLClient {
+	t.Helper()
+	registerMySQLDialer()
+
+	driverConn, bridgeConn := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &PipedMySQLClient{
+		sessionID:  sessionID,
+		connID:     connID,
+		tr:         tr,
+		demux:      demux,
+		driverConn: driverConn,
+		bridgeConn: bridgeConn,
+		cancel:     cancel,
+		done:       make(chan struct{}),
+	}
+
+	// Register the driver side of the pipe under a unique token, then
+	// point the DSN at it. go-sql-driver calls our dial func with this
+	// token as the address.
+	bridgeAddr := uuid.New().String()
+	mysqlBridgeRegistry.Store(bridgeAddr, driverConn)
+
+	// parseTime=false keeps results as raw bytes/strings which is all the
+	// tests need. The user/password here must match what libhoop uses to
+	// auth upstream (it reads them from connection env vars, not the
+	// DSN), but the driver still needs *a* user in its handshake response
+	// for libhoop to parse; use the real one.
+	dsn := fmt.Sprintf("%s:%s@hoopbridge(%s)/%s?timeout=30s&readTimeout=30s&writeTimeout=30s",
+		mc.User, mc.Password, bridgeAddr, mc.Database)
+
+	connector, err := mysql.NewConnector(mustParseDSN(t, dsn))
+	if err != nil {
+		cancel()
+		t.Fatalf("mysql bridge: failed to build connector: %v", err)
+	}
+	db := sql.OpenDB(connector)
+	// One connection: the bridge backs exactly one net.Pipe. A pool >1
+	// would have the driver try to dial a second bridge conn that doesn't
+	// exist.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
+	p.DB = db
+
+	// Start the byte pumps before the driver dials so the handshake
+	// (server greeting → client response → auth result) can flow.
+	go p.outboundPump(ctx)
+	go p.inboundPump(ctx)
+
+	// Bootstrap the upstream connection. In MySQL the *server* speaks
+	// first (sends the greeting), but libhoop only dials the upstream —
+	// and thus only produces the greeting — once it receives the first
+	// MySQLConnectionWrite for this (sid, connID). The go-sql-driver
+	// client, conversely, blocks reading the greeting before it writes
+	// anything. That's a bootstrap deadlock: neither side moves first.
+	//
+	// Break it with a zero-length trigger packet. processMySQLProtocol
+	// treats the first packet as the proxy-creation signal and does not
+	// forward its payload upstream (the client handshake response is read
+	// from libhoop's clientInitBuffer on a *later* write), so an empty
+	// payload is safe — it only kicks off MySQL()/Run(), which emits the
+	// greeting the driver is waiting for.
+	p.sendWrite(nil)
+
+	t.Cleanup(func() { p.Close() })
+	return p
+}
+
+// outboundPump copies bytes the driver writes (handshake response,
+// COM_QUERY, COM_QUIT, ...) into MySQLConnectionWrite packets bound for
+// the agent.
+func (p *PipedMySQLClient) outboundPump(ctx context.Context) {
+	buf := make([]byte, 32*1024)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		n, err := p.bridgeConn.Read(buf)
+		if n > 0 {
+			p.sendWrite(append([]byte(nil), buf[:n]...))
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// inboundPump copies the payloads of MySQLConnectionWrite packets the
+// agent emits for this connection (server greeting, auth result, result
+// sets) back into the driver's net.Conn.
+func (p *PipedMySQLClient) inboundPump(ctx context.Context) {
+	if p.demux == nil {
+		return
+	}
+	ch := p.demux.Channel(p.connID)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case pkt, ok := <-ch:
+			if !ok {
+				return
+			}
+			if len(pkt.Payload) == 0 {
+				continue
+			}
+			if _, err := p.bridgeConn.Write(pkt.Payload); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (p *PipedMySQLClient) sendWrite(payload []byte) {
+	select {
+	case <-p.done:
+		return
+	default:
+	}
+	defer func() { _ = recover() }() // tolerate inject racing a transport close
+	pkt := &pb.Packet{
+		Type: pbagent.MySQLConnectionWrite,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(p.sessionID),
+			pb.SpecClientConnectionID: []byte(p.connID),
+		},
+		Payload: payload,
+	}
+	p.tr.Inject(pkt)
+}
+
+// SessionID returns the agent-side session ID.
+func (p *PipedMySQLClient) SessionID() string { return p.sessionID }
+
+// ConnID returns the gateway-side connection ID this client occupies.
+func (p *PipedMySQLClient) ConnID() string { return p.connID }
+
+// Close tears down the *sql.DB, both pipe ends, and the pumps. Safe to
+// call multiple times.
+func (p *PipedMySQLClient) Close() {
+	p.closeOnce.Do(func() {
+		close(p.done)
+		p.cancel()
+		if p.DB != nil {
+			_ = p.DB.Close()
+		}
+		_ = p.driverConn.Close()
+		_ = p.bridgeConn.Close()
+	})
+}
+
+func mustParseDSN(t *testing.T, dsn string) *mysql.Config {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("mysql bridge: failed to parse DSN: %v", err)
+	}
+	return cfg
+}
+
+// PingWithTimeout runs DB.PingContext bounded by timeout. Establishing the
+// first connection forces the full bridged handshake through libhoop, so a
+// successful ping is the integration smoke test for MySQL auth.
+func (p *PipedMySQLClient) PingWithTimeout(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return p.DB.PingContext(ctx)
+}

--- a/agent/integration/testutil/mysql_container.go
+++ b/agent/integration/testutil/mysql_container.go
@@ -1,0 +1,186 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// MySQLContainer wraps a MariaDB container for integration tests.
+// MariaDB is used instead of Oracle MySQL because it boots faster, ships
+// a smaller image, and speaks the same wire protocol libhoop's MySQL
+// proxy targets. Credentials are fixed so test code can reference them
+// directly.
+type MySQLContainer struct {
+	Host      string
+	Port      string
+	User      string
+	Password  string
+	Database  string
+	Container testcontainers.Container
+}
+
+// StartMySQL boots a MariaDB container with a fixed root password and a
+// pre-created test database. The wait strategy blocks until MariaDB logs
+// that it is ready for connections *and* the port is accepting them —
+// MariaDB's entrypoint starts a throwaway server for initialization
+// before the real one, so matching the second "ready" log line plus the
+// listening port avoids connecting to the init server.
+func StartMySQL(t T) *MySQLContainer {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	const user = "root"
+	const password = "testpass"
+	const database = "testdb"
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mariadb:11",
+			ExposedPorts: []string{"3306/tcp"},
+			Env: map[string]string{
+				"MARIADB_ROOT_PASSWORD": password,
+				"MARIADB_DATABASE":      database,
+			},
+			WaitingFor: wait.ForAll(
+				// The init phase logs this line once for the temporary
+				// server and once for the real one; the "port: 3306"
+				// qualifier only appears for the real server.
+				wait.ForLog("mariadbd: ready for connections").
+					WithOccurrence(1),
+				wait.ForListeningPort("3306/tcp"),
+			).WithDeadline(90 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to start mariadb container: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = container.Terminate(context.Background())
+	})
+
+	mappedPort, err := container.MappedPort(ctx, "3306/tcp")
+	if err != nil {
+		t.Fatalf("failed to get mapped mysql port: %v", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("failed to get mysql container host: %v", err)
+	}
+
+	c := &MySQLContainer{
+		Host:      host,
+		Port:      mappedPort.Port(),
+		User:      user,
+		Password:  password,
+		Database:  database,
+		Container: container,
+	}
+
+	// MariaDB accepts TCP a moment before it can actually authenticate;
+	// poll a real handshake to be sure before returning.
+	c.waitForReady(t)
+
+	return c
+}
+
+func (c *MySQLContainer) waitForReady(t T) {
+	deadline := time.Now().Add(60 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if lastErr = c.ping(); lastErr == nil {
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	t.Fatalf("mariadb container never became ready within 60s: %v", lastErr)
+}
+
+// ConnString returns a go-sql-driver/mysql DSN that connects directly to
+// the container (bypassing the agent). Used by the sidecar admin
+// connection in concurrency tests to count active backends.
+func (c *MySQLContainer) ConnString() string {
+	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s",
+		c.User, c.Password, c.Host, c.Port, c.Database)
+}
+
+// ping opens a short-lived direct connection to the container and runs a
+// trivial query, returning any error. Used by waitForReady to confirm
+// the real (non-init) MariaDB server is accepting authenticated
+// connections.
+func (c *MySQLContainer) ping() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("mysql", c.ConnString())
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	return db.PingContext(ctx)
+}
+
+// ProcessCount opens a sidecar admin connection and returns the number of
+// connections to the test database currently visible in
+// information_schema.PROCESSLIST, excluding the sidecar's own
+// connection. Used by concurrency tests to assert how many upstream
+// connections the agent established.
+func (c *MySQLContainer) ProcessCount(t T) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("mysql", c.ConnString())
+	if err != nil {
+		t.Fatalf("mysqlstat: failed to open admin connection: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatalf("mysqlstat: admin ping failed: %v", err)
+	}
+
+	// CONNECTION_ID() is this admin session's own id; exclude it so the
+	// count reflects only agent-driven connections. Filtering on DB
+	// keeps the MariaDB system/event-scheduler threads out of the count.
+	var adminConnID int64
+	if err := db.QueryRowContext(ctx, "SELECT CONNECTION_ID()").Scan(&adminConnID); err != nil {
+		t.Fatalf("mysqlstat: failed to read CONNECTION_ID: %v", err)
+	}
+
+	var count int
+	row := db.QueryRowContext(ctx, `
+		SELECT count(*) FROM information_schema.PROCESSLIST
+		WHERE DB = ? AND ID <> ?`, c.Database, adminConnID)
+	if err := row.Scan(&count); err != nil {
+		t.Fatalf("mysqlstat: failed to count processes: %v", err)
+	}
+	return count
+}
+
+// WaitForProcessCount polls ProcessCount until it equals want or the
+// timeout elapses. MariaDB reaps connections on close but not instantly,
+// so teardown assertions need a poll rather than a single snapshot.
+func (c *MySQLContainer) WaitForProcessCount(t T, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last int
+	for time.Now().Before(deadline) {
+		last = c.ProcessCount(t)
+		if last == want {
+			return
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	t.Fatalf("mysqlstat: expected %d processes after %v, last observed=%d", want, timeout, last)
+}

--- a/agent/integration/testutil/mysql_session.go
+++ b/agent/integration/testutil/mysql_session.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+)
+
+// BuildMySQLEnvVars constructs the AgentConnectionParams env vars map for
+// a MySQL connection. The keys must match what parseConnectionEnvVars
+// looks up for ConnectionTypeMySQL (HOST, USER, PASS, PORT, DB). libhoop's
+// MySQL proxy uses USER/PASS to authenticate against the upstream itself.
+func BuildMySQLEnvVars(host, port, user, pass, dbname string) map[string]any {
+	return map[string]any{
+		"envvar:HOST": b64(host),
+		"envvar:USER": b64(user),
+		"envvar:PASS": b64(pass),
+		"envvar:PORT": b64(port),
+		"envvar:DB":   b64(dbname),
+	}
+}
+
+// SendMySQLTrigger injects a zero-payload MySQLConnectionWrite to bootstrap
+// the upstream connection. Exposed for diagnostics; normal tests get this
+// for free via DialPipedMySQL.
+func SendMySQLTrigger(tr *MockTransport, sessionID, connID string) {
+	tr.Inject(&pb.Packet{
+		Type: pbagent.MySQLConnectionWrite,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(sessionID),
+			pb.SpecClientConnectionID: []byte(connID),
+		},
+	})
+}
+
+// OpenMySQLSession opens a MySQL session on the agent and blocks until
+// SessionOpenOK is observed, returning the generated session ID. It reads
+// directly from the transport, so it must be called before StartRecvDemux
+// to avoid the demux swallowing the open reply.
+func OpenMySQLSession(t *testing.T, tr *MockTransport, mc *MySQLContainer) string {
+	t.Helper()
+	sessionID := uuid.New().String()
+	envVars := BuildMySQLEnvVars(mc.Host, mc.Port, mc.User, mc.Password, mc.Database)
+	pkt := BuildSessionOpenPacket(sessionID, string(pb.ConnectionTypeMySQL), envVars)
+	tr.Inject(pkt)
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case resp := <-tr.RecvCh():
+			switch resp.Type {
+			case pbclient.SessionOpenOK:
+				return sessionID
+			case pbclient.SessionClose:
+				t.Fatalf("mysql session open failed: %s", string(resp.Payload))
+			default:
+				continue
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for mysql SessionOpenOK")
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds an end-to-end MySQL integration test suite, mirroring the existing Postgres and SSH suites. Drives the real `controller.Agent` against a MariaDB testcontainer through libhoop's MySQL proxy.

## Approach: bridged real driver

libhoop's MySQL proxy is **not** a transparent byte pump like the Postgres one — it's a man-in-the-middle that speaks the full handshake with the client (forwards the upstream greeting, reads the client handshake response, then auths upstream itself). Hand-rolling that handshake would be hundreds of lines of fragile protocol code.

So the tests drive a **real `go-sql-driver/mysql` connection over a `net.Pipe` bridge** (`PipedMySQLClient`) whose bytes are shuttled to/from the agent as `MySQLConnectionWrite` packets. The driver handles greeting parsing, auth scramble, and result-set decoding; the bridge only moves bytes. This is the same real-client-over-a-bridge pattern as the SSH suite's `PipedSSHClient`.

A zero-length trigger packet bootstraps the upstream dial (MySQL servers speak first, but libhoop only dials on the first client packet).

## Coverage

**Base (`mysql_test.go`):** ping, simple query, full CRUD, multi-row result set, tx commit/rollback, bad-query error survival, bad-credentials rejection.

**Concurrency (`mysql_concurrency_test.go`):** parallel independent sessions, SessionClose-vs-handler teardown race. `ParallelSessions_OneHangs` is skipped — MySQL packets are dispatched synchronously (the async flag is SSH-only), so a slow upstream dial blocks the recv loop. Unskip when async dispatch covers MySQL.

## Test-infra fix

`MockTransport.Close` no longer closes `sendCh`/`recvCh`: long-lived bridge pumps and the demux still send on them and exit via `ctx.Done()`; closing underneath them is itself a data race (surfaced under `-race` on SSH). `Inject` now also unblocks on `ctx.Done()`.

## Dependencies

- **libhoop#75** — proxy atomics fix (`initialized`/`closed`/`pid`). Required for the suite to run clean under `-race`; these tests surfaced those races.
- **#1500** — re-enables `-race` in `make test-integration`.

With all three, the full suite (postgres + mysql + ssh) is green under `-race`.

Closes ENG-387, ENG-388.

Automated by MisterMal