### PR TITLE
docs(claude): analytics-event guardrail + document tunnel module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,7 @@
 
 ## Project Overview
 
-This is a Go workspace for the hoop gateway, agent, and CLI. The codebase follows a monorepo-style structure using `go.work`.
-
- with five modules: `gateway/`, `agent/`, `client/`, `common/`, `libhoop/`. There is also a Rust companion binary (`agentrs/`) for RDP/TLS proxy workloads, a legacy ClojureScript SPA (`webapp/`) - see `webapp/CLAUDE.md` for its own conventions, and a new React frontend (`webapp_v2/`) that is actively replacing it.
+This is a Go workspace for the hoop gateway, agent, and CLI. The codebase follows a monorepo-style structure using `go.work`, with six modules: `gateway/`, `agent/`, `client/`, `common/`, `libhoop/`, and `tunnel/`. There is also a Rust companion binary (`agentrs/`) for RDP/TLS proxy workloads, a legacy ClojureScript SPA (`webapp/`) - see `webapp/CLAUDE.md` for its own conventions, and a new React frontend (`webapp_v2/`) that is actively replacing it.
 
  `_libhoop/` is a symlink target; the build uses `ln -s _libhoop libhoop` (`make libhoop-map`) so Go sees the `libhoop` import path.
 
@@ -75,6 +73,12 @@ This is a Go workspace for the hoop gateway, agent, and CLI. The codebase follow
 - Rust binary for RDP proxy, TLS termination, WebSocket proxying.
 - Source: `agentrs/src/` — `main.rs`, `proxy.rs`, `rdp_proxy.rs`, `session.rs`, `tls.rs`, `ws/`.
 - Cross-compile for dev: `make build-dev-rust` (uses `cross` for Linux targets from macOS).
+
+### Tunnel (`tunnel/`)
+- Client-side tunnel daemon (`hsh-tunneld`) that lets a developer reach any hoop connection by name (e.g. `psql -h pg-prod.hoop`) as if it were on the local network.
+- Own Go module (`github.com/hoophq/hoop/tunnel`); entrypoint `tunnel/cmd/hsh-tunneld/`.
+- Per TCP flow it opens a fresh gRPC `Transport.Connect` stream to the existing gateway — **no new gateway protocol/endpoint**; the gateway sees ordinary client sessions.
+- Shipped with the unprivileged `hsh` CLI (separate `hoophq/hsh` repo).
 
 ## Transport Plugin System
 Plugins are registered in `gateway/main.go` in a **fixed, intentional order** — do not reorder casually:
@@ -187,6 +191,13 @@ See `DEV.md` "Feature Flags" section for the full developer guide and file refer
 - Add Swagger annotations (swag comments) on new/modified handlers.
 - Run `make generate-openapi-docs` to regenerate `gateway/api/openapi/autogen/`.
 - OpenAPI specs are served at `/api/openapiv2.json` and `/api/openapiv3.json`.
+
+### Product Analytics Events
+Analytics events are business KPIs measured downstream in PostHog/Mixpanel. Dropping or orphaning one fails **silently** — no compile error, no test failure, just a metric that quietly goes to zero. Treat them as a contract, not as incidental code.
+- Event names are constants in `gateway/analytics/events.go`. Emit them either via the `api.TrackRequest(analytics.EventX)` middleware in the route registration (`gateway/api/server.go`) or via `analytics.Track*` inside the handler. Never use a string literal — always the constant.
+- **When you add, duplicate, or supersede a route that performs an already-tracked action** (exec, session create, connect, resource CRUD), carry the same tracking onto the new route. A new path that replaces a tracked one MUST emit the same event (or a documented successor) — otherwise the metric silently dies on the old path. This is exactly how `hoop-exec-runbook` was lost: the V2 `POST /runbooks/exec` route superseded the tracked `POST /plugins/runbooks/connections/:name/exec` without `TrackRequest`.
+- **Never remove or rename an `Event*` constant, or delete its only emission site, without calling it out explicitly in the PR description** — state which metric/dashboard is affected and the successor event, if any. Event removal must be a deliberate, reviewed decision, never a side effect of a refactor.
+- When reviewing or refactoring routes/handlers that emit events, verify the `TrackRequest`/`Track*` call is preserved.
 
 ### Environment variables
 - Whenever a new env var is added, removed, or renamed in `gateway/appconfig/appconfig.go` (or anywhere read via `os.Getenv` in the gateway), **update the helm chart in the same PR**:

