### PR TITLE
refactor: replace clientexec usage with services.Exec

### DIFF
--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	apivalidation "github.com/hoophq/hoop/gateway/api/validation"
-	"github.com/hoophq/hoop/gateway/clientexec"
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/hoophq/hoop/gateway/services"
 	"github.com/hoophq/hoop/gateway/storagev2"
@@ -600,27 +599,24 @@ printjson(db.runCommand({ping:1}));`, nil
 }
 
 func testConnection(ctx *storagev2.Context, bearerToken string, conn *models.Connection) error {
-	client, err := clientexec.New(&clientexec.Options{
-		OrgID:          ctx.GetOrgID(),
-		ConnectionName: conn.Name,
-		BearerToken:    bearerToken,
-		UserAgent:      "webapp.editor.testconnection",
-		Verb:           pb.ClientVerbPlainExec,
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed creating client: %w", err)
-	}
-
-	defer client.Close()
-
 	currentConnectionType := pb.ToConnectionType(conn.Type, conn.SubType.String)
 	command, err := getScriptsForTestConnection(&currentConnectionType)
 	if err != nil {
 		return err
 	}
 
-	outcome := client.Run([]byte(command), nil)
+	outcome, err := services.Exec(context.Background(), services.ExecOptions{
+		OrgID:          ctx.GetOrgID(),
+		ConnectionName: conn.Name,
+		BearerToken:    bearerToken,
+		UserAgent:      "webapp.editor.testconnection",
+		Verb:           pb.ClientVerbPlainExec,
+		Script:         command,
+	})
+	if err != nil {
+		return fmt.Errorf("failed creating client: %w", err)
+	}
+
 	if outcome.ExitCode != 0 {
 		return fmt.Errorf("failed issuing test command, output=%v", outcome.Output)
 	}

--- a/gateway/api/connections/database_explorer.go
+++ b/gateway/api/connections/database_explorer.go
@@ -3,6 +3,7 @@ package apiconnections
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -14,8 +15,8 @@ import (
 	"github.com/hoophq/hoop/gateway/api/apiroutes"
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/api/openapi"
-	"github.com/hoophq/hoop/gateway/clientexec"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/services"
 	"github.com/hoophq/hoop/gateway/storagev2"
 )
 
@@ -82,33 +83,20 @@ print(JSON.stringify(result));`
 	}
 
 	userAgent := apiutils.NormalizeUserAgent(c.Request.Header.Values)
