### PR TITLE
feat(tunnel): add tunnel up/down IPC endpoints [RD-209]

### DIFF
--- a/tunnel/cmd/hsh-tunneld/main.go
+++ b/tunnel/cmd/hsh-tunneld/main.go
@@ -127,6 +127,11 @@ func runDaemon(logger *log.Logger) error {
 	tld := flag.String("tld", resolver.DefaultTLD, "TLD owned by the tunnel (HSH_TUNNEL_DOMAIN overrides)")
 	devName := flag.String("dev", "", "TUN device name (kernel picks if empty)")
 	sessionSeed := flag.String("session", "spike-session", "session seed (controls the /48 prefix)")
+	// refreshInterval drives the periodic connection-list refresh while
+	// the tunnel is up. 0 disables auto-refresh (manual
+	// /v1/connections/refresh still works). HSH_TUNNELD_REFRESH_INTERVAL
+	// (a Go duration like "30s") overrides.
+	refreshInterval := flag.Duration("refresh-interval", defaultRefreshInterval, "how often to auto-refresh the connection list while up (0 disables; HSH_TUNNELD_REFRESH_INTERVAL overrides)")
 	// ipcSocket and ipcTokenFile control the local control plane (RD-215).
 	// Empty `--ipc-socket` skips the IPC layer entirely, which keeps the
 	// daemon usable for standalone dev / integration tests where the
@@ -148,18 +153,32 @@ func runDaemon(logger *log.Logger) error {
 	if *configFile == "" {
 		*configFile = daemonconfig.DefaultConfigPathPlatform()
 	}
+	if env := os.Getenv("HSH_TUNNELD_REFRESH_INTERVAL"); env != "" {
+		if d, err := time.ParseDuration(env); err == nil {
+			*refreshInterval = d
+		} else {
+			logger.Printf("ignoring invalid HSH_TUNNELD_REFRESH_INTERVAL=%q: %v", env, err)
+		}
+	}
 
 	cfg := runOptions{
-		tld:          *tld,
-		devName:      *devName,
-		sessionSeed:  *sessionSeed,
-		ipcSocket:    *ipcSocket,
-		ipcTokenFile: *ipcTokenFile,
-		ipcGroup:     *ipcGroup,
-		configFile:   *configFile,
+		tld:             *tld,
+		devName:         *devName,
+		sessionSeed:     *sessionSeed,
+		ipcSocket:       *ipcSocket,
+		ipcTokenFile:    *ipcTokenFile,
+		ipcGroup:        *ipcGroup,
+		configFile:      *configFile,
+		refreshInterval: *refreshInterval,
 	}
 	return run(logger, cfg)
 }
+
+// defaultRefreshInterval is how often the daemon auto-refreshes the
+// connection list while the tunnel is up. A minute keeps newly-created
+// connections discoverable within a bounded delay without hammering the
+// gateway's /api/connections endpoint.
+const defaultRefreshInterval = time.Minute
 
 // runOptions groups every configurable knob `run` cares about. Using a
 // struct here keeps the function signature stable as we add more
@@ -176,6 +195,10 @@ type runOptions struct {
 
 	// configFile is the path of the daemon-managed TOML config file.
 	configFile string
+
+	// refreshInterval is how often to auto-refresh the connection list
+	// while the tunnel is up. Zero disables the background refresh.
+	refreshInterval time.Duration
 }
 
 func run(logger *log.Logger, opts runOptions) error {
@@ -260,6 +283,12 @@ func run(logger *log.Logger, opts runOptions) error {
 		logger.Printf("not logged in — netstack will not start.")
 		logger.Printf("  run `hsh tunnel login` (the tunnel will come up automatically when you finish).")
 	}
+
+	// Start the background connection-list refresh. It runs for the
+	// whole daemon lifetime (parented to ctx) and no-ops while the
+	// tunnel is down, so it covers both "tunnel already up at startup"
+	// and "tunnel comes up later via login" without extra wiring.
+	svc.StartAutoRefresh(ctx, opts.refreshInterval, logger.Printf)
 
 	// Block on signal. TearDown on shutdown is best-effort: the
 	// per-tunnel ctx is parented to ctx, so closing it cancels the

--- a/tunnel/cmd/hsh-tunneld/service.go
+++ b/tunnel/cmd/hsh-tunneld/service.go
@@ -413,3 +413,65 @@ func (s *daemonService) Reconnect(context.Context) error {
 	return ipc.ErrNotImplemented
 }
 
+// Up brings the tunnel netstack online using the daemon's persisted
+// token. It is the lifecycle counterpart to Down: a logged-in daemon
+// whose tunnel was taken Down can be brought back Up without
+// re-authenticating. It does not touch the token or the config file.
+//
+// Semantics:
+//   - already Up        → no-op success, AlreadyUp=true.
+//   - logged out        → ipc.ErrNotLoggedIn (409); no token to dial with.
+//   - bring-up failure  → error is recorded in lastError and returned
+//     (the HTTP layer renders a 500), matching BringUpFromConfig.
+func (s *daemonService) Up(context.Context) (ipc.TunnelUpResponse, error) {
+	// Fast path: if the manager already has a live tunnel, report it
+	// without re-dialling the gateway. State() is cheap and the check
+	// is advisory — BringUp re-checks under its own lock and returns
+	// ErrAlreadyUp if a concurrent Up won the slot, which we fold into
+	// the same AlreadyUp response below.
+	if s.mgr.State() == tunnelmgr.StateUp {
+		return ipc.TunnelUpResponse{Running: true, AlreadyUp: true}, nil
+	}
+
+	s.mu.RLock()
+	cfg := s.cfg
+	s.mu.RUnlock()
+	if !cfg.LoggedIn() {
+		return ipc.TunnelUpResponse{}, ipc.ErrNotLoggedIn
+	}
+
+	if err := s.mgr.BringUp(s.parentCtx, cfg); err != nil {
+		// A concurrent Up that won the race is success from the
+		// caller's point of view: the tunnel is Up.
+		if errors.Is(err, tunnelmgr.ErrAlreadyUp) {
+			return ipc.TunnelUpResponse{Running: true, AlreadyUp: true}, nil
+		}
+		s.SetLastError("bring up: " + err.Error())
+		return ipc.TunnelUpResponse{}, fmt.Errorf("bring up tunnel: %w", err)
+	}
+	s.SetLastError("")
+	if s.onTunnelUp != nil {
+		s.onTunnelUp(s.mgr.Snapshot())
+	}
+	return ipc.TunnelUpResponse{Running: true, AlreadyUp: false}, nil
+}
+
+// Down tears the tunnel netstack down while leaving the daemon's token
+// intact, so the user stays logged in. Idempotent: tearing down an
+// already-idle daemon succeeds with AlreadyDown=true.
+func (s *daemonService) Down(context.Context) (ipc.TunnelDownResponse, error) {
+	if s.mgr.State() == tunnelmgr.StateIdle {
+		return ipc.TunnelDownResponse{AlreadyDown: true}, nil
+	}
+
+	if err := s.mgr.TearDown(); err != nil {
+		s.SetLastError("tear down: " + err.Error())
+		return ipc.TunnelDownResponse{}, fmt.Errorf("tear down tunnel: %w", err)
+	}
+	s.SetLastError("")
+	if s.onTunnelDown != nil {
+		s.onTunnelDown()
+	}
+	return ipc.TunnelDownResponse{AlreadyDown: false}, nil
+}
+

--- a/tunnel/cmd/hsh-tunneld/service.go
+++ b/tunnel/cmd/hsh-tunneld/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/hoophq/hoop/common/version"
 
@@ -220,23 +221,25 @@ func (s *daemonService) Connections(context.Context) ([]ipc.Connection, error) {
 		return []ipc.Connection{}, nil
 	}
 
-	names := snap.Allocator.Names()
-	sort.Strings(names)
-	out := make([]ipc.Connection, 0, len(names))
-	for _, name := range names {
-		ip, ok := snap.Allocator.LookupName(name)
+	// Snapshot.Connections holds only the currently-active connections
+	// (a refresh hides ones deleted on the gateway). Sort by name for
+	// stable output.
+	conns := snap.Connections
+	sort.Slice(conns, func(i, j int) bool { return conns[i].Name < conns[j].Name })
+	out := make([]ipc.Connection, 0, len(conns))
+	for _, c := range conns {
+		ip, ok := snap.Allocator.LookupName(c.Name)
 		if !ok {
 			continue
 		}
-		subType := snap.SubTypeByName[name]
-		port, _ := portmap.CanonicalPort(subType)
+		port, _ := portmap.CanonicalPort(c.SubType)
 		conn := ipc.Connection{
-			Name:         name,
-			SubType:      subType,
+			Name:         c.Name,
+			SubType:      c.SubType,
 			VirtualIP:    ip.String(),
 			ExpectedPort: port,
 		}
-		if ipv4, ok := snap.Allocator.LookupNameV4(name); ok {
+		if ipv4, ok := snap.Allocator.LookupNameV4(c.Name); ok {
 			conn.VirtualIPV4 = ipv4.String()
 		}
 		out = append(out, conn)
@@ -473,5 +476,64 @@ func (s *daemonService) Down(context.Context) (ipc.TunnelDownResponse, error) {
 		s.onTunnelDown()
 	}
 	return ipc.TunnelDownResponse{AlreadyDown: false}, nil
+}
+
+// RefreshConnections re-fetches the connection list and reconciles it
+// into the live tunnel. No-op when the tunnel is down. A fetch failure
+// is recorded in lastError and returned so the UI can surface it, but
+// it does NOT tear the tunnel down — existing flows and the
+// last-known-good connection set keep working.
+func (s *daemonService) RefreshConnections(ctx context.Context) (ipc.RefreshConnectionsResponse, error) {
+	if s.mgr.State() != tunnelmgr.StateUp {
+		return ipc.RefreshConnectionsResponse{Running: false, Count: 0}, nil
+	}
+	if err := s.mgr.Refresh(ctx); err != nil {
+		s.SetLastError("refresh connections: " + err.Error())
+		return ipc.RefreshConnectionsResponse{}, fmt.Errorf("refresh connections: %w", err)
+	}
+	s.SetLastError("")
+	count := len(s.mgr.Snapshot().Connections)
+	return ipc.RefreshConnectionsResponse{Running: true, Count: count}, nil
+}
+
+// StartAutoRefresh launches the background connection-list refresh loop.
+// It ticks every `interval` and, when the tunnel is up, re-fetches and
+// reconciles the connection list so connections created or deleted on
+// the gateway show up without a manual `hsh tunnel refresh`. While the
+// tunnel is down the tick is a cheap no-op (RefreshConnections returns
+// early), so the loop can run for the whole daemon lifetime regardless
+// of login state.
+//
+// interval <= 0 disables auto-refresh entirely (the loop never starts);
+// the manual /v1/connections/refresh endpoint still works. The loop
+// exits when ctx is cancelled (daemon shutdown).
+//
+// logf is the daemon's logger (the service has none of its own); the
+// per-refresh result is already logged by tunnelmgr, so this only logs
+// loop lifecycle and tick errors.
+func (s *daemonService) StartAutoRefresh(ctx context.Context, interval time.Duration, logf func(string, ...any)) {
+	if interval <= 0 {
+		logf("auto-refresh disabled (interval=%v)", interval)
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		logf("auto-refresh started (every %v)", interval)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				// RefreshConnections no-ops when the tunnel is down and
+				// records its own lastError on fetch failure, so a
+				// transient gateway blip just logs and retries next tick
+				// — it never tears the tunnel down.
+				if _, err := s.RefreshConnections(ctx); err != nil {
+					logf("auto-refresh tick failed: %v", err)
+				}
+			}
+		}
+	}()
 }
 

--- a/tunnel/cmd/hsh-tunneld/service_test.go
+++ b/tunnel/cmd/hsh-tunneld/service_test.go
@@ -66,6 +66,37 @@ func TestService_DownWhenIdleIsNoOp(t *testing.T) {
 	}
 }
 
+// TestService_RefreshWhenDownIsNoOp verifies that a refresh against a
+// down tunnel reports Running=false and does not error — the periodic
+// loop relies on this to tick harmlessly while logged out.
+func TestService_RefreshWhenDownIsNoOp(t *testing.T) {
+	svc := newTestService(t, daemonconfig.Config{
+		APIURL: "https://gw.example.com",
+		Token:  "tok-123",
+	})
+
+	resp, err := svc.RefreshConnections(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshConnections() err = %v, want nil", err)
+	}
+	if resp.Running {
+		t.Errorf("Running = true, want false (tunnel is down)")
+	}
+	if resp.Count != 0 {
+		t.Errorf("Count = %d, want 0", resp.Count)
+	}
+}
+
+// TestManager_RefreshWhenIdleIsNoOp verifies the Manager-level guard:
+// Refresh against an idle manager returns nil without touching the
+// gateway (no panic, no fetch).
+func TestManager_RefreshWhenIdleIsNoOp(t *testing.T) {
+	svc := newTestService(t, daemonconfig.Config{})
+	if err := svc.mgr.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() on idle manager err = %v, want nil", err)
+	}
+}
+
 // TestService_DownStaysLoggedIn verifies the lifecycle/auth separation:
 // taking the tunnel down must NOT clear the token. The user remains
 // logged in and can bring the tunnel back up without re-authenticating.

