### PR TITLE
feat(docker): run gateway as non-root user (uid/gid 10001)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM ubuntu:noble-20250714
 ENV DEBIAN_FRONTEND=noninteractive
 ENV ACCEPT_EULA=y
 
-RUN mkdir -p /app && \
+RUN groupadd --gid 10001 hoop && \
+    useradd --uid 10001 --gid 10001 --no-create-home --shell /sbin/nologin hoop && \
+    mkdir -p /app && \
     mkdir -p /opt/hoop/sessions && \
     mkdir -p /opt/hoop/bin && \
     apt-get update -y && \
@@ -27,7 +29,7 @@ ENV LC_ALL=en_US.UTF-8
 COPY rootfs /
 COPY dist/binaries/ /tmp/
 RUN tar -xf /tmp/hoop_*_$(uname -s)_$(uname -m).tar.gz -C /app/ && \
-    chown root:root /app/hoop* && \
+    chown -R hoop:hoop /app /opt/hoop && \
     chmod 755 /app/hoop* && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
@@ -38,5 +40,7 @@ EXPOSE 15432
 
 ENV PATH="/app:${PATH}"
 ENV PATH="/opt/hoop/bin:${PATH}"
+
+USER hoop
 
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
  ### What
  Creates a dedicated system user \`hoop\` (uid/gid 10001), transfers ownership of
  \`/app\` and \`/opt/hoop\` to it, and switches to that user via \`USER hoop\` before
  \`ENTRYPOINT\`.

  ### Why
  Enables full Kubernetes Pod Security Standards (\`restricted\`) compliance when
  combined with the \`podSecurityContext\`/\`securityContext\` values added to the
  chart in #1513. Running as root in a container is a security anti-pattern;
  this makes the secure path the default.

  ### Backward compatibility
  \`persistence.enabled: false\` (default) — unaffected, container starts correctly
  as uid 10001. Users with \`persistence.enabled: true\` need to add
  \`podSecurityContext.fsGroup: 10001\` so Kubernetes fixes group ownership on the
  mounted PVC.

  ### Tested
  - kind cluster, k8s v1.31, \`pod-security.kubernetes.io/enforce=restricted\`
  - Full PSS-restricted securityContext (runAsNonRoot, runAsUser/Group/fsGroup 10001,
    seccompProfile RuntimeDefault, capabilities.drop ALL)
  - \`kubectl exec -- id\` → \`uid=10001(hoop) gid=10001(hoop)\`
  - Gateway started, \`/app/ui/public/index.html\` patched (write OK),
    \`/opt/hoop/sessions/clientexec/\` created (write OK)