-	client, err := clientexec.New(&clientexec.Options{
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*50)
+	defer cancelFn()
+	outcome, err := services.Exec(timeoutCtx, services.ExecOptions{
 		OrgID:                     ctx.GetOrgID(),
 		ConnectionName:            conn.Name,
 		ConnectionCommandOverride: getConnectionCommandOverride(currentConnectionType, conn.Command),
 		BearerToken:               apiroutes.GetAccessTokenFromRequest(c),
 		UserAgent:                 userAgent,
 		// it sets the execution to perform plain executions
-		Verb: pb.ClientVerbPlainExec,
+		Verb:   pb.ClientVerbPlainExec,
+		Script: script,
 	})
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed to create client: %v", err)
-		return
-	}
-
-	respCh := make(chan *clientexec.Response)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		select {
-		case respCh <- client.Run([]byte(script), nil):
-		default:
-		}
-	}()
-
-	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*50)
-	defer cancelFn()
-	select {
-	case outcome := <-respCh:
+	switch {
+	case err == nil:
 		if outcome.ExitCode != 0 {
 			errMsg := fmt.Errorf("command failed: %s", outcome.Output)
 			httputils.AbortWithErr(c, http.StatusInternalServerError, errMsg, "%v", errMsg)
@@ -140,10 +128,11 @@ print(JSON.stringify(result));`
 			}
 		}
 		c.JSON(http.StatusOK, openapi.ConnectionDatabaseListResponse{Databases: databases})
-	case <-timeoutCtx.Done():
-		client.Close()
+	case errors.Is(err, context.DeadlineExceeded):
 		log.Infof("runexec timeout (50s), it will return async")
 		c.JSON(http.StatusBadRequest, gin.H{"message": "Request timed out"})
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed to create client: %v", err)
 	}
 }
 
@@ -227,32 +216,19 @@ func ListTables(c *gin.Context) {
 	}
 
 	userAgent := apiutils.NormalizeUserAgent(c.Request.Header.Values)
-	client, err := clientexec.New(&clientexec.Options{
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancelFn()
+	outcome, err := services.Exec(timeoutCtx, services.ExecOptions{
 		OrgID:                     ctx.GetOrgID(),
 		ConnectionName:            conn.Name,
 		ConnectionCommandOverride: getConnectionCommandOverride(currentConnectionType, conn.Command),
 		BearerToken:               apiroutes.GetAccessTokenFromRequest(c),
 		UserAgent:                 userAgent,
 		Verb:                      pb.ClientVerbPlainExec,
+		Script:                    script,
 	})
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed to create client: %v", err)
-		return
-	}
-
-	respCh := make(chan *clientexec.Response)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		select {
-		case respCh <- client.Run([]byte(script), nil):
-		default:
-		}
-	}()
-
-	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancelFn()
-	select {
-	case outcome := <-respCh:
+	switch {
+	case err == nil:
 		if outcome.ExitCode != 0 {
 			log.Warnf("failed issuing plain exec: %s, output=%v", outcome.String(), outcome.Output)
 			c.JSON(http.StatusBadRequest, gin.H{"message": fmt.Sprintf("failed to list tables: %s", outcome.Output)})
@@ -288,8 +264,7 @@ func ListTables(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusOK, tables)
-	case <-timeoutCtx.Done():
-		client.Close()
+	case errors.Is(err, context.DeadlineExceeded):
 		log.Warnf("timeout (30s) obtaining tables for database '%s' using connection '%s'", dbName, conn.Name)
 		c.JSON(http.StatusBadRequest, gin.H{
 			"message":    fmt.Sprintf("Request timed out (30s) while fetching tables for database '%s'", dbName),
@@ -297,6 +272,8 @@ func ListTables(c *gin.Context) {
 			"database":   dbName,
 			"timeout":    "30s",
 		})
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed to create client: %v", err)
 	}
 }
 
@@ -395,31 +372,18 @@ func GetTableColumns(c *gin.Context) {
 	}
 
 	userAgent := apiutils.NormalizeUserAgent(c.Request.Header.Values)
-	client, err := clientexec.New(&clientexec.Options{
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancelFn()
+	outcome, err := services.Exec(timeoutCtx, services.ExecOptions{
 		OrgID:          ctx.GetOrgID(),
 		ConnectionName: conn.Name,
 		BearerToken:    apiroutes.GetAccessTokenFromRequest(c),
 		UserAgent:      userAgent,
 		Verb:           pb.ClientVerbPlainExec,
+		Script:         script,
 	})
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed to create client: %v", err)
-		return
-	}
-
-	respCh := make(chan *clientexec.Response)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		select {
-		case respCh <- client.Run([]byte(script), nil):
-		default:
-		}
-	}()
-
-	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancelFn()
-	select {
-	case outcome := <-respCh:
+	switch {
+	case err == nil:
 		if outcome.ExitCode != 0 {
 			log.Warnf("failed issuing plain exec: %s, output=%v", outcome.String(), outcome.Output)
 			c.JSON(http.StatusBadRequest, gin.H{"message": fmt.Sprintf("failed to get columns: %s", outcome.Output)})
@@ -440,8 +404,7 @@ func GetTableColumns(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusOK, response)
-	case <-timeoutCtx.Done():
-		client.Close()
+	case errors.Is(err, context.DeadlineExceeded):
 		log.Warnf("timeout (30s) obtaining columns for table '%s' in database '%s' using connection '%s'", tableName, dbName, conn.Name)
 		c.JSON(http.StatusBadRequest, gin.H{
 			"message":    fmt.Sprintf("Request timed out (30s) while fetching columns for table '%s'", tableName),
@@ -450,5 +413,7 @@ func GetTableColumns(c *gin.Context) {
 			"table":      tableName,
 			"timeout":    "30s",
 		})
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed to create client: %v", err)
 	}
 }

--- a/gateway/api/mcpserver/tools_exec.go
+++ b/gateway/api/mcpserver/tools_exec.go
@@ -213,33 +213,24 @@ func execHandler(ctx context.Context, _ *mcp.CallToolRequest, args execInput) (*
 	}
 	trackClient.TrackSessionUsageData(analytics.EventSessionCreated, sc.GetOrgID(), sc.GetUserID(), sessionID)
 
-	client, err := clientexec.New(&clientexec.Options{
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), execTimeout)
+	defer cancelFn()
+
+	resp, err := services.Exec(timeoutCtx, services.ExecOptions{
 		OrgID:          sc.GetOrgID(),
 		SessionID:      sessionID,
 		ConnectionName: conn.Name,
 		BearerToken:    token,
 		UserAgent:      fmt.Sprintf("mcp.exec/%s", sc.UserEmail),
 		Origin:         pb.ConnectionOriginClientAPI,
+		Script:         args.Input,
+		EnvVars:        args.EnvVars,
+		ClientArgs:     args.Args,
 	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed creating exec client: %w", err)
-	}
-
-	respCh := make(chan *clientexec.Response, 1)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		respCh <- client.Run([]byte(args.Input), args.EnvVars, args.Args...)
-	}()
-
-	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), execTimeout)
-	defer cancelFn()
-
-	select {
-	case resp := <-respCh:
+	switch {
+	case err == nil:
 		return execResponseToEnvelope(resp, sessionID)
-	case <-timeoutCtx.Done():
-		// Force the goroutine to unblock; its result will be persisted async.
-		client.Close()
+	case errors.Is(err, context.DeadlineExceeded):
 		log.With("sid", sessionID).Infof("mcp exec timeout (%s), returning status=running", execTimeout)
 		return jsonResult(map[string]any{
 			"status":     "running",
@@ -247,6 +238,8 @@ func execHandler(ctx context.Context, _ *mcp.CallToolRequest, args execInput) (*
 			"message":    fmt.Sprintf("execution still running after %s; poll sessions_get with session_id", execTimeout),
 			"next_step":  "poll sessions_get with session_id",
 		})
+	default:
+		return nil, nil, fmt.Errorf("failed creating exec client: %w", err)
 	}
 }
 

--- a/gateway/api/mcpserver/tools_reviews.go
+++ b/gateway/api/mcpserver/tools_reviews.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	reviewapi "github.com/hoophq/hoop/gateway/api/review"
-	"github.com/hoophq/hoop/gateway/clientexec"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/services"
 	"github.com/hoophq/hoop/gateway/storagev2"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -152,23 +152,6 @@ func reviewsExecuteHandler(ctx context.Context, _ *mcp.CallToolRequest, args rev
 		return errResult(err.Error()), nil, nil
 	}
 
-	client, err := clientexec.New(&clientexec.Options{
-		OrgID:          sc.GetOrgID(),
-		SessionID:      session.ID,
-		ConnectionName: session.Connection,
-		BearerToken:    token,
-		UserAgent:      fmt.Sprintf("mcp.reviews_execute/%s", sc.UserEmail),
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed creating exec client: %w", err)
-	}
-
-	respCh := make(chan *clientexec.Response, 1)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		respCh <- client.Run([]byte(session.BlobInput), review.InputEnvVars, review.InputClientArgs...)
-	}()
-
 	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancelFn()
 
@@ -179,8 +162,18 @@ func reviewsExecuteHandler(ctx context.Context, _ *mcp.CallToolRequest, args rev
 		}
 	}()
 
-	select {
-	case resp := <-respCh:
+	resp, err := services.Exec(timeoutCtx, services.ExecOptions{
+		OrgID:          sc.GetOrgID(),
+		SessionID:      session.ID,
+		ConnectionName: session.Connection,
+		BearerToken:    token,
+		UserAgent:      fmt.Sprintf("mcp.reviews_execute/%s", sc.UserEmail),
+		Script:         string(session.BlobInput),
+		EnvVars:        review.InputEnvVars,
+		ClientArgs:     review.InputClientArgs,
+	})
+	switch {
+	case err == nil:
 		env := map[string]any{
 			"session_id":        resp.SessionID,
 			"output":            resp.Output,
@@ -195,8 +188,7 @@ func reviewsExecuteHandler(ctx context.Context, _ *mcp.CallToolRequest, args rev
 			env["status"] = "completed"
 		}
 		return jsonResult(env)
-	case <-timeoutCtx.Done():
-		client.Close()
+	case errors.Is(err, context.DeadlineExceeded):
 		reviewStatus = models.ReviewStatusUnknown
 		return jsonResult(map[string]any{
 			"session_id": session.ID,
@@ -204,6 +196,8 @@ func reviewsExecuteHandler(ctx context.Context, _ *mcp.CallToolRequest, args rev
 			"message":    "execution still running after 50s; poll sessions_get with session_id",
 			"next_step":  "poll sessions_get with session_id",
 		})
+	default:
+		return nil, nil, fmt.Errorf("failed creating exec client: %w", err)
 	}
 }
 

--- a/gateway/api/mcpserver/tools_schema.go
+++ b/gateway/api/mcpserver/tools_schema.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,8 +10,8 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	pb "github.com/hoophq/hoop/common/proto"
 	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
-	"github.com/hoophq/hoop/gateway/clientexec"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/services"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -211,33 +212,27 @@ print(JSON.stringify(result));`
 
 func runSchemaExec(orgID, connectionName, script, token string) (string, bool, error) {
 	sessionID := uuid.NewString()
-	client, err := clientexec.New(&clientexec.Options{
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), schemaTimeout)
+	defer cancelFn()
+	resp, err := services.Exec(timeoutCtx, services.ExecOptions{
 		OrgID:          orgID,
 		SessionID:      sessionID,
 		ConnectionName: connectionName,
 		BearerToken:    token,
 		UserAgent:      "mcp.schema",
 		Verb:           pb.ClientVerbPlainExec,
+		Script:         script,
 	})
-	if err != nil {
-		return "", false, fmt.Errorf("failed creating exec client: %w", err)
-	}
-	respCh := make(chan *clientexec.Response, 1)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		respCh <- client.Run([]byte(script), nil)
-	}()
-	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), schemaTimeout)
-	defer cancelFn()
-	select {
-	case resp := <-respCh:
+	switch {
+	case err == nil:
 		if resp.ExitCode != 0 && resp.ExitCode != -2 {
 			log.With("sid", sessionID).Warnf("schema exec non-zero exit, %v", resp.String())
 			return "", false, fmt.Errorf("schema query failed: %s", resp.Output)
 		}
 		return resp.Output, false, nil
-	case <-timeoutCtx.Done():
-		client.Close()
+	case errors.Is(err, context.DeadlineExceeded):
 		return "", true, nil
+	default:
+		return "", false, fmt.Errorf("failed creating exec client: %w", err)
 	}
 }

--- a/gateway/api/runbooks/runbooks.go
+++ b/gateway/api/runbooks/runbooks.go
@@ -201,19 +201,6 @@ func RunExec(c *gin.Context) {
 		userAgent = "webapp.runbook.exec"
 	}
 
-	client, err := clientexec.New(&clientexec.Options{
-		OrgID:          ctx.GetOrgID(),
-		SessionID:      sessionID,
-		ConnectionName: connectionName,
-		BearerToken:    apiroutes.GetAccessTokenFromRequest(c),
-		UserAgent:      userAgent,
-		Origin:         proto.ConnectionOriginClientAPIRunbooks,
-	})
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating client for runbook execution: %v", err)
-		return
-	}
-
 	newSession := models.Session{
 		ID:                   sessionID,
 		OrgID:                ctx.GetOrgID(),
@@ -294,25 +281,28 @@ func RunExec(c *gin.Context) {
 	log.Infof("runbook exec, commit=%s, name=%s, connection=%s, parameters=%v",
 		runbook.CommitSHA[:8], req.FileName, connectionName, strings.TrimSpace(params))
 
-	respCh := make(chan *clientexec.Response)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		select {
-		case respCh <- client.Run(runbook.InputFile, runbook.EnvVars, req.ClientArgs...):
-		default:
-		}
-	}()
-
 	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*50)
 	defer cancelFn()
