### PR TITLE
fix(rdp): repair GPU OCR image, default PII guard to redact, + GCP deploy compose

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -63,7 +63,7 @@ MSPRESIDIO_ANONYMIZER_URL=
 RDP_OCR_SERVER_URL=
 
 # action the realtime agent-side PII guard takes on detection:
-# kill (default) | redact (blank the PII and continue) | redact_and_kill
+# redact (default: blank the PII and continue) | kill (drop and terminate) | redact_and_kill
 RDP_PII_GUARD_POLICY=
 
 # in case your DLP_PROVER is 'gcp', you must

--- a/Dockerfile.agent-ocr-gpu
+++ b/Dockerfile.agent-ocr-gpu
@@ -23,23 +23,54 @@ FROM ${HOOP_IMAGE}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Python + native libs RapidOCR's opencv dependency links. The CUDA userspace
-# libraries (cudart, cudnn) ship in the onnxruntime-gpu wheel's dependencies;
-# the driver is injected by the nvidia container runtime at run time.
+# runtime libraries are NOT bundled by the onnxruntime-gpu wheel — they are
+# installed explicitly below as nvidia-*-cu12 wheels. The driver itself is
+# injected by the nvidia container runtime at run time.
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         python3 python3-pip python3-venv \
         libglib2.0-0 libgl1 libxcb1 libsm6 libxext6 && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
-# onnxruntime-gpu 1.19+ targets CUDA 12 + cuDNN 9. Bounded pins for
-# reproducibility (mirrors the standalone GPU sidecar image).
+# onnxruntime-gpu must be pinned to the CUDA 12 line: 1.21+ moved to CUDA 13
+# (the wheel then needs libcudart.so.13) while declaring NO nvidia/* runtime
+# dependencies, so an unbounded pin resolved to 1.27 and crashed at import with
+# "libcudart.so.13: cannot open shared object file". 1.20.1 is the last CUDA 12
+# release.
+#
+# This image is FROM the hoop base (no CUDA libs of its own), so the CUDA 12
+# runtime libraries the provider links against are installed explicitly as
+# EXACT-pinned pip wheels — onnxruntime-gpu does NOT pull them transitively, and
+# leaving them unpinned reintroduces the same drift class of bug. The full set
+# is required: libonnxruntime_providers_cuda.so links cudart, cublas(+cublasLt),
+# cudnn, curand, cufft, nvrtc and nvjitlink; a partial set silently falls back
+# to CPU (RapidOCR logs "shifted to be executed under CPUExecutionProvider"),
+# which a GPU image must never do. Versions are the set validated on a T4 (ldd
+# resolves all provider deps; engine reports device=onnxruntime-cuda, no CPU
+# fallback). Keep in sync with Dockerfile.rapidocr-gpu.
 RUN python3 -m venv /opt/ocr-venv && \
     /opt/ocr-venv/bin/pip install --no-cache-dir \
-        "rapidocr>=3.1,<4" \
-        "onnxruntime-gpu>=1.19,<2" \
-        "fastapi>=0.115,<1" \
-        "uvicorn>=0.30,<1"
+        "rapidocr==3.8.4" \
+        "onnxruntime-gpu==1.20.1" \
+        "nvidia-cuda-runtime-cu12==12.9.79" \
+        "nvidia-cublas-cu12==12.9.2.10" \
+        "nvidia-cudnn-cu12==9.23.2.1" \
+        "nvidia-curand-cu12==10.3.10.19" \
+        "nvidia-cufft-cu12==11.4.1.4" \
+        "nvidia-cuda-nvrtc-cu12==12.9.86" \
+        "nvidia-nvjitlink-cu12==12.9.86" \
+        "fastapi==0.138.0" \
+        "uvicorn==0.49.0"
 ENV PATH="/opt/ocr-venv/bin:${PATH}"
+# The CUDA wheels install their .so files under nvidia/*/lib inside the venv's
+# site-packages. Rather than hardcode the python-minor-specific path (a rebuild
+# trap if the base image's python changes), symlink every CUDA .so into a fixed
+# directory and put only that on the loader path. Without this the CUDA
+# execution provider fails to load and inference silently falls back to CPU.
+RUN mkdir -p /opt/cuda-libs && \
+    find /opt/ocr-venv -path '*/nvidia/*/lib/*.so*' -exec ln -s {} /opt/cuda-libs/ \; && \
+    test -e /opt/cuda-libs/libcudart.so.12 && test -e /opt/cuda-libs/libcublasLt.so.12
+ENV LD_LIBRARY_PATH="/opt/cuda-libs"
 
 COPY scripts/dev/ocr-poc/device_policy.py /opt/ocr/device_policy.py
 COPY scripts/dev/ocr-poc/server_rapidocr.py /opt/ocr/server_rapidocr.py