--- a/tunnel/cmd/hsh-tunneld/service_test.go
+++ b/tunnel/cmd/hsh-tunneld/service_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"testing"
+
+	"github.com/hoophq/hoop/tunnel/daemonconfig"
+	"github.com/hoophq/hoop/tunnel/ipc"
+	"github.com/hoophq/hoop/tunnel/tunnelmgr"
+)
+
+// newTestService builds a daemonService backed by a freshly-constructed
+// Manager (which starts Idle and performs no I/O until BringUp). The
+// config path is empty so nothing touches disk. initialCfg controls the
+// logged-in state via its Token field.
+func newTestService(t *testing.T, initialCfg daemonconfig.Config) *daemonService {
+	t.Helper()
+	mgr, err := tunnelmgr.New(tunnelmgr.Options{
+		Logger:      log.New(io.Discard, "", 0),
+		SessionSeed: "test-seed",
+		TLD:         "hoop",
+		UserAgent:   "hsh-tunneld-test",
+	})
+	if err != nil {
+		t.Fatalf("tunnelmgr.New: %v", err)
+	}
+	svc, err := newDaemonService(daemonServiceOptions{
+		Manager:       mgr,
+		ParentContext: context.Background(),
+		ConfigPath:    "", // in-memory: do not persist
+		InitialConfig: initialCfg,
+	})
+	if err != nil {
+		t.Fatalf("newDaemonService: %v", err)
+	}
+	return svc
+}
+
+// TestService_UpWhileLoggedOut verifies that Up refuses to bring the
+// tunnel online when there is no token, returning the ErrNotLoggedIn
+// sentinel so the HTTP layer can map it to 409.
+func TestService_UpWhileLoggedOut(t *testing.T) {
+	svc := newTestService(t, daemonconfig.Config{APIURL: "https://gw.example.com"})
+
+	_, err := svc.Up(context.Background())
+	if !errors.Is(err, ipc.ErrNotLoggedIn) {
+		t.Fatalf("Up() err = %v, want ErrNotLoggedIn", err)
+	}
+}
+
+// TestService_DownWhenIdleIsNoOp verifies Down is idempotent: tearing
+// down an already-idle daemon succeeds and reports AlreadyDown=true
+// without error.
+func TestService_DownWhenIdleIsNoOp(t *testing.T) {
+	svc := newTestService(t, daemonconfig.Config{})
+
+	resp, err := svc.Down(context.Background())
+	if err != nil {
+		t.Fatalf("Down() err = %v, want nil", err)
+	}
+	if !resp.AlreadyDown {
+		t.Errorf("AlreadyDown = false, want true (manager was idle)")
+	}
+}
+
+// TestService_DownStaysLoggedIn verifies the lifecycle/auth separation:
+// taking the tunnel down must NOT clear the token. The user remains
+// logged in and can bring the tunnel back up without re-authenticating.
+func TestService_DownStaysLoggedIn(t *testing.T) {
+	svc := newTestService(t, daemonconfig.Config{
+		APIURL: "https://gw.example.com",
+		Token:  "tok-123",
+	})
+
+	if _, err := svc.Down(context.Background()); err != nil {
+		t.Fatalf("Down() err = %v", err)
+	}
+
+	st, err := svc.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status() err = %v", err)
+	}
+	if !st.LoggedIn {
+		t.Errorf("LoggedIn = false after Down, want true (Down must not clear the token)")
+	}
+}