-	select {
-	case outcome := <-respCh:
+	outcome, err := services.Exec(timeoutCtx, services.ExecOptions{
+		OrgID:          ctx.GetOrgID(),
+		SessionID:      sessionID,
+		ConnectionName: connectionName,
+		BearerToken:    apiroutes.GetAccessTokenFromRequest(c),
+		UserAgent:      userAgent,
+		Origin:         proto.ConnectionOriginClientAPIRunbooks,
+		Script:         string(runbook.InputFile),
+		EnvVars:        runbook.EnvVars,
+		ClientArgs:     req.ClientArgs,
+	})
+	switch {
+	case err == nil:
 		log.Infof("runbook exec response, %v", outcome)
 		c.JSON(http.StatusOK, outcome)
-	case <-timeoutCtx.Done():
-		client.Close()
+	case errors.Is(err, context.DeadlineExceeded):
 		log.Infof("runbook exec timeout (50s), it will return async")
 		c.JSON(http.StatusAccepted, clientexec.NewTimeoutResponse(sessionID))
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating client for runbook execution: %v", err)
 	}
 }
 

--- a/gateway/api/runbooks/runbooksV2.go
+++ b/gateway/api/runbooks/runbooksV2.go
@@ -542,19 +542,6 @@ func RunbookExec(c *gin.Context) {
 		userAgent = "webapp.runbook.exec"
 	}
 