--- a/deploy/docker-compose/docker-compose.gcp-gpu-agent.env.sample
+++ b/deploy/docker-compose/docker-compose.gcp-gpu-agent.env.sample
@@ -1,0 +1,21 @@
+# Copy to `.env` next to docker-compose.gcp-gpu-agent.yml and fill in.
+# Do NOT commit the real .env (it holds the agent secret).
+
+# Agent connection DSN, minted in the gateway UI:
+#   Admin -> Agents -> Create agent -> copy the key.
+# Format: grpcs://<agent-name>:<secret>@<gateway-host>:8010?mode=standard
+# Use grpcs:// (TLS) for a remote gateway; grpc:// only for a plaintext/local one.
+HOOP_KEY=grpcs://gpu-agent:REPLACE_WITH_SECRET@YOUR_GATEWAY_HOST:8010?mode=standard
+
+# Gateway HTTP/WS base URL — REQUIRED for the RDP PII guard. The Rust agent
+# (which runs the RDP proxy + PII guard) only starts when this is set; it
+# appends /api/ws and maps https:// -> wss://. This is the API endpoint
+# (usually https on 443), NOT the gRPC host/port in HOOP_KEY.
+#   e.g. https://your-gateway-host
+HOOP_GATEWAY_URL=https://YOUR_GATEWAY_HOST
+
+# Pinned GPU OCR image tag. No `latest-gpu` exists — always pin a version.
+OCR_IMAGE_TAG=1.98.0-gpu
+
+# OCR workers; each holds a model copy in the T4's 16GB VRAM. 4 is safe.
+WEB_CONCURRENCY=4

--- a/deploy/docker-compose/docker-compose.gcp-gpu-agent.yml
+++ b/deploy/docker-compose/docker-compose.gcp-gpu-agent.yml
@@ -1,0 +1,91 @@
+# GCP GPU agent for the realtime RDP PII guard.
+#
+# Runs on a single GCE VM with one NVIDIA T4 (nvidia-container-toolkit
+# required). Two services:
+#
+#   - agent: the bundled GPU agent image (hoophq/hoop-agent-ocr:<tag>-gpu).
+#     The OCR engine runs INSIDE this container on loopback (127.0.0.1:18868)
+#     with RDP_OCR_SERVER_URL baked in; do not expose or override it. The
+#     agent connects out to your existing gateway via HOOP_KEY (a DSN minted
+#     in the gateway UI).
+#   - presidio-analyzer: PII detection the agent calls via
+#     MSPRESIDIO_ANALYZER_URL. Only the analyzer is needed — redaction happens
+#     in the agent, so the anonymizer service is intentionally omitted.
+#
+# The GPU image REFUSES TO START without a visible GPU (device_policy.py),
+# and the entrypoint is fail-loud: if OCR is unhealthy the container exits
+# non-zero. Both are intentional so the guard never runs blind.
+#
+# Usage on the VM:
+#   docker compose -f docker-compose.gcp-gpu-agent.yml up -d
+#   docker compose -f docker-compose.gcp-gpu-agent.yml logs -f agent
+#
+# Required env (see .env alongside this file): HOOP_KEY, OCR_IMAGE_TAG.
+
+services:
+  agent:
+    image: hoophq/hoop-agent-ocr:${OCR_IMAGE_TAG}
+    restart: unless-stopped
+    # Run a STANDALONE agent that connects out to a remote gateway using
+    # HOOP_KEY. This overrides the image's default CMD (hoop-default-agent.sh),
+    # which is the all-in-one gateway+agent dev launcher: it requires
+    # POSTGRES_DB_URI, self-registers a "default" agent in that DB, and
+    # rewrites HOOP_KEY to point at a LOCAL gateway (127.0.0.1:8010). That is
+    # wrong here and crash-loops without a DB. `hoop start agent` reads HOOP_KEY
+    # from the environment directly. It is passed as the OCR supervisor
+    # entrypoint's "$@", so the bundled OCR engine still starts first.
+    command: ["hoop", "start", "agent"]
+    depends_on:
+      presidio-analyzer:
+        condition: service_healthy
+    environment:
+      # Connection DSN to the existing gateway (grpcs://name:secret@host:8010?mode=standard).
+      # Used by the Go agent (gRPC) for SSH/DB/etc.
+      - HOOP_KEY=${HOOP_KEY}
+      # Gateway HTTP/WS base URL. REQUIRED for the RDP path: `hoop start agent`
+      # only launches the Rust agent (hoop_rs / agentrs) — which runs the RDP
+      # proxy and the realtime PII guard — when this is set. agentrs appends
+      # /api/ws and maps https:// -> wss://, so this is the API endpoint
+      # (typically port 443), NOT the gRPC endpoint used in HOOP_KEY.
+      - HOOP_GATEWAY_URL=${HOOP_GATEWAY_URL}
+      # Presidio analyzer the agent calls for PII detection. The agent's
+      # supports_pii_guard capability is true only when BOTH this and the
+      # baked-in RDP_OCR_SERVER_URL are set.
+      - MSPRESIDIO_ANALYZER_URL=http://presidio-analyzer:3000
+      # OCR workers; each holds its own model copy in the T4's VRAM. 4 fits
+      # comfortably in 16GB. Tune down if you see VRAM pressure.
+      - WEB_CONCURRENCY=${WEB_CONCURRENCY:-4}
+    # Give the bundled engine GPUs via the nvidia container runtime.
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    # The engine takes ~30-120s to load models on first start; keep the
+    # container from being marked unhealthy too early at the orchestrator
+    # level (the entrypoint already gates on OCR health internally).
+    stop_grace_period: 30s
+
+  presidio-analyzer:
+    image: mcr.microsoft.com/presidio-analyzer:2.2.360
+    restart: unless-stopped
+    # Analyzer is internal-only; do not publish a host port. The agent reaches
+    # it over the compose network at http://presidio-analyzer:3000.
+    expose:
+      - "3000"
+    # The Presidio image is Python-based and does NOT ship curl, so the health
+    # probe uses urllib. /health returns 200 once the recognizers are loaded
+    # (~30-60s on first boot). The agent's depends_on waits for this so it
+    # never advertises PII-guard capability before the analyzer can answer.
+    healthcheck:
+      test:
+        - "CMD"
+        - "python3"
+        - "-c"
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:3000/health',timeout=3).status==200 else 1)"
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 90s