--- a/tunnel/ipc/client.go
+++ b/tunnel/ipc/client.go
@@ -160,6 +160,20 @@ func (c *Client) Reconnect(ctx context.Context) (ReconnectResponse, error) {
 	return out, err
 }
 
+// Up corresponds to POST /v1/tunnel/up.
+func (c *Client) Up(ctx context.Context) (TunnelUpResponse, error) {
+	var out TunnelUpResponse
+	err := c.do(ctx, http.MethodPost, "/v1/tunnel/up", nil, &out)
+	return out, err
+}
+
+// Down corresponds to POST /v1/tunnel/down.
+func (c *Client) Down(ctx context.Context) (TunnelDownResponse, error) {
+	var out TunnelDownResponse
+	err := c.do(ctx, http.MethodPost, "/v1/tunnel/down", nil, &out)
+	return out, err
+}
+
 // ----------------------------------------------------------------------
 // internals
 // ----------------------------------------------------------------------

--- a/tunnel/ipc/client.go
+++ b/tunnel/ipc/client.go
@@ -174,6 +174,13 @@ func (c *Client) Down(ctx context.Context) (TunnelDownResponse, error) {
 	return out, err
 }
 
+// RefreshConnections corresponds to POST /v1/connections/refresh.
+func (c *Client) RefreshConnections(ctx context.Context) (RefreshConnectionsResponse, error) {
+	var out RefreshConnectionsResponse
+	err := c.do(ctx, http.MethodPost, "/v1/connections/refresh", nil, &out)
+	return out, err
+}
+
 // ----------------------------------------------------------------------
 // internals
 // ----------------------------------------------------------------------

--- a/tunnel/ipc/openapi.yaml
+++ b/tunnel/ipc/openapi.yaml
@@ -150,6 +150,25 @@ components:
       properties:
         accepted: { type: boolean }
 
+    TunnelUpResponse:
+      type: object
+      required: [running, already_up]
+      properties:
+        running:
+          type: boolean
+          description: True once the netstack is published (always true on 200).
+        already_up:
+          type: boolean
+          description: True when the tunnel was already up before this call (no-op).
+
+    TunnelDownResponse:
+      type: object
+      required: [already_down]
+      properties:
+        already_down:
+          type: boolean
+          description: True when the tunnel was already idle before this call (no-op).
+
     ErrorResponse:
       type: object
       required: [error]
@@ -165,6 +184,7 @@ components:
             - bad_request
             - not_found
             - not_implemented
+            - not_logged_in
             - internal
 
   responses:
@@ -312,3 +332,45 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/ReconnectResponse" }
         "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /v1/tunnel/up:
+    post:
+      summary: Bring the tunnel netstack up using the persisted token.
+      description: |
+        Lifecycle counterpart to /v1/tunnel/down. Brings the netstack
+        online without touching authentication, so a logged-in daemon
+        whose tunnel was taken down can be restored without
+        re-authenticating. Synchronous: the response reflects the
+        post-call state. Idempotent: calling it on an already-up tunnel
+        returns already_up=true. Returns 409 when logged out (no token
+        to dial the gateway with).
+      responses:
+        "200":
+          description: Tunnel is up.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TunnelUpResponse" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "409":
+          description: Daemon is logged out; cannot bring the tunnel up.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /v1/tunnel/down:
+    post:
+      summary: Tear the tunnel netstack down, leaving the token intact.
+      description: |
+        Lifecycle counterpart to /v1/tunnel/up. Tears the netstack down
+        while keeping the daemon logged in, so the tunnel can be brought
+        back up later without re-authenticating. Idempotent: calling it
+        on an already-idle daemon returns already_down=true.
+      responses:
+        "200":
+          description: Tunnel is down.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TunnelDownResponse" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "500": { $ref: "#/components/responses/InternalError" }

--- a/tunnel/ipc/openapi.yaml
+++ b/tunnel/ipc/openapi.yaml
@@ -169,6 +169,17 @@ components:
           type: boolean
           description: True when the tunnel was already idle before this call (no-op).
 
+    RefreshConnectionsResponse:
+      type: object
+      required: [running, count]
+      properties:
+        running:
+          type: boolean
+          description: False when the tunnel was down at refresh time (no-op).
+        count:
+          type: integer
+          description: Number of active connections after the refresh (0 when down).
+
     ErrorResponse:
       type: object
       required: [error]
