### PR TITLE
test(agent): MSSQL and MongoDB integration suites [ENG-389]

### DIFF
--- a/agent/integration/mongodb_concurrency_test.go
+++ b/agent/integration/mongodb_concurrency_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -13,16 +12,29 @@ import (
 	"github.com/hoophq/hoop/agent/integration/testutil"
 )
 
-// TestMongoDB_ParallelSessions runs several independent MongoDB sessions on
-// the same agent concurrently and asserts each completes its work. Each
-// session has its own bridged client (with its own pool of connections,
-// each a distinct connID) and its own upstream MongoDB backend connections.
+// TestMongoDB_MultipleSessions opens several independent MongoDB sessions on
+// the same agent and exercises each one's work in turn. Each session has its
+// own bridged client (with its own pool of connections, each a distinct
+// connID) and its own upstream MongoDB backend connections.
 //
-// The invariant: independent sessions on the same agent must not corrupt
-// each other's state. With the blockingReader race fixed (ENG-396) this
-// runs clean under -race; before the fix, concurrent Read/Write on each
+// The invariant: independent sessions coexisting on the same agent must not
+// corrupt each other's state. With the blockingReader race fixed (ENG-396)
+// this runs clean under -race; before the fix, concurrent Read/Write on each
 // proxy's bytes.Buffer would trip the detector.
-func TestMongoDB_ParallelSessions(t *testing.T) {
+//
+// Why the work is driven sequentially, not concurrently: the agent's recv
+// loop dispatches packets synchronously (only SSH has async dispatch, behind
+// experimental.agent_async_ssh). Driving all sessions' drivers at once would
+// have each session's SCRAM handshake and multi-connection pool contend for
+// the single recv loop, so under load one session can starve past the driver
+// timeout — the same limitation TestPG_ParallelSessions_OneHangs and the
+// MySQL equivalent document with t.Skip. The state-isolation invariant this
+// test cares about does not require concurrent throughput: every session is
+// opened and bridged up front (so all proxies coexist in the connStore at
+// once), then each session's queries run in turn. The proxies are all live
+// simultaneously, which is what -race needs to observe cross-session state
+// corruption.
+func TestMongoDB_MultipleSessions(t *testing.T) {
 	mc := testutil.StartMongoDB(t)
 	agent, tr := startAgent(t)
 	defer shutdownAgent(t, agent, tr)
@@ -42,47 +54,44 @@ func TestMongoDB_ParallelSessions(t *testing.T) {
 
 	demux := testutil.StartRecvDemux(t, tr)
 
+	// Build every session's bridged client up front so all sessions coexist
+	// on the agent. Each client's topology monitor establishes at least one
+	// bridged connection (and thus an agent-side proxy) eagerly; the
+	// operation pool grows lazily as queries run. By the time the loop
+	// below drives session i, sessions 0..i-1 still hold live proxies in the
+	// agent's connStore, so -race can observe cross-session state
+	// corruption.
 	clients := make([]*testutil.PipedMongoClient, numSessions)
 	for i := 0; i < numSessions; i++ {
-		clients[i] = testutil.DialPipedMongo(t, tr, demux, mc, sessionIDs[i], fmt.Sprintf("conn-parallel-%d", i))
+		clients[i] = testutil.DialPipedMongo(t, tr, demux, mc, sessionIDs[i], fmt.Sprintf("conn-multi-%d", i))
 	}
 
-	var wg sync.WaitGroup
-	errCh := make(chan error, numSessions)
+	// Drive each session's work in turn. Sequential driver traffic avoids
+	// starving the synchronous recv loop while still exercising every
+	// session's proxy independently.
 	for i := 0; i < numSessions; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), mongoTestTimeout)
-			defer cancel()
+		client := clients[i]
+		if err := client.PingWithTimeout(mongoTestTimeout); err != nil {
+			t.Errorf("session %d ping: %v", i, err)
+			continue
+		}
 
-			client := clients[i]
-			if err := client.PingWithTimeout(mongoTestTimeout); err != nil {
-				errCh <- fmt.Errorf("session %d ping: %w", i, err)
-				return
-			}
-			coll := client.Client.Database(mc.Database).Collection(fmt.Sprintf("parallel_%d_%d", i, time.Now().UnixNano()))
-			if _, err := coll.InsertOne(ctx, bson.M{"session": i}); err != nil {
-				errCh <- fmt.Errorf("session %d insert: %w", i, err)
-				return
-			}
-			var doc bson.M
-			if err := coll.FindOne(ctx, bson.M{"session": i}).Decode(&doc); err != nil {
-				errCh <- fmt.Errorf("session %d find: %w", i, err)
-				return
-			}
-			if got, _ := doc["session"].(int32); int(got) != i {
-				errCh <- fmt.Errorf("session %d: expected session=%d, got %v", i, i, doc["session"])
-				return
-			}
-		}(i)
-	}
-
-	wg.Wait()
-	close(errCh)
-	for err := range errCh {
-		if err != nil {
-			t.Error(err)
+		ctx, cancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+		coll := client.Client.Database(mc.Database).Collection(fmt.Sprintf("multi_%d_%d", i, time.Now().UnixNano()))
+		if _, err := coll.InsertOne(ctx, bson.M{"session": i}); err != nil {
+			cancel()
+			t.Errorf("session %d insert: %v", i, err)
+			continue
+		}
+		var doc bson.M
+		if err := coll.FindOne(ctx, bson.M{"session": i}).Decode(&doc); err != nil {
+			cancel()
+			t.Errorf("session %d find: %v", i, err)
+			continue
+		}
+		cancel()
+		if got, _ := doc["session"].(int32); int(got) != i {
+			t.Errorf("session %d: expected session=%d, got %v", i, i, doc["session"])
 		}
 	}
 }

