### PR TITLE
feat(httpproxy): per-request AI Session Analyzer for native HTTP resources

### DIFF
--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -75,6 +75,13 @@ var catalog = map[string]Flag{
 		Stability:   StabilityBeta,
 		Components:  []Component{ComponentGateway, ComponentAgent, ComponentClient},
 	},
+	"experimental.http_session_analyzer": {
+		Name:        "experimental.http_session_analyzer",
+		Description: "Run the AI Session Analyzer on individual requests made through native HTTP resources (httpproxy/kubernetes/claude-code). Each request is warned or blocked per its risk tier without dropping the session. For WebSocket sessions only the initial upgrade request is analyzed; bytes exchanged after the upgrade are not inspected.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentGateway},
+	},
 }
 
 // All returns every registered flag, sorted by name.

--- a/gateway/aianalyzer/analyzer.go
+++ b/gateway/aianalyzer/analyzer.go
@@ -1,4 +1,9 @@
-package apiai
+// Package aianalyzer holds the provider-agnostic AI session risk classifier
+// used by the gateway. It depends only on the AI client abstraction
+// (gateway/aiclients) and the data layer (gateway/models) so it can be reused
+// from any layer — including the protocol proxies — without creating import
+// cycles through the API/service packages.
+package aianalyzer
 
 import (
 	"context"

--- a/gateway/aianalyzer/httprequest.go
+++ b/gateway/aianalyzer/httprequest.go
@@ -1,0 +1,124 @@
+package aianalyzer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/gateway/models"
+	"gorm.io/gorm"
+)
+
+// Outcome is the per-request action decided by the HTTP session analyzer.
+type Outcome string
+
+const (
+	// OutcomeAllow forwards the request unchanged.
+	OutcomeAllow Outcome = "allow"
+	// OutcomeWarn records/alerts on the request but still forwards it.
+	OutcomeWarn Outcome = "warn"
+	// OutcomeBlock rejects this single request without ending the session.
+	OutcomeBlock Outcome = "block"
+)
+
+// maxAnalyzedBodyBytes caps how much of the request body is sent to the model,
+// bounding latency and token cost for large payloads.
+const maxAnalyzedBodyBytes = 8 * 1024
+
+// HTTPDecision is the result of analyzing a single request made through a native
+// HTTP resource (httpproxy/kubernetes/claude-code).
+type HTTPDecision struct {
+	Outcome     Outcome
+	RiskLevel   RiskLevel
+	Title       string
+	Explanation string
+	RuleName    string
+}
+
+// AnalyzeHTTPRequest evaluates a single request flowing through a native HTTP
+// resource and maps the connection's configured risk tier to a per-request
+// outcome.
+//
+// Outcome mapping (per-request HTTP semantics):
+//   - allow_execution        -> OutcomeAllow (forward, no alert)
+//   - block_execution        -> OutcomeBlock (reject this request only)
+//   - require_access_request  -> OutcomeWarn  (record/alert + forward)
+//
+// require_access_request degrades to warn because interactive per-request
+// approval cannot work for proxied HTTP traffic: a request is synchronous and
+// short-lived while human review is asynchronous, and for WebSocket sessions
+// only the upgrade request is ever observed. Approval for HTTP resources is
+// enforced at credential-issuance time (the JIT/access-request flow), not per
+// request.
+//
+// Returns (nil, nil) when the connection has no analyzer rule configured — the
+// feature is opt-in per connection.
+func AnalyzeHTTPRequest(ctx context.Context, orgID uuid.UUID, connectionName, method, target string, body []byte) (*HTTPDecision, error) {
+	rule, err := models.GetAISessionAnalyzerRuleByConnection(models.DB, orgID, connectionName)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed obtaining ai session analyzer rule for connection %q: %w", connectionName, err)
+	}
+
+	content := buildHTTPContent(method, target, body)
+	res, err := AnalyzeSession(ctx, orgID, content, rule.CustomPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("failed analyzing http request: %w", err)
+	}
+
+	tier := rule.RiskEvaluation.Tier(riskLevelKey(res.RiskLevel))
+	return &HTTPDecision{
+		Outcome:     outcomeForAction(tier.Action),
+		RiskLevel:   res.RiskLevel,
+		Title:       res.Title,
+		Explanation: res.Explanation,
+		RuleName:    rule.Name,
+	}, nil
+}
+
+func outcomeForAction(action models.RiskEvaluationAction) Outcome {
+	switch action {
+	case models.BlockExecution:
+		return OutcomeBlock
+	case models.RequireAccessRequest:
+		return OutcomeWarn
+	default:
+		return OutcomeAllow
+	}
+}
+
+func riskLevelKey(level RiskLevel) models.RiskLevelKey {
+	switch level {
+	case RiskLevelHigh:
+		return models.RiskLevelKeyHigh
+	case RiskLevelMedium:
+		return models.RiskLevelKeyMedium
+	default:
+		return models.RiskLevelKeyLow
+	}
+}
+
+// buildHTTPContent renders the request line and (capped) body into the text the
+// model classifies. Only the method, target, and body are included — request
+// headers are intentionally omitted to avoid leaking the proxy auth token or
+// other sensitive headers into the model context.
+func buildHTTPContent(method, target string, body []byte) string {
+	var b strings.Builder
+	b.WriteString(method)
+	b.WriteString(" ")
+	b.WriteString(target)
+	if len(body) > 0 {
+		b.WriteString("\n\n")
+		if len(body) > maxAnalyzedBodyBytes {
+			b.Write(body[:maxAnalyzedBodyBytes])
+			b.WriteString("\n...[truncated]")
+		} else {
+			b.Write(body)
+		}
+	}
+	return b.String()
+}