@@ -372,5 +383,24 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/TunnelDownResponse" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /v1/connections/refresh:
+    post:
+      summary: Re-fetch and reconcile the connection list now.
+      description: |
+        On-demand counterpart to the daemon's periodic auto-refresh.
+        Re-fetches the connection list from the gateway and reconciles
+        it into the live tunnel: connections created on the gateway
+        become routable, deleted ones are hidden (their IP stays
+        reserved), all without disturbing in-flight flows. Synchronous.
+        A no-op (running=false) when the tunnel is down.
+      responses:
+        "200":
+          description: Refresh completed (or no-op when down).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RefreshConnectionsResponse" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "500": { $ref: "#/components/responses/InternalError" }

--- a/tunnel/ipc/server.go
+++ b/tunnel/ipc/server.go
@@ -75,6 +75,23 @@ type Service interface {
 	// gateway pipes asynchronously. Returns nil immediately (HTTP 202)
 	// — completion is observable via Status.LastError + Running.
 	Reconnect(ctx context.Context) error
+
+	// Up brings the tunnel netstack up using the daemon's persisted
+	// token, without touching authentication. It is the lifecycle
+	// counterpart to Logout/Login: a logged-in daemon whose tunnel was
+	// taken Down can be brought back Up without re-authenticating.
+	//
+	// Bring-up is synchronous: the response reflects the post-call
+	// state. Calling Up on an already-Up tunnel is a no-op success
+	// (AlreadyUp=true). Calling Up while logged out is a 409 conflict —
+	// there is no token to dial the gateway with.
+	Up(ctx context.Context) (TunnelUpResponse, error)
+
+	// Down tears the tunnel netstack down while leaving the daemon's
+	// token intact. Idempotent: calling Down on an already-idle daemon
+	// succeeds with AlreadyDown=true. The user stays logged in and can
+	// bring the tunnel back Up without re-authenticating.
+	Down(ctx context.Context) (TunnelDownResponse, error)
 }
 
 // ErrNotImplemented is the canonical sentinel a Service implementation