-	client, err := clientexec.New(&clientexec.Options{
-		OrgID:          ctx.GetOrgID(),
-		SessionID:      sessionID,
-		ConnectionName: connectionName,
-		BearerToken:    apiroutes.GetAccessTokenFromRequest(c),
-		UserAgent:      userAgent,
-		Origin:         proto.ConnectionOriginClientAPIRunbooks,
-	})
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating client for runbook execution: %v", err)
-		return
-	}
-
 	newSession := models.Session{
 		ID:                   sessionID,
 		OrgID:                ctx.GetOrgID(),
@@ -636,25 +623,28 @@ func RunbookExec(c *gin.Context) {
 	log.Infof("runbook exec, commit=%s, name=%s, connection=%s, parameters=%v",
 		runbook.CommitSHA[:8], req.FileName, connectionName, strings.TrimSpace(params))
 
-	respCh := make(chan *clientexec.Response)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		select {
-		case respCh <- client.Run(runbook.InputFile, runbook.EnvVars, req.ClientArgs...):
-		default:
-		}
-	}()
-
 	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*50)
 	defer cancelFn()
-	select {
-	case outcome := <-respCh:
+	outcome, err := services.Exec(timeoutCtx, services.ExecOptions{
+		OrgID:          ctx.GetOrgID(),
+		SessionID:      sessionID,
+		ConnectionName: connectionName,
+		BearerToken:    apiroutes.GetAccessTokenFromRequest(c),
+		UserAgent:      userAgent,
+		Origin:         proto.ConnectionOriginClientAPIRunbooks,
+		Script:         string(runbook.InputFile),
+		EnvVars:        runbook.EnvVars,
+		ClientArgs:     req.ClientArgs,
+	})
+	switch {
+	case err == nil:
 		log.Infof("runbook exec response, %v", outcome)
 		c.JSON(http.StatusOK, outcome)
-	case <-timeoutCtx.Done():
-		client.Close()
+	case errors.Is(err, context.DeadlineExceeded):
 		log.Infof("runbook exec timeout (50s), it will return async")
 		c.JSON(http.StatusAccepted, clientexec.NewTimeoutResponse(sessionID))
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating client for runbook execution: %v", err)
 	}
 }
 