--- a/webapp/CLAUDE.md
+++ b/webapp/CLAUDE.md
@@ -1,5 +1,12 @@
 # HOOP WebApp Development Guidelines
 
+> **Status:** This is the **legacy ClojureScript app**, being migrated to React in `../webapp_v2/`. New pages should be built in `webapp_v2/`; touch this codebase only to maintain not-yet-migrated pages. See the root `CLAUDE.md` ("Frontend Migration in Progress") and `webapp_v2/CONTEXT_MIGRATION.md` for the split.
+
+## Commands
+- Dev (shadow-cljs on :8280): `cd webapp && npm run dev`
+- Build bundle into the gateway: `make build-dev-webapp` (from repo root)
+- After a CLJS change, hard-reload the browser tab (Vite proxies the bundle and can't HMR it)
+
 ## Code Style Guidelines
 - **ClojureScript**: Follow idiomatic ClojureScript style
 - **Namespaces**: Organized by feature (connections, webclient, components)


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).
>
> This PR is labelled `skip-release` (docs-only).

## 📝 Description

Documentation-only updates to the project's `CLAUDE.md` files, coming out of an investigation into why `hoop-exec-runbook` analytics events dropped to zero after Dec 2025.

## 🔗 Related Issue

N/A — no associated issue.

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- **`CLAUDE.md` (root):** added a "Product Analytics Events" rule under API conventions — events are a contract with a *silent* failure mode; emit via the `events.go` constants, carry tracking onto any route that supersedes a tracked one, and never drop an `Event*` without an explicit PR note. The `hoop-exec-runbook` regression (V2 `POST /runbooks/exec` shipped without `TrackRequest`, silently zeroing the metric) is cited inline.
- **`CLAUDE.md` (root):** documented the `tunnel/` module (`hsh-tunneld` daemon) — present in `go.work` but missing from the module breakdown. Fixed the module count (five → six) and a dangling sentence fragment in the overview.
- **`webapp/CLAUDE.md`:** added a legacy-status banner pointing to `webapp_v2/` and the migration context, plus a Commands section, so the file is self-contained for anyone landing in the CLJS app.

## 🧪 Testing

Docs-only change — no automated tests applicable. Verified the rendered Markdown and confirmed referenced paths/commands exist (Makefile targets, companion docs, `tunnel/` module).

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: N/A

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed (Markdown render + reference checks)

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (N/A — docs only)
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**Why:** The analytics guardrail is the lightweight, prevention-at-authoring layer against the silent-event-loss failure mode. A deterministic CI guard and a production alert were considered as stronger backstops but intentionally left out of this PR. The module/legacy-doc fixes are verified currency gaps.

**Risk:** None — docs only. No code, config, or behavior changes.

### Quality scores (before → after)

Scored with the `claude-md-improver` rubric (Commands 20 / Architecture 20 / Non-obvious patterns 15 / Conciseness 15 / Currency 15 / Actionability 15).

| File | Before | After | Δ |
|---|---|---|---|
| `CLAUDE.md` (root) | 91 (A) | **96 (A)** | +5 |
| `webapp/CLAUDE.md` | 67 (C) | **83 (B)** | +16 |
| `webapp_v2/CLAUDE.md` | 94 (A) | 94 (A) | — (not edited) |
| **Average** | **84 (B)** | **91 (A−)** | **+7** |

Per-criterion deltas for the two edited files:

**`CLAUDE.md` (root): 91 → 96**

| Criterion | Before | After | What changed |
|---|---|---|---|
| Architecture clarity | 18 | 20 | `tunnel/` module now documented |
| Non-obvious patterns | 14 | 15 | Added the silent-event-loss gotcha |
| Currency | 12 | 14 | Module count + sentence fragment fixed (1 pt held: targeted re-check, not an exhaustive feature sweep) |
| _Commands / Conciseness / Actionability_ | 20 / 12 / 15 | 20 / 12 / 15 | unchanged |

**`webapp/CLAUDE.md`: 67 → 83**

| Criterion | Before | After | What changed |
|---|---|---|---|
| Commands/workflows | 6 | 15 | Dev + build commands added (no test/lint/REPL loop yet → not full marks) |
| Currency | 10 | 14 | Legacy / migration framing added with pointers |
| Actionability | 10 | 13 | Commands are copy-paste runnable |
| _Architecture / Non-obvious / Conciseness_ | 16 / 12 / 13 | 16 / 12 / 13 | unchanged |