--- a/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
@@ -69,8 +69,9 @@ stringData:
   RDP_PII_SCORE_THRESHOLD: '{{ .Values.config.RDP_PII_SCORE_THRESHOLD | default "0.9" }}'
   RDP_PII_ENTITY_DENYLIST: '{{ .Values.config.RDP_PII_ENTITY_DENYLIST | default "DATE_TIME,NRP" }}'
   # Action the agent-side realtime PII guard takes on detection:
-  # kill (default), redact (blank the PII and continue), or redact_and_kill.
-  RDP_PII_GUARD_POLICY: '{{ .Values.config.RDP_PII_GUARD_POLICY | default "kill" }}'
+  # redact (default: blank the PII and keep the session alive), kill (drop and
+  # terminate), or redact_and_kill.
+  RDP_PII_GUARD_POLICY: '{{ .Values.config.RDP_PII_GUARD_POLICY | default "redact" }}'
   RDP_OCR_SERVER_URL: '{{ .Values.config.RDP_OCR_SERVER_URL }}'
   WEBHOOK_APPKEY: '{{ .Values.config.WEBHOOK_APPKEY }}'
   WEBHOOK_APPURL: '{{ .Values.config.WEBHOOK_APPURL }}'

--- a/deploy/helm-chart/chart/gateway/values.yaml
+++ b/deploy/helm-chart/chart/gateway/values.yaml
@@ -154,9 +154,10 @@ config:
   # RDP_PII_SCORE_THRESHOLD: '0.9'
   # RDP_PII_ENTITY_DENYLIST: 'DATE_TIME,NRP'
   #
-  # Realtime agent-side PII guard action on detection: kill (default), redact
-  # (blank the PII region and continue the session), or redact_and_kill.
-  # RDP_PII_GUARD_POLICY: 'kill'
+  # Realtime agent-side PII guard action on detection: redact (default: blank
+  # the PII region and continue the session), kill (drop and terminate), or
+  # redact_and_kill.
+  # RDP_PII_GUARD_POLICY: 'redact'
   #
   # Optional OCR sidecar (RapidOCR/PaddleOCR HTTP server) used instead of the
   # local tesseract subprocess for RDP PII analysis — measured ~10x faster

--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -215,11 +215,18 @@ func Load() error {
 	} else {
 		rdpPIIEntityDenylist = []string{"DATE_TIME", "NRP"}
 	}