@@ -87,6 +104,14 @@ type Service interface {
 // consumers (especially the TS UI in hoophq/hsh) can code against the
 // full spec from day one and feature-detect by hitting the endpoint.
 var ErrNotImplemented = errors.New("ipc: endpoint not implemented in this daemon build")
+
+// ErrNotLoggedIn is the canonical sentinel a Service returns when an
+// operation requires authentication that is not present — e.g. Up
+// cannot bring the tunnel online without a token to dial the gateway.
+// The HTTP layer translates it to a 409 Conflict (the daemon is in the
+// wrong state for the request), distinguishing it from a 401 (the
+// caller's control-token was rejected).
+var ErrNotLoggedIn = errors.New("ipc: not logged in")
 
 // ServerOptions configures NewServer.
 type ServerOptions struct {
@@ -210,6 +235,8 @@ func (s *Server) buildHandler() http.Handler {
 	mux.HandleFunc("GET /v1/config", s.handleConfigGet)
 	mux.HandleFunc("PUT /v1/config", s.handleConfigPut)
 	mux.HandleFunc("POST /v1/reconnect", s.handleReconnect)
+	mux.HandleFunc("POST /v1/tunnel/up", s.handleTunnelUp)
+	mux.HandleFunc("POST /v1/tunnel/down", s.handleTunnelDown)
 
 	// Any other path returns a JSON 404 instead of the default text body
 	// so clients can parse the response uniformly.
@@ -356,6 +383,24 @@ func (s *Server) handleReconnect(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusAccepted, ReconnectResponse{Accepted: true})
 }
 
+func (s *Server) handleTunnelUp(w http.ResponseWriter, r *http.Request) {
+	resp, err := s.opts.Service.Up(r.Context())
+	if err != nil {
+		s.writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleTunnelDown(w http.ResponseWriter, r *http.Request) {
+	resp, err := s.opts.Service.Down(r.Context())
+	if err != nil {
+		s.writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // writeServiceError translates a Service-layer error into the right
 // HTTP status. The mapping is intentional and stable so the UI can
 // distinguish "feature not yet built" from "transient failure" without
@@ -364,6 +409,8 @@ func (s *Server) writeServiceError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ErrNotImplemented):
 		writeError(w, http.StatusNotImplemented, err.Error(), "not_implemented")
+	case errors.Is(err, ErrNotLoggedIn):
+		writeError(w, http.StatusConflict, err.Error(), "not_logged_in")
 	default:
 		// Generic internal error. We DO include the underlying message
 		// because this is a local-only control plane and the operator

--- a/tunnel/ipc/server.go
+++ b/tunnel/ipc/server.go
@@ -92,6 +92,14 @@ type Service interface {
 	// succeeds with AlreadyDown=true. The user stays logged in and can
 	// bring the tunnel back Up without re-authenticating.
 	Down(ctx context.Context) (TunnelDownResponse, error)
+
+	// RefreshConnections re-fetches the connection list from the gateway
+	// and reconciles it into the live tunnel (new connections become
+	// routable, deleted ones are hidden) without disturbing in-flight
+	// flows. It is the on-demand counterpart to the daemon's periodic
+	// auto-refresh. A no-op success when the tunnel is down. Returns the
+	// post-refresh active connection count.
+	RefreshConnections(ctx context.Context) (RefreshConnectionsResponse, error)
 }
 
 // ErrNotImplemented is the canonical sentinel a Service implementation
@@ -237,6 +245,7 @@ func (s *Server) buildHandler() http.Handler {
 	mux.HandleFunc("POST /v1/reconnect", s.handleReconnect)
 	mux.HandleFunc("POST /v1/tunnel/up", s.handleTunnelUp)
 	mux.HandleFunc("POST /v1/tunnel/down", s.handleTunnelDown)
+	mux.HandleFunc("POST /v1/connections/refresh", s.handleConnectionsRefresh)
 
 	// Any other path returns a JSON 404 instead of the default text body
 	// so clients can parse the response uniformly.
@@ -394,6 +403,15 @@ func (s *Server) handleTunnelUp(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleTunnelDown(w http.ResponseWriter, r *http.Request) {
 	resp, err := s.opts.Service.Down(r.Context())
+	if err != nil {
+		s.writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleConnectionsRefresh(w http.ResponseWriter, r *http.Request) {
+	resp, err := s.opts.Service.RefreshConnections(r.Context())
 	if err != nil {
 		s.writeServiceError(w, err)
 		return

--- a/tunnel/ipc/server_test.go
+++ b/tunnel/ipc/server_test.go
@@ -36,6 +36,12 @@ type fakeService struct {
 	updateGot     ConfigUpdateRequest
 	reconnectErr  error
 	reconnectHits int
+	upResp        TunnelUpResponse
+	upErr         error
+	upHits        int
+	downResp      TunnelDownResponse
+	downErr       error
+	downHits      int
 }
 
 func (f *fakeService) Status(context.Context) (StatusResponse, error) {
@@ -93,6 +99,20 @@ func (f *fakeService) Reconnect(context.Context) error {
 	defer f.mu.Unlock()
 	f.reconnectHits++
 	return f.reconnectErr
+}
+
+func (f *fakeService) Up(context.Context) (TunnelUpResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.upHits++
+	return f.upResp, f.upErr
+}
+
+func (f *fakeService) Down(context.Context) (TunnelDownResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.downHits++
+	return f.downResp, f.downErr
 }
 
 // newTestServer builds a Server backed by fakeService and a fresh
@@ -358,6 +378,95 @@ func TestServer_ReconnectReturns202(t *testing.T) {
 	}
 	if svc.reconnectHits != 1 {
 		t.Errorf("Reconnect called %d times, want 1", svc.reconnectHits)
+	}
+}
+
+func TestServer_TunnelUpReturns200(t *testing.T) {
+	svc := &fakeService{upResp: TunnelUpResponse{Running: true, AlreadyUp: false}}
+	srv, tok := newTestServer(t, svc)
+	rec := doReq(t, srv, tok, http.MethodPost, "/v1/tunnel/up", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if svc.upHits != 1 {
+		t.Errorf("Up called %d times, want 1", svc.upHits)
+	}
+	var resp TunnelUpResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Running || resp.AlreadyUp {
+		t.Errorf("resp = %+v, want running=true already_up=false", resp)
+	}
+}
+
+func TestServer_TunnelUpAlreadyUp(t *testing.T) {
+	svc := &fakeService{upResp: TunnelUpResponse{Running: true, AlreadyUp: true}}
+	srv, tok := newTestServer(t, svc)
+	rec := doReq(t, srv, tok, http.MethodPost, "/v1/tunnel/up", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp TunnelUpResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.AlreadyUp {
+		t.Errorf("already_up = false, want true")
+	}
+}
+
+// TestServer_TunnelUpNotLoggedIn verifies the ErrNotLoggedIn sentinel
+// maps to 409 with the not_logged_in code, distinct from a 401 control
+// token rejection.
+func TestServer_TunnelUpNotLoggedIn(t *testing.T) {
+	svc := &fakeService{upErr: ErrNotLoggedIn}
+	srv, tok := newTestServer(t, svc)
+	rec := doReq(t, srv, tok, http.MethodPost, "/v1/tunnel/up", nil)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%q", rec.Code, rec.Body.String())
+	}
+	var e ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &e); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if e.Code != "not_logged_in" {
+		t.Errorf("code = %q, want not_logged_in", e.Code)
+	}
+}
+
+func TestServer_TunnelDownReturns200(t *testing.T) {
+	svc := &fakeService{downResp: TunnelDownResponse{AlreadyDown: false}}
+	srv, tok := newTestServer(t, svc)
+	rec := doReq(t, srv, tok, http.MethodPost, "/v1/tunnel/down", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if svc.downHits != 1 {
+		t.Errorf("Down called %d times, want 1", svc.downHits)
+	}
+	var resp TunnelDownResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.AlreadyDown {
+		t.Errorf("already_down = true, want false")
+	}
+}
+
+func TestServer_TunnelDownAlreadyDown(t *testing.T) {
+	svc := &fakeService{downResp: TunnelDownResponse{AlreadyDown: true}}
+	srv, tok := newTestServer(t, svc)
+	rec := doReq(t, srv, tok, http.MethodPost, "/v1/tunnel/down", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp TunnelDownResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.AlreadyDown {
+		t.Errorf("already_down = false, want true")
 	}
 }
 

--- a/tunnel/ipc/server_test.go
+++ b/tunnel/ipc/server_test.go
@@ -42,6 +42,9 @@ type fakeService struct {
 	downResp      TunnelDownResponse
 	downErr       error
 	downHits      int
+	refreshResp   RefreshConnectionsResponse
+	refreshErr    error
+	refreshHits   int
 }
 
 func (f *fakeService) Status(context.Context) (StatusResponse, error) {
@@ -113,6 +116,13 @@ func (f *fakeService) Down(context.Context) (TunnelDownResponse, error) {
 	defer f.mu.Unlock()
 	f.downHits++
 	return f.downResp, f.downErr
+}
+
+func (f *fakeService) RefreshConnections(context.Context) (RefreshConnectionsResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.refreshHits++
+	return f.refreshResp, f.refreshErr
 }
 
 // newTestServer builds a Server backed by fakeService and a fresh
@@ -467,6 +477,41 @@ func TestServer_TunnelDownAlreadyDown(t *testing.T) {
 	}
 	if !resp.AlreadyDown {
 		t.Errorf("already_down = false, want true")
+	}
+}
+
+func TestServer_ConnectionsRefreshReturns200(t *testing.T) {
+	svc := &fakeService{refreshResp: RefreshConnectionsResponse{Running: true, Count: 3}}
+	srv, tok := newTestServer(t, svc)
+	rec := doReq(t, srv, tok, http.MethodPost, "/v1/connections/refresh", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if svc.refreshHits != 1 {
+		t.Errorf("RefreshConnections called %d times, want 1", svc.refreshHits)
+	}
+	var resp RefreshConnectionsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Running || resp.Count != 3 {
+		t.Errorf("resp = %+v, want running=true count=3", resp)
+	}
+}
+
+func TestServer_ConnectionsRefreshWhenDown(t *testing.T) {
+	svc := &fakeService{refreshResp: RefreshConnectionsResponse{Running: false, Count: 0}}
+	srv, tok := newTestServer(t, svc)
+	rec := doReq(t, srv, tok, http.MethodPost, "/v1/connections/refresh", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp RefreshConnectionsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Running {
+		t.Errorf("running = true, want false (tunnel down)")
 	}
 }
 

--- a/tunnel/ipc/spec.go
+++ b/tunnel/ipc/spec.go
@@ -247,6 +247,18 @@ type TunnelDownResponse struct {
 	AlreadyDown bool `json:"already_down"`
 }
 
+// RefreshConnectionsResponse is returned by POST
+// /v1/connections/refresh. The refresh is synchronous (the daemon
+// re-fetches and reconciles before responding).
+type RefreshConnectionsResponse struct {
+	// Running is false when the tunnel was down at refresh time (the
+	// call was a no-op — there is nothing to refresh against).
+	Running bool `json:"running"`
+	// Count is the number of active connections after the refresh.
+	// Zero when the tunnel is down.
+	Count int `json:"count"`
+}
+
 // ----------------------------------------------------------------------
 // Errors
 // ----------------------------------------------------------------------

--- a/tunnel/ipc/spec.go
+++ b/tunnel/ipc/spec.go
@@ -223,6 +223,30 @@ type ReconnectResponse struct {
 	Accepted bool `json:"accepted"`
 }
 
+// TunnelUpResponse is returned by POST /v1/tunnel/up. Bringing the
+// tunnel up is synchronous (the daemon dials the gateway and publishes
+// the netstack before responding), so a 200 means the tunnel is Up by
+// the time the caller sees it.
+type TunnelUpResponse struct {
+	// Running is true once the netstack is published. Always true on a
+	// 200 response; included so the UI can render state without a
+	// follow-up /v1/status call.
+	Running bool `json:"running"`
+	// AlreadyUp is true when the tunnel was already Up before this
+	// call (the request was a no-op). Lets the CLI say "already up"
+	// instead of "brought up" without racing a status poll.
+	AlreadyUp bool `json:"already_up"`
+}
+
+// TunnelDownResponse is returned by POST /v1/tunnel/down. Tearing the
+// tunnel down is synchronous and idempotent — calling it on an
+// already-idle daemon succeeds with AlreadyDown=true.
+type TunnelDownResponse struct {
+	// AlreadyDown is true when the tunnel was already Idle before this
+	// call (the request was a no-op).
+	AlreadyDown bool `json:"already_down"`
+}
+
 // ----------------------------------------------------------------------
 // Errors
 // ----------------------------------------------------------------------

--- a/tunnel/tunnelmgr/handlers.go
+++ b/tunnel/tunnelmgr/handlers.go
@@ -25,7 +25,7 @@ import (
 // MySQL connection; we reject before opening the upstream).
 func (m *Manager) makeAcceptFunc(
 	alloc *addressing.Allocator,
-	subTypeByName map[string]string,
+	registry *connRegistry,
 ) netstack.AcceptFunc {
 	logger := m.opts.Logger
 	return func(localAddr netip.Addr, localPort uint16) bool {
@@ -34,9 +34,13 @@ func (m *Manager) makeAcceptFunc(
 			logger.Printf("tunnelmgr: reject SYN %s:%d — unmapped address", localAddr, localPort)
 			return false
 		}
-		subType, ok := subTypeByName[name]
+		// subTypeOf returns ok=false for unknown names AND for
+		// connections that were deleted on the gateway (marked inactive
+		// by a refresh). Either way we refuse to open a pipe to a
+		// connection the gateway no longer offers.
+		subType, ok := registry.subTypeOf(name)
 		if !ok {
-			logger.Printf("tunnelmgr: reject SYN %s:%d -> %s — no subtype recorded", localAddr, localPort, name)
+			logger.Printf("tunnelmgr: reject SYN %s:%d -> %s — connection unknown or no longer active", localAddr, localPort, name)
 			return false
 		}
 		if !portmap.IsAcceptedPort(subType, localPort) {
@@ -59,7 +63,7 @@ func (m *Manager) makeAcceptFunc(
 // per-flow gRPC pipe.
 func (m *Manager) makeTCPHandler(
 	alloc *addressing.Allocator,
-	subTypeByName map[string]string,
+	registry *connRegistry,
 	gatewayCfg grpc.ClientConfig,
 ) netstack.Handler {
 	logger := m.opts.Logger
@@ -72,7 +76,7 @@ func (m *Manager) makeTCPHandler(
 			logger.Printf("tunnelmgr: inbound TCP to unmapped address %s — dropping", localAddr)
 			return
 		}
-		subType := subTypeByName[name]
+		subType, _ := registry.subTypeOf(name)
 		logger.Printf("tunnelmgr: accept %s:%d -> %s (%s)", localAddr, localPort, name, subType)
 		err := client.DialAndPipe(context.Background(), conn, client.PipeOptions{
 			GatewayConfig:  gatewayCfg,

--- a/tunnel/tunnelmgr/manager.go
+++ b/tunnel/tunnelmgr/manager.go
@@ -92,13 +92,16 @@ type Snapshot struct {
 	Since time.Time
 
 	// Allocator is the address allocator for the current session, or
-	// nil when idle. The IPC layer iterates it to build /v1/connections.
+	// nil when idle. Retained so callers can resolve a name→IP for the
+	// active connections in Connections below.
 	Allocator *addressing.Allocator
 
-	// SubTypeByName maps connection name → hoop subtype ("postgres",
-	// "mysql", ...). Keyed by the same names the allocator holds.
-	// nil when idle.
-	SubTypeByName map[string]string
+	// Connections is the set of currently-active tunnelable connections
+	// (name + subtype), captured under the registry lock at Snapshot
+	// time so callers can range over it without racing a concurrent
+	// refresh. nil/empty when idle. Connections deleted on the gateway
+	// are excluded even though their IP stays reserved in Allocator.
+	Connections []ConnInfo
 
 	// HostAddr / Gateway are the addresses the kernel and gVisor own
 	// on the current session's /48. Zero when idle.
@@ -178,16 +181,21 @@ type Manager struct {
 // "up" session. Held under Manager.mu while transitioning; readable
 // without the lock once published to Manager.current.
 type liveTunnel struct {
-	ctx        context.Context
-	cancel     context.CancelFunc
-	alloc      *addressing.Allocator
-	subTypeBy  map[string]string
-	stack      *netstack.Stack
+	ctx      context.Context
+	cancel   context.CancelFunc
+	alloc    *addressing.Allocator
+	registry *connRegistry
+	stack    *netstack.Stack
 	deviceName string
 	prefix     string
 	hostAddr   netip.Addr
 	gateway    netip.Addr
 	apiBase    string
+	// token is the gateway bearer token captured at bring-up, reused by
+	// Refresh to re-fetch the connection list without going through the
+	// daemon config again. It lives only in memory for the tunnel's
+	// lifetime (the daemon's config file is the durable copy).
+	token string
 
 	// routeCfg is the exact addressing handed to netstack.ConfigureRoutes
 	// at bring-up. Stored verbatim so teardown reverses precisely what was
@@ -246,7 +254,7 @@ func (m *Manager) Snapshot() Snapshot {
 		State:              m.state,
 		Since:              m.since,
 		Allocator:          m.current.alloc,
-		SubTypeByName:      m.current.subTypeBy,
+		Connections:        m.current.registry.activeConnections(),
 		HostAddr:           m.current.hostAddr,
 		Gateway:            m.current.gateway,
 		DeviceName:         m.current.deviceName,
@@ -428,25 +436,14 @@ func (m *Manager) buildTunnel(parentCtx context.Context, cfg daemonconfig.Config
 	m.opts.Logger.Printf("tunnelmgr: session prefix %s gateway %s",
 		alloc.Prefix(), alloc.Gateway())
 
-	conns, err := client.FetchConnections(ctx, client.FetchConnectionsOptions{
-		APIBaseURL: apiBase,
-		Token:      gatewayCfg.Token,
-	})
+	registry := newConnRegistry()
+	added, err := loadConnections(ctx, alloc, registry, apiBase, gatewayCfg.Token, m.opts.Logger)
 	if err != nil {
-		return cleanup(fmt.Errorf("fetch connections: %w", err))
+		return cleanup(err)
 	}
-	if len(conns) == 0 {
+	if added == 0 {
 		return cleanup(errors.New("no tunnelable connections found for this user"))
 	}
-
-	subTypeByName := make(map[string]string, len(conns))
-	for _, c := range conns {
-		if _, err := alloc.AddName(c.Name); err != nil {
-			return cleanup(fmt.Errorf("allocate %s: %w", c.Name, err))
-		}
-		subTypeByName[c.Name] = c.SubType
-	}
-	m.opts.Logger.Printf("tunnelmgr: loaded %d tunnelable connection(s)", len(conns))
 
 	rsvr := resolver.New(alloc, m.opts.TLD)
 	stack, err := netstack.New(ctx, netstack.Options{
@@ -455,8 +452,8 @@ func (m *Manager) buildTunnel(parentCtx context.Context, cfg daemonconfig.Config
 		PrefixV4:   alloc.PrefixV4(),
 		GatewayV4:  alloc.GatewayV4(),
 		DeviceName: m.opts.DeviceName,
-		TCPAccept:  m.makeAcceptFunc(alloc, subTypeByName),
-		TCPHandler: m.makeTCPHandler(alloc, subTypeByName, gatewayCfg),
+		TCPAccept:  m.makeAcceptFunc(alloc, registry),
+		TCPHandler: m.makeTCPHandler(alloc, registry, gatewayCfg),
 		DNSHandler: rsvr.HandleUDP,
 	})
 	if err != nil {
@@ -510,17 +507,78 @@ func (m *Manager) buildTunnel(parentCtx context.Context, cfg daemonconfig.Config
 		ctx:            ctx,
 		cancel:         cancel,
 		alloc:          alloc,
-		subTypeBy:      subTypeByName,
+		registry:       registry,
 		stack:          stack,
 		deviceName:     deviceName,
 		prefix:         alloc.Prefix().String(),
 		hostAddr:       alloc.HostAddr(),
 		gateway:        alloc.Gateway(),
 		apiBase:        apiBase,
+		token:          gatewayCfg.Token,
 		routeCfg:       routeCfg,
 		resolvedActive: resolvedActive,
 		resolved:       m.opts.ResolvedConfigurer,
 	}, nil
+}
+
+// loadConnections fetches the tunnelable connection list from the
+// gateway, allocates a stable IP for every name (append-only — existing
+// allocations are untouched and re-adds are no-ops), and reconciles the
+// registry's active set to exactly the fetched list. Returns the number
+// of currently-active connections (i.e. len of the fetched list on
+// success).
+//
+// Shared by buildTunnel (initial load) and Refresh (periodic / manual
+// re-load) so both paths apply identical filtering and allocation
+// semantics. The allocator's determinism means a name that vanished and
+// later reappears regains its original IP.
+func loadConnections(
+	ctx context.Context,
+	alloc *addressing.Allocator,
+	registry *connRegistry,
+	apiBase, token string,
+	logger Logger,
+) (activeCount int, err error) {
+	conns, err := client.FetchConnections(ctx, client.FetchConnectionsOptions{
+		APIBaseURL: apiBase,
+		Token:      token,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("fetch connections: %w", err)
+	}
+
+	active := make(map[string]string, len(conns))
+	for _, c := range conns {
+		if _, err := alloc.AddName(c.Name); err != nil {
+			return 0, fmt.Errorf("allocate %s: %w", c.Name, err)
+		}
+		active[c.Name] = c.SubType
+	}
+
+	added, removed := registry.reconcile(active)
+	logger.Printf("tunnelmgr: connection list synced — %d active (%d new, %d retired)",
+		len(active), added, removed)
+	return len(active), nil
+}
+
+// Refresh re-fetches the connection list and reconciles it into the
+// live tunnel without disturbing the netstack, routes, or in-flight
+// flows. New connections become routable immediately (the allocator and
+// resolver hold live references); connections deleted on the gateway
+// are marked inactive (hidden from listings, new SYNs rejected) but
+// keep their reserved IP.
+//
+// No-op (returns nil) when the tunnel is not up — there is nothing to
+// refresh against and the periodic caller may race a teardown.
+func (m *Manager) Refresh(ctx context.Context) error {
+	m.mu.RLock()
+	t := m.current
+	m.mu.RUnlock()
+	if t == nil {
+		return nil
+	}
+	_, err := loadConnections(ctx, t.alloc, t.registry, t.apiBase, t.token, m.opts.Logger)
+	return err
 }
 
 // Compile-time assertion: *log.Logger satisfies our Logger interface.

--- a/tunnel/tunnelmgr/manager_test.go
+++ b/tunnel/tunnelmgr/manager_test.go
@@ -128,8 +128,8 @@ func TestSnapshot_IsDecoupledFromInternal(t *testing.T) {
 	_ = snap.HostAddr
 	_ = snap.Gateway
 	_ = snap.DeviceName
-	_ = snap.Allocator     // nil OK
-	_ = snap.SubTypeByName // nil OK
+	_ = snap.Allocator   // nil OK
+	_ = snap.Connections // nil OK
 }
 
 func TestIsInsecureScheme(t *testing.T) {

--- a/tunnel/tunnelmgr/registry.go
+++ b/tunnel/tunnelmgr/registry.go
@@ -1,0 +1,107 @@
+package tunnelmgr
+
+import "sync"
+
+// connRegistry is the concurrency-safe owner of the per-tunnel
+// connection metadata: for each *.hoop name, its subtype and whether
+// it is currently active (still present on the gateway).
+//
+// Why it exists: the netstack accept/handler closures and the
+// /v1/connections Snapshot reader run on independent goroutines and
+// read this metadata on every SYN / status poll. The periodic refresh
+// (RD-209) writes it from yet another goroutine. A bare
+// map[string]string shared by reference would be a data race; this type
+// serialises all access behind a single RWMutex.
+//
+// Relationship to the Allocator: the Allocator owns name→IP and is
+// append-only (IPs are deterministic from the session seed and never
+// reassigned — see addressing/allocator.go). The registry layers the
+// mutable "is this connection still offered by the gateway" state on
+// top. When a connection is deleted on the gateway a refresh marks it
+// inactive here (it drops out of listings and stops accepting new
+// SYNs) while its IP stays reserved in the Allocator, so if it
+// reappears it gets the same address.
+type connRegistry struct {
+	mu      sync.RWMutex
+	entries map[string]connEntry
+}
+
+type connEntry struct {
+	subType string
+	// active is true while the gateway still offers this connection.
+	// A refresh flips it to false for connections that vanished; the
+	// accept path rejects new SYNs to inactive names and the listing
+	// hides them.
+	active bool
+}
+
+func newConnRegistry() *connRegistry {
+	return &connRegistry{entries: make(map[string]connEntry)}
+}
+
+// subTypeOf returns the subtype for an ACTIVE connection. The second
+// return is false for unknown names AND for known-but-inactive ones —
+// callers (the netstack accept func) treat both as "do not serve".
+func (r *connRegistry) subTypeOf(name string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.entries[name]
+	if !ok || !e.active {
+		return "", false
+	}
+	return e.subType, true
+}
+
+// ConnInfo is a flattened, value-copied view of one active connection,
+// safe to hand to callers outside the registry lock.
+type ConnInfo struct {
+	Name    string
+	SubType string
+}
+
+// activeConnections returns a snapshot of the currently-active
+// connections, copied out under the read lock so callers can range over
+// the result without holding the lock or racing a refresh. Unordered;
+// callers that need stable output sort by Name themselves.
+func (r *connRegistry) activeConnections() []ConnInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]ConnInfo, 0, len(r.entries))
+	for name, e := range r.entries {
+		if e.active {
+			out = append(out, ConnInfo{Name: name, SubType: e.subType})
+		}
+	}
+	return out
+}
+
+// reconcile sets the registry to exactly the supplied active set:
+// upserts each (name, subType) as active and marks every other
+// previously-known entry inactive. Entries are never deleted — an
+// inactive entry stays so its IP reservation in the Allocator remains
+// meaningful if the connection later reappears. Returns the number of
+// names that became newly active (added or reactivated) and the number
+// that went inactive, for logging.
+func (r *connRegistry) reconcile(active map[string]string) (added, removed int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for name, subType := range active {
+		prev, existed := r.entries[name]
+		if !existed || !prev.active {
+			added++
+		}
+		r.entries[name] = connEntry{subType: subType, active: true}
+	}
+
+	for name, e := range r.entries {
+		if !e.active {
+			continue
+		}
+		if _, stillActive := active[name]; !stillActive {
+			r.entries[name] = connEntry{subType: e.subType, active: false}
+			removed++
+		}
+	}
+	return added, removed
+}

--- a/tunnel/tunnelmgr/registry_test.go
+++ b/tunnel/tunnelmgr/registry_test.go
@@ -1,0 +1,129 @@
+package tunnelmgr
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+)
+
+// TestConnRegistry_ConcurrentAccess is the regression guard for the
+// data race this whole type exists to fix: the netstack accept/handler
+// closures read the registry on every SYN while a refresh writes it.
+// Run under `go test -race` it must report no races.
+func TestConnRegistry_ConcurrentAccess(t *testing.T) {
+	r := newConnRegistry()
+	r.reconcile(map[string]string{"pg": "postgres", "my": "mysql"})
+
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+
+	// Readers: mimic the accept func + listing/Snapshot paths. They run
+	// until stop is closed.
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_, _ = r.subTypeOf("pg")
+					_ = r.activeConnections()
+				}
+			}
+		}()
+	}
+
+	// Writer: mimic the periodic refresh churning the active set. When
+	// it finishes we stop the readers and wait for them to drain.
+	for i := 0; i < 1000; i++ {
+		r.reconcile(map[string]string{
+			"pg":                       "postgres",
+			fmt.Sprintf("dyn-%d", i%3): "mysql",
+		})
+	}
+	close(stop)
+	readers.Wait()
+}
+
+func TestConnRegistry_ReconcileAddsAndRetires(t *testing.T) {
+	r := newConnRegistry()
+
+	// First sync: two connections appear.
+	added, removed := r.reconcile(map[string]string{
+		"pg-prod": "postgres",
+		"my-prod": "mysql",
+	})
+	if added != 2 || removed != 0 {
+		t.Fatalf("first reconcile: added=%d removed=%d, want 2/0", added, removed)
+	}
+	if sub, ok := r.subTypeOf("pg-prod"); !ok || sub != "postgres" {
+		t.Errorf("pg-prod subtype = %q ok=%v, want postgres/true", sub, ok)
+	}
+
+	// Second sync: my-prod vanished, a new mssql appeared, pg-prod stays.
+	added, removed = r.reconcile(map[string]string{
+		"pg-prod":  "postgres",
+		"sql-prod": "mssql",
+	})
+	if added != 1 || removed != 1 {
+		t.Fatalf("second reconcile: added=%d removed=%d, want 1/1", added, removed)
+	}
+
+	// my-prod is now inactive: subTypeOf must report not-found so the
+	// accept path rejects new SYNs.
+	if _, ok := r.subTypeOf("my-prod"); ok {
+		t.Errorf("my-prod still active after it vanished from the gateway")
+	}
+	// The survivor and the newcomer are active.
+	if _, ok := r.subTypeOf("pg-prod"); !ok {
+		t.Errorf("pg-prod should still be active")
+	}
+	if _, ok := r.subTypeOf("sql-prod"); !ok {
+		t.Errorf("sql-prod should be active")
+	}
+
+	got := r.activeConnections()
+	names := make([]string, len(got))
+	for i, c := range got {
+		names[i] = c.Name
+	}
+	sort.Strings(names)
+	if len(names) != 2 || names[0] != "pg-prod" || names[1] != "sql-prod" {
+		t.Errorf("activeConnections = %v, want [pg-prod sql-prod]", names)
+	}
+}
+
+func TestConnRegistry_ReactivateKeepsNoStaleDuplicate(t *testing.T) {
+	r := newConnRegistry()
+	r.reconcile(map[string]string{"pg": "postgres"})
+	// pg vanishes...
+	r.reconcile(map[string]string{})
+	if _, ok := r.subTypeOf("pg"); ok {
+		t.Fatal("pg should be inactive after vanishing")
+	}
+	// ...then comes back. It must count as newly-added and be active
+	// again with the same name (the allocator keeps its IP reserved).
+	added, removed := r.reconcile(map[string]string{"pg": "postgres"})
+	if added != 1 || removed != 0 {
+		t.Fatalf("reactivate: added=%d removed=%d, want 1/0", added, removed)
+	}
+	if sub, ok := r.subTypeOf("pg"); !ok || sub != "postgres" {
+		t.Errorf("pg subtype = %q ok=%v after reactivation, want postgres/true", sub, ok)
+	}
+	if n := len(r.activeConnections()); n != 1 {
+		t.Errorf("activeConnections len = %d, want 1 (no stale duplicate)", n)
+	}
+}
+
+func TestConnRegistry_IdempotentReconcile(t *testing.T) {
+	r := newConnRegistry()
+	r.reconcile(map[string]string{"pg": "postgres"})
+	// Reconciling the identical set again must report no churn.
+	added, removed := r.reconcile(map[string]string{"pg": "postgres"})
+	if added != 0 || removed != 0 {
+		t.Errorf("idempotent reconcile: added=%d removed=%d, want 0/0", added, removed)
+	}
+}


### PR DESCRIPTION
## Summary

Separates the tunnel **netstack lifecycle** from **authentication**. Until now the tunnel came up only on login and tore down only on logout, conflating 'who am I' with 'is the netstack running'.

Adds two IPC endpoints that drive `Manager.BringUp`/`TearDown` without touching the token:

| Endpoint | Behavior |
|----------|----------|
| `POST /v1/tunnel/up` | Bring the netstack online using the persisted token. Synchronous, idempotent (`already_up`). Returns **409 not_logged_in** when logged out (no token to dial with). |
| `POST /v1/tunnel/down` | Tear the netstack down, **keep the token**. Idempotent (`already_down`). User stays logged in. |

This lets a user pause/resume the tunnel without re-authenticating.

## Changes
- `ipc.Service`: `Up`/`Down` methods + `TunnelUpResponse`/`TunnelDownResponse`.
- `ipc.Server`: handlers, routes, and a new `ErrNotLoggedIn` sentinel that maps to **409** (distinct from 401 control-token rejection).
- `ipc.Client`: `Up`/`Down` round-trip methods.
- `daemonService`: `Up` reuses `BringUp` (folds `ErrAlreadyUp` into `already_up`); `Down` reuses `TearDown`; neither touches the token or config file.
- `openapi.yaml`: both endpoints + the `not_logged_in` code.

## Testing
- Handler-level: 200 success, `already_up`/`already_down`, 409 `not_logged_in`.
- Service-level: logged-out → `ErrNotLoggedIn`, idle `Down` no-op, `Down` keeps the token (lifecycle/auth separation).
- `go build ./tunnel/...`, `go vet ./tunnel/...`, `go test ./tunnel/...` all green.

## Consumer
Paired with hoophq/hsh PR (tunnel up/down CLI + unified login). The CLI degrades gracefully against an older daemon (501).

Automated by MisterMal