--- a/gateway/api/session/run-exec.go
+++ b/gateway/api/session/run-exec.go
@@ -2,6 +2,7 @@ package sessionapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -14,6 +15,7 @@ import (
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/clientexec"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/services"
 	"github.com/hoophq/hoop/gateway/storagev2"
 	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
 )
@@ -113,27 +115,6 @@ func RunReviewedExec(c *gin.Context) {
 		userAgent = "webapp.review.exec"
 	}
 
-	// TODO: refactor to use response from openapi package
-	client, err := clientexec.New(&clientexec.Options{
-		OrgID:          ctx.GetOrgID(),
-		SessionID:      session.ID,
-		ConnectionName: session.Connection,
-		BearerToken:    apiroutes.GetAccessTokenFromRequest(c),
-		UserAgent:      userAgent,
-	})
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating client: %v", err)
-		return
-	}
-
-	respCh := make(chan *clientexec.Response)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		select {
-		case respCh <- client.Run([]byte(session.BlobInput), review.InputEnvVars, review.InputClientArgs...):
-		default:
-		}
-	}()
 	log := log.With("sid", session.ID)
 	log.Infof("review apiexec, reviewid=%v, connection=%v, owner=%v, input-lenght=%v",
 		review.ID, review.ConnectionName, review.OwnerEmail, len(session.BlobInput))