--- a/gateway/aianalyzer/httprequest_test.go
+++ b/gateway/aianalyzer/httprequest_test.go
@@ -1,0 +1,73 @@
+package aianalyzer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hoophq/hoop/gateway/models"
+)
+
+func TestOutcomeForAction(t *testing.T) {
+	cases := []struct {
+		action models.RiskEvaluationAction
+		want   Outcome
+	}{
+		{models.AllowExecution, OutcomeAllow},
+		{models.BlockExecution, OutcomeBlock},
+		// Per-request HTTP cannot do interactive approval, so it degrades to warn.
+		{models.RequireAccessRequest, OutcomeWarn},
+		{models.RiskEvaluationAction(""), OutcomeAllow},
+		{models.RiskEvaluationAction("unknown"), OutcomeAllow},
+	}
+	for _, tc := range cases {
+		if got := outcomeForAction(tc.action); got != tc.want {
+			t.Errorf("outcomeForAction(%q) = %q, want %q", tc.action, got, tc.want)
+		}
+	}
+}
+
+func TestRiskLevelKey(t *testing.T) {
+	cases := []struct {
+		level RiskLevel
+		want  models.RiskLevelKey
+	}{
+		{RiskLevelHigh, models.RiskLevelKeyHigh},
+		{RiskLevelMedium, models.RiskLevelKeyMedium},
+		{RiskLevelLow, models.RiskLevelKeyLow},
+		{RiskLevel("bogus"), models.RiskLevelKeyLow},
+	}
+	for _, tc := range cases {
+		if got := riskLevelKey(tc.level); got != tc.want {
+			t.Errorf("riskLevelKey(%q) = %q, want %q", tc.level, got, tc.want)
+		}
+	}
+}
+
+func TestBuildHTTPContent(t *testing.T) {
+	t.Run("no body", func(t *testing.T) {
+		got := buildHTTPContent("GET", "/api/pods?ns=prod", nil)
+		if got != "GET /api/pods?ns=prod" {
+			t.Errorf("unexpected content: %q", got)
+		}
+	})
+
+	t.Run("with body", func(t *testing.T) {
+		got := buildHTTPContent("POST", "/v1/messages", []byte(`{"q":"drop table users"}`))
+		want := "POST /v1/messages\n\n{\"q\":\"drop table users\"}"
+		if got != want {
+			t.Errorf("unexpected content: %q", got)
+		}
+	})
+
+	t.Run("body is truncated", func(t *testing.T) {
+		body := []byte(strings.Repeat("a", maxAnalyzedBodyBytes+100))
+		got := buildHTTPContent("PUT", "/x", body)
+		if !strings.HasSuffix(got, "\n...[truncated]") {
+			t.Errorf("expected truncation marker, got suffix %q", got[len(got)-32:])
+		}
+		// request line + "\n\n" + capped body + marker
+		if len(got) > len("PUT /x")+2+maxAnalyzedBodyBytes+len("\n...[truncated]") {
+			t.Errorf("content longer than cap: %d bytes", len(got))
+		}
+	})
+}