-	// What the agent-side guard does on detection: kill (default, preserve
-	// the original behavior), redact (blank the PII and continue), or
-	// redact_and_kill. Gateway-wide default; a per-connection override is a
-	// future enhancement.
-	rdpPIIGuardPolicy := "kill"
+	// What the agent-side guard does on detection: redact (default: blank the
+	// PII region and keep the session alive), kill (drop the batch and
+	// terminate), or redact_and_kill. Gateway-wide default; a per-connection
+	// override is a future enhancement.
+	//
+	// The default is redact, not kill: killing the session on the first
+	// detected entity (e.g. an EMAIL_ADDRESS rendered anywhere on the desktop)
+	// makes the guard unusable as a default — the user gets a black screen with
+	// no feedback within seconds. Redact keeps the session usable while still
+	// preventing PII from reaching the client. Operators who want hard
+	// termination must opt in explicitly with kill/redact_and_kill.
+	rdpPIIGuardPolicy := "redact"
 	switch v := os.Getenv("RDP_PII_GUARD_POLICY"); v {
 	case "kill", "redact", "redact_and_kill":
 		rdpPIIGuardPolicy = v

--- a/scripts/dev/ocr-poc/Dockerfile.rapidocr-gpu
+++ b/scripts/dev/ocr-poc/Dockerfile.rapidocr-gpu
@@ -20,13 +20,39 @@ RUN apt-get update && \
         python3 python3-pip libglib2.0-0 libgl1 libxcb1 libsm6 libxext6 && \
     rm -rf /var/lib/apt/lists/*
 
-# onnxruntime-gpu 1.19+ targets CUDA 12 + cuDNN 9 (both in the base image).
-# Bounded pins: open-ended ranges make benchmark numbers non-reproducible.
+# onnxruntime-gpu must be pinned to the CUDA 12 line. 1.21+ moved to CUDA 13
+# (needs libcudart.so.13) while declaring NO nvidia/* runtime deps, so an
+# open-ended pin resolved to 1.27 and crashed at import even on this CUDA 12
+# base. 1.20.1 is the last CUDA 12 release.
+#
+# The full CUDA 12 runtime wheel set is installed explicitly and EXACT-pinned
+# (cudart, cublas, cudnn, curand, cufft, nvrtc, nvjitlink) so the engine is
+# self-contained, reproducible, and not reliant on the exact base-image library
+# set — in particular this base ships cuDNN 8 while onnxruntime 1.20 needs
+# cuDNN 9. A partial set silently falls back to CPU ("shifted to be executed
+# under CPUExecutionProvider"), which a GPU image must never do. Versions are
+# the set validated on a T4 (ldd resolves all provider deps; device=
+# onnxruntime-cuda, no CPU fallback). Keep in sync with Dockerfile.agent-ocr-gpu.
 RUN pip3 install --no-cache-dir \
-    "rapidocr>=3.1,<4" \
-    "onnxruntime-gpu>=1.19,<2" \
-    "fastapi>=0.115,<1" \
-    "uvicorn>=0.30,<1"
+    "rapidocr==3.8.4" \
+    "onnxruntime-gpu==1.20.1" \
+    "nvidia-cuda-runtime-cu12==12.9.79" \
+    "nvidia-cublas-cu12==12.9.2.10" \
+    "nvidia-cudnn-cu12==9.23.2.1" \
+    "nvidia-curand-cu12==10.3.10.19" \
+    "nvidia-cufft-cu12==11.4.1.4" \
+    "nvidia-cuda-nvrtc-cu12==12.9.86" \
+    "nvidia-nvjitlink-cu12==12.9.86" \
+    "fastapi==0.138.0" \
+    "uvicorn==0.49.0"
+# Symlink every CUDA .so into a fixed directory and put only that on the loader
+# path, instead of hardcoding the python-minor dist-packages location (a rebuild
+# trap if the base image's python changes). Without this the CUDA execution
+# provider fails to load and inference silently falls back to CPU.
+RUN mkdir -p /opt/cuda-libs && \
+    find /usr -path '*/nvidia/*/lib/*.so*' -exec ln -s {} /opt/cuda-libs/ \; && \
+    test -e /opt/cuda-libs/libcudart.so.12 && test -e /opt/cuda-libs/libcublasLt.so.12
+ENV LD_LIBRARY_PATH="/opt/cuda-libs"
 
 COPY device_policy.py server_rapidocr.py /app/
 # Parallel inference workers: uvicorn forks $WEB_CONCURRENCY processes, each


### PR DESCRIPTION
Three fixes for the agent-side RDP PII guard on GPU:

1. **Repair the GPU OCR image** — it crash-looped on `libcudart.so.13`. Pin `onnxruntime-gpu==1.20.1` (CUDA 12), ship the full CUDA-12 runtime wheels, and resolve them via a `/opt/cuda-libs` symlink farm. Validated on a T4: `device=onnxruntime-cuda`, no CPU fallback.
2. **Default policy `kill` → `redact`** (behavior change). `kill` killed the session on the first detected entity → black screen in seconds. Changed in code + helm + `.env.sample`.
3. **Add `deploy/docker-compose/docker-compose.gcp-gpu-agent.yml`** — single-VM GCE+T4 deploy.

Automated by MisterMal