### PR TITLE
[Fix] Hoop versions commands on Windows

### DIFF
--- a/client/cmd/versions/install_flow.go
+++ b/client/cmd/versions/install_flow.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/hoophq/hoop/client/cmd/styles"
@@ -39,13 +40,13 @@ func installAndActivate(target string) error {
 
 	if store.Active == target {
 		if _, err := os.Stat(layout.BinLink); err == nil {
-			fmt.Printf("Already on %s (symlink: %s)\n", target, layout.BinLink)
+			fmt.Printf("Already on %s (active CLI: %s)\n", target, layout.BinLink)
 			if !skipPathHint {
 				_ = runPathHint(layout)
 			}
 			return nil
 		}
-		// Store thinks this is active but the symlink is gone; fall
+		// Store thinks this is active but the bin path is gone; fall
 		// through to repair it.
 	}
 
@@ -76,7 +77,7 @@ func installAndActivate(target string) error {
 
 	fmt.Printf("Active hoop version is now %s\n", entry.Version)
 	fmt.Printf("Installed at: %s\n", layout.VersionBinary(entry.Version))
-	fmt.Printf("Symlink:      %s -> %s\n", layout.BinLink, layout.VersionBinary(entry.Version))
+	fmt.Printf("Active CLI:   %s\n", layout.BinLink)
 
 	if !skipPathHint {
 		_ = runPathHint(layout)
@@ -96,6 +97,19 @@ func runPathHint(layout upgrade.Layout) error {
 		return err
 	}
 	if upgrade.IsPathConfigured(os.Getenv("PATH"), home) {
+		return nil
+	}
+
+	// Windows has no shell rc file to append to; the durable PATH lives in
+	// the user environment. Print the (safe, non-destructive) PowerShell
+	// snippet and let the user apply it — we don't mutate the registry on
+	// their behalf.
+	if runtime.GOOS == "windows" {
+		fmt.Println()
+		fmt.Println(styles.KeywordHighlight("Heads up:") + " " + layout.BinDir + " is not in your PATH.")
+		fmt.Println("Add it to your user PATH so new terminals can find the active hoop CLI:")
+		fmt.Printf("  PowerShell: [Environment]::SetEnvironmentVariable(\"Path\", [Environment]::GetEnvironmentVariable(\"Path\", \"User\") + \";%s\", \"User\")\n", layout.BinDir)
+		fmt.Println("Then open a new terminal. You can also add it via System Settings > Environment Variables.")
 		return nil
 	}
 

--- a/client/cmd/versions/sync.go
+++ b/client/cmd/versions/sync.go
@@ -73,6 +73,16 @@ This usually means you're connected to a local development build that wasn't sta
   - To install the latest published release instead, run `+"`hoop versions upgrade`"+`.`,
 			apiURL, target)
 
+	case errors.Is(err, upgrade.ErrBelowWindowsFloor):
+		winFloor := upgrade.MinInstallableVersionWindows[1:] // strip leading "v"
+		return fmt.Errorf(`the gateway at %s is on version %s, but `+"`hoop versions`"+` only supports Windows from %s onward.
+Hoop CLIs older than %s don't manage themselves correctly on Windows, so a matching CLI can't be installed for you here.
+
+What to do:
+  - recommended: upgrade the gateway to %s or newer, then re-run `+"`hoop versions sync`"+`.
+  - manual: download a Windows build of hoop %s by hand from https://github.com/hoophq/hoop/releases. That CLI won't be able to self-manage on Windows, so future version changes will also need to be done by hand.`,
+			apiURL, target, winFloor, winFloor, winFloor, target)
+
 	case errors.Is(err, upgrade.ErrBelowFloor):
 		return fmt.Errorf(`the gateway at %s is on version %s, but the `+"`hoop versions sync`"+` command was only introduced in %s.0.
 Hoop CLIs older than %s.0 don't ship this command, so it can't install a matching CLI for you.

--- a/client/cmd/versions/versions.go
+++ b/client/cmd/versions/versions.go
@@ -112,7 +112,7 @@ var useCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("Active hoop version is now %s\n", target)
-		fmt.Printf("Symlink: %s -> %s\n", layout.BinLink, layout.VersionBinary(target))
+		fmt.Printf("Active CLI: %s\n", layout.BinLink)
 		return nil
 	},
 }
@@ -206,7 +206,7 @@ var removeCmd = &cobra.Command{
 			return fmt.Errorf("version %s is not installed", target)
 		}
 		if store.Active == target && !removeForceFlag {
-			return fmt.Errorf("version %s is currently active; pass --force to remove it (this will unlink %s)", target, layout.BinLink)
+			return fmt.Errorf("version %s is currently active; pass --force to remove it (this will remove %s)", target, layout.BinLink)
 		}
 
 		if err := os.RemoveAll(layout.VersionDir(target)); err != nil {
@@ -214,11 +214,12 @@ var removeCmd = &cobra.Command{
 		}
 		store.Remove(target)
 		if store.Active == "" {
-			// SetActive cleared it because we just removed the active one;
-			// also unlink the symlink so we don't leave a dangling link.
+			// Removing the active version cleared store.Active; also drop
+			// the bin path (symlink on Unix, copy on Windows) so we don't
+			// leave a dangling link or a stale copy behind.
 			if _, err := os.Lstat(layout.BinLink); err == nil {
 				if err := os.Remove(layout.BinLink); err != nil {
-					return fmt.Errorf("failed removing dangling symlink %s: %w", layout.BinLink, err)
+					return fmt.Errorf("failed removing active CLI path %s: %w", layout.BinLink, err)
 				}
 			}
 		}

--- a/client/upgrade/activate.go
+++ b/client/upgrade/activate.go
@@ -1,0 +1,45 @@
+package upgrade
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ErrBinLinkConflict is returned when the active-version path
+// ($HOME/.hoop/bin/hoop, or hoop.exe on Windows) already exists but was
+// not created by the version manager. On Unix that means it is a regular
+// file or a symlink pointing outside $HOME/.hoop/versions; on Windows it
+// means its contents don't match any installed version's binary. In both
+// cases we refuse to overwrite it because it may belong to the user —
+// most often a stale `make build-dev-client` output from before the dev
+// binary moved to $HOME/.hoop/dev/hoop.
+var ErrBinLinkConflict = errors.New("hoop bin path is owned by something else; refusing to overwrite")
+
+// SetActive makes version the active one by pointing the bin path
+// ($HOME/.hoop/bin/hoop) at the installed binary, then updates the
+// store's Active field. It does NOT save the store; callers do that
+// explicitly so install/activate semantics stay separable.
+//
+// The activation mechanism is OS-specific (see the activate function):
+// a symlink on Unix, a copy on Windows where unprivileged symlinks are
+// not available by default. Returns ErrBinLinkConflict when the bin path
+// is owned by something other than the version manager.
+func SetActive(l Layout, store *Store, version string) error {
+	version = NormalizeVersion(version)
+	target := l.VersionBinary(version)
+	if _, err := os.Stat(target); err != nil {
+		return fmt.Errorf("version %s is not installed (missing %s)", version, target)
+	}
+	if !store.Has(version) {
+		return fmt.Errorf("version %s is not in the versions store; reinstall it with `hoop versions install %s`", version, version)
+	}
+	if err := l.EnsureDirs(); err != nil {
+		return err
+	}
+	if err := activate(l, store, target); err != nil {
+		return err
+	}
+	store.Active = version
+	return nil
+}

--- a/client/upgrade/activate_windows.go
+++ b/client/upgrade/activate_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package upgrade
+
+// activate points the bin path at the installed binary. On Windows,
+// unprivileged symlink creation is not available by default, so the active
+// version is published as a copy at $HOME\.hoop\bin\hoop.exe.
+func activate(l Layout, store *Store, target string) error {
+	return copyActivate(l, store, target)
+}

--- a/client/upgrade/copyactivate.go
+++ b/client/upgrade/copyactivate.go
@@ -1,0 +1,148 @@
+package upgrade
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// copyActivate makes target the active binary by copying it to the bin
+// path. It is the Windows activation strategy: unprivileged symlinks are
+// not available there by default, so a copy is the robust, dependency-free
+// alternative.
+//
+// Windows will not let a process overwrite or delete a running executable,
+// but it WILL let one be renamed. So when the bin copy is the very process
+// performing the upgrade, copyActivate first renames the live binary aside
+// (hoop.exe.old-<nanos>) and then drops the new binary into place. Retired
+// copies are swept on a later run, once the process holding them exits.
+//
+// The function refuses to clobber a bin file the manager didn't create:
+// see assertOwnedCopy.
+func copyActivate(l Layout, store *Store, target string) error {
+	binPath := l.BinLink
+	if err := assertOwnedCopy(l, store, binPath); err != nil {
+		return err
+	}
+	dir := filepath.Dir(binPath)
+
+	// Stage the new binary next to the destination so the final move is a
+	// same-directory rename (atomic, no cross-volume copy).
+	staged := filepath.Join(dir, binaryName+".new")
+	_ = os.Remove(staged)
+	if err := copyFile(target, staged); err != nil {
+		return err
+	}
+
+	if _, err := os.Lstat(binPath); err == nil {
+		retired := fmt.Sprintf("%s.old-%d", binPath, time.Now().UnixNano())
+		if err := os.Rename(binPath, retired); err != nil {
+			os.Remove(staged)
+			return fmt.Errorf("failed retiring previous %s: %w", binPath, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		os.Remove(staged)
+		return fmt.Errorf("failed inspecting %s: %w", binPath, err)
+	}
+
+	if err := os.Rename(staged, binPath); err != nil {
+		os.Remove(staged)
+		return fmt.Errorf("failed installing %s: %w", binPath, err)
+	}
+
+	sweepRetired(dir)
+	return nil
+}
+
+// assertOwnedCopy returns nil iff binPath doesn't exist, or exists and its
+// contents match one of the installed versions' binaries (i.e. it is a
+// copy this tool made). Otherwise it returns ErrBinLinkConflict so we
+// never destroy a file the user placed at the bin path themselves.
+//
+// We compare against the on-disk version binaries rather than the store's
+// recorded checksum because the store records the tarball's sha256, not
+// the extracted binary's.
+func assertOwnedCopy(l Layout, store *Store, binPath string) error {
+	binSum, err := fileSHA256(binPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed reading %s: %w", binPath, err)
+	}
+	for _, v := range store.Versions {
+		versionSum, err := fileSHA256(l.VersionBinary(v.Version))
+		if err != nil {
+			// A recorded version whose binary is missing on disk can't be
+			// the source of the bin copy; skip it.
+			continue
+		}
+		if binSum == versionSum {
+			return nil
+		}
+	}
+	return fmt.Errorf(`%w:
+
+%s already exists and was not created by `+"`hoop versions`"+`.
+
+To recover, move or delete it and re-run the same command:
+  - keep it:    move "%s" to another location
+  - discard it: del "%s"`,
+		ErrBinLinkConflict, binPath, binPath, binPath)
+}
+
+// sweepRetired best-effort removes binaries previously moved aside by
+// copyActivate. The copy that belongs to a still-running process can't be
+// deleted yet; it will be swept on a subsequent run after that process
+// exits. Errors are intentionally ignored — a leftover file is harmless.
+func sweepRetired(dir string) {
+	matches, err := filepath.Glob(filepath.Join(dir, binaryName+".old-*"))
+	if err != nil {
+		return
+	}
+	for _, m := range matches {
+		_ = os.Remove(m)
+	}
+}
+
+// copyFile copies src to dst (0755), truncating dst if it exists. dst is
+// removed on a partial copy so callers never observe a half-written file.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed opening %s: %w", src, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("failed creating %s: %w", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(dst)
+		return fmt.Errorf("failed copying to %s: %w", dst, err)
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(dst)
+		return fmt.Errorf("failed closing %s: %w", dst, err)
+	}
+	return nil
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/client/upgrade/copyactivate_test.go
+++ b/client/upgrade/copyactivate_test.go
@@ -1,0 +1,89 @@
+package upgrade
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeVersionBinary(t *testing.T, l Layout, version string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(l.VersionDir(version), 0700); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(l.VersionBinary(version), content, 0755); err != nil {
+		t.Fatalf("write version binary: %v", err)
+	}
+}
+
+func TestCopyActivateFreshAndRetarget(t *testing.T) {
+	home := t.TempDir()
+	l := LayoutFromHome(home)
+	if err := l.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	v1 := []byte("hoop-1.0.0-bytes")
+	v2 := []byte("hoop-1.1.0-different-bytes")
+	writeVersionBinary(t, l, "1.0.0", v1)
+	writeVersionBinary(t, l, "1.1.0", v2)
+	store := &Store{Versions: []VersionEntry{{Version: "1.0.0"}, {Version: "1.1.0"}}}
+
+	// Fresh activation: bin path doesn't exist yet.
+	if err := copyActivate(l, store, l.VersionBinary("1.0.0")); err != nil {
+		t.Fatalf("copyActivate 1.0.0: %v", err)
+	}
+	if got, _ := os.ReadFile(l.BinLink); !bytes.Equal(got, v1) {
+		t.Fatalf("bin path is not a copy of 1.0.0: %q", got)
+	}
+
+	// Retarget: the existing bin path is a copy we made (owned), so the
+	// switch is allowed and the bytes change to 1.1.0.
+	if err := copyActivate(l, store, l.VersionBinary("1.1.0")); err != nil {
+		t.Fatalf("copyActivate 1.1.0: %v", err)
+	}
+	if got, _ := os.ReadFile(l.BinLink); !bytes.Equal(got, v2) {
+		t.Fatalf("bin path is not a copy of 1.1.0: %q", got)
+	}
+
+	// No staging or retired leftovers should remain after a clean run.
+	leftovers, _ := filepath.Glob(filepath.Join(l.BinDir, binaryName+".*"))
+	if len(leftovers) != 0 {
+		t.Fatalf("unexpected leftovers in bin dir: %v", leftovers)
+	}
+}
+
+func TestCopyActivateRefusesForeignFile(t *testing.T) {
+	home := t.TempDir()
+	l := LayoutFromHome(home)
+	if err := l.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	writeVersionBinary(t, l, "1.0.0", []byte("hoop-1.0.0-bytes"))
+	store := &Store{Versions: []VersionEntry{{Version: "1.0.0"}}}
+
+	// A file the version manager didn't create (content matches no version).
+	if err := os.WriteFile(l.BinLink, []byte("a user's own binary"), 0755); err != nil {
+		t.Fatalf("write foreign file: %v", err)
+	}
+
+	err := copyActivate(l, store, l.VersionBinary("1.0.0"))
+	if !errors.Is(err, ErrBinLinkConflict) {
+		t.Fatalf("expected ErrBinLinkConflict, got %v", err)
+	}
+	// The foreign file must be left untouched.
+	if got, _ := os.ReadFile(l.BinLink); !bytes.Equal(got, []byte("a user's own binary")) {
+		t.Fatalf("foreign file was modified: %q", got)
+	}
+}
+
+func TestAssertOwnedCopyAllowsMissingBin(t *testing.T) {
+	l := LayoutFromHome(t.TempDir())
+	if err := l.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	if err := assertOwnedCopy(l, &Store{}, l.BinLink); err != nil {
+		t.Fatalf("assertOwnedCopy on missing bin should be nil, got %v", err)
+	}
+}

--- a/client/upgrade/floor.go
+++ b/client/upgrade/floor.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"errors"
 	"fmt"
+	"runtime"
 
 	"golang.org/x/mod/semver"
 )
@@ -15,6 +16,18 @@ import (
 // The prefix "v" matches what golang.org/x/mod/semver expects. Update
 // this constant if the version manager is back-ported to an older minor.
 const MinInstallableMinor = "v1.74"
+
+// MinInstallableVersionWindows is the lowest full release the version
+// manager will install on Windows. Windows support landed later than the
+// general floor: earlier Windows builds ship a `hoop versions` that can't
+// manage itself (the release tarball carries hoop.exe but the extractor
+// looked for "hoop", and activation was symlink-only). Installing one of
+// those would strand a Windows user on a CLI that can't self-update.
+//
+// Unlike MinInstallableMinor this is a full MAJOR.MINOR.PATCH because the
+// fix shipped in a patch release. The prefix "v" matches what
+// golang.org/x/mod/semver expects.
+const MinInstallableVersionWindows = "v1.86.1"
 
 // Sentinel errors returned by ValidateInstallableVersion. Callers
 // (`hoop versions sync` and `hoop versions upgrade` in particular)
@@ -35,21 +48,45 @@ var (
 	// ErrBelowFloor means the version is a real semver but predates the
 	// release line in which the version manager shipped.
 	ErrBelowFloor = errors.New("version predates the hoop version manager")
+
+	// ErrBelowWindowsFloor means the version is a real semver but predates
+	// the release in which the version manager gained Windows support
+	// (MinInstallableVersionWindows). It is only ever returned on Windows.
+	ErrBelowWindowsFloor = errors.New("version predates Windows support for the hoop version manager")
 )
 
 // ValidateInstallableVersion returns an error if target cannot be
-// installed by the version manager. The returned error wraps one of the
-// Err* sentinels above (with %w) so callers can branch on errors.Is.
+// installed by the version manager on the host OS. The returned error
+// wraps one of the Err* sentinels above (with %w) so callers can branch
+// on errors.Is.
 //
 // The target should NOT carry a leading "v" — callers normalize through
 // NormalizeVersion first.
 func ValidateInstallableVersion(target string) error {
+	return validateInstallableVersion(target, runtime.GOOS)
+}
+
+// validateInstallableVersion is the testable core of
+// ValidateInstallableVersion. Taking goos as a parameter lets unit tests
+// exercise the Windows-specific floor without running on Windows, the same
+// way platformFor backs CurrentPlatform.
+//
+// Windows enforces its own (strictly higher) floor instead of the general
+// one, so a Windows client always gets the Windows-specific message rather
+// than the misleading "introduced in 1.74.0" line.
+func validateInstallableVersion(target, goos string) error {
 	if target == "" || target == "unknown" {
 		return fmt.Errorf("%w (got %q)", ErrUnknownGatewayVersion, target)
 	}
 	v := "v" + target
 	if !semver.IsValid(v) {
 		return fmt.Errorf("%w: %q", ErrInvalidVersion, target)
+	}
+	if goos == "windows" {
+		if semver.Compare(v, MinInstallableVersionWindows) < 0 {
+			return fmt.Errorf("%w: %s is older than %s", ErrBelowWindowsFloor, target, MinInstallableVersionWindows[1:])
+		}
+		return nil
 	}
 	if semver.Compare(semver.MajorMinor(v), MinInstallableMinor) < 0 {
 		return fmt.Errorf("%w: %s is older than %s.0", ErrBelowFloor, target, MinInstallableMinor[1:])

--- a/client/upgrade/floor_test.go
+++ b/client/upgrade/floor_test.go
@@ -66,6 +66,75 @@ func TestValidateInstallableVersion(t *testing.T) {
 	}
 }
 
+func TestValidateInstallableVersionWindowsFloor(t *testing.T) {
+	// Sanity: the Windows floor must be valid, patch-level semver.
+	if !strings.HasPrefix(MinInstallableVersionWindows, "v") {
+		t.Fatalf("MinInstallableVersionWindows must be semver-prefixed, got %q", MinInstallableVersionWindows)
+	}
+
+	cases := []struct {
+		in   string
+		goos string
+		want error // nil means must pass; otherwise must wrap this sentinel
+	}{
+		// Windows: the floor is MinInstallableVersionWindows (1.86.1).
+		{"1.86.1", "windows", nil},
+		{"1.86.2", "windows", nil},
+		{"1.87.0", "windows", nil},
+		{"2.0.0", "windows", nil},
+
+		// Windows, below the Windows floor: ErrBelowWindowsFloor — even
+		// for versions that would pass the general (Unix) floor.
+		{"1.86.0", "windows", ErrBelowWindowsFloor},
+		{"1.85.9", "windows", ErrBelowWindowsFloor},
+		{"1.74.0", "windows", ErrBelowWindowsFloor},
+		{"1.50.0", "windows", ErrBelowWindowsFloor},
+
+		// Non-Windows keeps the general floor unchanged.
+		{"1.74.0", "linux", nil},
+		{"1.74.0", "darwin", nil},
+		{"1.85.0", "linux", nil},
+		{"1.73.0", "linux", ErrBelowFloor},
+
+		// Invalid/unknown handling is OS-independent.
+		{"unknown", "windows", ErrUnknownGatewayVersion},
+		{"", "windows", ErrUnknownGatewayVersion},
+		{"banana", "windows", ErrInvalidVersion},
+		{"1.2.3.4", "windows", ErrInvalidVersion},
+	}
+	for _, tc := range cases {
+		err := validateInstallableVersion(tc.in, tc.goos)
+		switch {
+		case tc.want == nil:
+			if err != nil {
+				t.Errorf("validateInstallableVersion(%q, %q): want nil, got %v", tc.in, tc.goos, err)
+			}
+		default:
+			if err == nil {
+				t.Errorf("validateInstallableVersion(%q, %q): want error wrapping %v, got nil", tc.in, tc.goos, tc.want)
+				continue
+			}
+			if !errors.Is(err, tc.want) {
+				t.Errorf("validateInstallableVersion(%q, %q): want errors.Is(%v), got %v", tc.in, tc.goos, tc.want, err)
+			}
+		}
+	}
+}
+
+func TestValidateInstallableVersionWindowsFloorMessage(t *testing.T) {
+	err := validateInstallableVersion("1.80.0", "windows")
+	if !errors.Is(err, ErrBelowWindowsFloor) {
+		t.Fatalf("expected ErrBelowWindowsFloor, got %v", err)
+	}
+	winFloor := MinInstallableVersionWindows[1:] // "1.86.1"
+	if !strings.Contains(err.Error(), winFloor) {
+		t.Errorf("message should mention the Windows floor (%s): %v", winFloor, err)
+	}
+	if !strings.Contains(err.Error(), "1.80.0") {
+		t.Errorf("message should mention the rejected version 1.80.0: %v", err)
+	}
+}
+
 func TestValidateInstallableVersionBelowFloorMessage(t *testing.T) {
 	err := ValidateInstallableVersion("1.50.0")
 	if err == nil {

--- a/client/upgrade/installer.go
+++ b/client/upgrade/installer.go
@@ -93,8 +93,8 @@ func (i *Installer) Install(version string, platform Platform, store *Store) (Ve
 		)
 	}
 
-	extractedBinary := filepath.Join(tmpDir, binaryName)
-	if err := extractHoopBinary(tarballPath, extractedBinary); err != nil {
+	extractedBinary := filepath.Join(tmpDir, platform.ExecutableName())
+	if err := extractHoopBinary(tarballPath, extractedBinary, platform.ExecutableName()); err != nil {
 		return VersionEntry{}, err
 	}
 
@@ -198,9 +198,13 @@ func (i *Installer) downloadFile(url, dst string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-// extractHoopBinary extracts the entry named "hoop" (matching by basename)
+// extractHoopBinary extracts the entry whose basename equals wantName
 // from a gzip+tar archive into dst. Any other entries are skipped.
-func extractHoopBinary(tarball, dst string) error {
+//
+// wantName is platform-dependent: the Windows release tarball carries
+// hoop.exe while the Unix tarballs carry hoop (see Platform.ExecutableName),
+// so callers pass the name for the platform they are installing.
+func extractHoopBinary(tarball, dst, wantName string) error {
 	f, err := os.Open(tarball)
 	if err != nil {
 		return fmt.Errorf("failed opening tarball %s: %w", tarball, err)
@@ -223,7 +227,7 @@ func extractHoopBinary(tarball, dst string) error {
 		if hdr.Typeflag != tar.TypeReg {
 			continue
 		}
-		if filepath.Base(hdr.Name) != binaryName {
+		if filepath.Base(hdr.Name) != wantName {
 			continue
 		}
 		out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
@@ -241,5 +245,5 @@ func extractHoopBinary(tarball, dst string) error {
 		}
 		return nil
 	}
-	return fmt.Errorf("hoop binary not found inside %s", tarball)
+	return fmt.Errorf("hoop binary (%s) not found inside %s", wantName, tarball)
 }

--- a/client/upgrade/installer_test.go
+++ b/client/upgrade/installer_test.go
@@ -51,7 +51,7 @@ func TestExtractHoopBinary(t *testing.T) {
 	})
 
 	dst := filepath.Join(dir, "hoop")
-	if err := extractHoopBinary(tarballPath, dst); err != nil {
+	if err := extractHoopBinary(tarballPath, dst, "hoop"); err != nil {
 		t.Fatalf("extractHoopBinary failed: %v", err)
 	}
 	got, err := os.ReadFile(dst)
@@ -63,13 +63,43 @@ func TestExtractHoopBinary(t *testing.T) {
 	}
 }
 
+// TestExtractHoopBinaryWindows guards the Windows release layout: the
+// tarball carries hoop.exe (Go appends .exe for GOOS=windows), so the
+// extractor must match that name rather than the bare "hoop".
+func TestExtractHoopBinaryWindows(t *testing.T) {
+	dir := t.TempDir()
+	tarballPath := filepath.Join(dir, "hoop-win.tar.gz")
+	binaryContent := []byte("MZ\x90\x00fake-windows-binary")
+	writeTarball(t, tarballPath, map[string][]byte{
+		"hoop.exe":  binaryContent,
+		"README.md": []byte("ignored"),
+	})
+
+	dst := filepath.Join(dir, "hoop.exe")
+	if err := extractHoopBinary(tarballPath, dst, "hoop.exe"); err != nil {
+		t.Fatalf("extractHoopBinary(windows) failed: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read extracted binary: %v", err)
+	}
+	if !bytes.Equal(got, binaryContent) {
+		t.Fatalf("extracted content mismatch: got %q want %q", got, binaryContent)
+	}
+
+	// The Unix name must NOT match a Windows artifact.
+	if err := extractHoopBinary(tarballPath, dst, "hoop"); err == nil {
+		t.Fatalf("expected miss when looking for bare 'hoop' inside a Windows tarball")
+	}
+}
+
 func TestExtractHoopBinaryMissing(t *testing.T) {
 	dir := t.TempDir()
 	tarballPath := filepath.Join(dir, "no-hoop.tar.gz")
 	writeTarball(t, tarballPath, map[string][]byte{
 		"README.md": []byte("nothing useful here"),
 	})
-	err := extractHoopBinary(tarballPath, filepath.Join(dir, "out"))
+	err := extractHoopBinary(tarballPath, filepath.Join(dir, "out"), "hoop")
 	if err == nil {
 		t.Fatalf("expected error when no hoop binary inside tarball")
 	}
@@ -128,6 +158,50 @@ func TestInstallerEndToEnd(t *testing.T) {
 	}
 	if entry2.Version != version {
 		t.Fatalf("second install entry version=%s", entry2.Version)
+	}
+}
+
+// TestInstallerWindowsArtifact exercises the full download+extract path
+// against a Windows release artifact (which contains hoop.exe). It is the
+// regression test for the bug where `hoop versions install` on Windows
+// failed with "hoop binary not found inside ...tar.gz" because the
+// extractor only ever looked for the bare name "hoop".
+func TestInstallerWindowsArtifact(t *testing.T) {
+	binaryContent := []byte("MZ\x90\x00fake-windows-binary-v1.99.0")
+	tarball := buildTarball(t, map[string][]byte{"hoop.exe": binaryContent})
+	sum := sha256Hex(tarball)
+
+	version := "1.99.0"
+	platform := Platform{OS: "Windows", Arch: "x86_64"}
+	artifactName := ArtifactName(version, platform)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/release/"+version+"/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "%s  %s\n", sum, artifactName)
+	})
+	mux.HandleFunc("/release/"+version+"/"+artifactName, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(tarball)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	layout := LayoutFromHome(t.TempDir())
+	store := &Store{}
+	inst := &Installer{Layout: layout, Client: srv.Client(), BaseURL: srv.URL + "/release"}
+
+	entry, err := inst.Install(version, platform, store)
+	if err != nil {
+		t.Fatalf("Install(windows): %v", err)
+	}
+	got, err := os.ReadFile(layout.VersionBinary(version))
+	if err != nil {
+		t.Fatalf("read installed binary: %v", err)
+	}
+	if !bytes.Equal(got, binaryContent) {
+		t.Fatalf("installed binary mismatch")
+	}
+	if entry.SHA256 != sum {
+		t.Fatalf("entry sha=%s want %s", entry.SHA256, sum)
 	}
 }
 

--- a/client/upgrade/paths.go
+++ b/client/upgrade/paths.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // File and directory names under $HOME/.hoop used by the version manager.
@@ -19,9 +20,15 @@ const (
 	homeDirName       = ".hoop"
 	binDirName        = "bin"
 	versionsDirName   = "versions"
-	binaryName        = "hoop"
 	versionsStoreFile = "versions.toml"
 )
+
+// binaryName is the hoop executable filename on the host OS. On Windows
+// the Go toolchain appends a .exe suffix at build time, so the release
+// tarball contains hoop.exe and both the per-version install path and the
+// active-version file must use that same name — otherwise os.Stat checks
+// and PATH resolution would look for a file that doesn't exist.
+var binaryName = executableName(runtime.GOOS == "windows")
 
 // Layout resolves the absolute paths the version manager works with.
 // All fields are absolute paths. Layout does not create any directories;

--- a/client/upgrade/platform.go
+++ b/client/upgrade/platform.go
@@ -66,6 +66,25 @@ func ArtifactName(version string, p Platform) string {
 	return fmt.Sprintf("hoop_%s_%s.tar.gz", version, p)
 }
 
+// ExecutableName returns the hoop executable filename packaged inside the
+// release artifact for this platform. Windows binaries carry a .exe
+// suffix because the Go toolchain appends it for GOOS=windows builds, so
+// the Windows tarball contains hoop.exe rather than hoop.
+func (p Platform) ExecutableName() string {
+	return executableName(p.OS == "Windows")
+}
+
+// executableName is the single source of truth for the OS-dependent hoop
+// binary filename. It is shared by Platform.ExecutableName (which keys off
+// the release OS label) and the host-side layout (which keys off
+// runtime.GOOS) so the two can never drift.
+func executableName(windows bool) string {
+	if windows {
+		return "hoop.exe"
+	}
+	return "hoop"
+}
+
 // ArtifactURL returns the full https URL for the release tarball.
 func ArtifactURL(version string, p Platform) string {
 	return fmt.Sprintf("%s/%s/%s", ReleasesBaseURL, version, ArtifactName(version, p))

--- a/client/upgrade/symlink.go
+++ b/client/upgrade/symlink.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package upgrade
 
 import (
@@ -5,44 +7,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
-// ErrBinLinkConflict is returned when $HOME/.hoop/bin/hoop already
-// exists but is a regular file or a symlink pointing outside of
-// $HOME/.hoop/versions. We refuse to overwrite it because it may
-// belong to the user — most often a stale `make build-dev-client`
-// output from before the dev binary moved to $HOME/.hoop/dev/hoop.
-var ErrBinLinkConflict = errors.New("hoop bin path is owned by something else; refusing to overwrite")
-
-// SetActive atomically updates the active symlink at $HOME/.hoop/bin/hoop
-// to point at the installed version's binary and updates the store's
-// Active field. It does NOT save the store; callers do that explicitly.
-//
-// Returns ErrBinLinkConflict if a non-symlink file exists at the bin path
-// or if an existing symlink resolves outside the versions directory.
-func SetActive(l Layout, store *Store, version string) error {
-	version = NormalizeVersion(version)
-	target := l.VersionBinary(version)
-	if _, err := os.Stat(target); err != nil {
-		return fmt.Errorf("version %s is not installed (missing %s)", version, target)
-	}
-	if !store.Has(version) {
-		return fmt.Errorf("version %s is not in the versions store; reinstall it with `hoop versions install %s`", version, version)
-	}
-	if err := l.EnsureDirs(); err != nil {
-		return err
-	}
-	if runtime.GOOS == "windows" {
-		return fmt.Errorf("setting the active version requires symlink privileges that are not available by default on Windows; install the matching version with brew/chocolatey or download from %s", ReleasesBaseURL)
-	}
-
-	if err := safeReplaceSymlink(l, target); err != nil {
-		return err
-	}
-	store.Active = version
-	return nil
+// activate points the bin path at the installed binary. On Unix this is a
+// symlink swap; the store argument is unused here (it is only needed by
+// the Windows copy-based activation, which can't rely on symlinks).
+func activate(l Layout, _ *Store, target string) error {
+	return safeReplaceSymlink(l, target)
 }
 
 // safeReplaceSymlink replaces the bin symlink with a new target pointing


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Makes the `hoop versions` command group (`install`, `sync`, `upgrade`) work on Windows.

Previously every one of those subcommands failed on Windows with `hoop binary not found inside ...tar.gz`. The installer matched the archive entry by the exact name `hoop`, but Windows release tarballs contain `hoop.exe` (the Go toolchain appends `.exe` for `GOOS=windows`), so extraction never found the binary. Activation was also hard-blocked on Windows because it relied on Unix symlinks.

This PR makes the binary name OS-aware, fixes extraction, adds a copy-based activation strategy for Windows, gives Windows-appropriate PATH guidance, and enforces a Windows-specific minimum installable version. Unix behavior is unchanged.

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when this PR is merged -->

Fixes #

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- OS-aware hoop binary name (`hoop` vs `hoop.exe`), shared by release-artifact extraction and the on-disk layout via a single helper so the two can't drift.
- Extractor now matches the target platform's binary name — the actual fix for the `install`/`sync`/`upgrade` failure on Windows.
- Windows activation via a safe copy (running-exe-aware replace + content-based ownership guard) instead of the Unix-only symlink; Unix continues to use the atomic symlink swap.
- Windows-aware PATH hint (non-destructive PowerShell user-PATH snippet) and neutralized the symlink-specific CLI output (`Active CLI:` instead of `Symlink:`).
- Windows-specific install floor of `1.86.1` (`ErrBelowWindowsFloor`): older Windows builds can't manage themselves, so `install`/`sync`/`upgrade` refuse them with a tailored message.
- Tests: Windows artifact extraction + end-to-end install, copy activation (fresh/retarget/foreign-file refusal), and the Windows floor (incl. message content).

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: N/A (Go CLI)
- **OS**: macOS/Linux for unit tests; cross-compiled for `windows/amd64`

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

`go test ./client/upgrade/...` passes; `go build` and `go vet` are clean for both `darwin` and `windows/amd64`.

> Pending: a manual smoke test on a real Windows host (`hoop versions install <v> --use` then `hoop versions upgrade` while running from `bin\hoop.exe`) to exercise the running-executable replacement path, which can't be reproduced via cross-compilation.

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
<!-- You can drag and drop images directly into this text area -->

N/A

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

<!-- Add any additional notes, concerns, or discussion points here -->
<!-- Is there anything specific you'd like reviewers to focus on? -->

- **Suggested label: `patch`** (fixes a broken feature on Windows; non-breaking). If you'd rather frame it as "adds Windows platform support," `minor` also fits — maintainer's call.
- **Please confirm `1.86.1` is the release this ships in.** The Windows floor is a single constant (`MinInstallableVersionWindows` in `client/upgrade/floor.go`); bump it if the cut version changes.
- **Reviewer focus:** `client/upgrade/copyactivate.go` (the running-exe-safe replacement + ownership guard) and the Windows floor messaging in `client/cmd/versions/sync.go`.

---

<!-- Thank you for contributing to our project! 🙏 -->