### PR TITLE
fix: re-add reviewed by info in session details

### DIFF
--- a/webapp/src/css/tailwind.css
+++ b/webapp/src/css/tailwind.css
@@ -17,6 +17,10 @@
   z-index: 202;
 }
 
+.rt-TooltipContent {
+  z-index: 202;
+}
+
 .radix-themes {
   --cursor-button: pointer;
   --cursor-checkbox: default;

--- a/webapp/src/webapp/sessions/components/session_details.cljs
+++ b/webapp/src/webapp/sessions/components/session_details.cljs
@@ -1,6 +1,6 @@
 (ns webapp.sessions.components.session-details
   (:require
-   ["@radix-ui/themes" :refer [Avatar Badge Box Button Flex Text]]
+   ["@radix-ui/themes" :refer [Avatar Badge Box Button Flex Text Tooltip]]
    ["lucide-react" :refer [Hash BadgeCheck CalendarArrowDown CalendarArrowUp
                            ChevronDown ChevronUp CircleCheckBig CircleUser
                            Clock2 ExternalLink FastForward KeyRound OctagonX Package
@@ -35,7 +35,27 @@
 (defmethod ^:private access-request-badge :default [_]
   nil)
 
-;; Review group item with icon and badge
+(defn- review-action-verb [status]
+  (case status
+    "APPROVED" "approved"
+    "REJECTED" "rejected"
+    nil))
+
+(defn- review-reviewer-info [group]
+  (let [reviewer (:reviewed_by group)
+        reviewer-name (or (:email reviewer) (:name reviewer))
+        verb (review-action-verb (:status group))
+        review-date (:review_date group)]
+    (when (and reviewer-name verb)
+      [:> Flex {:gap "1" :align "center" :class "text-gray-11"}
+       [:> CircleUser {:size 16}]
+       [:> Text {:size "2" :weight "medium" :class "text-gray-12"} reviewer-name]
+       [:> Text {:size "2"} (str verb " this")]
+       (when review-date
+         [:> Tooltip {:content (formatters/time-parsed->full-date review-date)}
+          [:> Text {:size "2" :class "cursor-default"}
+           (formatters/time-ago-full-date review-date)]])])))
+
 (defn- review-group-item [group]
   [:> Flex {:gap "6" :align "center"}
    [:> Flex {:gap "2" :align "center" :class "w-[128px]"}
@@ -43,7 +63,8 @@
      [:> Users {:size 20 :class "text-gray-11"}]]
     [:> Text {:size "2" :class "text-gray-11 flex block truncate"}
      [tooltip/truncate-tooltip {:text (:group group)}]]]
-   [access-request-badge (:status group)]])
+   [access-request-badge (:status group)]
+   [review-reviewer-info group]])
 
 (defmulti ^:private status-badge identity)
 (defmethod ^:private status-badge "done" [_]


### PR DESCRIPTION
## 📝 Description

Show who approved/rejected each review group in the session details modal. Each decided review group now displays the reviewer's name, the action ("approved"/"rejected") and a relative timestamp ("…this 10 minutes ago"), with a tooltip revealing the exact review date on hover.

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added reviewer attribution to each review group row in `webapp/src/webapp/sessions/components/session_details.cljs`: person icon + reviewer name (email, falling back to display name) + "approved/rejected this" + relative time, sourced from the existing `review.review_groups_data[].reviewed_by` / `review_date` fields (no backend changes needed).
- Wrapped the relative time in a Radix `Tooltip` showing the full review date on hover; pending groups (no decision yet) render no attribution.
- Fixed Radix tooltip layering inside modals by adding `.rt-TooltipContent { z-index: 202; }` in `webapp/src/css/tailwind.css`, matching the existing `.rt-PopperContent` override. This fixes tooltips in every modal, not just this component.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: MacOs

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots

<img width="2862" height="1168" alt="CleanShot 2026-06-03 at 16 06 02@2x" src="https://github.com/user-attachments/assets/356e534e-862b-462e-80b9-608e8169490f" />
<img width="2866" height="1498" alt="CleanShot 2026-06-03 at 16 06 39@2x" src="https://github.com/user-attachments/assets/5e75d166-4e61-4969-8dde-a12f1360df6d" />


## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
