### PR TITLE
edit add auto-generate notes on auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -124,9 +124,49 @@ jobs:
             echo "::error::Release $NEXT already exists. Another run may have created it; investigate before retrying."
             exit 1
           fi
+          # Create the release with GitHub's auto-generated changelog (the PRs
+          # merged since $PREVIOUS). The tag push (made with the PAT) triggers
+          # release.yml, which builds and uploads every artifact linked below.
           gh release create "$NEXT" \
             --title "$NEXT" \
             --target "$SHA" \
             --generate-notes \
             --notes-start-tag "$PREVIOUS"
+
+          # Append a curated Assets section to the auto-generated changelog so the
+          # release page links straight to the published binaries, image, charts
+          # and gateway bundles. These are stable, predictable URLs; the files go
+          # live a few minutes later once release.yml finishes publishing to
+          # S3 (releases.hoop.dev) and Docker Hub.
+          CHANGELOG=$(gh release view "$NEXT" --json body --jq '.body')
+          ASSETS=$(cat <<EOF
+          ## Assets
+
+          - [hoop-darwin-arm64](https://releases.hoop.dev/release/${NEXT}/hoop_${NEXT}_Darwin_arm64.tar.gz)
+          - [hoop-darwin-amd64](https://releases.hoop.dev/release/${NEXT}/hoop_${NEXT}_Darwin_x86_64.tar.gz)
+          - [hoop-linux-arm64](https://releases.hoop.dev/release/${NEXT}/hoop_${NEXT}_Linux_arm64.tar.gz)
+          - [hoop-linux-amd64](https://releases.hoop.dev/release/${NEXT}/hoop_${NEXT}_Linux_x86_64.tar.gz)
+          - [hoop-windows-arm64](https://releases.hoop.dev/release/${NEXT}/hoop_${NEXT}_Windows_arm64.tar.gz)
+          - [hoop-windows-amd64](https://releases.hoop.dev/release/${NEXT}/hoop_${NEXT}_Windows_x86_64.tar.gz)
+          - [checksums.txt](https://releases.hoop.dev/release/${NEXT}/checksums.txt)
+
+          ## Docker Images
+
+          - [hoophq/hoop:latest](https://hub.docker.com/r/hoophq/hoop)
+          - [hoophq/hoop:${NEXT}](https://hub.docker.com/r/hoophq/hoop)
+
+          ## Helm Chart
+
+          - [hoop-chart-${NEXT}](https://releases.hoop.dev/release/${NEXT}/hoop-chart-${NEXT}.tgz)
+          - [hoopagent-chart-${NEXT}](https://releases.hoop.dev/release/${NEXT}/hoopagent-chart-${NEXT}.tgz)
+
+          ## Bundles
+
+          - [hoop-gateway-bundle-amd64](https://releases.hoop.dev/release/${NEXT}/hoopgateway_${NEXT}-Linux_amd64.tar.gz)
+          - [hoop-gateway-bundle-arm64](https://releases.hoop.dev/release/${NEXT}/hoopgateway_${NEXT}-Linux_arm64.tar.gz)
+          EOF
+          )
+
+          gh release edit "$NEXT" --notes "$(printf '%s\n\n%s\n' "$CHANGELOG" "$ASSETS")"
+
           echo "Created release $NEXT (previous: $PREVIOUS) — release.yml will now build and publish artifacts."


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

<!-- Please provide a brief description of the changes in this PR -->

The **Auto Release** workflow (`.github/workflows/auto-release.yml`) now appends a curated
**Assets / Docker Images / Helm Chart / Bundles** section to the GitHub Release notes, restoring
the human-readable asset links that the old manual `make publish` (`scripts/publish-release.sh`)
flow used to produce. Previously the auto-created release only carried GitHub's `--generate-notes`
changelog, with no direct links to the published binaries, images, charts, or gateway bundles.

The auto-generated changelog is preserved: the release is still created with `--generate-notes`,
then its body is read back and the Assets section is appended via `gh release edit` (since
`gh release create` rejects combining `--generate-notes` with `--notes`).

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when this PR is merged -->

Fixes #

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [x] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- Append a curated `## Assets`, `## Docker Images`, `## Helm Chart`, and `## Bundles` section to the auto-generated release notes in the `Create GitHub release` step.
- Keep the PR-derived changelog by creating the release with `--generate-notes`, then reading the body back and re-saving it with the Assets section appended via `gh release edit`.
- Link the 6 CLI binaries + `checksums.txt` (S3/`releases.hoop.dev`), the gateway/agent Docker images (Docker Hub), both Helm charts, and both gateway bundles using stable, predictable per-version URLs.

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: macOS (local validation) / `ubuntu-latest` (CI runner)

### Tests performed:
- [ ] Unit tests pass <!-- N/A: workflow YAML, no unit tests -->
- [ ] Integration tests pass <!-- N/A -->
- [x] Manual testing completed

Manual validation:
- De-indented the step's block scalar exactly as a YAML parser would and ran `bash -n` — syntax OK, heredoc closes at column 0 (no stray markdown indentation).
- Executed the step with a stubbed `gh` (`NEXT=1.86.2`) and confirmed the auto-generated changelog is preserved with the Assets section appended below it.
- Verified every asset URL pattern returns `200` against the existing `1.86.1` release (all 6 binaries, `checksums.txt`, both Helm charts, both gateway bundles).

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
<!-- You can drag and drop images directly into this text area -->

N/A

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes <!-- N/A: workflow-only change -->
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes