### PR TITLE
Change Regex Tooltip string from go to python

### DIFF
--- a/webapp/src/webapp/guardrails/rules_table.cljs
+++ b/webapp/src/webapp/guardrails/rules_table.cljs
@@ -73,7 +73,7 @@
                      (when (= (.-key e) "Enter")
                        (.preventDefault e)))
        :value (get @pattern-state idx "")}]
-     [:> Tooltip {:content "Use Go regex syntax."}
+     [:> Tooltip {:content "Use Python regex syntax."}
       [:> CircleHelp {:size 16}]]]
 
     (= "deny_words_list" (:type rule))


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Fixes a misleading tooltip in the Guardrails rule editor. The "Pattern Match" rule input showed *"Use Go regex syntax."*, but guardrail patterns are actually compiled by Microsoft Presidio using Python's `re` module — not Go's RE2 engine. The tooltip now correctly reads *"Use Python regex syntax."* so users author patterns in the right flavor.

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when this PR is merged -->

Fixes #

## 🚀 Type of Change

<!-- Please mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

<!-- List the main changes made in this PR -->

- Updated the Pattern Match rule tooltip in `webapp/src/webapp/guardrails/rules_table.cljs` from "Use Go regex syntax." to "Use Python regex syntax."
- Verified the guardrails documentation (`setup/configuration/guardrails-configuration.mdx`) already correctly references Python regex syntax.
- Confirmed the runbooks `pattern` validation reference remains "go regular expression" since it is genuinely compiled by Go's `regexp` package.

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

Open the Guardrails rule editor, add a "Pattern Match" rule, and hover the help icon next to the pattern input — the tooltip now reads "Use Python regex syntax."

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
<!-- You can drag and drop images directly into this text area -->

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

<!-- Add any additional notes, concerns, or discussion points here -->
<!-- Is there anything specific you'd like reviewers to focus on? -->

This is a UI text-only correction with no behavioral change. Suggested label: **`patch`** (user-facing fix to a misleading tooltip). If you'd prefer not to cut a release for a one-line copy change, use **`skip-release`** instead.

---

<!-- Thank you for contributing to our project! 🙏 -->