### PR TITLE
ci: auto-deploy released versions to demo/sandbox/customer envs

### DIFF
--- a/.github/actions/deploy-app/action.yml
+++ b/.github/actions/deploy-app/action.yml
@@ -1,0 +1,67 @@
+name: Deploy app via infra
+description: >-
+  Dispatch the hoophq/infra "Deploy By App" workflow for a single environment
+  and wait for that deploy to finish, failing the step if the deploy fails.
+
+inputs:
+  version:
+    description: Semantic version to deploy, e.g. "1.94.0".
+    required: true
+  app:
+    description: >-
+      Target environment name. Must have hoopcloud/<app>/values.yml in
+      hoophq/infra.
+    required: true
+  github-token:
+    description: >-
+      PAT with actions:write on hoophq/infra. The default GITHUB_TOKEN cannot
+      trigger workflows in another repository.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Dispatch infra Deploy By App and wait
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        VERSION: ${{ inputs.version }}
+        APP: ${{ inputs.app }}
+      run: |
+        set -euo pipefail
+
+        # Record a timestamp slightly before dispatch (30s back to absorb any
+        # clock skew between this runner and GitHub) so we can correlate the
+        # run we are about to create.
+        dispatched_after=$(date -u -d '30 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
+
+        gh workflow run deploy-by-app.yml --repo hoophq/infra \
+          -f version="$VERSION" -f app="$APP"
+        echo "Dispatched 'Deploy By App': app=$APP version=$VERSION"
+
+        # workflow_dispatch does not return a run id. The infra workflow's
+        # run-name is "Deploy App <app> (<version>)" — unique per release — so
+        # we poll for the matching run created after our dispatch and take the
+        # newest (handles a manual re-run of the same version).
+        title="Deploy App ${APP} (${VERSION})"
+        run_id=""
+        for _ in $(seq 1 30); do
+          run_id=$(gh run list --repo hoophq/infra \
+            --workflow deploy-by-app.yml --event workflow_dispatch --limit 50 \
+            --json databaseId,displayTitle,createdAt \
+            --jq "[.[] | select(.displayTitle == \"$title\" and .createdAt >= \"$dispatched_after\")] | sort_by(.createdAt) | last | .databaseId")
+          if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+            break
+          fi
+          sleep 5
+        done
+
+        if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+          echo "::error::Timed out locating the dispatched infra run for '$title'."
+          exit 1
+        fi
+
+        echo "Watching infra run $run_id ($title) until completion..."
+        # --exit-status makes this step fail when the deploy fails, so a
+        # broken rollout surfaces here instead of passing silently.
+        gh run watch "$run_id" --repo hoophq/infra --exit-status

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1,0 +1,118 @@
+name: Auto Deploy
+
+# Deploys a freshly-released version to a fixed set of environments by
+# dispatching the existing hoophq/infra "Deploy By App" workflow once per env.
+#
+# Why `workflow_run` and not `on: release`?
+# The infra deploy runs:
+#   helm upgrade --install hoop \
+#     oci://ghcr.io/hoophq/helm-charts/hoop-chart --version <v> \
+#     --set image.gw.tag=<v> --wait
+# Both the chart (oci://ghcr.io/hoophq/helm-charts) and the image
+# (hoophq/hoop:<v>) are published by release.yml ("Hoop Release"). Neither
+# exists at `release: published` time — that event fires from auto-release.yml
+# *before* release.yml has built anything. So we wait for the "Hoop Release"
+# workflow to finish successfully, which guarantees the artifacts are live.
+#
+# Canary ordering (mirrors infra's "Deploy All Instances"):
+#   - Demo environments (appdemo, hoopdemo) and the sandbox canary deploy in
+#     parallel as soon as the release succeeds.
+#   - Customer environments (tryrunops) deploy only after the sandbox deploy
+#     succeeds, so a broken release is caught on sandbox before it reaches a
+#     customer. A failing demo never blocks a customer deploy.
+# Each deploy reuses the local composite action .github/actions/deploy-app,
+# which dispatches infra's "Deploy By App" and waits for it to finish.
+on:
+  workflow_run:
+    workflows: ["Hoop Release"]
+    types: [completed]
+
+# Serialize deploys across releases. `cancel-in-progress: false` never
+# interrupts an in-flight `helm upgrade` (cancelling mid-rollout can leave a
+# release wedged). If several releases pile up while one is deploying, GitHub
+# keeps only the newest queued run, so we converge to the latest version
+# without ever racing two helm upgrades on the same namespace.
+concurrency:
+  group: auto-deploy
+  cancel-in-progress: false
+
+# The deploy jobs check out the repo to use the local composite action; the
+# cross-repo PAT (GH_TOKEN) handles the actual infra dispatch.
+permissions:
+  contents: read
+
+jobs:
+  resolve-version:
+    name: Resolve version
+    # Only deploy when the release build actually succeeded. release.yml only
+    # ever runs on tag pushes, so we also assert event == 'push' defensively.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve released version from tag
+        id: resolve
+        env:
+          # release.yml is triggered by the tag push, so head_branch carries
+          # the tag name, e.g. "1.94.0" (verified against historical runs).
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$HEAD_BRANCH" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Triggering run ref '$HEAD_BRANCH' is not a semver release tag; refusing to deploy."
+            exit 1
+          fi
+          echo "version=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Resolved release version: $HEAD_BRANCH"
+
+  deploy-demos:
+    name: Deploy ${{ matrix.app }}
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    strategy:
+      # Independent namespaces — if one fails, still attempt the others and let
+      # each report its own status.
+      fail-fast: false
+      matrix:
+        app: [appdemo, hoopdemo]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/deploy-app
+        with:
+          version: ${{ needs.resolve-version.outputs.version }}
+          app: ${{ matrix.app }}
+          github-token: ${{ secrets.GH_TOKEN }}
+
+  deploy-canary:
+    name: Deploy sandbox (canary)
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/deploy-app
+        with:
+          version: ${{ needs.resolve-version.outputs.version }}
+          app: sandbox
+          github-token: ${{ secrets.GH_TOKEN }}
+
+  deploy-customers:
+    name: Deploy ${{ matrix.app }}
+    # Gate customer environments on the sandbox canary specifically: they only
+    # deploy once sandbox has upgraded successfully. (resolve-version is also
+    # needed here to read its version output.)
+    needs: [resolve-version, deploy-canary]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [tryrunops]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/deploy-app
+        with:
+          version: ${{ needs.resolve-version.outputs.version }}
+          app: ${{ matrix.app }}
+          github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## 📝 Description

Automates deployment of new releases. Release automation already existed (`auto-release.yml` → `release.yml` builds & publishes the chart + image), but deploying those artifacts to our environments was still a manual `Deploy By App` run in `hoophq/infra` — which is how environments like demo drifted off the latest version.

This adds an **Auto Deploy** workflow that, once a release finishes building, deploys it by dispatching the existing `hoophq/infra` `Deploy By App` workflow once per environment and waiting for each to finish.

## 🔗 Related Issue


## 🚀 Type of Change

- [x] 🔧 Build configuration change

## 📋 Changes Made

- Add `.github/workflows/auto-deploy.yml`, triggered on **`workflow_run` of "Hoop Release" success** (not `on: release`).
- Add `.github/actions/deploy-app` composite action that dispatches infra `Deploy By App` and waits for the run (`gh run watch --exit-status`), so a failed rollout fails the job instead of passing silently.
- Deploy targets: `appdemo`, `hoopdemo`, `sandbox` in parallel; `tryrunops` (customer) gated behind the **sandbox canary**.
- Serialize deploys across releases (`concurrency: auto-deploy`, `cancel-in-progress: false`) so an in-flight `helm upgrade` is never interrupted.

## 🧪 Testing

A `workflow_run` trigger only fires from the copy on the default branch, so this can't be exercised before merge. Validated pre-merge:

- Workflow + composite action YAML parse cleanly.
- Embedded shell passes `bash -n`; the semver guard and the `jq` run-correlation filter were unit-tested against realistic `gh run list` output.
- Confirmed all four target envs have `hoopcloud/<app>/values.yml` in `hoophq/infra`, and that `release.yml`'s `head_branch` equals the version tag (so version resolution is reliable).

_Browser/OS and screenshots: N/A (CI-only change)._

### Tests performed:
- [x] Manual testing completed (static validation; see above)

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## 📄 Additional Notes

**Why `workflow_run` and not `on: release`:** the infra deploy runs `helm upgrade ... --version <v> --set image.gw.tag=<v>`. Both the chart (`oci://ghcr.io/hoophq/helm-charts`) and image (`hoophq/hoop:<v>`) are published by `release.yml`; neither exists at `release: published` time (that fires from `auto-release.yml` before anything is built). So we wait for "Hoop Release" to succeed.

**⚠️ Prerequisite to confirm before the first post-merge release:** `secrets.GH_TOKEN` must have `actions:write` on `hoophq/infra` (it already dispatches `hoophq/brew`, so likely org-scoped). Without it, the dispatch step fails.

**Canary scope / known limitation:** the sandbox canary only catches failures that surface as a failed helm rollout (pods not Ready within helm's timeout). It will not catch logic regressions where pods come up healthy but misbehave. A sandbox smoke test between the canary and customer stages is a natural follow-up.

**Follow-ups (not in this PR):** add a sandbox smoke test; extend the `deploy-customers` matrix to the remaining customer envs (enjoei, rdstation, unico, dock, multitenant).