--- a/gateway/api/ai/ai.go
+++ b/gateway/api/ai/ai.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/hoophq/hoop/gateway/aianalyzer"
 	"github.com/hoophq/hoop/gateway/analytics"
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/api/openapi"
@@ -557,6 +558,6 @@ func toSessionAnalyzerRuleResponse(r *models.AISessionAnalyzerRules) openapi.AIS
 //	@Router			/ai/session-analyzer/system-prompt [get]
 func GetSessionAnalyzerSystemPrompt(c *gin.Context) {
 	c.JSON(http.StatusOK, openapi.AISessionAnalyzerSystemPrompt{
-		Prompt: SessionAnalyzerSystemPrompt,
+		Prompt: aianalyzer.SessionAnalyzerSystemPrompt,
 	})
 }

--- a/gateway/api/session/session.go
+++ b/gateway/api/session/session.go
@@ -20,8 +20,8 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/common/memory"
 	"github.com/hoophq/hoop/common/proto"
+	"github.com/hoophq/hoop/gateway/aianalyzer"
 	"github.com/hoophq/hoop/gateway/analytics"
-	apiai "github.com/hoophq/hoop/gateway/api/ai"
 	"github.com/hoophq/hoop/gateway/api/apiroutes"
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/api/openapi"
@@ -68,18 +68,18 @@ func AIAnalyze(ctx context.Context, orgID uuid.UUID, connName, script string) (*
 		return nil, nil, nil
 	}
 
-	analyzerRes, err := apiai.AnalyzeSession(ctx, orgID, script, aiAnalyzerRule.CustomPrompt)
+	analyzerRes, err := aianalyzer.AnalyzeSession(ctx, orgID, script, aiAnalyzerRule.CustomPrompt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed analyzing session, reason: %w", err)
 	}
 
 	var levelKey models.RiskLevelKey
 	switch analyzerRes.RiskLevel {
-	case apiai.RiskLevelHigh:
+	case aianalyzer.RiskLevelHigh:
 		levelKey = models.RiskLevelKeyHigh
-	case apiai.RiskLevelMedium:
+	case aianalyzer.RiskLevelMedium:
 		levelKey = models.RiskLevelKeyMedium
-	case apiai.RiskLevelLow:
+	case aianalyzer.RiskLevelLow:
 		levelKey = models.RiskLevelKeyLow
 	}
 	tier := aiAnalyzerRule.RiskEvaluation.Tier(levelKey)

--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -16,12 +17,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/featureflag"
 	"github.com/hoophq/hoop/common/grpc"
 	"github.com/hoophq/hoop/common/keys"
 	"github.com/hoophq/hoop/common/log"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbagent "github.com/hoophq/hoop/common/proto/agent"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
+	"github.com/hoophq/hoop/gateway/aianalyzer"
 	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/idp"
 	"github.com/hoophq/hoop/gateway/models"
@@ -37,6 +40,13 @@ const (
 	// NOTE in the future we might want to support custom headers as well
 	proxyTokenHeader = "Authorization"
 	proxyTokenCookie = "hoop_proxy_token"
+
+	// featureFlagHTTPSessionAnalyzer gates per-request AI risk analysis for
+	// native HTTP resources. Must match the catalog entry in common/featureflag.
+	featureFlagHTTPSessionAnalyzer = "experimental.http_session_analyzer"
+	// analyzerTimeout bounds the per-request AI analysis call so a slow/hung
+	// provider cannot hold a proxied request open indefinitely.
+	analyzerTimeout = 25 * time.Second
 )
 
 var instanceStore sync.Map