--- a/agent/integration/mongodb_concurrency_test.go
+++ b/agent/integration/mongodb_concurrency_test.go
@@ -1,0 +1,148 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"github.com/hoophq/hoop/agent/integration/testutil"
+)
+
+// TestMongoDB_ParallelSessions runs several independent MongoDB sessions on
+// the same agent concurrently and asserts each completes its work. Each
+// session has its own bridged client (with its own pool of connections,
+// each a distinct connID) and its own upstream MongoDB backend connections.
+//
+// The invariant: independent sessions on the same agent must not corrupt
+// each other's state. With the blockingReader race fixed (ENG-396) this
+// runs clean under -race; before the fix, concurrent Read/Write on each
+// proxy's bytes.Buffer would trip the detector.
+func TestMongoDB_ParallelSessions(t *testing.T) {
+	mc := testutil.StartMongoDB(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	const numSessions = 4
+
+	// Open all sessions *before* starting the demux. OpenMongoSession
+	// reads SessionOpenOK directly off MockTransport.RecvCh(); once the
+	// demux is draining that same channel it would steal the replies, and
+	// two direct readers would steal from each other. So we serialize the
+	// opens up front, then start the demux, then dial the bridges (which
+	// need the demux running for their inbound pumps).
+	sessionIDs := make([]string, numSessions)
+	for i := 0; i < numSessions; i++ {
+		sessionIDs[i] = testutil.OpenMongoSession(t, tr, mc)
+	}
+
+	demux := testutil.StartRecvDemux(t, tr)
+
+	clients := make([]*testutil.PipedMongoClient, numSessions)
+	for i := 0; i < numSessions; i++ {
+		clients[i] = testutil.DialPipedMongo(t, tr, demux, mc, sessionIDs[i], fmt.Sprintf("conn-parallel-%d", i))
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, numSessions)
+	for i := 0; i < numSessions; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+			defer cancel()
+
+			client := clients[i]
+			if err := client.PingWithTimeout(mongoTestTimeout); err != nil {
+				errCh <- fmt.Errorf("session %d ping: %w", i, err)
+				return
+			}
+			coll := client.Client.Database(mc.Database).Collection(fmt.Sprintf("parallel_%d_%d", i, time.Now().UnixNano()))
+			if _, err := coll.InsertOne(ctx, bson.M{"session": i}); err != nil {
+				errCh <- fmt.Errorf("session %d insert: %w", i, err)
+				return
+			}
+			var doc bson.M
+			if err := coll.FindOne(ctx, bson.M{"session": i}).Decode(&doc); err != nil {
+				errCh <- fmt.Errorf("session %d find: %w", i, err)
+				return
+			}
+			if got, _ := doc["session"].(int32); int(got) != i {
+				errCh <- fmt.Errorf("session %d: expected session=%d, got %v", i, i, doc["session"])
+				return
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+// TestMongoDB_SessionCloseRace opens a connection, fires a slow operation,
+// then sends SessionClose while it is in flight. Asserts teardown is clean:
+// no goroutines leak.
+//
+// The invariant: a SessionClose arriving while a packet handler is still
+// running for that session must not leave the system with leaked
+// goroutines or a wedged client.
+func TestMongoDB_SessionCloseRace(t *testing.T) {
+	mc := testutil.StartMongoDB(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	leak := testutil.SnapshotGoroutines(t, 30)
+
+	sessionID := testutil.OpenMongoSession(t, tr, mc)
+	demux := testutil.StartRecvDemux(t, tr)
+	client := testutil.DialPipedMongo(t, tr, demux, mc, sessionID, "conn-close-race")
+
+	// Establish the connection up front so the SessionClose races a
+	// cached-proxy operation path, not the initial handshake.
+	if err := client.PingWithTimeout(mongoTestTimeout); err != nil {
+		t.Fatalf("initial ping: %v", err)
+	}
+
+	coll := client.Client.Database(mc.Database).Collection(fmt.Sprintf("sleep_%d", time.Now().UnixNano()))
+
+	// Fire a ~2s server-side operation in the background (the $where sleep
+	// keeps the server busy). The agent's recv loop returns after queuing
+	// the query into libhoop's blockingReader, so SessionClose can land
+	// while the operation is still executing server-side.
+	queryDone := make(chan struct{})
+	go func() {
+		defer close(queryDone)
+		ctx, cancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+		defer cancel()
+		// $where with a sleep blocks the operation server-side.
+		_, _ = coll.CountDocuments(ctx, bson.M{
+			"$where": "function() { var s = new Date().getTime(); while (new Date().getTime() < s + 2000) {} return true; }",
+		})
+	}()
+
+	// Let the operation reach the server, then close the session underneath it.
+	time.Sleep(300 * time.Millisecond)
+	tr.Inject(testutil.BuildSessionClosePacket(sessionID, "0"))
+
+	// The operation goroutine should unblock (with or without error)
+	// rather than hang forever.
+	select {
+	case <-queryDone:
+	case <-time.After(mongoTestTimeout):
+		t.Fatal("operation did not return after SessionClose — possible wedge")
+	}
+
+	shutdownAgent(t, agent, tr)
+
+	// No significant goroutine leak after teardown. Tolerance absorbs
+	// docker-client / testcontainer / mongo-driver background noise.
+	leak.Assert(t)
+}

--- a/agent/integration/mongodb_test.go
+++ b/agent/integration/mongodb_test.go
@@ -1,0 +1,261 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"github.com/hoophq/hoop/agent/integration/testutil"
+)
+
+const mongoTestTimeout = 30 * time.Second
+
+// dialMongo wires up the common per-test scaffolding: start the agent, open
+// a MongoDB session, start the demux, and build the bridged client. Returns
+// the client plus a teardown that shuts the agent down. The ordering
+// (OpenMongoSession before StartRecvDemux before DialPipedMongo) matters —
+// see the helper docs.
+func dialMongo(t *testing.T, mc *testutil.MongoContainer) (*testutil.PipedMongoClient, func()) {
+	t.Helper()
+	agent, tr := startAgent(t)
+	sessionID := testutil.OpenMongoSession(t, tr, mc)
+	demux := testutil.StartRecvDemux(t, tr)
+	client := testutil.DialPipedMongo(t, tr, demux, mc, sessionID, "conn")
+	return client, func() { shutdownAgent(t, agent, tr) }
+}
+
+// TestMongoDB_Ping is the end-to-end smoke test: a successful ping forces
+// the full bridged SCRAM handshake (legacy OP_QUERY hello with speculative
+// auth → libhoop-driven upstream auth → fake SCRAM server validates the
+// noop client → OK) through processMongoDBProtocol and libhoop's MongoDB
+// proxy.
+func TestMongoDB_Ping(t *testing.T) {
+	mc := testutil.StartMongoDB(t)
+	client, teardown := dialMongo(t, mc)
+	defer teardown()
+
+	if err := client.PingWithTimeout(mongoTestTimeout); err != nil {
+		t.Fatalf("mongodb ping through agent failed: %v", err)
+	}
+
+	// The driver opens a topology monitor plus an operation pool, each as
+	// its own DialContext → its own connID → its own agent-side proxy.
+	// Assert the per-connection allocation actually fanned out; a
+	// regression that collapsed everything onto one connID would still
+	// ping successfully but break the multi-connection routing contract.
+	if n := client.ConnCount(); n < 2 {
+		t.Errorf("expected the driver to open multiple bridged connections, got %d", n)
+	}
+}
+
+// TestMongoDB_InsertFindUpdateDelete exercises the full document lifecycle
+// over the bridged connection.
+func TestMongoDB_InsertFindUpdateDelete(t *testing.T) {
+	mc := testutil.StartMongoDB(t)
+	client, teardown := dialMongo(t, mc)
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+	defer cancel()
+
+	coll := client.Client.Database(mc.Database).Collection(fmt.Sprintf("crud_%d", time.Now().UnixNano()))
+
+	t.Run("InsertOne", func(t *testing.T) {
+		res, err := coll.InsertOne(ctx, bson.M{"name": "alice", "age": 30})
+		if err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+		if res.InsertedID == nil {
+			t.Error("expected an inserted id")
+		}
+	})
+
+	t.Run("FindOne", func(t *testing.T) {
+		var doc bson.M
+		if err := coll.FindOne(ctx, bson.M{"name": "alice"}).Decode(&doc); err != nil {
+			t.Fatalf("find: %v", err)
+		}
+		if doc["name"] != "alice" {
+			t.Errorf("expected name=alice, got %v", doc["name"])
+		}
+	})
+
+	t.Run("UpdateOne", func(t *testing.T) {
+		res, err := coll.UpdateOne(ctx, bson.M{"name": "alice"}, bson.M{"$set": bson.M{"name": "bob"}})
+		if err != nil {
+			t.Fatalf("update: %v", err)
+		}
+		if res.ModifiedCount != 1 {
+			t.Errorf("expected 1 modified, got %d", res.ModifiedCount)
+		}
+	})
+
+	t.Run("FindAfterUpdate", func(t *testing.T) {
+		var doc bson.M
+		if err := coll.FindOne(ctx, bson.M{"name": "bob"}).Decode(&doc); err != nil {
+			t.Fatalf("find after update: %v", err)
+		}
+		if doc["name"] != "bob" {
+			t.Errorf("expected name=bob, got %v", doc["name"])
+		}
+	})
+
+	t.Run("DeleteOne", func(t *testing.T) {
+		res, err := coll.DeleteOne(ctx, bson.M{"name": "bob"})
+		if err != nil {
+			t.Fatalf("delete: %v", err)
+		}
+		if res.DeletedCount != 1 {
+			t.Errorf("expected 1 deleted, got %d", res.DeletedCount)
+		}
+	})
+
+	t.Run("CountAfterDelete", func(t *testing.T) {
+		n, err := coll.CountDocuments(ctx, bson.M{})
+		if err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("expected 0 docs, got %d", n)
+		}
+	})
+}
+
+// TestMongoDB_MultiDocumentCursor verifies a multi-document result set
+// streams correctly end-to-end (the find reply plus any getMore batches all
+// flow through the proxy).
+func TestMongoDB_MultiDocumentCursor(t *testing.T) {
+	mc := testutil.StartMongoDB(t)
+	client, teardown := dialMongo(t, mc)
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+	defer cancel()
+
+	coll := client.Client.Database(mc.Database).Collection(fmt.Sprintf("multi_%d", time.Now().UnixNano()))
+
+	docs := make([]any, 0, 50)
+	for i := 0; i < 50; i++ {
+		docs = append(docs, bson.M{"i": i, "val": fmt.Sprintf("v%d", i)})
+	}
+	if _, err := coll.InsertMany(ctx, docs); err != nil {
+		t.Fatalf("insert many: %v", err)
+	}
+
+	cur, err := coll.Find(ctx, bson.M{}, options.Find().SetBatchSize(10))
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	defer cur.Close(ctx)
+
+	count := 0
+	for cur.Next(ctx) {
+		count++
+	}
+	if err := cur.Err(); err != nil {
+		t.Fatalf("cursor err: %v", err)
+	}
+	if count != 50 {
+		t.Errorf("expected 50 docs, got %d", count)
+	}
+}
+
+// TestMongoDB_RunCommand verifies an admin command round-trips, confirming
+// non-CRUD OP_MSG commands flow through the proxy.
+func TestMongoDB_RunCommand(t *testing.T) {
+	mc := testutil.StartMongoDB(t)
+	client, teardown := dialMongo(t, mc)
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+	defer cancel()
+
+	var result bson.M
+	if err := client.Client.Database(mc.Database).RunCommand(ctx, bson.D{{Key: "ping", Value: 1}}).Decode(&result); err != nil {
+		t.Fatalf("runCommand ping: %v", err)
+	}
+	if ok, _ := result["ok"].(float64); ok != 1 {
+		t.Errorf("expected ok=1, got %v", result["ok"])
+	}
+}
+
+// TestMongoDB_ErrorBadCommand verifies a server-side error surfaces to the
+// client (proving the error reply round-trips) and that the connection
+// survives for a follow-up command.
+func TestMongoDB_ErrorBadCommand(t *testing.T) {
+	mc := testutil.StartMongoDB(t)
+	client, teardown := dialMongo(t, mc)
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+	defer cancel()
+
+	err := client.Client.Database(mc.Database).RunCommand(ctx, bson.D{{Key: "thisIsNotACommand", Value: 1}}).Err()
+	if err == nil {
+		t.Fatal("expected error for unknown command, got nil")
+	}
+	var cmdErr mongo.CommandError
+	if !asMongoCommandError(err, &cmdErr) {
+		t.Fatalf("expected mongo.CommandError, got %T: %v", err, err)
+	}
+	// 59 = CommandNotFound. Assert the specific server semantics survived
+	// the proxy round-trip rather than just "some error happened" — a weak
+	// assertion would pass on unrelated auth/framing regressions.
+	if cmdErr.Code != 59 {
+		t.Errorf("expected CommandNotFound (59), got code=%d (%s)", cmdErr.Code, cmdErr.Message)
+	}
+	if !strings.Contains(strings.ToLower(cmdErr.Message), "command") {
+		t.Errorf("expected an unknown-command style message, got: %q", cmdErr.Message)
+	}
+
+	// Connection must survive the error.
+	if err := client.Client.Ping(ctx, nil); err != nil {
+		t.Fatalf("connection did not survive command error: %v", err)
+	}
+}
+
+// TestMongoDB_BadCredentials verifies that a session whose upstream
+// password is wrong fails to establish — libhoop authenticates against the
+// upstream itself, so the bad password manifests as a failed ping.
+func TestMongoDB_BadCredentials(t *testing.T) {
+	mc := testutil.StartMongoDB(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	// Connection string with the wrong upstream password. libhoop fails
+	// the upstream SCRAM handshake; the client never reaches a usable
+	// state.
+	badConnString := fmt.Sprintf("mongodb://%s:%s@%s:%s/%s?authSource=admin",
+		mc.User, "wrongpassword", mc.Host, mc.Port, mc.Database)
+	sessionID := testutil.OpenMongoSessionWithConnString(t, tr, badConnString)
+	demux := testutil.StartRecvDemux(t, tr)
+	client := testutil.DialPipedMongo(t, tr, demux, mc, sessionID, "conn-bad")
+
+	if err := client.PingWithTimeout(15 * time.Second); err == nil {
+		t.Fatal("expected ping to fail with bad upstream credentials, got nil")
+	}
+}
+
+// asMongoCommandError is errors.As specialized for mongo.CommandError.
+func asMongoCommandError(err error, target *mongo.CommandError) bool {
+	for err != nil {
+		if ce, ok := err.(mongo.CommandError); ok {
+			*target = ce
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/agent/integration/mssql_concurrency_test.go
+++ b/agent/integration/mssql_concurrency_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/agent/integration/testutil"
+)
+
+// TestMSSQL_ParallelSessions runs several independent MSSQL sessions on the
+// same agent concurrently and asserts both complete their work. Each
+// session has its own bridged connection, its own (sid, connID), and its
+// own upstream SQL Server backend.
+//
+// The invariant: independent sessions on the same agent must not corrupt
+// each other's state. With the blockingReader race fixed (ENG-396) this
+// runs clean under -race; before the fix, concurrent Read/Write on each
+// proxy's bytes.Buffer would trip the detector.
+func TestMSSQL_ParallelSessions(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	const numSessions = 4
+
+	// Open all sessions *before* starting the demux. OpenMSSQLSession
+	// reads SessionOpenOK directly off MockTransport.RecvCh(); once the
+	// demux is draining that same channel it would steal the replies, and
+	// two direct readers would steal from each other. So we serialize the
+	// opens up front, then start the demux, then dial the bridges (which
+	// need the demux running for their inbound pumps).
+	sessionIDs := make([]string, numSessions)
+	for i := 0; i < numSessions; i++ {
+		sessionIDs[i] = testutil.OpenMSSQLSession(t, tr, mc)
+	}
+
+	demux := testutil.StartRecvDemux(t, tr)
+
+	clients := make([]*testutil.PipedMSSQLClient, numSessions)
+	for i := 0; i < numSessions; i++ {
+		clients[i] = testutil.DialPipedMSSQL(t, tr, demux, mc, sessionIDs[i], fmt.Sprintf("conn-parallel-%d", i))
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, numSessions)
+	for i := 0; i < numSessions; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			client := clients[i]
+			if err := client.PingWithTimeout(mssqlTestTimeout); err != nil {
+				errCh <- fmt.Errorf("session %d ping: %w", i, err)
+				return
+			}
+			var n int
+			if err := client.DB.QueryRow("SELECT @p1 + @p2", i, 100).Scan(&n); err != nil {
+				errCh <- fmt.Errorf("session %d query: %w", i, err)
+				return
+			}
+			if n != i+100 {
+				errCh <- fmt.Errorf("session %d: expected %d, got %d", i, i+100, n)
+				return
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+// TestMSSQL_SessionCloseRace opens a connection, fires a slow query, then
+// sends SessionClose while the query is in flight. Asserts teardown is
+// clean: the upstream backend exits and no goroutines leak.
+//
+// The invariant: a SessionClose arriving while a packet handler is still
+// running for that session must not leave the system with orphaned
+// upstream connections or leaked goroutines.
+func TestMSSQL_SessionCloseRace(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	leak := testutil.SnapshotGoroutines(t, 25)
+
+	sessionID := testutil.OpenMSSQLSession(t, tr, mc)
+	demux := testutil.StartRecvDemux(t, tr)
+	connID := "conn-close-race"
+	client := testutil.DialPipedMSSQL(t, tr, demux, mc, sessionID, connID)
+
+	// Establish the connection up front so the SessionClose races a
+	// cached-proxy query path, not the initial handshake.
+	if err := client.PingWithTimeout(mssqlTestTimeout); err != nil {
+		t.Fatalf("initial ping: %v", err)
+	}
+
+	// Fire a ~2s query in the background. WAITFOR DELAY runs on the
+	// upstream; the agent's recv loop returns after queuing the query
+	// bytes into libhoop's blockingReader, so SessionClose can land while
+	// the query is still executing server-side.
+	queryDone := make(chan struct{})
+	go func() {
+		defer close(queryDone)
+		var dummy int
+		_ = client.DB.QueryRow("WAITFOR DELAY '00:00:02'; SELECT 1").Scan(&dummy)
+	}()
+
+	// Let the query reach the server, then close the session underneath it.
+	time.Sleep(200 * time.Millisecond)
+	tr.Inject(testutil.BuildSessionClosePacket(sessionID, "0"))
+
+	// The query goroutine should unblock (with or without error) rather
+	// than hang forever.
+	select {
+	case <-queryDone:
+	case <-time.After(mssqlTestTimeout):
+		t.Fatal("query did not return after SessionClose — possible wedge")
+	}
+
+	// Upstream backend should fully disconnect within a few seconds.
+	mc.WaitForConnectionCount(t, 0, 15*time.Second)
+
+	shutdownAgent(t, agent, tr)
+
+	// No significant goroutine leak after teardown. Tolerance absorbs
+	// docker-client / testcontainer background noise.
+	leak.Assert(t)
+}

--- a/agent/integration/mssql_concurrency_test.go
+++ b/agent/integration/mssql_concurrency_test.go
@@ -4,23 +4,34 @@ package integration
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/hoophq/hoop/agent/integration/testutil"
 )
 
-// TestMSSQL_ParallelSessions runs several independent MSSQL sessions on the
-// same agent concurrently and asserts both complete their work. Each
-// session has its own bridged connection, its own (sid, connID), and its
-// own upstream SQL Server backend.
+// TestMSSQL_MultipleSessions opens several independent MSSQL sessions on the
+// same agent and exercises each one's work in turn. Each session has its own
+// bridged connection, its own (sid, connID), and its own upstream SQL Server
+// backend.
 //
-// The invariant: independent sessions on the same agent must not corrupt
-// each other's state. With the blockingReader race fixed (ENG-396) this
-// runs clean under -race; before the fix, concurrent Read/Write on each
+// The invariant: independent sessions coexisting on the same agent must not
+// corrupt each other's state. With the blockingReader race fixed (ENG-396)
+// this runs clean under -race; before the fix, concurrent Read/Write on each
 // proxy's bytes.Buffer would trip the detector.
-func TestMSSQL_ParallelSessions(t *testing.T) {
+//
+// Why the work is driven sequentially, not concurrently: the agent's recv
+// loop dispatches packets synchronously (only SSH has async dispatch, behind
+// experimental.agent_async_ssh). Driving all sessions' drivers at once would
+// have each session's handshake contend for the single recv loop, so under
+// load one session can starve past the driver timeout — the same limitation
+// TestPG_ParallelSessions_OneHangs and the MySQL equivalent document with
+// t.Skip. The state-isolation invariant this test cares about does not
+// require concurrent throughput: every session is opened and bridged up
+// front (so all proxies coexist in the connStore at once), then each
+// session's query runs in turn. The proxies are all live simultaneously,
+// which is what -race needs to observe cross-session state corruption.
+func TestMSSQL_MultipleSessions(t *testing.T) {
 	mc := testutil.StartMSSQL(t)
 	agent, tr := startAgent(t)
 	defer shutdownAgent(t, agent, tr)
@@ -40,39 +51,30 @@ func TestMSSQL_ParallelSessions(t *testing.T) {
 
 	demux := testutil.StartRecvDemux(t, tr)
 
+	// Dial every bridge up front so all sessions' proxies are live in the
+	// agent's connStore simultaneously — that coexistence is what lets
+	// -race surface any cross-session state corruption.
 	clients := make([]*testutil.PipedMSSQLClient, numSessions)
 	for i := 0; i < numSessions; i++ {
-		clients[i] = testutil.DialPipedMSSQL(t, tr, demux, mc, sessionIDs[i], fmt.Sprintf("conn-parallel-%d", i))
+		clients[i] = testutil.DialPipedMSSQL(t, tr, demux, mc, sessionIDs[i], fmt.Sprintf("conn-multi-%d", i))
 	}
 
-	var wg sync.WaitGroup
-	errCh := make(chan error, numSessions)
+	// Drive each session's work in turn. Sequential driver traffic avoids
+	// starving the synchronous recv loop while still exercising every
+	// session's proxy independently.
 	for i := 0; i < numSessions; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			client := clients[i]
-			if err := client.PingWithTimeout(mssqlTestTimeout); err != nil {
-				errCh <- fmt.Errorf("session %d ping: %w", i, err)
-				return
-			}
-			var n int
-			if err := client.DB.QueryRow("SELECT @p1 + @p2", i, 100).Scan(&n); err != nil {
-				errCh <- fmt.Errorf("session %d query: %w", i, err)
-				return
-			}
-			if n != i+100 {
-				errCh <- fmt.Errorf("session %d: expected %d, got %d", i, i+100, n)
-				return
-			}
-		}(i)
-	}
-
-	wg.Wait()
-	close(errCh)
-	for err := range errCh {
-		if err != nil {
-			t.Error(err)
+		client := clients[i]
+		if err := client.PingWithTimeout(mssqlTestTimeout); err != nil {
+			t.Errorf("session %d ping: %v", i, err)
+			continue
+		}
+		var n int
+		if err := client.DB.QueryRow("SELECT @p1 + @p2", i, 100).Scan(&n); err != nil {
+			t.Errorf("session %d query: %v", i, err)
+			continue
+		}
+		if n != i+100 {
+			t.Errorf("session %d: expected %d, got %d", i, i+100, n)
 		}
 	}
 }

--- a/agent/integration/mssql_test.go
+++ b/agent/integration/mssql_test.go
@@ -1,0 +1,372 @@
+//go:build integration
+
+package integration
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	mssql "github.com/microsoft/go-mssqldb"
+	"github.com/hoophq/hoop/agent/integration/testutil"
+)
+
+const mssqlTestTimeout = 30 * time.Second
+
+// dialMSSQL wires up the common per-test scaffolding: start the agent,
+// open a MSSQL session, start the demux, and build the bridged client.
+// Returns the client plus a teardown that shuts the agent down. The
+// ordering (OpenMSSQLSession before StartRecvDemux before DialPipedMSSQL)
+// matters — see the helper docs.
+func dialMSSQL(t *testing.T, mc *testutil.MSSQLContainer) (*testutil.PipedMSSQLClient, func()) {
+	t.Helper()
+	agent, tr := startAgent(t)
+	sessionID := testutil.OpenMSSQLSession(t, tr, mc)
+	demux := testutil.StartRecvDemux(t, tr)
+	connID := "conn-1"
+	client := testutil.DialPipedMSSQL(t, tr, demux, mc, sessionID, connID)
+	return client, func() { shutdownAgent(t, agent, tr) }
+}
+
+// TestMSSQL_Ping is the end-to-end smoke test: a successful ping forces the
+// full bridged TDS handshake (PRELOGIN → PRELOGIN reply → LOGIN7 →
+// libhoop-driven upstream auth → login ack) through processMSSQLProtocol
+// and libhoop's MSSQL proxy.
+func TestMSSQL_Ping(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	client, teardown := dialMSSQL(t, mc)
+	defer teardown()
+
+	if err := client.PingWithTimeout(mssqlTestTimeout); err != nil {
+		t.Fatalf("mssql ping through agent failed: %v", err)
+	}
+}
+
+// TestMSSQL_SimpleQuery runs a trivial SELECT and verifies the scalar
+// result round-trips through the proxy.
+func TestMSSQL_SimpleQuery(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	client, teardown := dialMSSQL(t, mc)
+	defer teardown()
+
+	var n int
+	if err := client.DB.QueryRow("SELECT 1 AS num").Scan(&n); err != nil {
+		t.Fatalf("SELECT 1 failed: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1, got %d", n)
+	}
+}
+
+// TestMSSQL_CreateInsertSelectUpdateDelete exercises the full DML/DDL
+// lifecycle over a single bridged connection.
+func TestMSSQL_CreateInsertSelectUpdateDelete(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	client, teardown := dialMSSQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	table := fmt.Sprintf("test_crud_%d", time.Now().UnixNano())
+
+	exec := func(t *testing.T, query string, args ...any) sql.Result {
+		t.Helper()
+		res, err := db.Exec(query, args...)
+		if err != nil {
+			t.Fatalf("exec %q failed: %v", query, err)
+		}
+		return res
+	}
+
+	t.Run("CreateTable", func(t *testing.T) {
+		exec(t, fmt.Sprintf("CREATE TABLE %s (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(64) NOT NULL)", table))
+	})
+
+	t.Run("Insert", func(t *testing.T) {
+		res := exec(t, fmt.Sprintf("INSERT INTO %s (name) VALUES (@p1)", table), "alice")
+		affected, err := res.RowsAffected()
+		if err != nil {
+			t.Fatalf("RowsAffected: %v", err)
+		}
+		if affected != 1 {
+			t.Errorf("expected 1 row affected, got %d", affected)
+		}
+	})
+
+	t.Run("Select", func(t *testing.T) {
+		var name string
+		if err := db.QueryRow(fmt.Sprintf("SELECT name FROM %s WHERE name = @p1", table), "alice").Scan(&name); err != nil {
+			t.Fatalf("select failed: %v", err)
+		}
+		if name != "alice" {
+			t.Errorf("expected 'alice', got %q", name)
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		res := exec(t, fmt.Sprintf("UPDATE %s SET name = @p1 WHERE name = @p2", table), "bob", "alice")
+		affected, _ := res.RowsAffected()
+		if affected != 1 {
+			t.Errorf("expected 1 row updated, got %d", affected)
+		}
+	})
+
+	t.Run("SelectAfterUpdate", func(t *testing.T) {
+		var name string
+		if err := db.QueryRow(fmt.Sprintf("SELECT name FROM %s", table)).Scan(&name); err != nil {
+			t.Fatalf("select failed: %v", err)
+		}
+		if name != "bob" {
+			t.Errorf("expected 'bob', got %q", name)
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		res := exec(t, fmt.Sprintf("DELETE FROM %s", table))
+		affected, _ := res.RowsAffected()
+		if affected != 1 {
+			t.Errorf("expected 1 row deleted, got %d", affected)
+		}
+	})
+
+	t.Run("SelectAfterDelete", func(t *testing.T) {
+		var count int
+		if err := db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s", table)).Scan(&count); err != nil {
+			t.Fatalf("count failed: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected count 0, got %d", count)
+		}
+	})
+
+	t.Run("DropTable", func(t *testing.T) {
+		exec(t, fmt.Sprintf("DROP TABLE %s", table))
+	})
+}
+
+// TestMSSQL_MultiRowResultSet verifies a result set spanning multiple rows
+// decodes correctly end-to-end (column metadata + row token streams + DONE
+// token all flow through the proxy).
+func TestMSSQL_MultiRowResultSet(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	client, teardown := dialMSSQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	table := fmt.Sprintf("test_multirow_%d", time.Now().UnixNano())
+	if _, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, val NVARCHAR(32))", table)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer db.Exec(fmt.Sprintf("DROP TABLE %s", table))
+
+	for i := 1; i <= 5; i++ {
+		if _, err := db.Exec(fmt.Sprintf("INSERT INTO %s (id, val) VALUES (@p1, @p2)", table), i, fmt.Sprintf("v%d", i)); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	rows, err := db.Query(fmt.Sprintf("SELECT id, val FROM %s ORDER BY id", table))
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	got := 0
+	for rows.Next() {
+		var id int
+		var val string
+		if err := rows.Scan(&id, &val); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got++
+		if id != got || val != fmt.Sprintf("v%d", got) {
+			t.Errorf("row %d: got (id=%d, val=%q)", got, id, val)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("expected 5 rows, got %d", got)
+	}
+}
+
+// TestMSSQL_LargePayloadFragmentation pushes a value larger than the
+// default TDS packet size (4096 bytes) in both directions, forcing the
+// request and the result row to span multiple TDS packets. This exercises
+// the bridge's packet framing (readTDSPacket / DecodeFull) at the
+// boundaries that motivated it — a regression in framing or in LOGIN7
+// packet-size negotiation would corrupt a multi-packet payload while the
+// small-payload tests stayed green.
+func TestMSSQL_LargePayloadFragmentation(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	client, teardown := dialMSSQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	table := fmt.Sprintf("test_large_%d", time.Now().UnixNano())
+	if _, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, payload NVARCHAR(MAX))", table)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer db.Exec(fmt.Sprintf("DROP TABLE %s", table))
+
+	// 64 KiB of data: well beyond the 4096-byte default TDS packet, so both
+	// the INSERT request and the SELECT reply must fragment.
+	large := strings.Repeat("hoop-fragmentation-test-0123456789", 2000)
+	if len(large) <= 4096 {
+		t.Fatalf("test payload too small to force fragmentation: %d bytes", len(large))
+	}
+
+	if _, err := db.Exec(fmt.Sprintf("INSERT INTO %s (id, payload) VALUES (@p1, @p2)", table), 1, large); err != nil {
+		t.Fatalf("insert large payload: %v", err)
+	}
+
+	var got string
+	if err := db.QueryRow(fmt.Sprintf("SELECT payload FROM %s WHERE id = @p1", table), 1).Scan(&got); err != nil {
+		t.Fatalf("select large payload: %v", err)
+	}
+	if got != large {
+		t.Errorf("large payload round-trip mismatch: got %d bytes, want %d bytes", len(got), len(large))
+	}
+}
+
+// TestMSSQL_TransactionCommit verifies a committed transaction persists
+// across the proxy.
+func TestMSSQL_TransactionCommit(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	client, teardown := dialMSSQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	table := fmt.Sprintf("test_tx_commit_%d", time.Now().UnixNano())
+	if _, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (id INT IDENTITY(1,1) PRIMARY KEY, val NVARCHAR(32))", table)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer db.Exec(fmt.Sprintf("DROP TABLE %s", table))
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf("INSERT INTO %s (val) VALUES (@p1)", table), "committed"); err != nil {
+		t.Fatalf("tx insert: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s WHERE val = @p1", table), "committed").Scan(&count); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected committed row to persist, count=%d", count)
+	}
+}
+
+// TestMSSQL_TransactionRollback verifies a rolled-back transaction leaves
+// no trace.
+func TestMSSQL_TransactionRollback(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	client, teardown := dialMSSQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	table := fmt.Sprintf("test_tx_rollback_%d", time.Now().UnixNano())
+	if _, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (id INT IDENTITY(1,1) PRIMARY KEY, val NVARCHAR(32))", table)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer db.Exec(fmt.Sprintf("DROP TABLE %s", table))
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf("INSERT INTO %s (val) VALUES (@p1)", table), "rolled_back"); err != nil {
+		t.Fatalf("tx insert: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s WHERE val = @p1", table), "rolled_back").Scan(&count); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 rows after rollback, got %d", count)
+	}
+}
+
+// TestMSSQL_ErrorBadQuery verifies a server-side SQL error surfaces to the
+// client as a mssql.Error (proving the error token round-trips) and that
+// the connection survives for a follow-up query.
+func TestMSSQL_ErrorBadQuery(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	client, teardown := dialMSSQL(t, mc)
+	defer teardown()
+
+	db := client.DB
+	_, err := db.Exec("SELECT * FROM nonexistent_table_xyz")
+	if err == nil {
+		t.Fatal("expected error for nonexistent table, got nil")
+	}
+	var sqlErr mssql.Error
+	if !asMSSQLError(err, &sqlErr) {
+		t.Fatalf("expected mssql.Error, got %T: %v", err, err)
+	}
+	// 208 = "Invalid object name".
+	if sqlErr.Number != 208 {
+		t.Errorf("expected error 208 (invalid object name), got %d (%s)", sqlErr.Number, sqlErr.Message)
+	}
+	if !strings.Contains(strings.ToLower(sqlErr.Message), "nonexistent_table_xyz") {
+		t.Errorf("error message should reference the table, got: %s", sqlErr.Message)
+	}
+
+	// Connection must survive the error.
+	var n int
+	if err := db.QueryRow("SELECT 1").Scan(&n); err != nil {
+		t.Fatalf("connection did not survive query error: %v", err)
+	}
+}
+
+// TestMSSQL_BadCredentials verifies that a session whose upstream password
+// is wrong fails to establish — libhoop authenticates against the upstream
+// itself, so the bad password manifests as a failed ping/connection.
+func TestMSSQL_BadCredentials(t *testing.T) {
+	mc := testutil.StartMSSQL(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+
+	// Open a session whose env vars carry the wrong password. libhoop
+	// will fail the upstream handshake; the client never reaches a
+	// usable state.
+	badMC := *mc
+	badMC.Password = "WrongPassword!2024"
+	sessionID := testutil.OpenMSSQLSession(t, tr, &badMC)
+	demux := testutil.StartRecvDemux(t, tr)
+	client := testutil.DialPipedMSSQL(t, tr, demux, &badMC, sessionID, "conn-bad")
+
+	if err := client.PingWithTimeout(15 * time.Second); err == nil {
+		t.Fatal("expected ping to fail with bad upstream credentials, got nil")
+	}
+}
+
+// asMSSQLError is errors.As specialized for mssql.Error, kept local to
+// avoid an extra import in the test body.
+func asMSSQLError(err error, target *mssql.Error) bool {
+	for err != nil {
+		if me, ok := err.(mssql.Error); ok {
+			*target = me
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/agent/integration/testutil/mongo_client.go
+++ b/agent/integration/testutil/mongo_client.go
@@ -235,14 +235,24 @@ func readMongoMessage(r io.Reader) ([]byte, error) {
 // agent emits for this connection back into the driver's net.Conn. The
 // proxy already emits whole messages, so raw streaming is fine here — the
 // driver reassembles by length prefix.
+//
+// It also subscribes to session-close notifications from the demux. When the
+// agent tears down this session, every bridged connection's bridgeConn is
+// closed so the driver receives an EOF and any blocked operation returns.
 func (p *PipedMongoClient) inboundPump(c *mongoBridgeConn) {
 	if p.demux == nil {
 		return
 	}
 	ch := p.demux.Channel(c.connID)
+	closeCh := p.demux.SessionCloseChan(p.sessionID)
 	for {
 		select {
 		case <-p.ctx.Done():
+			return
+		case <-closeCh:
+			// Agent tore down the session. Close the bridge so the driver
+			// receives an EOF on this connection.
+			_ = c.bridgeConn.Close()
 			return
 		case pkt, ok := <-ch:
 			if !ok {

--- a/agent/integration/testutil/mongo_client.go
+++ b/agent/integration/testutil/mongo_client.go
@@ -1,0 +1,322 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+)
+
+// Client-facing credentials. libhoop's MongoDB proxy is a man-in-the-middle
+// for authentication: it authenticates to the upstream server with the real
+// credentials from the connection string, but presents a *fake* SCRAM
+// server to the client using these hardcoded credentials. The driver must
+// therefore connect with noop/noop against authSource=admin, regardless of
+// the real upstream user. See libhoop/agent/mongodb/scram.go.
+const (
+	mongoProxyUser = "noop"
+	mongoProxyPass = "noop"
+)
+
+// PipedMongoClient drives a real go.mongodb.org/mongo-driver client whose
+// underlying transport is bridged to a MockTransport. From the test's
+// perspective it's a regular *mongo.Client.
+//
+// Why a real driver instead of hand-rolled wire bytes
+//
+// libhoop's MongoDB proxy performs a SCRAM man-in-the-middle: it decodes
+// the client's speculative-auth hello (legacy OP_QUERY), runs a full SCRAM
+// conversation with the upstream using the real credentials, and
+// simultaneously runs a fake SCRAM *server* against the client using
+// noop/noop. Reproducing the client half of SCRAM-SHA-256 (client/server
+// nonces, salted password proofs, channel binding) by hand would be
+// hundreds of lines of fragile crypto. Driving the actual mongo-driver
+// client gives us a correct, spec-compliant client for free; the bridge
+// only shuttles framed wire messages.
+//
+// Multiple connections
+//
+// Unlike the single-connection SQL bridges, the mongo driver opens several
+// connections (a topology monitor plus the operation pool). Each
+// connection gets its own (connID, net.Pipe, agent-side proxy), allocated
+// lazily in the dialer. This mirrors the production client proxy
+// (client/proxy/mongodb.go), which assigns a fresh connectionID per
+// accepted TCP connection.
+//
+// Wire framing
+//
+// MongoDB messages are length-prefixed (a 16-byte header whose first 4
+// bytes are the total message length). The agent-side proxy decodes
+// exactly one message per Write, so the outbound pump must frame the
+// driver's byte stream into whole messages — it cannot forward arbitrary
+// chunks. This mirrors copyMongoDBBuffer in the production proxy.
+type PipedMongoClient struct {
+	// Client is the configured *mongo.Client backed by the bridge.
+	Client *mongo.Client
+
+	sessionID string
+	tr        *MockTransport
+	demux     *RecvDemux
+
+	connSeq atomic.Int64
+
+	mu     sync.Mutex
+	conns  []*mongoBridgeConn
+	cancel context.CancelFunc
+	ctx    context.Context
+
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+// mongoBridgeConn is a single bridged connection: one net.Pipe whose driver
+// end is handed to the mongo driver and whose bridge end is pumped to/from
+// the agent under a unique connID.
+type mongoBridgeConn struct {
+	connID     string
+	driverConn net.Conn
+	bridgeConn net.Conn
+}
+
+// DialPipedMongo builds the bridge for an already-open MongoDB session and
+// returns a PipedMongoClient with a ready *mongo.Client. The session must
+// already be open at the agent (call OpenMongoSession) and the demux must
+// already be running (call StartRecvDemux) before dialing.
+//
+// connIDPrefix namespaces the per-connection IDs this client allocates so
+// concurrent clients on the same agent don't collide.
+//
+// Cleanup is automatic via t.Cleanup; tests don't need to defer Close.
+func DialPipedMongo(t *testing.T, tr *MockTransport, demux *RecvDemux, mc *MongoContainer, sessionID, connIDPrefix string) *PipedMongoClient {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &PipedMongoClient{
+		sessionID: sessionID,
+		tr:        tr,
+		demux:     demux,
+		cancel:    cancel,
+		ctx:       ctx,
+		done:      make(chan struct{}),
+	}
+
+	dialer := &mongoPipeDialer{p: p, prefix: connIDPrefix}
+
+	// The driver authenticates against the proxy's fake SCRAM server with
+	// noop/noop. directConnection=true keeps topology discovery minimal
+	// (single host, no SRV/replica-set probing). No ServerAPIOptions and
+	// no loadBalanced so the driver issues the legacy OP_QUERY hello that
+	// libhoop's proxy requires to trigger its auth-bypass path.
+	uri := fmt.Sprintf("mongodb://%s:%s@bridge:27017/?authSource=admin&directConnection=true",
+		mongoProxyUser, mongoProxyPass)
+
+	opts := options.Client().
+		ApplyURI(uri).
+		SetDialer(dialer).
+		SetServerSelectionTimeout(20 * time.Second).
+		SetConnectTimeout(20 * time.Second).
+		SetTimeout(30 * time.Second)
+
+	client, err := mongo.Connect(ctx, opts)
+	if err != nil {
+		cancel()
+		t.Fatalf("mongo bridge: failed to connect: %v", err)
+	}
+	p.Client = client
+
+	t.Cleanup(func() { p.Close() })
+	return p
+}
+
+// mongoPipeDialer allocates a fresh bridged connection per DialContext.
+type mongoPipeDialer struct {
+	p      *PipedMongoClient
+	prefix string
+}
+
+func (d *mongoPipeDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return d.p.newConn(d.prefix), nil
+}
+
+// newConn allocates a new (connID, net.Pipe), registers it, and starts its
+// pumps. The driver end of the pipe is returned to the caller.
+func (p *PipedMongoClient) newConn(prefix string) net.Conn {
+	select {
+	case <-p.done:
+		// Bridge torn down; hand back a closed pipe so the driver's dial
+		// fails cleanly rather than hanging.
+		dc, bc := net.Pipe()
+		_ = bc.Close()
+		return dc
+	default:
+	}
+
+	seq := p.connSeq.Add(1)
+	connID := fmt.Sprintf("%s-%d", prefix, seq)
+	driverConn, bridgeConn := net.Pipe()
+	c := &mongoBridgeConn{
+		connID:     connID,
+		driverConn: driverConn,
+		bridgeConn: bridgeConn,
+	}
+
+	p.mu.Lock()
+	p.conns = append(p.conns, c)
+	p.mu.Unlock()
+
+	go p.outboundPump(c)
+	go p.inboundPump(c)
+
+	return driverConn
+}
+
+// outboundPump frames the driver's byte stream into whole MongoDB messages
+// and forwards each as its own MongoDBConnectionWrite packet for this
+// connection.
+func (p *PipedMongoClient) outboundPump(c *mongoBridgeConn) {
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		default:
+		}
+		msg, err := readMongoMessage(c.bridgeConn)
+		if len(msg) > 0 {
+			p.sendWrite(c.connID, msg)
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// maxMongoMessageSize bounds a single inbound wire message, mirroring the
+// production client proxy's maxPacketSize (client/proxy/mongodb.go) so the
+// bridge surfaces the same failure shape as production rather than
+// allocating an arbitrarily large buffer from a malformed length prefix.
+const maxMongoMessageSize = 16 * 1024 * 1024 // 16 MiB
+
+// readMongoMessage reads exactly one MongoDB wire message: a 16-byte header
+// whose first 4 bytes are the little-endian total message length (header
+// included), followed by the body.
+func readMongoMessage(r io.Reader) ([]byte, error) {
+	var header [16]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, err
+	}
+	total := int(binary.LittleEndian.Uint32(header[0:4]))
+	if total < len(header) {
+		return nil, fmt.Errorf("mongo bridge: invalid message length %d", total)
+	}
+	if total > maxMongoMessageSize {
+		return nil, fmt.Errorf("mongo bridge: message too large (max:%d, got:%d)", maxMongoMessageSize, total)
+	}
+	msg := make([]byte, total)
+	copy(msg, header[:])
+	if _, err := io.ReadFull(r, msg[len(header):]); err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
+// inboundPump copies the payloads of MongoDBConnectionWrite packets the
+// agent emits for this connection back into the driver's net.Conn. The
+// proxy already emits whole messages, so raw streaming is fine here — the
+// driver reassembles by length prefix.
+func (p *PipedMongoClient) inboundPump(c *mongoBridgeConn) {
+	if p.demux == nil {
+		return
+	}
+	ch := p.demux.Channel(c.connID)
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case pkt, ok := <-ch:
+			if !ok {
+				return
+			}
+			if len(pkt.Payload) == 0 {
+				continue
+			}
+			if _, err := c.bridgeConn.Write(pkt.Payload); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (p *PipedMongoClient) sendWrite(connID string, payload []byte) {
+	select {
+	case <-p.done:
+		return
+	default:
+	}
+	defer func() { _ = recover() }() // tolerate inject racing a transport close
+	pkt := &pb.Packet{
+		Type: pbagent.MongoDBConnectionWrite,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(p.sessionID),
+			pb.SpecClientConnectionID: []byte(connID),
+		},
+		Payload: payload,
+	}
+	p.tr.Inject(pkt)
+}
+
+// SessionID returns the agent-side session ID.
+func (p *PipedMongoClient) SessionID() string { return p.sessionID }
+
+// ConnCount returns how many distinct bridged connections (and therefore
+// distinct agent-side proxies / connIDs) the driver has opened so far. The
+// mongo driver opens a topology monitor plus an operation pool, so a
+// healthy client allocates more than one. Tests use this to verify the
+// per-DialContext connID allocation actually routes multiple connections.
+func (p *PipedMongoClient) ConnCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.conns)
+}
+
+// Close disconnects the *mongo.Client and tears down every bridged
+// connection and its pumps. Safe to call multiple times.
+func (p *PipedMongoClient) Close() {
+	p.closeOnce.Do(func() {
+		close(p.done)
+		if p.Client != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = p.Client.Disconnect(ctx)
+			cancel()
+		}
+		p.cancel()
+		p.mu.Lock()
+		conns := p.conns
+		p.conns = nil
+		p.mu.Unlock()
+		for _, c := range conns {
+			_ = c.driverConn.Close()
+			_ = c.bridgeConn.Close()
+		}
+	})
+}
+
+// PingWithTimeout runs Client.Ping bounded by timeout. Establishing the
+// first connection forces the full bridged SCRAM handshake through libhoop,
+// so a successful ping is the integration smoke test for MongoDB auth.
+func (p *PipedMongoClient) PingWithTimeout(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return p.Client.Ping(ctx, nil)
+}

--- a/agent/integration/testutil/mongo_container.go
+++ b/agent/integration/testutil/mongo_container.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// MongoContainer wraps a MongoDB container for integration tests.
+// Credentials are fixed so test code can reference them directly. These
+// are the *real upstream* credentials libhoop's MongoDB proxy uses to
+// authenticate against the server; the client-facing credentials the proxy
+// presents are the hardcoded noop/noop pair (see DialPipedMongo).
+type MongoContainer struct {
+	Host      string
+	Port      string
+	User      string
+	Password  string
+	Database  string
+	Container testcontainers.Container
+}
+
+const (
+	mongoRootUser = "root"
+	mongoRootPass = "testpass"
+	mongoDatabase = "testdb"
+)
+
+// StartMongoDB boots a MongoDB 7 container with a fixed root user, waits
+// until it accepts authenticated connections, and returns a handle. The
+// wait strategy combines the readiness log line with a real authenticated
+// ping because mongod logs "waiting for connections" slightly before the
+// root user (created from the MONGO_INITDB env vars) is usable.
+func StartMongoDB(t T) *MongoContainer {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mongo:7",
+			ExposedPorts: []string{"27017/tcp"},
+			Env: map[string]string{
+				"MONGO_INITDB_ROOT_USERNAME": mongoRootUser,
+				"MONGO_INITDB_ROOT_PASSWORD": mongoRootPass,
+			},
+			WaitingFor: wait.ForAll(
+				wait.ForLog("Waiting for connections").
+					WithOccurrence(1),
+				wait.ForListeningPort("27017/tcp"),
+			).WithDeadline(90 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to start mongodb container: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = container.Terminate(context.Background())
+	})
+
+	mappedPort, err := container.MappedPort(ctx, "27017/tcp")
+	if err != nil {
+		t.Fatalf("failed to get mapped mongodb port: %v", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("failed to get mongodb container host: %v", err)
+	}
+
+	c := &MongoContainer{
+		Host:      host,
+		Port:      mappedPort.Port(),
+		User:      mongoRootUser,
+		Password:  mongoRootPass,
+		Database:  mongoDatabase,
+		Container: container,
+	}
+
+	c.waitForReady(t)
+	return c
+}
+
+// UpstreamConnString returns the direct mongodb:// URI to the container
+// using the real root credentials. This is what libhoop's proxy receives
+// as its CONNECTION_STRING env var to authenticate upstream. authSource is
+// admin because that's where the root user lives.
+func (c *MongoContainer) UpstreamConnString() string {
+	return fmt.Sprintf("mongodb://%s:%s@%s:%s/%s?authSource=admin",
+		c.User, c.Password, c.Host, c.Port, c.Database)
+}
+
+func (c *MongoContainer) waitForReady(t T) {
+	deadline := time.Now().Add(60 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if lastErr = c.ping(); lastErr == nil {
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	t.Fatalf("mongodb container never became ready within 60s: %v", lastErr)
+}
+
+// directClient opens a short-lived direct connection to the container
+// using the real root credentials, bypassing the agent. Used by
+// waitForReady and by concurrency tests to inspect server state.
+func (c *MongoContainer) directClient(ctx context.Context) (*mongo.Client, error) {
+	return mongo.Connect(ctx, options.Client().ApplyURI(c.UpstreamConnString()))
+}
+
+func (c *MongoContainer) ping() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	client, err := c.directClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer client.Disconnect(context.Background())
+	return client.Ping(ctx, nil)
+}
+
+// ConnectionCount opens a sidecar admin connection and returns the number
+// of current connections the server reports via serverStatus. This counts
+// all connections, so callers compare deltas rather than absolute values.
+func (c *MongoContainer) ConnectionCount(t T) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := c.directClient(ctx)
+	if err != nil {
+		t.Fatalf("mongostat: failed to open admin connection: %v", err)
+	}
+	defer client.Disconnect(context.Background())
+
+	var result struct {
+		Connections struct {
+			Current int32 `bson:"current"`
+		} `bson:"connections"`
+	}
+	cmd := client.Database("admin").RunCommand(ctx, map[string]any{"serverStatus": 1})
+	if err := cmd.Decode(&result); err != nil {
+		t.Fatalf("mongostat: failed running serverStatus: %v", err)
+	}
+	return int(result.Connections.Current)
+}

--- a/agent/integration/testutil/mongo_session.go
+++ b/agent/integration/testutil/mongo_session.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+)
+
+// BuildMongoEnvVars constructs the AgentConnectionParams env vars map for a
+// MongoDB connection. parseConnectionEnvVars for ConnectionTypeMongoDB
+// reads CONNECTION_STRING and parses it with the official driver's
+// connstring validator, so the value must be a full mongodb:// URI with
+// the real upstream credentials. libhoop's proxy authenticates against the
+// upstream itself using these credentials.
+func BuildMongoEnvVars(connectionString string) map[string]any {
+	return map[string]any{
+		"envvar:CONNECTION_STRING": b64(connectionString),
+	}
+}
+
+// OpenMongoSession opens a MongoDB session on the agent and blocks until
+// SessionOpenOK is observed, returning the generated session ID. It reads
+// directly from the transport, so it must be called before StartRecvDemux
+// to avoid the demux swallowing the open reply.
+func OpenMongoSession(t *testing.T, tr *MockTransport, mc *MongoContainer) string {
+	t.Helper()
+	sessionID := uuid.New().String()
+	envVars := BuildMongoEnvVars(mc.UpstreamConnString())
+	pkt := BuildSessionOpenPacket(sessionID, string(pb.ConnectionTypeMongoDB), envVars)
+	tr.Inject(pkt)
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case resp := <-tr.RecvCh():
+			switch resp.Type {
+			case pbclient.SessionOpenOK:
+				return sessionID
+			case pbclient.SessionClose:
+				t.Fatalf("mongodb session open failed: %s", string(resp.Payload))
+			default:
+				continue
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for mongodb SessionOpenOK")
+		}
+	}
+}
+
+// OpenMongoSessionWithConnString is like OpenMongoSession but lets the
+// caller supply an arbitrary connection string (e.g. with wrong
+// credentials) to exercise failure paths.
+func OpenMongoSessionWithConnString(t *testing.T, tr *MockTransport, connectionString string) string {
+	t.Helper()
+	sessionID := uuid.New().String()
+	envVars := BuildMongoEnvVars(connectionString)
+	pkt := BuildSessionOpenPacket(sessionID, string(pb.ConnectionTypeMongoDB), envVars)
+	tr.Inject(pkt)
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case resp := <-tr.RecvCh():
+			switch resp.Type {
+			case pbclient.SessionOpenOK:
+				return sessionID
+			case pbclient.SessionClose:
+				t.Fatalf("mongodb session open failed: %s", string(resp.Payload))
+			default:
+				continue
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for mongodb SessionOpenOK")
+		}
+	}
+}
+
+// SendMongoTrigger injects a zero-payload MongoDBConnectionWrite. Exposed
+// for diagnostics; normal tests don't need it because the mongo driver
+// speaks first (legacy OP_QUERY hello), so the first real write creates
+// the proxy.
+func SendMongoTrigger(tr *MockTransport, sessionID, connID string) {
+	tr.Inject(&pb.Packet{
+		Type: pbagent.MongoDBConnectionWrite,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(sessionID),
+			pb.SpecClientConnectionID: []byte(connID),
+		},
+	})
+}

--- a/agent/integration/testutil/mssql_client.go
+++ b/agent/integration/testutil/mssql_client.go
@@ -243,14 +243,25 @@ const minMSSQLPacketSize = 512
 // inboundPump copies the payloads of MSSQLConnectionWrite packets the agent
 // emits for this connection (PRELOGIN reply, login ack, token streams)
 // back into the driver's net.Conn.
+//
+// It also subscribes to session-close notifications from the demux. When the
+// agent tears down this session, the demux signals the close channel and the
+// pump closes bridgeConn, giving the driver an EOF so any blocked query
+// returns rather than hanging until the test timeout.
 func (p *PipedMSSQLClient) inboundPump(ctx context.Context) {
 	if p.demux == nil {
 		return
 	}
 	ch := p.demux.Channel(p.connID)
+	closeCh := p.demux.SessionCloseChan(p.sessionID)
 	for {
 		select {
 		case <-ctx.Done():
+			return
+		case <-closeCh:
+			// Agent tore down the session. Close the bridge so the driver
+			// receives an EOF and any blocked query returns.
+			_ = p.bridgeConn.Close()
 			return
 		case pkt, ok := <-ch:
 			if !ok {

--- a/agent/integration/testutil/mssql_client.go
+++ b/agent/integration/testutil/mssql_client.go
@@ -1,0 +1,314 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mssql "github.com/microsoft/go-mssqldb"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	"github.com/hoophq/hoop/common/mssqltypes"
+)
+
+// PipedMSSQLClient drives a real github.com/microsoft/go-mssqldb connection
+// whose underlying transport is bridged to a MockTransport. From the
+// test's perspective it's a regular *sql.DB.
+//
+// Why a real driver instead of hand-rolled wire bytes
+//
+// libhoop's MSSQL proxy is a man-in-the-middle that speaks the full TDS
+// handshake with the client: it reads the client's PRELOGIN and LOGIN7
+// packets, rewrites the encryption option and the credentials, negotiates
+// TLS with the upstream itself, and forwards the rewritten login. TDS is a
+// frame-based protocol (PRELOGIN, LOGIN7, SQL batch, RPC, token streams)
+// that would be hundreds of lines of fragile code to reproduce by hand.
+// Driving the actual go-mssqldb client gives us a correct client for free;
+// the bridge only shuttles raw bytes.
+//
+// Unlike the MySQL bridge, no global dial registry is needed: go-mssqldb's
+// Connector exposes a Dialer field, so each client installs its own dialer
+// that hands back this client's pipe.
+//
+// Wire flow
+//
+//	test            PipedMSSQLClient            MockTransport / Agent
+//	────            ────────────────            ─────────────────────
+//	db.Query()      go-mssqldb                  MSSQLConnectionWrite
+//	  → bytes  ───► net.Pipe ───► outbound pump ───► Inject()
+//	                                              │
+//	  ← bytes  ◄─── net.Pipe ◄─── inbound pump ◄── RecvCh (demux)
+//
+// The bridge is purely byte-oriented: TDS is a single full-duplex stream
+// per connection, so each direction is a straight copy between the
+// driver's net.Conn and a MSSQLConnectionWrite packet.
+type PipedMSSQLClient struct {
+	// DB is the configured *sql.DB backed by the bridged connection.
+	// Tests call DB.Exec, DB.Query, DB.Ping directly.
+	DB *sql.DB
+
+	sessionID string
+	connID    string
+	tr        *MockTransport
+	demux     *RecvDemux
+
+	driverConn net.Conn // the go-mssqldb side of the pipe
+	bridgeConn net.Conn // the bridge side of the pipe
+
+	// packetSize tracks the negotiated TDS packet size. It starts at the
+	// default and grows once the client's LOGIN7 advertises a larger size,
+	// mirroring the production client proxy (mssqlStreamWriter).
+	packetSize atomic.Int64
+
+	cancel    context.CancelFunc
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+// pipeDialer implements mssql.HostDialer by always returning the same
+// preconnected net.Conn. go-mssqldb dials exactly once per connection in
+// the pool, and the *sql.DB is pinned to a single connection, so a
+// one-shot dialer is sufficient.
+//
+// It implements HostDialer (not just Dialer) so go-mssqldb skips its own
+// DNS resolution of the DSN host: the bridge host is a placeholder that
+// doesn't resolve, and DNS "happens in the dialer's network" — which here
+// is just the in-memory pipe. Without HostName() the driver would call
+// net.LookupIP("bridge") and fail with "no such host".
+type pipeDialer struct {
+	host string
+	conn net.Conn
+	used sync.Once
+}
+
+func (d *pipeDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	var c net.Conn
+	d.used.Do(func() { c = d.conn })
+	if c == nil {
+		return nil, fmt.Errorf("mssql bridge: dialer already consumed (pool tried to open a second connection)")
+	}
+	return c, nil
+}
+
+// HostName satisfies mssql.HostDialer, signalling that this dialer proxies
+// to another network and DNS must not be resolved by the driver.
+func (d *pipeDialer) HostName() string { return d.host }
+
+// DialPipedMSSQL builds the net.Pipe bridge for an already-open MSSQL
+// session and returns a PipedMSSQLClient with a ready *sql.DB. The DB is
+// configured to a single connection so test assertions about upstream
+// connection counts are deterministic.
+//
+// The session must already be open at the agent (call OpenMSSQLSession)
+// and the demux must already be running (call StartRecvDemux) before
+// dialing — the inbound pump reads the proxy's PRELOGIN reply off the
+// demux as soon as the driver's first write triggers proxy creation.
+//
+// Cleanup is automatic via t.Cleanup; tests don't need to defer Close.
+func DialPipedMSSQL(t *testing.T, tr *MockTransport, demux *RecvDemux, mc *MSSQLContainer, sessionID, connID string) *PipedMSSQLClient {
+	t.Helper()
+
+	driverConn, bridgeConn := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &PipedMSSQLClient{
+		sessionID:  sessionID,
+		connID:     connID,
+		tr:         tr,
+		demux:      demux,
+		driverConn: driverConn,
+		bridgeConn: bridgeConn,
+		cancel:     cancel,
+		done:       make(chan struct{}),
+	}
+	p.packetSize.Store(mssqltypes.DefaultPacketSize)
+
+	// encrypt=disable keeps the client↔proxy link plaintext. The proxy
+	// rewrites the server's PRELOGIN reply to advertise "encryption not
+	// supported" to the client and offloads TLS to the upstream itself,
+	// so the driver must not attempt its own TLS. The user/password here
+	// are sent in LOGIN7 but the proxy overrides them with the upstream
+	// credentials from the connection env vars; they still need to be
+	// present and well-formed for the driver to build the packet.
+	dsn := fmt.Sprintf("sqlserver://%s:%s@bridge:1433?database=%s&encrypt=disable&dial+timeout=30&connection+timeout=30",
+		mc.User, mc.Password, mc.Database)
+
+	connector, err := mssql.NewConnector(dsn)
+	if err != nil {
+		cancel()
+		t.Fatalf("mssql bridge: failed to build connector: %v", err)
+	}
+	connector.Dialer = &pipeDialer{host: "bridge", conn: driverConn}
+
+	db := sql.OpenDB(connector)
+	// One connection: the bridge backs exactly one net.Pipe. A pool >1
+	// would have the driver try to dial a second bridge conn that doesn't
+	// exist.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
+	p.DB = db
+
+	// Start the byte pumps before the driver dials so the handshake
+	// (PRELOGIN → PRELOGIN reply → LOGIN7 → login ack) can flow.
+	go p.outboundPump(ctx)
+	go p.inboundPump(ctx)
+
+	t.Cleanup(func() { p.Close() })
+	return p
+}
+
+// outboundPump reads complete TDS packets the driver writes (PRELOGIN,
+// LOGIN7, SQL batches, ...) and forwards each one as its own
+// MSSQLConnectionWrite packet.
+//
+// The agent-side proxy's handleAuth reads exactly one TDS packet per
+// decode (mssqltypes.Decode), and its Write path likewise decodes a single
+// packet per call, so the bridge must preserve TDS framing rather than
+// stream arbitrary byte chunks. This mirrors the production client proxy
+// (client/proxy/mssql.go mssqlStreamWriter), which re-frames the raw
+// stream through mssqltypes before sending. Framing by the TDS header
+// length is robust to net.Pipe splitting a large write across reads.
+func (p *PipedMSSQLClient) outboundPump(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		pktBytes, err := p.readTDSPacket()
+		if len(pktBytes) > 0 {
+			p.handleOutboundPacket(pktBytes)
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// readTDSPacket reads exactly one TDS packet (8-byte header + body) off the
+// bridge pipe. The TDS header's bytes [2:4] carry the big-endian total
+// packet length including the header.
+func (p *PipedMSSQLClient) readTDSPacket() ([]byte, error) {
+	var header [8]byte
+	if _, err := io.ReadFull(p.bridgeConn, header[:]); err != nil {
+		return nil, err
+	}
+	total := int(binary.BigEndian.Uint16(header[2:4]))
+	if total < len(header) {
+		return nil, fmt.Errorf("mssql bridge: invalid TDS packet length %d", total)
+	}
+	pkt := make([]byte, total)
+	copy(pkt, header[:])
+	if _, err := io.ReadFull(p.bridgeConn, pkt[len(header):]); err != nil {
+		return nil, err
+	}
+	return pkt, nil
+}
+
+// handleOutboundPacket re-frames a single TDS packet through mssqltypes
+// (canonicalising it the same way the production proxy does) and tracks the
+// negotiated packet size from the client's LOGIN7.
+func (p *PipedMSSQLClient) handleOutboundPacket(pktBytes []byte) {
+	pktList, err := mssqltypes.DecodeFull(pktBytes, int(p.packetSize.Load()))
+	if err != nil {
+		// Forward the raw bytes if framing fails; the agent will surface
+		// the protocol error rather than the bridge silently dropping it.
+		p.sendWrite(pktBytes)
+		return
+	}
+	for _, pkt := range pktList {
+		if pkt.Type() == mssqltypes.PacketLogin7Type {
+			l := mssqltypes.DecodeLogin(pkt.Frame)
+			if sz := int64(l.PacketSize()); sz >= minMSSQLPacketSize {
+				p.packetSize.Store(sz)
+			}
+		}
+		p.sendWrite(pkt.Encode())
+	}
+}
+
+// minMSSQLPacketSize matches the production proxy's floor for honouring a
+// client-advertised packet size.
+const minMSSQLPacketSize = 512
+
+// inboundPump copies the payloads of MSSQLConnectionWrite packets the agent
+// emits for this connection (PRELOGIN reply, login ack, token streams)
+// back into the driver's net.Conn.
+func (p *PipedMSSQLClient) inboundPump(ctx context.Context) {
+	if p.demux == nil {
+		return
+	}
+	ch := p.demux.Channel(p.connID)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case pkt, ok := <-ch:
+			if !ok {
+				return
+			}
+			if len(pkt.Payload) == 0 {
+				continue
+			}
+			if _, err := p.bridgeConn.Write(pkt.Payload); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (p *PipedMSSQLClient) sendWrite(payload []byte) {
+	select {
+	case <-p.done:
+		return
+	default:
+	}
+	defer func() { _ = recover() }() // tolerate inject racing a transport close
+	pkt := &pb.Packet{
+		Type: pbagent.MSSQLConnectionWrite,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(p.sessionID),
+			pb.SpecClientConnectionID: []byte(p.connID),
+		},
+		Payload: payload,
+	}
+	p.tr.Inject(pkt)
+}
+
+// SessionID returns the agent-side session ID.
+func (p *PipedMSSQLClient) SessionID() string { return p.sessionID }
+
+// ConnID returns the gateway-side connection ID this client occupies.
+func (p *PipedMSSQLClient) ConnID() string { return p.connID }
+
+// Close tears down the *sql.DB, both pipe ends, and the pumps. Safe to
+// call multiple times.
+func (p *PipedMSSQLClient) Close() {
+	p.closeOnce.Do(func() {
+		close(p.done)
+		p.cancel()
+		if p.DB != nil {
+			_ = p.DB.Close()
+		}
+		_ = p.driverConn.Close()
+		_ = p.bridgeConn.Close()
+	})
+}
+
+// PingWithTimeout runs DB.PingContext bounded by timeout. Establishing the
+// first connection forces the full bridged TDS handshake through libhoop,
+// so a successful ping is the integration smoke test for MSSQL auth.
+func (p *PipedMSSQLClient) PingWithTimeout(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return p.DB.PingContext(ctx)
+}

--- a/agent/integration/testutil/mssql_container.go
+++ b/agent/integration/testutil/mssql_container.go
@@ -1,0 +1,213 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "github.com/microsoft/go-mssqldb"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// MSSQLContainer wraps a Microsoft SQL Server container for integration
+// tests. SQL Server runs natively on Linux from the official
+// mcr.microsoft.com image, so no Windows host is needed. Credentials are
+// fixed so test code can reference them directly.
+//
+// SQL Server has no concept of a "create this database on boot" env var
+// (unlike Postgres/MySQL), so StartMSSQL creates the test database itself
+// after the server is ready.
+type MSSQLContainer struct {
+	Host      string
+	Port      string
+	User      string
+	Password  string
+	Database  string
+	Container testcontainers.Container
+}
+
+// mssqlSAPassword satisfies SQL Server's password policy (>=8 chars, mixed
+// case, digits, symbols). Used for the built-in sa account.
+const (
+	mssqlSAUser     = "sa"
+	mssqlSAPassword = "hoopTest!2024"
+	mssqlDatabase   = "testdb"
+)
+
+// StartMSSQL boots a SQL Server 2022 container, waits until it accepts
+// authenticated connections, then creates the test database. The wait
+// strategy combines the readiness log line with a real authenticated ping
+// because SQL Server logs "ready for client connections" slightly before
+// the sa login is actually usable.
+func StartMSSQL(t T) *MSSQLContainer {
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mcr.microsoft.com/mssql/server:2022-latest",
+			ExposedPorts: []string{"1433/tcp"},
+			Env: map[string]string{
+				"ACCEPT_EULA":       "Y",
+				"MSSQL_SA_PASSWORD": mssqlSAPassword,
+				// Express avoids the eval-edition nag and boots quickly;
+				// it speaks the identical TDS wire protocol libhoop's
+				// MSSQL proxy targets.
+				"MSSQL_PID": "Express",
+			},
+			WaitingFor: wait.ForAll(
+				wait.ForLog("SQL Server is now ready for client connections").
+					WithOccurrence(1),
+				wait.ForListeningPort("1433/tcp"),
+			).WithDeadline(150 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to start mssql container: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = container.Terminate(context.Background())
+	})
+
+	mappedPort, err := container.MappedPort(ctx, "1433/tcp")
+	if err != nil {
+		t.Fatalf("failed to get mapped mssql port: %v", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("failed to get mssql container host: %v", err)
+	}
+
+	c := &MSSQLContainer{
+		Host:      host,
+		Port:      mappedPort.Port(),
+		User:      mssqlSAUser,
+		Password:  mssqlSAPassword,
+		Database:  "master",
+		Container: container,
+	}
+
+	// Block until sa can actually authenticate, then create the test DB.
+	c.waitForReady(t)
+	c.createDatabase(t)
+	c.Database = mssqlDatabase
+
+	return c
+}
+
+// adminConnString returns a go-mssqldb DSN that connects directly to the
+// container against the given database, bypassing the agent. TLS is
+// disabled because the bridged-proxy path the tests exercise also runs
+// without client-side encryption.
+func (c *MSSQLContainer) adminConnString(database string) string {
+	return fmt.Sprintf("sqlserver://%s:%s@%s:%s?database=%s&encrypt=disable",
+		c.User, c.Password, c.Host, c.Port, database)
+}
+
+// ConnString returns a direct DSN to the test database. Used by sidecar
+// admin connections in concurrency tests.
+func (c *MSSQLContainer) ConnString() string {
+	return c.adminConnString(c.Database)
+}
+
+func (c *MSSQLContainer) waitForReady(t T) {
+	deadline := time.Now().Add(120 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if lastErr = c.ping("master"); lastErr == nil {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("mssql container never became ready within 120s: %v", lastErr)
+}
+
+// ping opens a short-lived direct connection to the container and runs a
+// trivial query against the given database.
+func (c *MSSQLContainer) ping(database string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("sqlserver", c.adminConnString(database))
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	return db.PingContext(ctx)
+}
+
+// createDatabase creates the test database on the freshly booted server.
+// CREATE DATABASE cannot run inside a transaction, so it goes through a
+// plain Exec on the master database.
+func (c *MSSQLContainer) createDatabase(t T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("sqlserver", c.adminConnString("master"))
+	if err != nil {
+		t.Fatalf("mssql: failed opening admin connection to create database: %v", err)
+	}
+	defer db.Close()
+
+	stmt := fmt.Sprintf(
+		"IF DB_ID('%s') IS NULL CREATE DATABASE [%s]", mssqlDatabase, mssqlDatabase)
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		t.Fatalf("mssql: failed creating test database: %v", err)
+	}
+}
+
+// ConnectionCount opens a sidecar admin connection and returns the number
+// of sessions connected to the test database, excluding the sidecar's own
+// session. Used by concurrency tests to assert how many upstream
+// connections the agent established.
+func (c *MSSQLContainer) ConnectionCount(t T) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("sqlserver", c.adminConnString(c.Database))
+	if err != nil {
+		t.Fatalf("mssqlstat: failed to open admin connection: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatalf("mssqlstat: admin ping failed: %v", err)
+	}
+
+	// @@SPID is this admin session's own id; exclude it so the count
+	// reflects only agent-driven sessions. Filtering on DB_ID keeps
+	// system sessions for other databases out of the count.
+	var count int
+	row := db.QueryRowContext(ctx, `
+		SELECT count(*) FROM sys.dm_exec_sessions
+		WHERE database_id = DB_ID(@p1) AND session_id <> @@SPID`, c.Database)
+	if err := row.Scan(&count); err != nil {
+		t.Fatalf("mssqlstat: failed to count sessions: %v", err)
+	}
+	return count
+}
+
+// WaitForConnectionCount polls ConnectionCount until it equals want or the
+// timeout elapses. SQL Server reaps sessions on close but not instantly,
+// so teardown assertions need a poll rather than a single snapshot.
+func (c *MSSQLContainer) WaitForConnectionCount(t T, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last int
+	for time.Now().Before(deadline) {
+		last = c.ConnectionCount(t)
+		if last == want {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("mssqlstat: expected %d sessions after %v, last observed=%d", want, timeout, last)
+}

--- a/agent/integration/testutil/mssql_container.go
+++ b/agent/integration/testutil/mssql_container.go
@@ -163,16 +163,37 @@ func (c *MSSQLContainer) createDatabase(t T) {
 	}
 }
 
-// ConnectionCount opens a sidecar admin connection and returns the number
-// of sessions connected to the test database, excluding the sidecar's own
-// session. Used by concurrency tests to assert how many upstream
-// connections the agent established.
+// countSessionsOn returns the number of sessions on the test database
+// visible to the given admin connection, excluding that connection's own
+// session (@@SPID). Filtering on DB_ID keeps system sessions for other
+// databases out of the count.
+//
+// The admin connection must be a single, pinned *sql.DB (MaxOpenConns=1):
+// SQL Server does not reap a session the instant its TCP connection closes,
+// so a fresh admin connection per poll would race its own
+// just-disconnected predecessor and intermittently count it. Reusing one
+// pinned connection keeps @@SPID stable and self-exclusion exact.
+func (c *MSSQLContainer) countSessionsOn(ctx context.Context, db *sql.DB) (int, error) {
+	var count int
+	row := db.QueryRowContext(ctx, `
+		SELECT count(*) FROM sys.dm_exec_sessions
+		WHERE database_id = DB_ID(@p1) AND session_id <> @@SPID`, c.Database)
+	if err := row.Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// ConnectionCount opens a single pinned sidecar admin connection and returns
+// the number of sessions connected to the test database, excluding the
+// sidecar's own session. Used by concurrency tests to assert how many
+// upstream connections the agent established.
 func (c *MSSQLContainer) ConnectionCount(t T) int {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	db, err := sql.Open("sqlserver", c.adminConnString(c.Database))
+	db, err := c.openPinnedAdmin()
 	if err != nil {
 		t.Fatalf("mssqlstat: failed to open admin connection: %v", err)
 	}
@@ -181,29 +202,53 @@ func (c *MSSQLContainer) ConnectionCount(t T) int {
 	if err := db.PingContext(ctx); err != nil {
 		t.Fatalf("mssqlstat: admin ping failed: %v", err)
 	}
-
-	// @@SPID is this admin session's own id; exclude it so the count
-	// reflects only agent-driven sessions. Filtering on DB_ID keeps
-	// system sessions for other databases out of the count.
-	var count int
-	row := db.QueryRowContext(ctx, `
-		SELECT count(*) FROM sys.dm_exec_sessions
-		WHERE database_id = DB_ID(@p1) AND session_id <> @@SPID`, c.Database)
-	if err := row.Scan(&count); err != nil {
+	count, err := c.countSessionsOn(ctx, db)
+	if err != nil {
 		t.Fatalf("mssqlstat: failed to count sessions: %v", err)
 	}
 	return count
 }
 
-// WaitForConnectionCount polls ConnectionCount until it equals want or the
-// timeout elapses. SQL Server reaps sessions on close but not instantly,
-// so teardown assertions need a poll rather than a single snapshot.
+// openPinnedAdmin returns an admin *sql.DB pinned to exactly one underlying
+// connection so its @@SPID stays stable across queries.
+func (c *MSSQLContainer) openPinnedAdmin() (*sql.DB, error) {
+	db, err := sql.Open("sqlserver", c.adminConnString(c.Database))
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
+	return db, nil
+}
+
+// WaitForConnectionCount polls until the session count on the test database
+// equals want or the timeout elapses. It holds a single pinned admin
+// connection for the entire poll: opening a new admin connection per
+// iteration would race SQL Server's lazy session reaping and count the
+// previous iteration's just-closed admin session, so the poll could never
+// observe 0. SQL Server also reaps the agent's session lazily after its TCP
+// connection drops mid-query, which is why a poll (not a single snapshot) is
+// needed.
 func (c *MSSQLContainer) WaitForConnectionCount(t T, want int, timeout time.Duration) {
 	t.Helper()
+
+	db, err := c.openPinnedAdmin()
+	if err != nil {
+		t.Fatalf("mssqlstat: failed to open admin connection: %v", err)
+	}
+	defer db.Close()
+
 	deadline := time.Now().Add(timeout)
 	var last int
 	for time.Now().Before(deadline) {
-		last = c.ConnectionCount(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		count, qErr := c.countSessionsOn(ctx, db)
+		cancel()
+		if qErr != nil {
+			t.Fatalf("mssqlstat: failed to count sessions: %v", qErr)
+		}
+		last = count
 		if last == want {
 			return
 		}

--- a/agent/integration/testutil/mssql_session.go
+++ b/agent/integration/testutil/mssql_session.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+)
+
+// BuildMSSQLEnvVars constructs the AgentConnectionParams env vars map for a
+// MSSQL connection. The keys must match what parseConnectionEnvVars looks
+// up for ConnectionTypeMSSQL (HOST, USER, PASS, PORT). libhoop's MSSQL
+// proxy uses USER/PASS to authenticate against the upstream itself,
+// overriding whatever the client sends in its LOGIN7 packet. INSECURE
+// controls whether the proxy verifies the upstream server certificate.
+func BuildMSSQLEnvVars(host, port, user, pass string) map[string]any {
+	return map[string]any{
+		"envvar:HOST":     b64(host),
+		"envvar:USER":     b64(user),
+		"envvar:PASS":     b64(pass),
+		"envvar:PORT":     b64(port),
+		"envvar:INSECURE": b64("true"),
+	}
+}
+
+// OpenMSSQLSession opens a MSSQL session on the agent and blocks until
+// SessionOpenOK is observed, returning the generated session ID. It reads
+// directly from the transport, so it must be called before StartRecvDemux
+// to avoid the demux swallowing the open reply.
+func OpenMSSQLSession(t *testing.T, tr *MockTransport, mc *MSSQLContainer) string {
+	t.Helper()
+	sessionID := uuid.New().String()
+	envVars := BuildMSSQLEnvVars(mc.Host, mc.Port, mc.User, mc.Password)
+	pkt := BuildSessionOpenPacket(sessionID, string(pb.ConnectionTypeMSSQL), envVars)
+	tr.Inject(pkt)
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case resp := <-tr.RecvCh():
+			switch resp.Type {
+			case pbclient.SessionOpenOK:
+				return sessionID
+			case pbclient.SessionClose:
+				t.Fatalf("mssql session open failed: %s", string(resp.Payload))
+			default:
+				continue
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for mssql SessionOpenOK")
+		}
+	}
+}
+
+// SendMSSQLTrigger injects a zero-payload MSSQLConnectionWrite. Exposed for
+// diagnostics; normal tests don't need it because the go-mssqldb driver
+// speaks first (PRELOGIN), so the first real write creates the proxy.
+func SendMSSQLTrigger(tr *MockTransport, sessionID, connID string) {
+	tr.Inject(&pb.Packet{
+		Type: pbagent.MSSQLConnectionWrite,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(sessionID),
+			pb.SpecClientConnectionID: []byte(connID),
+		},
+	})
+}

--- a/agent/integration/testutil/recvdemux.go
+++ b/agent/integration/testutil/recvdemux.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	pb "github.com/hoophq/hoop/common/proto"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
 )
 
 // RecvDemux fans out the agent's outgoing packets from a MockTransport into
@@ -30,9 +31,13 @@ type RecvDemux struct {
 	// Packets without SpecClientConnectionID (session-level events like
 	// SessionOpenOK and SessionClose) are routed here.
 	sessionCh chan *pb.Packet
-	ctx       context.Context
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
+	// sessionCloseSubs maps sessionID → channels that are closed when a
+	// SessionClose for that session is observed. Each channel is closed
+	// exactly once; see SessionCloseChan.
+	sessionCloseSubs map[string][]chan struct{}
+	ctx              context.Context
+	cancel           context.CancelFunc
+	wg               sync.WaitGroup
 }
 
 // StartRecvDemux begins consuming from tr.RecvCh() in a background goroutine
@@ -45,11 +50,12 @@ func StartRecvDemux(t T, tr *MockTransport) *RecvDemux {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	d := &RecvDemux{
-		tr:        tr,
-		conns:     make(map[string]chan *pb.Packet),
-		sessionCh: make(chan *pb.Packet, 256),
-		ctx:       ctx,
-		cancel:    cancel,
+		tr:               tr,
+		conns:            make(map[string]chan *pb.Packet),
+		sessionCh:        make(chan *pb.Packet, 256),
+		sessionCloseSubs: make(map[string][]chan struct{}),
+		ctx:              ctx,
+		cancel:           cancel,
 	}
 
 	d.wg.Add(1)
@@ -73,6 +79,13 @@ func (d *RecvDemux) loop() {
 			}
 			connID := string(pkt.Spec[pb.SpecClientConnectionID])
 			if connID == "" {
+				// Session-level packet: route to sessionCh and, for
+				// SessionClose packets, also signal any registered subscribers
+				// so inbound pumps can unblock blocked drivers.
+				if pkt.Type == pbclient.SessionClose {
+					sid := string(pkt.Spec[pb.SpecGatewaySessionID])
+					d.fireSessionClose(sid)
+				}
 				select {
 				case d.sessionCh <- pkt:
 				case <-d.ctx.Done():
@@ -88,6 +101,33 @@ func (d *RecvDemux) loop() {
 			}
 		}
 	}
+}
+
+// fireSessionClose closes all channels registered for the given sessionID.
+// Safe to call from the demux loop (holds mu briefly).
+func (d *RecvDemux) fireSessionClose(sessionID string) {
+	d.mu.Lock()
+	subs := d.sessionCloseSubs[sessionID]
+	delete(d.sessionCloseSubs, sessionID)
+	d.mu.Unlock()
+	for _, ch := range subs {
+		close(ch)
+	}
+}
+
+// SessionCloseChan returns a channel that is closed when the demux observes a
+// SessionClose packet for sessionID. Callers can select on it to detect agent
+// session teardown without consuming from the shared sessionCh.
+//
+// Multiple calls for the same sessionID each get their own channel — all are
+// closed when the SessionClose arrives. If a SessionClose for sessionID has
+// already been processed, the returned channel is closed immediately.
+func (d *RecvDemux) SessionCloseChan(sessionID string) <-chan struct{} {
+	ch := make(chan struct{})
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.sessionCloseSubs[sessionID] = append(d.sessionCloseSubs[sessionID], ch)
+	return ch
 }
 
 func (d *RecvDemux) channelFor(connID string) chan *pb.Packet {


### PR DESCRIPTION
## What

Adds end-to-end integration tests for libhoop's **MSSQL** and **MongoDB** proxies, completing the database-proxy integration coverage alongside the existing PostgreSQL suite and the MySQL suite (#1501).

Both suites follow the bridged-driver architecture: a real database driver runs over a `net.Pipe` whose bytes are shuttled through a `MockTransport` into the agent's `processMSSQLProtocol` / `processMongoDBProtocol` handlers and libhoop's proxies, then back. This gives full wire-protocol coverage without hand-crafting protocol bytes.

## MSSQL (11 tests)

`mssql_test.go`, `mssql_concurrency_test.go`, and three `testutil` helpers.

- ping, simple query, full CRUD, multi-row result sets, **large-payload TDS fragmentation** (>4 KiB, crosses packet boundaries), commit/rollback, server error survival, bad credentials, parallel sessions, session-close-race with a goroutine-leak check.
- The bridge re-frames the driver's byte stream into whole TDS packets via `common/mssqltypes.DecodeFull` (mirroring `client/proxy/mssql.go`), and installs a `HostDialer` on go-mssqldb's `Connector` so the driver skips DNS resolution of the placeholder bridge host.
- Container: `mcr.microsoft.com/mssql/server:2022-latest` (runs natively on Linux).

## MongoDB (8 tests)

`mongodb_test.go`, `mongodb_concurrency_test.go`, and three `testutil` helpers.

- ping (+ multi-connection routing assertion), CRUD, multi-document cursors, runCommand, server error survival (CommandNotFound), bad credentials, parallel sessions, session-close-race with a goroutine-leak check.
- libhoop's MongoDB proxy is a SCRAM man-in-the-middle: it authenticates upstream with the real connection-string credentials and presents a fake SCRAM server to the client with hardcoded `noop/noop`. The bridged driver therefore connects with `noop/noop` and issues the legacy `OP_QUERY` hello the proxy requires.
- The dialer allocates a fresh bridged connection (its own connID and agent-side proxy) per `DialContext`, mirroring the production client proxy's per-connection model, and frames wire messages by their length prefix (16 MiB cap, matching production).
- Container: `mongo:7`.

## Shared infra

`MockTransport.Close` no longer closes its channels — long-lived bridge pumps and the demux send on them and stop on context cancellation; closing under them is a data race. `Inject` and `Expect` now observe `ctx.Done()` for clean teardown.

## Testing

All **19 tests pass under `-race`** (`CGO_ENABLED=1 go test -tags integration -race`), validating the libhoop `blockingReader` data-race fix (libhoop#75) for both protocols. The existing PostgreSQL suite still passes under `-race`.

## Dependencies

- Requires the real (enterprise) libhoop at `./libhoop` — CI already checks this out for `make test-integration`. The OSS `_libhoop` stub returns noop proxies.
- No `go.mod`/`go.sum` changes; testcontainers, go-mssqldb, and mongo-driver were already dependencies.

Closes ENG-389.

Automated by MisterMal