### PR TITLE
fix(client): recommend OS-agnostic version manager on version mismatch

### DIFF
--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hoophq/hoop/client/cmd/styles"
 	clientconfig "github.com/hoophq/hoop/client/config"
 	"github.com/hoophq/hoop/client/proxy"
+	clientupgrade "github.com/hoophq/hoop/client/upgrade"
 	"github.com/hoophq/hoop/common/grpc"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/common/memory"
@@ -609,21 +610,44 @@ func (c *connect) printHeader(connectionType pb.ConnectionType, pkt *pb.Packet) 
 }
 
 func printVersionMismatchWarning(agentVersion string) {
-	cliVersion := version.Get().Version
+	printVersionMismatchWarningTo(os.Stderr, version.Get().Version, agentVersion)
+}
+
+// printVersionMismatchWarningTo renders the CLI/agent version-mismatch
+// warning to w. The writer and cliVersion are parameters so unit tests can
+// drive it deterministically; the exported caller wires in os.Stderr and the
+// build-stamped version.
+func printVersionMismatchWarningTo(w io.Writer, cliVersion, agentVersion string) {
+	if os.Getenv(clientupgrade.DisableVersionCheckEnv) == "true" {
+		return
+	}
 	if agentVersion == "" || cliVersion == "" || cliVersion == "unknown" || agentVersion == cliVersion {
 		return
 	}
+
+	// Prefer the exact agent version via the OS-agnostic version manager.
+	// If the agent predates the version manager (or reports an unmanageable
+	// version), fall back to the docs rather than printing an install command
+	// that would fail with a floor error.
+	target := clientupgrade.NormalizeVersion(agentVersion)
+	action := "For installation options, visit: https://hoop.dev/docs/clients/cli-versions"
+	if clientupgrade.ValidateInstallableVersion(target) == nil {
+		action = fmt.Sprintf(
+			"Install and activate the matching version with the hoop CLI version manager:\n"+
+				"  hoop versions install %s --use\n\n"+
+				"For more options, visit: https://hoop.dev/docs/clients/cli-versions",
+			target)
+	}
+
 	msg := styles.ClientErrorSimple(fmt.Sprintf(
 		"⚠️  VERSION MISMATCH DETECTED! ⚠️\n"+
 			"Your CLI version (%s) does not match the agent version (%s).\n"+
 			"This WILL cause unexpected behavior.\n\n"+
-			"Please update your CLI to match the agent version:\n"+
-			"  brew tap hoophq/brew https://github.com/hoophq/brew.git\n"+
-			"  brew install hoop@%s\n\n"+
-			"For more installation options, visit: https://hoop.dev/docs/clients/cli#installation",
-		cliVersion, agentVersion, agentVersion))
+			"%s\n\n"+
+			"(set %s=true to silence this warning)",
+		cliVersion, agentVersion, action, clientupgrade.DisableVersionCheckEnv))
 
-	_, _ = fmt.Fprintf(os.Stderr, "\n%s\n\n", msg)
+	_, _ = fmt.Fprintf(w, "\n%s\n\n", msg)
 }
 
 func (c *connect) printErrorAndExit(format string, v ...any) {

--- a/client/cmd/connect_test.go
+++ b/client/cmd/connect_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	clientupgrade "github.com/hoophq/hoop/client/upgrade"
+)
+
+func TestPrintVersionMismatchWarning(t *testing.T) {
+	const installLine = "hoop versions install"
+	const docsLine = "https://hoop.dev/docs/clients/cli-versions"
+
+	tests := []struct {
+		name         string
+		cliVersion   string
+		agentVersion string
+		disableEnv   string
+		wantOutput   bool
+		wantContains []string
+		wantMissing  []string
+	}{
+		{
+			name:         "versions match - no warning",
+			cliVersion:   "1.87.2",
+			agentVersion: "1.87.2",
+			wantOutput:   false,
+		},
+		{
+			name:         "cli version unknown - no warning",
+			cliVersion:   "unknown",
+			agentVersion: "1.87.2",
+			wantOutput:   false,
+		},
+		{
+			name:         "empty agent version - no warning",
+			cliVersion:   "1.87.2",
+			agentVersion: "",
+			wantOutput:   false,
+		},
+		{
+			name:         "disabled via env - no warning",
+			cliVersion:   "1.86.0",
+			agentVersion: "1.87.2",
+			disableEnv:   "true",
+			wantOutput:   false,
+		},
+		{
+			name:         "installable agent version recommends version manager",
+			cliVersion:   "1.86.0",
+			agentVersion: "1.87.2",
+			wantOutput:   true,
+			wantContains: []string{"1.86.0", "1.87.2", installLine + " 1.87.2 --use", clientupgrade.DisableVersionCheckEnv},
+		},
+		{
+			name:         "leading v on agent version is normalized in the command",
+			cliVersion:   "1.86.0",
+			agentVersion: "v1.87.2",
+			wantOutput:   true,
+			wantContains: []string{installLine + " 1.87.2 --use"},
+			wantMissing:  []string{installLine + " v1.87.2"},
+		},
+		{
+			name:         "below-floor agent version falls back to docs",
+			cliVersion:   "1.87.2",
+			agentVersion: "1.70.0",
+			wantOutput:   true,
+			wantContains: []string{"1.70.0", docsLine},
+			wantMissing:  []string{installLine},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the env explicitly so the test is hermetic regardless of
+			// the surrounding shell. t.Setenv restores it on cleanup.
+			t.Setenv(clientupgrade.DisableVersionCheckEnv, tt.disableEnv)
+
+			var buf bytes.Buffer
+			printVersionMismatchWarningTo(&buf, tt.cliVersion, tt.agentVersion)
+			out := buf.String()
+
+			if !tt.wantOutput {
+				if out != "" {
+					t.Fatalf("expected no output, got %q", out)
+				}
+				return
+			}
+			if out == "" {
+				t.Fatalf("expected a warning, got empty output")
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected output to contain %q, got %q", want, out)
+				}
+			}
+			for _, missing := range tt.wantMissing {
+				if strings.Contains(out, missing) {
+					t.Errorf("expected output NOT to contain %q, got %q", missing, out)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1516. The `hoop connect` version-mismatch warning hard-coded Homebrew upgrade instructions (`brew install hoop@<version>`), which only make sense on macOS — Windows and Linux users got useless guidance.

The warning now recommends the OS-agnostic CLI version manager:

```
⚠️  VERSION MISMATCH DETECTED! ⚠️
Your CLI version (1.86.0) does not match the agent version (1.87.2).
This WILL cause unexpected behavior.

Install and activate the matching version with the hoop CLI version manager:
  hoop versions install 1.87.2 --use

For more options, visit: https://hoop.dev/docs/clients/cli-versions

(set HOOP_DISABLE_VERSION_CHECK=true to silence this warning)
```

## What changed

`printVersionMismatchWarning` in `client/cmd/connect.go`:

- **Recommends `hoop versions install <agentVersion> --use`**, using the exact agent version (normalized via `NormalizeVersion`, so a leading `v` is stripped).
- **Falls back to the [cli-versions docs](https://hoop.dev/docs/clients/cli-versions)** when the agent version predates the version manager floor (1.74, or 1.86.1 on Windows), via `ValidateInstallableVersion` — so it never prints a command that would fail with a floor error.
- **Honors `HOOP_DISABLE_VERSION_CHECK=true`** and surfaces a silence hint, aligning it with the existing gateway-header warning (`WarnOnceFromServerHeader`).

Reuses existing helpers from `client/upgrade` (`DisableVersionCheckEnv`, `NormalizeVersion`, `ValidateInstallableVersion`) — no new constants or duplicated logic. Added a `printVersionMismatchWarningTo(w, cliVersion, agentVersion)` test seam mirroring the established `warnOnceFromServerHeaderTo` pattern.

## Testing

New table-driven test `client/cmd/connect_test.go` (7 cases): match / unknown / empty / env-disabled no-ops, installable recommendation, `v`-prefix normalization, and below-floor docs fallback. `gofmt` and `go vet` clean; `client/cmd` + `client/upgrade` suites pass.