### PR TITLE
[Feat Oracle Native] hoop (client + agent + gateway wiring)

### DIFF
--- a/_libhoop/core.go
+++ b/_libhoop/core.go
@@ -24,6 +24,7 @@ type DBCore interface {
 	Postgres() (Proxy, error)
 	MSSQL() (Proxy, error)
 	MongoDB() (Proxy, error)
+	Oracle() (Proxy, error)
 }
 
 type License interface {

--- a/_libhoop/libhoop.go
+++ b/_libhoop/libhoop.go
@@ -28,6 +28,7 @@ func (c *core) MySQL() (Proxy, error)    { return &noopProxy{connectionType: "my
 func (c *core) MSSQL() (Proxy, error)    { return &noopProxy{connectionType: "mssql"}, nil }
 func (c *core) MongoDB() (Proxy, error)  { return &noopProxy{connectionType: "mongodb"}, nil }
 func (c *core) Postgres() (Proxy, error) { return &noopProxy{connectionType: "postgres"}, nil }
+func (c *core) Oracle() (Proxy, error)   { return &noopProxy{connectionType: "oracle"}, nil }
 
 func (c *core) SSM() (Proxy, error) {
 	return &noopProxy{connectionType: "aws-ssm"}, nil

--- a/agent/controller/agent.go
+++ b/agent/controller/agent.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	
 
 	"github.com/getsentry/sentry-go"
 	"github.com/hoophq/hoop/agent/config"
@@ -225,6 +226,10 @@ func (a *Agent) processPacket(pkt *pb.Packet) {
 	// MongoDB Protocol
 	case pbagent.MongoDBConnectionWrite:
 		a.processMongoDBProtocol(pkt)
+
+	// Oracle Protocol
+	case pbagent.OracleConnectionWrite:
+		a.processOracleProtocol(pkt)
 
 	// raw tcp
 	case pbagent.TCPConnectionWrite:

--- a/agent/controller/oracle.go
+++ b/agent/controller/oracle.go
@@ -7,6 +7,7 @@ import (
 	"libhoop"
 	"strings"
 
+	"github.com/hoophq/hoop/agent/controller/featureflagstate"
 	"github.com/hoophq/hoop/common/log"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
@@ -14,6 +15,13 @@ import (
 
 func (a *Agent) processOracleProtocol(pkt *pb.Packet) {
 	sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
+	// Native Oracle access is gated behind a feature flag. When it is off, refuse
+	// to open the proxy session instead of starting the TNS handshake.
+	if !featureflagstate.IsEnabled("beta.oracle_native") {
+		log.Infof("session=%s - oracle native access disabled by feature flag, closing session", sessionID)
+		a.sendClientSessionClose(sessionID, "oracle native access is not enabled for this organization")
+		return
+	}
 	streamClient := pb.NewStreamWriter(a.client, pbclient.OracleConnectionWrite, pkt.Spec)
 	connParams := a.connectionParams(sessionID)
 	if connParams == nil {
@@ -33,6 +41,16 @@ func (a *Agent) processOracleProtocol(pkt *pb.Packet) {
 	clientObj := a.connStore.Get(clientConnectionIDKey)
 	if serverWriter, ok := clientObj.(io.WriteCloser); ok {
 		if _, err := serverWriter.Write(pkt.Payload); err != nil {
+			// An input guardrail violation surfaces here as a typed error. Close
+			// the session preserving the structured guardrails info (and the
+			// human-readable rule message) the same way the other protocols do,
+			// instead of the generic "fail to write packet".
+			if isGuardrailsError(err) {
+				log.Infof("session=%v - oracle guardrails validation failed, closing session: %v", sessionID, err)
+				a.sendClientSessionCloseFromError(sessionID, err)
+				_ = serverWriter.Close()
+				return
+			}
 			log.Errorf("failed sending packet, err=%v", err)
 			a.sendClientSessionClose(sessionID, "fail to write packet")
 			_ = serverWriter.Close()

--- a/agent/controller/oracle.go
+++ b/agent/controller/oracle.go
@@ -15,8 +15,8 @@ import (
 
 func (a *Agent) processOracleProtocol(pkt *pb.Packet) {
 	sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
-	// Native Oracle access is gated behind a feature flag. When it is off, refuse
-	// to open the proxy session instead of starting the TNS handshake.
+	// Native Oracle access is gated behind a feature flag. When it is off, 
+	//It will refuse to open the proxy session instead of starting the TNS handshake.
 	if !featureflagstate.IsEnabled("beta.oracle_native") {
 		log.Infof("session=%s - oracle native access disabled by feature flag, closing session", sessionID)
 		a.sendClientSessionClose(sessionID, "oracle native access is not enabled for this organization")

--- a/agent/controller/oracle.go
+++ b/agent/controller/oracle.go
@@ -1,0 +1,103 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"libhoop"
+	"strings"
+
+	"github.com/hoophq/hoop/common/log"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+)
+
+func (a *Agent) processOracleProtocol(pkt *pb.Packet) {
+	sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
+	streamClient := pb.NewStreamWriter(a.client, pbclient.OracleConnectionWrite, pkt.Spec)
+	connParams := a.connectionParams(sessionID)
+	if connParams == nil {
+		log.Errorf("session=%s - connection params not found", sessionID)
+		a.sendClientSessionClose(sessionID, "connection params not found, contact the administrator")
+		return
+	}
+
+	clientConnectionID := string(pkt.Spec[pb.SpecClientConnectionID])
+	if clientConnectionID == "" {
+		log.Println("connection id not found in memory")
+		a.sendClientSessionClose(sessionID, "connection id not found, contact the administrator")
+		return
+	}
+
+	clientConnectionIDKey := fmt.Sprintf("%s:%s", sessionID, clientConnectionID)
+	clientObj := a.connStore.Get(clientConnectionIDKey)
+	if serverWriter, ok := clientObj.(io.WriteCloser); ok {
+		if _, err := serverWriter.Write(pkt.Payload); err != nil {
+			log.Errorf("failed sending packet, err=%v", err)
+			a.sendClientSessionClose(sessionID, "fail to write packet")
+			_ = serverWriter.Close()
+		}
+		return
+	}
+
+	connenv, err := parseConnectionEnvVars(connParams.EnvVars, pb.ConnectionTypeOracleDB)
+	if err != nil {
+		log.Errorf("oracle credentials not found in memory, err=%v", err)
+		a.sendClientSessionClose(sessionID, "credentials are empty, contact the administrator")
+		return
+	}
+
+	log.Infof("session=%v - starting oracle connection at %v:%v", sessionID, connenv.host, connenv.port)
+
+	var dataMaskingEntityTypesData string
+	if connParams.DataMaskingEntityTypesData != nil {
+		dataMaskingEntityTypesData = string(connParams.DataMaskingEntityTypesData)
+	}
+	var guardRailRules string
+	if connParams.GuardRailRules != nil {
+		guardRailRules = string(connParams.GuardRailRules)
+	}
+	var analyzerMetricsRules string
+	if connParams.AnalyzerMetricsRules != nil {
+		analyzerMetricsRules = string(connParams.AnalyzerMetricsRules)
+	}
+
+	opts := map[string]string{
+		"sid":                       sessionID,
+		"hostname":                  connenv.host,
+		"port":                      connenv.port,
+		"username":                  connenv.user,
+		"password":                  connenv.pass,
+		// The hoop client always presents the local Oracle proxy with the fixed
+		// placeholder noop/noop (see client/cmd/connect.go). Oracle auth is
+		// mutual, so the proxy needs the placeholder password to re-key the
+		// handshake and keep the server's response verifiable by real OCI
+		// clients (sqlplus).
+		"client_password":           "noop",
+		"service_name":              connenv.serviceName,
+		"dlp_provider":              connParams.DlpProvider,
+		"dlp_mode":                  connParams.DlpMode,
+		"mspresidio_analyzer_url":   connParams.DlpPresidioAnalyzerURL,
+		"mspresidio_anonymizer_url": connParams.DlpPresidioAnonymizerURL,
+		"dlp_gcp_credentials":       connParams.DlpGcpRawCredentialsJSON,
+		"dlp_info_types":            strings.Join(connParams.DLPInfoTypes, ","),
+		"dlp_masking_character":     "#",
+		"data_masking_entity_data":  dataMaskingEntityTypesData,
+		"guard_rail_rules":          guardRailRules,
+		"analyzer_metrics_rules":    analyzerMetricsRules,
+	}
+
+	serverWriter, err := libhoop.NewDBCore(context.Background(), streamClient, opts).Oracle()
+	if err != nil {
+		errMsg := fmt.Sprintf("failed connecting with oracle server, err=%v", err)
+		log.Errorf(errMsg)
+		a.sendClientSessionClose(sessionID, errMsg)
+		return
+	}
+	serverWriter.Run(func(_ int, errMsg string) {
+		a.sendClientSessionClose(sessionID, errMsg)
+	})
+	// write the first packet when establishing the connection
+	_, _ = serverWriter.Write(pkt.Payload)
+	a.connStore.Set(clientConnectionIDKey, serverWriter)
+}

--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -277,6 +277,23 @@ func runConnect(args []string, clientEnvVars map[string]string, durationFlagChan
 						"uri":  fmt.Sprintf("mongodb://noop:noop@%s:%s/?directConnection=true", srv.Host().Host, srv.Host().Port),
 					})
 				}
+			case pb.ConnectionTypeOracleDB:
+				srv := proxy.NewOracleServer(c.proxyPort, c.client)
+				if err := srv.Serve(string(sessionID)); err != nil {
+					c.processGracefulExit(err)
+				}
+				c.loader.Stop()
+				c.client.StartKeepAlive()
+				c.connStore.Set(string(sessionID), srv)
+				c.printHeader(connectionType, pkt)
+				fmt.Println()
+				fmt.Println("--------------------oracle-credentials----------------------")
+				fmt.Printf("      host=%s port=%s user=noop password=noop\n", srv.Host().Host, srv.Host().Port)
+				fmt.Println("------------------------------------------------------------")
+				fmt.Println("ready to accept connections!")
+				if jsonMode {
+					emitReady(map[string]string{"host": srv.Host().Host, "port": srv.Host().Port, "user": "noop", "password": "noop"})
+				}
 			case pb.ConnectionTypeTCP:
 				tcp := proxy.NewTCPServer(c.proxyPort, c.client, pbagent.TCPConnectionWrite)
 				if err := tcp.Serve(string(sessionID)); err != nil {
@@ -471,6 +488,19 @@ func runConnect(args []string, clientEnvVars map[string]string, durationFlagChan
 			sessionID := pkt.Spec[pb.SpecGatewaySessionID]
 			srvObj := c.connStore.Get(string(sessionID))
 			srv, ok := srvObj.(*proxy.MongoDBServer)
+			if !ok {
+				return
+			}
+			connectionID := string(pkt.Spec[pb.SpecClientConnectionID])
+			_, err := srv.PacketWriteClient(connectionID, pkt)
+			if err != nil {
+				errMsg := fmt.Errorf("failed writing to client, err=%v", err)
+				c.processGracefulExit(errMsg)
+			}
+		case pbclient.OracleConnectionWrite:
+			sessionID := pkt.Spec[pb.SpecGatewaySessionID]
+			srvObj := c.connStore.Get(string(sessionID))
+			srv, ok := srvObj.(*proxy.OracleServer)
 			if !ok {
 				return
 			}

--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -278,6 +278,9 @@ func runConnect(args []string, clientEnvVars map[string]string, durationFlagChan
 					})
 				}
 			case pb.ConnectionTypeOracleDB:
+				if !clientconfig.IsFeatureEnabled(config, "beta.oracle_native") {
+					c.processGracefulExit(fmt.Errorf("oracle native access is not enabled for your organization"))
+				}
 				srv := proxy.NewOracleServer(c.proxyPort, c.client)
 				if err := srv.Serve(string(sessionID)); err != nil {
 					c.processGracefulExit(err)

--- a/client/cmd/proxymanager.go
+++ b/client/cmd/proxymanager.go
@@ -145,6 +145,12 @@ func runAutoConnect(client pb.ClientTransport) (err error) {
 					return err
 				}
 				connStore.Set(sid, srv)
+			case pb.ConnectionTypeOracleDB:
+				srv := proxy.NewOracleServer(proxyPort, client)
+				if err := srv.Serve(sid); err != nil {
+					return err
+				}
+				connStore.Set(sid, srv)
 			case pb.ConnectionTypeTCP:
 				srv := proxy.NewTCPServer(proxyPort, client, pbagent.TCPConnectionWrite)
 				if err := srv.Serve(sid); err != nil {
@@ -196,6 +202,16 @@ func runAutoConnect(client pb.ClientTransport) (err error) {
 			srv, ok := srvObj.(*proxy.MongoDBServer)
 			if !ok {
 				return fmt.Errorf("mongodb proxy server instance not found")
+			}
+			connectionID := string(pkt.Spec[pb.SpecClientConnectionID])
+			if _, err := srv.PacketWriteClient(connectionID, pkt); err != nil {
+				return fmt.Errorf("failed writing to client, err=%v", err)
+			}
+		case pbclient.OracleConnectionWrite:
+			srvObj := connStore.Get(sid)
+			srv, ok := srvObj.(*proxy.OracleServer)
+			if !ok {
+				return fmt.Errorf("oracle proxy server instance not found")
 			}
 			connectionID := string(pkt.Spec[pb.SpecClientConnectionID])
 			if _, err := srv.PacketWriteClient(connectionID, pkt); err != nil {

--- a/client/proxy/defaults.go
+++ b/client/proxy/defaults.go
@@ -19,6 +19,7 @@ const (
 	defaultTCPPort       = "8999"
 	defaultSSHPort       = "2222"
 	defaultHttpProxyPort = "8081"
+	defaultOraclePort    = "15211"
 )
 
 var defaultListenAddrValue string

--- a/client/proxy/oracle.go
+++ b/client/proxy/oracle.go
@@ -1,0 +1,126 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+
+	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/common/memory"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+)
+
+type OracleServer struct {
+	listenAddr      string
+	client          pb.ClientTransport
+	connectionStore memory.Store
+	listener        net.Listener
+}
+
+func NewOracleServer(listenPort string, client pb.ClientTransport) *OracleServer {
+	listenAddr := defaultListenAddr(defaultOraclePort)
+	if listenPort != "" {
+		listenAddr = defaultListenAddr(listenPort)
+	}
+	return &OracleServer{
+		listenAddr:      listenAddr,
+		client:          client,
+		connectionStore: memory.New(),
+	}
+}
+
+func (s *OracleServer) Serve(sessionID string) error {
+	lis, err := net.Listen("tcp4", s.listenAddr)
+	if err != nil {
+		return fmt.Errorf("failed listening on %v: %v", s.listenAddr, err)
+	}
+	s.listener = lis
+	go func() {
+		connectionID := 0
+		for {
+			connectionID++
+			oracleClient, err := lis.Accept()
+			if err != nil {
+				log.Infof("oracle proxy listener closed, err=%v", err)
+				lis.Close()
+				break
+			}
+			go s.serveConn(sessionID, strconv.Itoa(connectionID), oracleClient)
+		}
+	}()
+	return nil
+}
+
+func (s *OracleServer) serveConn(sessionID, connectionID string, oracleClient net.Conn) {
+	defer func() {
+		log.Infof("session=%v | conn=%s | remote=%s - oracle tcp connection closing",
+			sessionID, connectionID, oracleClient.RemoteAddr())
+		s.connectionStore.Del(connectionID)
+		_ = oracleClient.Close()
+		_ = s.client.Send(&pb.Packet{
+			Type: pbagent.TCPConnectionClose,
+			Spec: map[string][]byte{
+				pb.SpecClientConnectionID: []byte(connectionID),
+				pb.SpecGatewaySessionID:   []byte(sessionID),
+			},
+		})
+	}()
+
+	connWrapper := pb.NewConnectionWrapper(oracleClient, make(chan struct{}))
+	s.connectionStore.Set(connectionID, connWrapper)
+
+	log.Infof("session=%v | conn=%s | client=%s - oracle client connected",
+		sessionID, connectionID, oracleClient.RemoteAddr())
+
+	w := pb.NewStreamWriter(s.client, pbagent.OracleConnectionWrite, map[string][]byte{
+		string(pb.SpecClientConnectionID): []byte(connectionID),
+		string(pb.SpecGatewaySessionID):   []byte(sessionID),
+	})
+	buf := make([]byte, 32*1024)
+	for {
+		nr, er := oracleClient.Read(buf)
+		if nr > 0 {
+			if _, ew := w.Write(buf[:nr]); ew != nil {
+				log.Infof("session=%v | conn=%s - failed writing to stream: %v", sessionID, connectionID, ew)
+				break
+			}
+		}
+		if er != nil {
+			if er != io.EOF {
+				log.Infof("session=%v | conn=%s - read error: %v", sessionID, connectionID, er)
+			}
+			break
+		}
+	}
+	connWrapper.Close()
+}
+
+func (s *OracleServer) PacketWriteClient(connectionID string, pkt *pb.Packet) (int, error) {
+	conn, err := s.getConnection(connectionID)
+	if err != nil {
+		sid := string(pkt.Spec[pb.SpecGatewaySessionID])
+		log.Warnf("session=%v | conn=%v | discarding oracle packet: %v", sid, connectionID, err)
+		return 0, nil
+	}
+	return conn.Write(pkt.Payload)
+}
+
+func (s *OracleServer) CloseTCPConnection(connectionID string) {
+	if conn, err := s.getConnection(connectionID); err == nil {
+		_ = conn.Close()
+	}
+}
+
+func (s *OracleServer) Close() error { return s.listener.Close() }
+func (s *OracleServer) Host() Host   { return getListenAddr(s.listenAddr) }
+
+func (s *OracleServer) getConnection(connectionID string) (io.WriteCloser, error) {
+	obj := s.connectionStore.Get(connectionID)
+	conn, ok := obj.(io.WriteCloser)
+	if !ok {
+		return nil, fmt.Errorf("oracle connection %q not found", connectionID)
+	}
+	return conn, nil
+}

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -89,6 +89,13 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentAgent},
 	},
+	"beta.oracle_native": {
+		Name:        "beta.oracle_native",
+		Description: "Enable native Oracle (TNS) database access so clients like sqlplus/DBeaver connect through hoop's local proxy. When disabled, Oracle connections cannot open a native proxy session.",
+		Default:     false,
+		Stability:   StabilityBeta,
+		Components:  []Component{ComponentGateway, ComponentAgent, ComponentClient},
+	},
 }
 
 // All returns every registered flag, sorted by name.

--- a/common/proto/agent/agent.go
+++ b/common/proto/agent/agent.go
@@ -18,6 +18,7 @@ const (
 	MySQLConnectionWrite     = "AgentMySQLConnectionWrite"
 	MSSQLConnectionWrite     = "AgentMSSQLConnectionWrite"
 	MongoDBConnectionWrite   = "AgentMongoDBConnectionWrite"
+	OracleConnectionWrite    = "AgentOracleConnectionWrite"
 	SSHConnectionWrite       = "AgentSSHConnectionWrite"
 	SSMConnectionWrite       = "AgentSSMConnectionWrite"
 	HttpProxyConnectionWrite = "AgentHttpProxyConnectionWrite"

--- a/common/proto/client/client.go
+++ b/common/proto/client/client.go
@@ -19,6 +19,7 @@ const (
 	MySQLConnectionWrite     = "ClientMySQLConnectionWrite"
 	MSSQLConnectionWrite     = "ClientMSSQLConnectionWrite"
 	MongoDBConnectionWrite   = "ClientMongoDBConnectionWrite"
+	OracleConnectionWrite    = "ClientOracleConnectionWrite"
 	SSHConnectionWrite       = "ClientSSHConnectionWrite"
 	SSMConnectionWrite       = "ClientSSMConnectionWrite"
 	WriteStdout              = "ClientWriteStdout"

--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -289,6 +289,12 @@ func (p *auditPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 		if decJSONPayload != nil {
 			return nil, p.writeOnReceive(pctx, eventlogv1.InputType, decJSONPayload, eventMetadata)
 		}
+	case pbagent.OracleConnectionWrite:
+		// native Oracle clients (sqlplus, DBeaver, …) stream raw TNS bytes; log
+		// the printable text (SQL and text fields) extracted from each packet.
+		if queryText := decodeOracleClientQuery(pkt.Payload); queryText != nil {
+			return nil, p.writeOnReceive(pctx, eventlogv1.InputType, queryText, eventMetadata)
+		}
 	case pbclient.WriteStdout, pbclient.WriteStderr:
 		err := p.writeOnReceive(pctx, eventlogv1.OutputType, pkt.Payload, eventMetadata)
 		if err != nil {

--- a/gateway/transport/plugins/audit/decoders.go
+++ b/gateway/transport/plugins/audit/decoders.go
@@ -4,8 +4,30 @@ import (
 	"bytes"
 	"fmt"
 
+	oracletypes "libhoop/agent/oracle/types"
+
 	"github.com/hoophq/hoop/common/mongotypes"
 )
+
+// minOracleTextRunLen is the shortest printable-ASCII run extracted from an
+// Oracle TTC payload. It mirrors the threshold libhoop uses for Oracle input
+// guardrails and metrics, keeping the audit log consistent with what those
+// subsystems already scan.
+const minOracleTextRunLen = 4
+
+// decodeOracleClientQuery extracts printable text (SQL statements and other
+// text fields) from a raw Oracle client (TNS) payload. Oracle has no
+// gateway-side wire decoder, so - like the input guardrails and metrics
+// analyzer in libhoop - this relies on printable-run extraction rather than
+// precise OPI/SQL parsing. Returns nil when the payload carries no text (e.g.
+// binary handshake/auth packets), so those frames produce no audit entry.
+func decodeOracleClientQuery(payload []byte) []byte {
+	text := oracletypes.ExtractText(payload, minOracleTextRunLen)
+	if text == "" {
+		return nil
+	}
+	return []byte(text)
+}
 
 // decodeMySQLCommandQuery try to decode a packet to see if it's a COMM_QUERY type
 // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query.html

--- a/gateway/transport/plugins/audit/decoders.go
+++ b/gateway/transport/plugins/audit/decoders.go
@@ -3,8 +3,7 @@ package audit
 import (
 	"bytes"
 	"fmt"
-
-	oracletypes "libhoop/agent/oracle/types"
+	"unicode"
 
 	"github.com/hoophq/hoop/common/mongotypes"
 )
@@ -22,11 +21,41 @@ const minOracleTextRunLen = 4
 // precise OPI/SQL parsing. Returns nil when the payload carries no text (e.g.
 // binary handshake/auth packets), so those frames produce no audit entry.
 func decodeOracleClientQuery(payload []byte) []byte {
-	text := oracletypes.ExtractText(payload, minOracleTextRunLen)
+	text := extractPrintableText(payload, minOracleTextRunLen)
 	if text == "" {
 		return nil
 	}
 	return []byte(text)
+}
+
+// extractPrintableText scans b and returns a single string built from all
+// contiguous runs of printable ASCII bytes whose length is >= minLen, separated
+// by spaces. It is a local copy of libhoop's oracletypes.ExtractText: the
+// gateway must not import a libhoop internal package (it only exists in the full
+// build, not the OSS _libhoop stub), and this helper depends on nothing but the
+// standard library.
+func extractPrintableText(b []byte, minLen int) string {
+	out := make([]byte, 0, len(b)/2)
+	run := make([]byte, 0, 64)
+
+	flush := func() {
+		if len(run) >= minLen {
+			if len(out) > 0 {
+				out = append(out, ' ')
+			}
+			out = append(out, run...)
+		}
+		run = run[:0]
+	}
+	for _, ch := range b {
+		if ch >= 0x20 && ch < 0x7F && unicode.IsPrint(rune(ch)) {
+			run = append(run, ch)
+		} else {
+			flush()
+		}
+	}
+	flush()
+	return string(out)
 }
 
 // decodeMySQLCommandQuery try to decode a packet to see if it's a COMM_QUERY type


### PR DESCRIPTION
## 📝 Description

Wires native Oracle access end-to-end through the client, agent, and gateway,
exposing the new libhoop Oracle proxy. The whole path is gated behind the
`beta.oracle_native` feature flag, so a fresh deployment has it off by default.

The agent opens the libhoop Oracle proxy with the connection's DLP and guardrail
configuration; the CLI exposes a local Oracle TCP port so sqlplus/DBeaver can
connect through `hoop connect`.

## 🔗 Related Issue

Merge this PR first https://github.com/hoophq/libhoop/pull/77

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

- **Agent dispatch** (`agent/controller/agent.go`, `agent/controller/oracle.go`):
  added `processOracleProtocol`, which starts the libhoop Oracle proxy with the
  connection's credentials and DLP/guardrail params, and surfaces guardrail
  violations as structured session-close errors. Gated by `beta.oracle_native`.
- **CLI local proxy** (`client/proxy/oracle.go`, `client/proxy/defaults.go`): a
  local Oracle TCP listener (default port 15211) that relays the client stream to
  the agent over the gRPC transport.
- **CLI commands** (`client/cmd/connect.go`, `client/cmd/proxymanager.go`): handle
  `ConnectionTypeOracleDB`, print the local connection credentials, and enforce
  the feature flag client-side.
- **Feature flag** (`common/featureflag/featureflag.go`): registered
  `beta.oracle_native` (default off; agent + client components).
- **Wire protocol** (`common/proto/agent`, `common/proto/client`): added the
  `OracleConnectionWrite` packet type for both directions.
- **Audit** (`gateway/transport/plugins/audit/`): Oracle session decoders so
  native Oracle sessions are recorded like the other protocols.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (backend / CLI)
- **OS**: macOS / Linux

### Tests performed:
- [x] Unit tests pass (`make test-oss`)
- [x] Integration tests pass
- [x] Manual testing completed

Manual: ran `make run-dev` with an Oracle connection configured, enabled
`beta.oracle_native`, and connected via `hoop connect` with sqlplus and DBeaver.
Verified auth injection, output masking across all fetch batches (with a DLP
provider + entity types on the connection), and that the session is blocked when
the flag is off.

## 📄 Additional Notes

Requires the companion libhoop PR (native Oracle proxy). No migrations or
frontend changes — the feature flag appears automatically in the admin UI.
Masking/guardrail behavior is configured per-connection (DLP provider, data-mask
entity types, guardrail rule packs) exactly like the other database protocols.