@@ -51,13 +61,16 @@ type HttpProxyServer struct {
 }
 
 type httpProxySession struct {
-	sid           string
-	ctx           context.Context
-	cancelFn      func(msg string, a ...any)
-	streamClient  pb.ClientTransport
-	responseStore sync.Map    // stores response channels per connectionID
-	closed        atomic.Bool // fast-fail flag to avoid mutex contention on session close
-	connCounter   atomic.Int64
+	sid            string
+	orgID          string // owning org, used to gate and run the AI session analyzer
+	connectionName string
+	userSubject    string
+	ctx            context.Context
+	cancelFn       func(msg string, a ...any)
+	streamClient   pb.ClientTransport
+	responseStore  sync.Map    // stores response channels per connectionID
+	closed         atomic.Bool // fast-fail flag to avoid mutex contention on session close
+	connCounter    atomic.Int64
 }
 
 func GetServerInstance() *HttpProxyServer {
@@ -356,8 +369,11 @@ func (s *HttpProxyServer) getOrCreateSession(secretKeyHash, correlationID string
 		fmt.Errorf("http proxy connection access expired"))
 
 	session := &httpProxySession{
-		sid: sid,
-		ctx: ctx,
+		sid:            sid,
+		orgID:          dba.OrgID,
+		connectionName: dba.ConnectionName,
+		userSubject:    dba.UserSubject,
+		ctx:            ctx,
 		cancelFn: func(msg string, a ...any) {
 			cancelFn(fmt.Errorf(msg, a...))
 			timeoutCancelFn()
@@ -506,6 +522,15 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 	}
 	defer r.Body.Close()
 
+	// Per-request AI risk analysis. handleRequest is invoked once per connection
+	// (a new connectionID each time), and post-WebSocket-upgrade frames are
+	// pumped elsewhere, so this only ever sees a connection's initiating request
+	// — for a WebSocket that is the upgrade request, giving allow/deny at connect
+	// time without inspecting the stream that follows.
+	if sess.analyzeRequestBlocked(w, r, body) {
+		return
+	}
+
 	// Determine proxy base URL from request (use Host header, not listenAddr)
 	// This ensures redirects go to the correct host (e.g., dev.hoop.dev instead of 0.0.0.0)
 	// Check X-Forwarded-Proto for requests behind reverse proxy
@@ -615,6 +640,10 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 
 		// Check if this is a WebSocket upgrade response
 		if resp.StatusCode == http.StatusSwitchingProtocols {
+			if sess.orgID != "" && featureflag.IsEnabled(sess.orgID, featureFlagHTTPSessionAnalyzer) {
+				log.With("sid", sess.sid, "conn", sess.connectionName).
+					Infof("ai analyzer: websocket upgrade established; only the upgrade request was analyzed, post-upgrade frames are not inspected")
+			}
 			sess.handleWebSocketUpgraded(w, response, responseChan, connectionID)
 			return
 		}
@@ -629,6 +658,71 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 
 		sess.writeBufferedResponse(w, resp, responseChan, connectionID)
 	}
+}
+
+// analyzeRequestBlocked runs the AI session analyzer on a single proxied HTTP
+// request when the feature is enabled for the session's org. It returns true
+// when the request was blocked — in that case a 403 has already been written to
+// w and the caller must stop processing. The session itself is left intact so
+// other requests on the same credential keep working.
+//
+// Failures to analyze (provider/LLM/infra errors) fail open: an analyzer outage
+// is an infrastructure problem, not a risk signal, and blocking every request on
+// it would take the whole HTTP resource down. Such failures are logged loudly
+// and the request is allowed through.
+func (sess *httpProxySession) analyzeRequestBlocked(w http.ResponseWriter, r *http.Request, body []byte) bool {
+	if sess.orgID == "" || !featureflag.IsEnabled(sess.orgID, featureFlagHTTPSessionAnalyzer) {
+		return false
+	}
+	orgID, err := uuid.Parse(sess.orgID)
+	if err != nil {
+		log.With("sid", sess.sid).Warnf("ai analyzer: invalid org id %q, skipping analysis: %v", sess.orgID, err)
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(sess.ctx, analyzerTimeout)
+	defer cancel()
+
+	decision, err := aianalyzer.AnalyzeHTTPRequest(ctx, orgID, sess.connectionName, r.Method, r.URL.RequestURI(), body)
+	if err != nil {
+		log.With("sid", sess.sid, "conn", sess.connectionName, "method", r.Method, "path", r.URL.Path).
+			Errorf("ai analyzer: failed analyzing request, allowing through: %v", err)
+		return false
+	}
+	if decision == nil {
+		// No analyzer rule configured for this connection — feature is opt-in.
+		return false
+	}
+
+	logger := log.With("sid", sess.sid, "org", sess.orgID, "conn", sess.connectionName,
+		"user", sess.userSubject, "method", r.Method, "path", r.URL.Path,
+		"rule", decision.RuleName, "risk", string(decision.RiskLevel), "title", decision.Title)
+
+	switch decision.Outcome {
+	case aianalyzer.OutcomeBlock:
+		logger.Warnf("ai analyzer blocked request: %s", decision.Explanation)
+		writeAnalyzerForbidden(w, decision)
+		return true
+	case aianalyzer.OutcomeWarn:
+		logger.Warnf("ai analyzer flagged request (allowed): %s", decision.Explanation)
+		return false
+	default:
+		return false
+	}
+}
+
+// writeAnalyzerForbidden writes the 403 response returned to the client when the
+// analyzer blocks a single request.
+func writeAnalyzerForbidden(w http.ResponseWriter, d *aianalyzer.HTTPDecision) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("server", "httpproxy-hoopgateway")
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error":       "request blocked by hoop ai session analyzer",
+		"risk_level":  string(d.RiskLevel),
+		"title":       d.Title,
+		"explanation": d.Explanation,
+	})
 }
 
 // writeBufferedResponse forwards a regular (non-SSE, non-WebSocket) HTTP response


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Adds per-request AI risk analysis for native HTTP resources (httpproxy / Kubernetes / Claude Code) served through the gateway HTTP proxy. When an org has an AI Session Analyzer rule on the connection and the feature flag is on, each request is classified and either **warned** (logged/alerted and forwarded) or **blocked** (rejected with a clean `403` without tearing down the session). For WebSocket sessions only the initial upgrade request is analyzed — bytes exchanged after the upgrade are not inspected.

