### PR TITLE
feat(helm/gateway): add configurable pod and container securityContext

### DIFF
--- a/deploy/helm-chart/chart/gateway/templates/deployment.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/deployment.yaml
@@ -28,10 +28,18 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: hoopgateway
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: '{{ .Values.image.gw.repository | default "hoophq/hoop" }}:{{ .Values.image.gw.tag | default "latest" }}'
         name: hoopgateway
         imagePullPolicy: {{ .Values.image.gw.pullPolicy | default "Always" }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         args:
         - hoop
         - start
@@ -61,6 +69,10 @@ spec:
         args:
         - hoop-default-agent.sh
         imagePullPolicy: {{ .Values.defaultAgent.imagePullPolicy | default "Always" }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- if $.Values.persistence.enabled }}
         volumeMounts:
         - mountPath: /opt/hoop/sessions

--- a/deploy/helm-chart/chart/gateway/values.yaml
+++ b/deploy/helm-chart/chart/gateway/values.yaml
@@ -118,6 +118,15 @@ podAnnotations: {}
 ##
 deploymentAnnotations: {}
 
+# -- Pod-level security context for the gateway Pod
+# (e.g. fsGroup, runAsNonRoot, runAsUser, seccompProfile)
+podSecurityContext: {}
+
+# -- Container-level security context for the gateway and default-agent
+# containers (e.g. allowPrivilegeEscalation, capabilities,
+# readOnlyRootFilesystem, runAsNonRoot, seccompProfile)
+securityContext: {}
+
 # hoop gateway configuration. Please refer to https://hoop.dev/docs/self-hosting
 config:
   POSTGRES_DB_URI: ''


### PR DESCRIPTION
  > Release label needed: **`minor`** (new non-breaking feature). I don't have
  > permission to set labels on this repo — could a maintainer please add it?

  ## 📝 Description

  Adds `podSecurityContext` (Pod-level) and `securityContext` (container-level)
  values to the **gateway** chart, wired into the gateway Deployment — applied to
  the `hoopgateway` container and the optional `defaultagent` sidecar.

  The chart currently exposes no way to set a security context, so the gateway Pod
  cannot be hardened to satisfy Kubernetes Pod Security Admission beyond
  `privileged`. Operators running under `baseline`/`restricted` PSS (SOC2 /
  regulated environments) need to set `allowPrivilegeEscalation: false`,
  `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`, etc.

  Defaults are empty (`{}`), so `{{- with }}` renders nothing and output is
  **unchanged** for existing users — fully backward-compatible.

  ## 🔗 Related Issue

  N/A (driven by a downstream PSS-hardening requirement; no public issue).

  ## 🚀 Type of Change

  - [x] ✨ New feature (non-breaking change which adds functionality)

  ## 📋 Changes Made

  - `values.yaml`: add `podSecurityContext: {}` and `securityContext: {}` (empty defaults, helm-docs comments).
  - `templates/deployment.yaml`: render pod-level `securityContext` under `spec.template.spec`, and container-level `securityContext` on both the `hoopgateway` container and the optional
  `defaultagent` sidecar, each guarded by `{{- with }}` so empty defaults emit nothing.

  ## 🧪 Testing

  ### Test Configuration:
  - **OS**: Linux + kind (k8s v1.31.0)
  - **Browser(s)**: N/A (no UI change)

  ### Tests performed:
  - [x] Manual testing completed

  Details:
  - `helm lint` passes.
  - `helm template` with **default** values is **byte-for-byte identical** to the current chart (empty `diff`) → proves backward compatibility.
  - `helm template` with an opt-in values file renders the pod-level context under `spec.template.spec` and the container-level context in both `hoopgateway` and `defaultagent`, with valid
  indentation.
  - Verified live on a kind cluster: gateway pod runs `1/1` with both contexts applied; admitted under a namespace labelled `pod-security.kubernetes.io/enforce=baseline`. A `restricted`
  label warns only `runAsNonRoot != true` (see notes).

  Opt-in example:
  ```yaml
  podSecurityContext:
    seccompProfile:
      type: RuntimeDefault
  securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop: ["ALL"]

  ✅ Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings (helm lint clean)
  - [x] I have checked my code and corrected any misspellings

  📄 Additional Notes

  - Scope: covers the gateway Deployment (gateway + defaultagent). The
  optional Presidio / Postgres sub-deployments are intentionally out of scope —
  they're third-party images (mcr.microsoft.com/presidio-*, postgres,
  envoyproxy/envoy) with distinct requirements; reusing .Values.securityContext
  for them would be incorrect. Happy to follow up with dedicated keys if desired.
  - Full PSS restricted (runAsNonRoot: true) is not achievable by this PR
  alone: the gateway image runs as root with no non-root user and root-owned
  dirs (/opt/hoop/sessions, /app). Confirmed on kind — a restricted
  namespace warns runAsNonRoot != true. A non-root image (dedicated user +
  chown + USER) is needed for that — happy to raise as a separate issue/PR.