### PR TITLE
feat: polish provisioning UI and relocate to Discover

### DIFF
--- a/webapp/src/webapp/provisioning/views/bulk_import.cljs
+++ b/webapp/src/webapp/provisioning/views/bulk_import.cljs
@@ -58,7 +58,7 @@
 
 (defn step-indicator [current-step]
   (let [cur-idx (.indexOf step-keys current-step)]
-    [:> Flex {:align "center" :gap "1"}
+    [:> Flex {:align "center" :gap "2"}
      (for [[i s] (map-indexed vector steps)]
        ^{:key (:key s)}
        [step-segment {:index i
@@ -145,10 +145,10 @@
                    :detail    (str row-count " rows detected \u00b7 "
                                    (format-file-size file-size*))
                    :on-remove clear-file!})}]
-   [:> Flex
+   [:> Flex {:justify "end"}
     [:> Button {:size "2" :disabled (not file-selected)
                 :on-click start-parse!}
-     "Parse file \u2192"]]])
+     "Import"]]])
 
 
 (def ^:private parsing-checklist
@@ -527,10 +527,10 @@
                          :class "max-h-[90vh] overflow-hidden"}
       [:> Flex {:direction "column" :gap "0"
                 :style {:max-height "calc(90vh - 48px)"}}
-       [:> Flex {:align "center" :justify "between" :gap "4" :mb "5" :wrap "wrap"}
-        [:> Flex {:align "center" :gap "4" :wrap "wrap"}
+       [:> Flex {:align "start" :justify "between" :gap "4" :mb "5" :wrap "wrap"}
+        [:> Flex {:direction "column" :gap "3"}
          [:> Dialog.Title {:asChild true}
-          [:> Heading {:as "span" :size "6"} "Import inventory"]]
+          [:> Heading {:as "span" :size "6"} "Import Resources"]]
          [step-indicator step]]
         [:> Dialog.Close {:asChild true}
          [:> IconButton {:variant "ghost" :color "gray" :size "2"

--- a/webapp/src/webapp/provisioning/views/inventory/main.cljs
+++ b/webapp/src/webapp/provisioning/views/inventory/main.cljs
@@ -3,7 +3,7 @@
    ["@radix-ui/themes" :refer [Badge Box Button Checkbox Flex Heading
                                 Table Tabs Text TextField Tooltip]]
    ["lucide-react" :refer [AlertCircle Check ChevronRight Database
-                            Key Pencil Plus Rocket Search Upload
+                            Key Pencil Rocket Search Upload
                             UserCog X]]
    [clojure.string :as cs]
    [re-frame.core :as rf]
@@ -264,7 +264,7 @@
 (defn- inventory-header [{:keys [total-resources ready-count on-open-bulk-import]}]
   [:> Flex {:align "center" :justify "between" :mb "6"}
    [:> Flex {:direction "column" :gap "2"}
-    [:> Heading {:size "8"} "Resource Catalog"]
+    [:> Heading {:size "8"} "Provisioning Hub"]
     [:> Flex {:align "center" :gap "3"}
      [:> Text {:size "2" :color "gray"}
       "Track and provision every database resource connected to Hoop."]
@@ -274,7 +274,7 @@
      [:> Text {:size "2" :color "green"} (str ready-count " complete")]]]
    [:> Flex {:gap "2"}
     [:> Button {:size "3" :on-click on-open-bulk-import}
-     [:> Plus {:size 16}] " Add to Inventory"]]])
+     [:> Upload {:size 16}] " Import Resources"]]])
 
 (defn- inventory-tabs [{:keys [active-tab counts on-change]}]
   [:> Tabs.Root {:value         (name active-tab)

--- a/webapp/src/webapp/provisioning/views/shared.cljs
+++ b/webapp/src/webapp/provisioning/views/shared.cljs
@@ -151,7 +151,7 @@
    (when detail
      [:> Text {:size "1" :color "gray"} detail])
    (when on-remove
-     [:> Button {:variant "ghost" :size "1" :color "gray"
+     [:> Button {:variant "soft" :size "1" :color "red"
                  :on-click (fn [e]
                              (.stopPropagation e)
                              (on-remove))}

--- a/webapp_v2/src/layout/Sidebar/constants.js
+++ b/webapp_v2/src/layout/Sidebar/constants.js
@@ -32,7 +32,6 @@ export const MAIN_ITEMS = [
   { label: 'Terminal', path: '/client', icon: SquareCode, adminOnly: false },
   { label: 'Runbooks', path: '/runbooks', icon: BookUp2, adminOnly: false },
   { label: 'Sessions', path: '/sessions', icon: GalleryVerticalEnd, adminOnly: false },
-  { label: 'Provisioning', path: '/provisioning', icon: Boxes, adminOnly: true },
   {
     label: 'Search',
     icon: Search,
@@ -58,6 +57,7 @@ export const DISCOVER_ITEMS = [
   { label: 'AI Session Analyzer', path: '/features/ai-session-analyzer', icon: Sparkles, adminOnly: true },
   { label: 'Live Data Masking', path: '/features/data-masking', icon: VenetianMask, adminOnly: true },
   { label: 'Access Control', path: '/features/access-control', icon: UserRoundCheck, adminOnly: true },
+  { label: 'Provisioning Hub', path: '/provisioning', icon: Boxes, adminOnly: true },
   {
     label: 'Rulepacks',
     path: '/rulepacks',


### PR DESCRIPTION
## 📝 Description

Relocates Provisioning to the admin-only Discover section, renames it to "Provisioning Hub", and applies small copy and layout improvements to the page header and import modal.

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- **Sidebar**: moved Provisioning from the main menu into Discover (between Access Control and Resource Discovery) and renamed it to "Provisioning Hub".
- **Page header**: "Resource Catalog" → "Provisioning Hub"; "Add to Inventory" button → "Import Resources" (Plus icon → Upload).
- **Import modal**: title "Import inventory" → "Import Resources"; primary button "Parse file →" → "Import", right-aligned; step indicator moved under the title with slightly larger gaps between steps.
- **Drop-zone Remove button**: gray ghost → red soft for higher contrast.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots

<img width="3024" height="1808" alt="CleanShot 2026-06-22 at 10 20 02@2x" src="https://github.com/user-attachments/assets/c39ecc3b-709d-4faf-8ac7-64a179a52ac3" />
<img width="3024" height="1808" alt="CleanShot 2026-06-22 at 10 20 29@2x" src="https://github.com/user-attachments/assets/d39a26fe-0adb-472a-a02e-e4472a3abaee" />

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
