### PR TITLE
fix: send Slack message through AI Session Analyzer

### DIFF
--- a/gateway/api/mcpserver/tools_exec.go
+++ b/gateway/api/mcpserver/tools_exec.go
@@ -180,13 +180,13 @@ func execHandler(ctx context.Context, _ *mcp.CallToolRequest, args execInput) (*
 		if aiAccessRule == nil {
 			return nil, nil, fmt.Errorf("ai analyzer requested review without resolving access request rule")
 		}
-		review, err := sessionapi.CreateReviewFromAIAnalysis(orgID, sessionID, conn.Name,
+		review, err := sessionapi.CreateReviewFromAIAnalysis(orgID, sessionID, conn,
 			sessionapi.AIReviewRequester{
-				UserID:       sc.UserID,
-				UserEmail:    sc.UserEmail,
-				UserName:     sc.UserName,
-				UserSlackID:  sc.SlackID,
-				ConnectionID: conn.ID,
+				UserID:      sc.UserID,
+				UserEmail:   sc.UserEmail,
+				UserName:    sc.UserName,
+				UserSlackID: sc.SlackID,
+				UserGroups:  sc.UserGroups,
 			},
 			aiAccessRule, args.Input, args.EnvVars, args.Args)
 		if err != nil {

--- a/gateway/api/session/ai_review.go
+++ b/gateway/api/session/ai_review.go
@@ -107,6 +107,14 @@ func sendSlackMessage(requester AIReviewRequester, connection *models.Connection
 		log.With("sid", rev.SessionID).Errorf("failed fetching plugin connection for slack review message: %v", err)
 		return err
 	}
+	if pluginConfig == nil {
+		log.With("sid", rev.SessionID).Infof("no plugin connection found for slack review message, skipping")
+		return nil
+	}
+	if len(pluginConfig.Config) == 0 {
+		log.With("sid", rev.SessionID).Infof("plugin connection for slack review message has empty config, skipping")
+		return nil
+	}
 
 	sreq := &slackModel.MessageReviewRequest{
 		Name:           requester.UserName,

--- a/gateway/api/session/ai_review.go
+++ b/gateway/api/session/ai_review.go
@@ -8,21 +8,25 @@ import (
 	"github.com/aws/smithy-go/ptr"
 	"github.com/google/uuid"
 	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/models"
+	slackModel "github.com/hoophq/hoop/gateway/slack"
+	"github.com/hoophq/hoop/gateway/transport/plugins/slack"
+	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
 )
 
 type AIReviewRequester struct {
-	UserID       string
-	UserEmail    string
-	UserName     string
-	UserSlackID  string
-	ConnectionID string
+	UserID      string
+	UserEmail   string
+	UserName    string
+	UserSlackID string
+	UserGroups  []string
 }
 
 func CreateReviewFromAIAnalysis(
 	orgID uuid.UUID,
 	sessionID string,
-	connectionName string,
+	connection *models.Connection,
 	requester AIReviewRequester,
 	accessRule *models.AccessRequestRule,
 	sessionInput string,
@@ -56,8 +60,8 @@ func CreateReviewFromAIAnalysis(
 		OrgID:                 orgID.String(),
 		Type:                  models.ReviewTypeOneTime,
 		SessionID:             sessionID,
-		ConnectionName:        connectionName,
-		ConnectionID:          sql.NullString{String: requester.ConnectionID, Valid: requester.ConnectionID != ""},
+		ConnectionName:        connection.Name,
+		ConnectionID:          sql.NullString{String: connection.ID, Valid: connection.ID != ""},
 		InputEnvVars:          inputEnvVars,
 		InputClientArgs:       inputClientArgs,
 		OwnerID:               requester.UserID,
@@ -78,5 +82,59 @@ func CreateReviewFromAIAnalysis(
 	if err := models.CreateReview(rev, sessionInput); err != nil {
 		return nil, fmt.Errorf("ai analyzer review: failed creating review: %w", err)
 	}
+
+	if err := sendSlackMessage(requester, connection, rev, sessionInput); err != nil {
+		log.With("sid", sessionID, "review-id", rev.ID).Errorf("failed sending slack message for ai analyzer review: %v", err)
+		// do not return error if slack message sending fails, as the review is already created and actionable in the webapp
+	}
+
 	return rev, nil
+}
+
+func sendSlackMessage(requester AIReviewRequester, connection *models.Connection, rev *models.Review, reviewInput string) error {
+	slackSvc := slack.GetSlackServiceInstance(rev.OrgID)
+	log.With("sid", rev.SessionID).Infof("executing slack on-receive, hasinstance=%v", slackSvc != nil)
+	if slackSvc == nil {
+		return nil
+	}
+
+	if rev.Status != models.ReviewStatusPending {
+		return nil
+	}
+
+	pluginConfig, err := models.GetPluginConnection(connection.OrgID, plugintypes.PluginSlackName, connection.ID)
+	if err != nil {
+		log.With("sid", rev.SessionID).Errorf("failed fetching plugin connection for slack review message: %v", err)
+		return err
+	}
+
+	sreq := &slackModel.MessageReviewRequest{
+		Name:           requester.UserName,
+		Email:          requester.UserEmail,
+		Connection:     rev.ConnectionName,
+		ConnectionType: connection.Type,
+		SessionID:      rev.SessionID,
+		UserGroups:     requester.UserGroups,
+		SlackChannels:  pluginConfig.Config,
+	}
+
+	appc := appconfig.Get()
+	sreq.ID = rev.ID
+	sreq.WebappURL = fmt.Sprintf("%s/sessions/%s", appc.ApiURL(), rev.SessionID)
+	sreq.ApprovalGroups = slack.ParseGroups(rev.ReviewGroups)
+	if rev.AccessDurationSec > 0 {
+		ad := time.Duration(rev.AccessDurationSec) * time.Second
+		sreq.SessionTime = &ad
+	}
+	sreq.Script = reviewInput
+
+	if sreq.WebappURL == "" || len(sreq.ApprovalGroups) == 0 || len(sreq.ApprovalGroups) >= slack.SlackMaxButtons {
+		log.With("sid", rev.SessionID).Infof("no review message to process, has-webapp-url=%v, approval-groups=%v/%v",
+			sreq.WebappURL != "", len(sreq.ApprovalGroups), slack.SlackMaxButtons)
+		return nil
+	}
+	log.With("sid", rev.SessionID).Infof("sending slack review message, conn=%v, jit=%v", sreq.Connection, sreq.SessionTime != nil)
+	result := slackSvc.SendMessageReview(sreq)
+	log.With("sid", rev.SessionID).Infof("review slack message sent, %v", result)
+	return nil
 }

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -64,7 +64,7 @@ func AIAnalyze(ctx context.Context, orgID uuid.UUID, connName, script string) (*
 	if err != nil && err != gorm.ErrRecordNotFound {
 		return nil, nil, fmt.Errorf("failed obtaining ai session analyzer rule for connection %v, reason: %w", connName, err)
 	}
-	if aiAnalyzerRule == nil {
+	if aiAnalyzerRule == nil || script == "" {
 		return nil, nil, nil
 	}
 
@@ -286,13 +286,13 @@ func Post(c *gin.Context) {
 				"failed creating ai-driven review")
 			return
 		}
-		review, err := CreateReviewFromAIAnalysis(orgID, sid, conn.Name,
+		review, err := CreateReviewFromAIAnalysis(orgID, sid, conn,
 			AIReviewRequester{
-				UserID:       ctx.UserID,
-				UserEmail:    ctx.UserEmail,
-				UserName:     ctx.UserName,
-				UserSlackID:  ctx.SlackID,
-				ConnectionID: conn.ID,
+				UserID:      ctx.UserID,
+				UserEmail:   ctx.UserEmail,
+				UserName:    ctx.UserName,
+				UserSlackID: ctx.SlackID,
+				UserGroups:  ctx.UserGroups,
 			},
 			aiAccessRule, req.Script, req.EnvVars, req.ClientArgs)
 		if err != nil {

--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -202,13 +202,20 @@ func (p *auditPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 						return nil, plugintypes.InternalErr("ai analyzer requested review without resolving access request rule",
 							fmt.Errorf("aiAccessRule is nil for sid=%s", pctx.SID))
 					}
-					review, err := sessionapi.CreateReviewFromAIAnalysis(orgID, pctx.SID, pctx.ConnectionName,
+					ctx := storagev2.NewContext(pctx.UserID, pctx.OrgID)
+					ctx.WithUserInfo(pctx.UserName, pctx.UserEmail, "active", "", pctx.UserGroups)
+
+					conn, err := models.GetBareConnectionByNameOrID(ctx, pctx.ConnectionName, models.DB)
+					if err != nil {
+						return nil, plugintypes.InternalErr("failed retrieving connection for ai-driven review", err)
+					}
+					review, err := sessionapi.CreateReviewFromAIAnalysis(orgID, pctx.SID, conn,
 						sessionapi.AIReviewRequester{
-							UserID:       pctx.UserID,
-							UserEmail:    pctx.UserEmail,
-							UserName:     pctx.UserName,
-							UserSlackID:  pctx.UserSlackID,
-							ConnectionID: pctx.ConnectionID,
+							UserID:      pctx.UserID,
+							UserEmail:   pctx.UserEmail,
+							UserName:    pctx.UserName,
+							UserSlackID: pctx.UserSlackID,
+							UserGroups:  pctx.UserGroups,
 						},
 						aiAccessRule, string(pkt.Payload), nil, nil)
 					if err != nil {

--- a/gateway/transport/plugins/slack/slack.go
+++ b/gateway/transport/plugins/slack/slack.go
@@ -20,7 +20,7 @@ var ErrMissingRequiredCredentials = fmt.Errorf("missing required credentials for
 
 const (
 	PluginConfigEnvVarsParam = "plugin_config"
-	slackMaxButtons          = 20
+	SlackMaxButtons          = 20
 )
 
 type (
@@ -33,7 +33,7 @@ type (
 var instances map[string]*slack.SlackService
 var mu sync.RWMutex
 
-func getSlackServiceInstance(orgID string) *slack.SlackService {
+func GetSlackServiceInstance(orgID string) *slack.SlackService {
 	mu.Lock()
 	defer mu.Unlock()
 	return instances[orgID]
@@ -130,7 +130,7 @@ func (p *slackPlugin) OnStartup(_ plugintypes.Context) error {
 }
 
 func (p *slackPlugin) OnUpdate(oldState, newState plugintypes.PluginResource) error {
-	slackInstance := getSlackServiceInstance(newState.GetOrgID())
+	slackInstance := GetSlackServiceInstance(newState.GetOrgID())
 	if slackInstance == nil {
 		slackInstance = &slack.SlackService{}
 	}
@@ -190,7 +190,7 @@ func (p *slackPlugin) OnUpdate(oldState, newState plugintypes.PluginResource) er
 
 // SendApprovedMessage sends a message informing the session is ready
 func SendApprovedMessage(orgID, slackID, sid, apiURL string) {
-	if slacksvc := getSlackServiceInstance(orgID); slacksvc != nil {
+	if slacksvc := GetSlackServiceInstance(orgID); slacksvc != nil {
 		msg := fmt.Sprintf("Your session is ready.\nFollow this link to see the details: %s/sessions/%s",
 			apiURL, sid)
 		_ = slacksvc.PostMessage(slackID, msg)
@@ -202,7 +202,7 @@ func (p *slackPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 	if pkt.Type != pbagent.SessionOpen {
 		return nil, nil
 	}
-	slackSvc := getSlackServiceInstance(pctx.OrgID)
+	slackSvc := GetSlackServiceInstance(pctx.OrgID)
 	log.With("sid", pctx.SID).Infof("executing slack on-receive, hasinstance=%v", slackSvc != nil)
 	if slackSvc == nil {
 		return nil, nil
@@ -232,7 +232,7 @@ func (p *slackPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 		}
 		sreq.ID = rev.ID
 		sreq.WebappURL = fmt.Sprintf("%s/sessions/%s", p.apiURL, rev.SessionID)
-		sreq.ApprovalGroups = parseGroups(rev.ReviewGroups)
+		sreq.ApprovalGroups = ParseGroups(rev.ReviewGroups)
 		if rev.AccessDurationSec > 0 {
 			ad := time.Duration(rev.AccessDurationSec) * time.Second
 			sreq.SessionTime = &ad
@@ -240,9 +240,9 @@ func (p *slackPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 		sreq.Script = reviewInput
 	}
 
-	if sreq.WebappURL == "" || len(sreq.ApprovalGroups) == 0 || len(sreq.ApprovalGroups) >= slackMaxButtons {
+	if sreq.WebappURL == "" || len(sreq.ApprovalGroups) == 0 || len(sreq.ApprovalGroups) >= SlackMaxButtons {
 		log.With("sid", pctx.SID).Infof("no review message to process, has-webapp-url=%v, approval-groups=%v/%v",
-			sreq.WebappURL != "", len(sreq.ApprovalGroups), slackMaxButtons)
+			sreq.WebappURL != "", len(sreq.ApprovalGroups), SlackMaxButtons)
 		return nil, nil
 	}
 	log.With("sid", pctx.SID).Infof("sending slack review message, conn=%v, jit=%v", sreq.Connection, sreq.SessionTime != nil)
@@ -278,7 +278,7 @@ func parseSlackConfig(envVars map[string]string) (*slackConfig, error) {
 	return &sc, nil
 }
 
-func parseGroups(reviewGroups []models.ReviewGroups) []string {
+func ParseGroups(reviewGroups []models.ReviewGroups) []string {
 	groups := make([]string, 0)
 	for _, g := range reviewGroups {
 		groups = append(groups, g.GroupName)

--- a/webapp/src/webapp/plugins/views/plugin_configurations/slack.cljs
+++ b/webapp/src/webapp/plugins/views/plugin_configurations/slack.cljs
@@ -30,7 +30,7 @@
         {:on-submit (fn [e]
                       (.preventDefault e)
                       (let [connection  (merge current-connection-config
-                                               {:config (map str/trim (str/split @slack-channels-value #","))})
+                                               {:config (remove empty? (map str/trim (str/split @slack-channels-value #",")))})
                             dissoced-connections (filter #(not= (:id %)
                                                                 (:id connection))
                                                          (:connections plugin))
@@ -46,7 +46,6 @@
         [forms/input {:value @slack-channels-value
                       :id "slack-channels"
                       :name "slack-channels"
-                      :required true
                       :on-change #(reset! slack-channels-value (-> % .-target .-value))
                       :placeholder "C039AQNN5DF, C031T9LDGAH"}]
         [:footer


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
>
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Reviews created by the **AI Session Analyzer** were only actionable from the webapp — no Slack
notification was ever sent, unlike the regular review flow handled by the Slack plugin's
`OnReceive`. This PR wires the AI-analyzer review path into the Slack service so approvers get the
same interactive review message they get for normal reviews.

A new `sendSlackMessage` helper is invoked right after the AI-driven review is persisted. It reuses
the existing Slack plugin service instance and message-building logic. Slack delivery is best-effort:
if it fails, the error is logged and the review still stands (actionable in the webapp).

## 🔗 Related Issue

N/A

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Send Slack review notifications for reviews created by the AI Session Analyzer. Added `sendSlackMessage` in `gateway/api/session/ai_review.go`, which
posts the review message via the Slack plugin service after the review is created; failures are logged and non-fatal.
- Changed `CreateReviewFromAIAnalysis` to accept the full `*models.Connection` (name, ID, type) instead of just the connection name, and reworked
`AIReviewRequester` to carry `UserGroups` and drop the now-redundant `ConnectionID`. Updated all call sites: session `Post`, MCP `execHandler`, and the audit  
plugin `OnReceive`.
- Audit plugin now resolves the connection through `models.GetBareConnectionByNameOrID` before creating the AI-driven review.
- Exported Slack plugin helpers for reuse from the session package: `getSlackServiceInstance` → `GetSlackServiceInstance`, `parseGroups` → `ParseGroups`,
and `slackMaxButtons` → `SlackMaxButtons`.
- `AIAnalyze` now short-circuits (returns no analysis) when `script == ""`, preventing review creation for empty input.

## 🧪 Testing

Built and statically vetted the affected gateway packages, then manually validated the end-to-end
flow by triggering an AI Session Analyzer review and confirming the interactive review message is
delivered to the configured Slack channel/groups, and that the review remains usable in the webapp
when Slack is unavailable.

### Test Configuration

- **Browser(s)**: Chrome (latest)
- **OS**: macOS (darwin/arm64), Go 1.26.3

### Tests performed

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

- `AIAnalyze` now short-circuits (returns no analysis) when `script == ""`, preventing review creation for empty input.

## 🧪 Testing

Built and statically vetted the affected gateway packages, then manually validated the end-to-end
flow by triggering an AI Session Analyzer review and confirming the interactive review message is
delivered to the configured Slack channel/groups, and that the review remains usable in the webapp
when Slack is unavailable.

### Test Configuration

- **Browser(s)**: Brave
- **OS**: macOS

### Tests performed

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

---