@@ -146,20 +127,30 @@ func RunReviewedExec(c *gin.Context) {
 			log.Warnf("failed updating review to status=%v, err=%v", review.Status, err)
 		}
 	}()
-	select {
-	case resp := <-respCh:
+
+	// TODO: refactor to use response from openapi package
+	resp, err := services.Exec(timeoutCtx, services.ExecOptions{
+		OrgID:          ctx.GetOrgID(),
+		SessionID:      session.ID,
+		ConnectionName: session.Connection,
+		BearerToken:    apiroutes.GetAccessTokenFromRequest(c),
+		UserAgent:      userAgent,
+		Script:         string(session.BlobInput),
+		EnvVars:        review.InputEnvVars,
+		ClientArgs:     review.InputClientArgs,
+	})
+	switch {
+	case err == nil:
 		log.Infof("review exec response, %v", resp)
 		c.JSON(http.StatusOK, resp)
-	case <-timeoutCtx.Done():
+	case errors.Is(err, context.DeadlineExceeded):
 		log.Infof("review exec timeout (50s), it will return async")
-		// closing the client will force the goroutine to end
-		// and the result will return async
-		client.Close()
-
 		// we do not know the status of this in the future.
 		// replaces the current "PROCESSING" status
 		reviewStatus = models.ReviewStatusUnknown
 		c.JSON(http.StatusAccepted, clientexec.NewTimeoutResponse(session.ID))
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating client: %v", err)
 	}
 }
 

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -330,38 +330,28 @@ func Post(c *gin.Context) {
 	trackClient.TrackSessionUsageData(analytics.EventSessionCreated, ctx.OrgID, ctx.UserID, sid)
 
 	// TODO: refactor to use response from openapi package
-	client, err := clientexec.New(&clientexec.Options{
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*50)
+	defer cancelFn()
+	outcome, err := services.Exec(timeoutCtx, services.ExecOptions{
 		OrgID:          ctx.GetOrgID(),
 		SessionID:      sid,
 		ConnectionName: conn.Name,
 		BearerToken:    apiroutes.GetAccessTokenFromRequest(c),
 		UserAgent:      userAgent,
+		Script:         req.Script,
+		EnvVars:        req.EnvVars,
+		ClientArgs:     req.ClientArgs,
 	})
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating client: %v", err)
-		return
-	}
-
-	log.Infof("started runexec method for connection %v", conn.Name)
-	respCh := make(chan *clientexec.Response)
-	go func() {
-		defer func() { close(respCh); client.Close() }()
-		select {
-		case respCh <- client.Run([]byte(req.Script), req.EnvVars, req.ClientArgs...):
-		default:
-		}
-	}()
-	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*50)
-	defer cancelFn()
-	select {
-	case outcome := <-respCh:
+	switch {
+	case err == nil:
 		log.Infof("runexec response, %v", outcome)
 		outcome.AIAnalysis = ToOpenApiSessionAIAnalysis(analyzeRes)
 		c.JSON(http.StatusOK, outcome)
-	case <-timeoutCtx.Done():
-		client.Close()
+	case errors.Is(err, context.DeadlineExceeded):
 		log.Infof("runexec timeout (50s), it will return async")
 		c.JSON(http.StatusAccepted, clientexec.NewTimeoutResponse(sid))
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating client: %v", err)
 	}
 }
 

--- a/gateway/eventrouting/dispatcher.go
+++ b/gateway/eventrouting/dispatcher.go
@@ -2,6 +2,7 @@ package eventrouting
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,9 +10,9 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	pb "github.com/hoophq/hoop/common/proto"
 	commonRunbooks "github.com/hoophq/hoop/common/runbooks"
-	"github.com/hoophq/hoop/gateway/clientexec"
 	"github.com/hoophq/hoop/gateway/events"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/services"
 )
 
 const dispatchExecTimeout = 60 * time.Second
@@ -70,19 +71,6 @@ func processDispatch(pCtx context.Context, d *models.EventDispatch) error {
 	}
 
 	sessionID := uuid.NewString()
-	client, err := clientexec.New(&clientexec.Options{
-		OrgID:                  sub.OrgID,
-		SessionID:              sessionID,
-		ConnectionName:         conn.Name,
-		UserAgent:              "eventrouting.dispatcher",
-		Origin:                 pb.ConnectionOriginClientAPI,
-		Verb:                   pb.ClientVerbExec,
-		ImpersonateUserSubject: sub.CreatedByUserID,
-	})
-	if err != nil {
-		return fmt.Errorf("failed creating exec client: %w", err)
-	}
-	defer client.Close()
 
 	hookID := uuid.NewString()
 	_ = models.SetDispatchSessionID(models.DB, d.ID, hookID)
@@ -96,30 +84,36 @@ func processDispatch(pCtx context.Context, d *models.EventDispatch) error {
 		"impersonate", sub.CreatedByUserID,
 	).Infof("event-routing: executing runbook via connection %q", conn.Name)
 
-	respCh := make(chan *clientexec.Response, 1)
-	go func() {
-		respCh <- client.Run(file.InputFile, nil)
-	}()
-
 	timeoutCtx, cancel := context.WithTimeout(pCtx, dispatchExecTimeout)
 	defer cancel()
 
-	select {
-	case resp := <-respCh:
-		if resp.HasReview {
-			return fmt.Errorf("dispatch blocked by review (review_uri=%s)", resp.Output)
+	resp, err := services.Exec(timeoutCtx, services.ExecOptions{
+		OrgID:                  sub.OrgID,
+		SessionID:              sessionID,
+		ConnectionName:         conn.Name,
+		UserAgent:              "eventrouting.dispatcher",
+		Origin:                 pb.ConnectionOriginClientAPI,
+		Verb:                   pb.ClientVerbExec,
+		ImpersonateUserSubject: sub.CreatedByUserID,
+		Script:                 string(file.InputFile),
+	})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("dispatch exec timed out after %s", dispatchExecTimeout)
 		}
-		if resp.ExitCode != 0 {
-			return fmt.Errorf("runbook exited with code %d: %s", resp.ExitCode, truncate(resp.Output, 500))
-		}
-		log.With("dispatch_id", d.ID, "sid", sessionID).
-			Infof("event-routing: runbook finished, exit=%d, truncated=%v, duration_ms=%d",
-				resp.ExitCode, resp.Truncated, resp.ExecutionTimeMili)
-		return nil
-	case <-timeoutCtx.Done():
-		client.Close()
-		return fmt.Errorf("dispatch exec timed out after %s", dispatchExecTimeout)
+		return fmt.Errorf("failed creating exec client: %w", err)
 	}
+
+	if resp.HasReview {
+		return fmt.Errorf("dispatch blocked by review (review_uri=%s)", resp.Output)
+	}
+	if resp.ExitCode != 0 {
+		return fmt.Errorf("runbook exited with code %d: %s", resp.ExitCode, truncate(resp.Output, 500))
+	}
+	log.With("dispatch_id", d.ID, "sid", sessionID).
+		Infof("event-routing: runbook finished, exit=%d, truncated=%v, duration_ms=%d",
+			resp.ExitCode, resp.Truncated, resp.ExecutionTimeMili)
+	return nil
 }
 
 func truncate(s string, n int) string {

--- a/gateway/services/exec.go
+++ b/gateway/services/exec.go
@@ -1,0 +1,74 @@
+package services
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/gateway/clientexec"
+)
+
+type ExecOptions struct {
+	OrgID                     string
+	SessionID                 string
+	ConnectionName            string
+	ConnectionCommandOverride []string
+	BearerToken               string
+	Verb                      string
+	UserAgent                 string
+	Origin                    string
+	ImpersonateUserSubject    string
+
+	Script     string
+	EnvVars    map[string]string
+	ClientArgs []string
+}
+
+func Exec(ctx context.Context, opts ExecOptions) (*clientexec.Response, error) {
+	log := log.With("sid", opts.SessionID)
+
+	client, err := clientexec.New(&clientexec.Options{
+		OrgID:                     opts.OrgID,
+		SessionID:                 opts.SessionID,
+		ConnectionName:            opts.ConnectionName,
+		ConnectionCommandOverride: opts.ConnectionCommandOverride,
+		BearerToken:               opts.BearerToken,
+		UserAgent:                 opts.UserAgent,
+		Verb:                      opts.Verb,
+		Origin:                    opts.Origin,
+		ImpersonateUserSubject:    opts.ImpersonateUserSubject,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var closeOnce sync.Once
+	closeClient := func() {
+		closeOnce.Do(func() {
+			client.Close()
+		})
+	}
+
+	log.Infof("started runexec method for connection %v", opts.ConnectionName)
+
+	respCh := make(chan *clientexec.Response, 1)
+
+	go func() {
+		defer closeClient()
+
+		respCh <- client.Run(
+			[]byte(opts.Script),
+			opts.EnvVars,
+			opts.ClientArgs...,
+		)
+	}()
+
+	select {
+	case resp := <-respCh:
+		return resp, nil
+
+	case <-ctx.Done():
+		closeClient()
+		return nil, ctx.Err()
+	}
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Introduces a centralized `services.Exec` helper in `gateway/services/exec.go` and replaces the repeated `clientexec.New` + goroutine + channel + `select` boilerplate scattered across the gateway API handlers and the event-routing dispatcher. The new helper encapsulates client creation, execution, context-based timeout handling, and guaranteed single client close (via `sync.Once`), returning a `(*clientexec.Response, error)` so callers can handle results with a simple `switch` on the error (including `context.DeadlineExceeded` for the async/timeout path).

This is a pure refactor — no behavioral changes to the execution flow, timeouts, or response semantics.

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `gateway/services/exec.go` with a reusable `Exec(ctx, ExecOptions)` function and an `ExecOptions` struct that wraps `clientexec` creation, execution, context-driven timeout handling, and idempotent client close via `sync.Once`.
- Refactored all exec call sites to use `services.Exec` instead of the duplicated `clientexec.New` + goroutine + channel + `select` pattern: `session/run-exec.go`, `session/session.go`, `connections/connections.go`, `connections/database_explorer.go` (ListDatabases, ListTables, GetTableColumns), `mcpserver/tools_exec.go`, `mcpserver/tools_reviews.go`, `mcpserver/tools_schema.go`, `runbooks/runbooks.go`, `runbooks/runbooksV2.go`, and `eventrouting/dispatcher.go`.
- Standardized timeout/async handling to branch on `errors.Is(err, context.DeadlineExceeded)`, preserving the existing async-return behavior on timeout.
- Removed now-unused direct `clientexec` imports from the refactored handlers.

## 🧪 Testing

This is a non-functional refactor that preserves the existing execution and timeout behavior across all affected exec call sites.

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

<!-- N/A — backend refactor with no UI changes -->

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

`services.Exec` centralizes the timeout/close semantics that were previously copy-pasted (and slightly inconsistent) across handlers. The `sync.Once`-guarded close prevents double-close races when both the response and the context-cancellation paths fire. Reviewers may want to focus on the timeout branches in `eventrouting/dispatcher.go` and `session/run-exec.go`, where the timeout now surfaces as `context.DeadlineExceeded` rather than a separate channel case.