### PR TITLE
docs: fix typo in DEV guide

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -179,7 +179,7 @@ This project uses [swag](https://github.com/swaggo/swag) to generate the api doc
 make generate-openapi-docs
 ```
 
-The gateway will expose the the openapi spec at `/api/openapiv2.json` and `/api/openapiv3.json`. Use your favorite openapi ui to view the documentation:
+The gateway will expose the openapi spec at `/api/openapiv2.json` and `/api/openapiv3.json`. Use your favorite openapi ui to view the documentation:
 
 - https://swagger.io/tools/swagger-ui/
 - https://redocly.github.io/redoc/


### PR DESCRIPTION
Removes a duplicated word in the DEV guide (`the the` → `the`).

This is a documentation-only change.