The change is gated behind a feature flag and defaults off, so a fresh deployment behaves exactly as before.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- New `gateway/aianalyzer` package holding the provider-agnostic risk classifier. Extracted from `gateway/api/ai` so the proxy layer can call it (the previous package pulled in `analytics → services → httpproxy`, which would have been an import cycle). `apiai` and `sessionapi` now call the new package; the exec analyzer behavior is unchanged.
- `aianalyzer.AnalyzeHTTPRequest` classifies a single request (method + target + capped body, no headers) and maps the connection's existing risk-tier config to a per-request outcome: `allow_execution → allow`, `block_execution → block`, `require_access_request → warn`.
- Per-request analysis wired into the gateway HTTP proxy server (`handleRequest`): **block** writes a clean `403` for that request and never forwards it to the agent, leaving the session alive; **warn** emits a structured log and forwards.
- WebSocket sessions: only the upgrade request is analyzed (allow/deny at connect time); post-upgrade frames are not inspected, and that is logged explicitly when an upgrade is established.
- New `experimental.http_session_analyzer` feature flag (gateway component, default `false`) gating the whole path. Analyzer/LLM failures fail open (logged) so an analyzer outage can't take the resource down.
- Reuses the existing AI Session Analyzer rules/provider config — no new config surface, no DB migration, no frontend change.
- Unit tests for the outcome mapping, risk-level mapping, and request-content building (incl. body truncation).

## 🧪 Testing

`go build ./gateway/... ./common/...`, `go vet`, and `gofmt` are clean. New unit tests for the pure decision logic pass via `go test ./gateway/aianalyzer/...`. No end-to-end run against a live gateway/provider yet.

### Test Configuration:
- **Browser(s)**: N/A (backend change)
- **OS**: macOS (darwin)

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## 📸 Screenshots (if applicable)

N/A — backend only.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

### 🚧 Not in scope (intentionally left out)

- **`hoop connect` (client local proxy) is not covered.** Only the gateway HTTP proxy server path is instrumented (credential-token / "Open in Native Client" / `hoop claude configure` flows). The `hoop connect` path is a raw byte tunnel with no per-request boundaries at the gateway, so it needs a separate design (request reassembly or an agent-assisted verdict) tracked as follow-up.
- **WebSocket / streaming internals are not inspected** — by design we only evaluate the upgrade request (allow/deny at connect time).
- **No per-request approval.** `require_access_request` is reused and mapped to `warn` for HTTP because interactive per-request approval can't work for proxied HTTP; approval for these resources still belongs at credential-issuance time. No new "warn" config action was introduced.
- **No frontend changes.** Configuration reuses the existing AI Session Analyzer rule UI; its action labels are still exec-centric (e.g. "Require access request" reads like it gates approval, but on HTTP it warns). Adapting the UI copy / adding a first-class "warn" action is a follow-up.
- **"Record/alert" = structured logs.** No per-request persistence or session-timeline UI for HTTP analyzer results yet.
- **No request scoping.** When the flag is on and a rule matches, every request is analyzed (one rule lookup + one LLM call). Method/route scoping, caching, and sampling are follow-ups to manage latency/cost.

---

<!-- Thank you for contributing to our project! 🙏 -->