### PR TITLE
fix: deleting duplicate command tokens removes wrong item

### DIFF
--- a/webapp/src/webapp/components/multiselect.cljs
+++ b/webapp/src/webapp/components/multiselect.cljs
@@ -5,6 +5,7 @@
    ["react-select/creatable" :default CreatableSelect]
    ["@radix-ui/themes" :refer [Text Tooltip]]
    [clojure.string :as cs]
+   [goog.object :as gobj]
    [reagent.core :as r]
    [webapp.components.infinite-scroll :refer [infinite-scroll]]))
 
@@ -144,11 +145,11 @@
                         (if input-value
                           (case (.-key event)
                             "Enter" (do
-                                      (on-change (conj (js->clj value) {"label" input-value "value" input-value}))
+                                      (on-change (conj (js->clj value) {"label" input-value "value" input-value "id" (str (random-uuid))}))
                                       (on-input-change "")
                                       (.preventDefault event))
                             "Tab" (do
-                                    (on-change (conj (js->clj value) {"label" input-value "value" input-value}))
+                                    (on-change (conj (js->clj value) {"label" input-value "value" input-value "id" (str (random-uuid))}))
                                     (on-input-change "")
                                     (.preventDefault event))
                             nil)
@@ -169,6 +170,9 @@
        :menuIsOpen false
        :isDisabled disabled?
        :required required?
+       :getOptionValue (fn [option]
+                         (or (gobj/get option "id")
+                             (gobj/get option "value")))
        :onChange (fn [value]
                    (on-change (js->clj value)))
        :onInputChange on-input-change

--- a/webapp/src/webapp/connections/views/setup/events/process_form.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/process_form.cljs
@@ -649,7 +649,7 @@
                 (str/join " " (:command connection)))
      :command-args (if (empty? (:command connection))
                      []
-                     (mapv #(hash-map "value" % "label" %) (:command connection)))
+                     (mapv #(hash-map "value" % "label" % "id" (str (random-uuid))) (:command connection)))
      :configuration-files (or normalized-config-files
                               (when (or (= connection-type "custom")
                                         (= connection-type "database"))


### PR DESCRIPTION
> Note for maintainers: please add the `patch` label (bug fix, non-breaking).

When command args contain duplicate values (e.g. multiple `-o` flags), react-select identified items by value rather than position, causing the wrong token to be removed on delete. Each token now carries a unique id so react-select can distinguish duplicates correctly.

## 📝 Description

Fixes a bug where deleting a command token in a connection's command args removed the wrong item when duplicate values were present (e.g. multiple `-o` SSH flags). The underlying cause: react-select identifies multi-select items by their `value` field, so duplicate tokens were indistinguishable and deletion targeted the first match rather than the clicked item.

Each token now carries a unique `id` on creation, and `getOptionValue` is configured to use that id so react-select can distinguish duplicates correctly. Existing connections loaded for editing also get unique ids assigned at load time.

## 🔗 Related Issue

Fixes #1116

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- `webapp/src/webapp/components/multiselect.cljs` — assign unique `id` on new tokens, add `getOptionValue` to `text-input` so react-select uses the id for identity
- `webapp/src/webapp/connections/views/setup/events/process_form.cljs` — assign unique `id` when loading existing command args so the fix also applies in edit mode

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS

### Tests performed:
- [x] Manual testing completed

Manual repro steps:
1. Create a new connection with command tokens `ssh`, `-o`, `OptionOne`, `-o`, `OptionTwo`
2. Click delete on the first `-o` — confirm the first one disappears (not the second)
3. Edit an existing connection with duplicate tokens — confirm deletion targets the correct item
4. Confirm non-duplicate tokens still delete normally

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings