### PR TITLE
feat: surface gcp_oauth (BigQuery) consent flow in MCP exec & reviews

### DIFF
--- a/client/cmd/connect.go
+++ b/client/cmd/connect.go
@@ -29,6 +29,7 @@ import (
 	pbagent "github.com/hoophq/hoop/common/proto/agent"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
 	"github.com/hoophq/hoop/common/version"
+	"github.com/hoophq/hoop/gateway/federation"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc/codes"
@@ -602,7 +603,7 @@ func (c *connect) processGracefulExit(err error) {
 	// tags that error with a stable marker; turn it into an actionable
 	// "connect your account" prompt with a clickable consent link instead of a
 	// raw rpc error. This never returns when it matches.
-	if connectionName, ok := parseFederationOAuthNotConnected(err.Error()); ok {
+	if connectionName, ok := federation.ParseOAuthNotConnected(err.Error()); ok {
 		printFederationOAuthConsentAndExit(c.apiURL, c.token, c.tlsCA, c.jsonMode, connectionName, err)
 	}
 	for _, obj := range c.connStore.List() {

--- a/client/cmd/connect_federation_oauth.go
+++ b/client/cmd/connect_federation_oauth.go
@@ -14,36 +14,6 @@ import (
 	"github.com/hoophq/hoop/common/log"
 )
 
-// federationOAuthNotConnectedCode is the stable, machine-readable marker the
-// gateway embeds in the session-open precondition error when a per-user
-// federation provider (gcp_oauth) has no stored credential for the user. See
-// gateway/transport/client.go.
-const federationOAuthNotConnectedCode = "code=oauth_not_connected"
-
-// parseFederationOAuthNotConnected reports whether errMsg is the gateway's
-// "user has not connected their account" precondition error and, when present,
-// extracts the connection name from the `connection=<name>` tag. Matching on
-// the stable code (not the human-readable text) keeps this resilient to message
-// wording changes, and works whether errMsg is a raw rpc error string or an
-// HTTP error body that embeds it.
-func parseFederationOAuthNotConnected(errMsg string) (connectionName string, ok bool) {
-	if !strings.Contains(errMsg, federationOAuthNotConnectedCode) {
-		return "", false
-	}
-	const marker = "connection="
-	idx := strings.Index(errMsg, marker)
-	if idx == -1 {
-		return "", true
-	}
-	rest := errMsg[idx+len(marker):]
-	// The tag is rendered as "[code=oauth_not_connected connection=<name>]";
-	// the name ends at the first space or closing bracket.
-	if end := strings.IndexAny(rest, " ]"); end != -1 {
-		return strings.TrimSpace(rest[:end]), true
-	}
-	return strings.TrimSpace(rest), true
-}
-
 // printFederationOAuthConsentAndExit renders an actionable "connect your Google
 // account" prompt in place of the raw error, fetching the consent URL from the
 // gateway with the user's stored access token and best-effort opening the

--- a/client/cmd/exec.go
+++ b/client/cmd/exec.go
@@ -23,6 +23,7 @@ import (
 	pbagent "github.com/hoophq/hoop/common/proto/agent"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
 	"github.com/hoophq/hoop/common/version"
+	"github.com/hoophq/hoop/gateway/federation"
 	"github.com/spf13/cobra"
 )
 
@@ -365,7 +366,7 @@ func runExecSession(sessionID string) {
 		// not connected their per-user account (gcp_oauth consent). Surface an
 		// actionable consent link instead of the raw error body. The connection
 		// name is recovered from the stable marker embedded in the error.
-		if connectionName, ok := parseFederationOAuthNotConnected(string(body)); ok {
+		if connectionName, ok := federation.ParseOAuthNotConnected(string(body)); ok {
 			printFederationOAuthConsentAndExit(config.ApiURL, config.Token, config.TlsCA(), jsonMode,
 				connectionName, fmt.Errorf("%s", string(body)))
 		}

--- a/gateway/api/connections/connection_federation_oauth.go
+++ b/gateway/api/connections/connection_federation_oauth.go
@@ -78,6 +78,119 @@ func federationOAuthRedirectURI() string {
 	return appconfig.Get().FullApiURL() + federationOAuthCallbackPath
 }
 
+// Sentinel errors returned by BuildFederationConsentURL so callers can map a
+// known condition to the right transport-level status (HTTP code, MCP
+// envelope) without string matching.
+var (
+	// ErrFederationNoUser indicates the consent flow was started without an
+	// authenticated user (no user id/email on the request context).
+	ErrFederationNoUser = errors.New("an authenticated user is required to start the consent flow")
+	// ErrFederationConnectionNotFound indicates the connection does not exist
+	// or is not visible to the calling user.
+	ErrFederationConnectionNotFound = errors.New("connection not found")
+	// ErrFederationNotConfigured indicates the connection has no federation
+	// configuration, so there is nothing to consent to.
+	ErrFederationNotConfigured = errors.New("federation not configured for this connection")
+	// ErrFederationNotGCPOAuth indicates the connection is federated with a
+	// provider other than gcp_oauth, which has no per-user consent flow.
+	ErrFederationNotGCPOAuth = errors.New("the OAuth consent flow is only available for gcp_oauth federation")
+)
+
+// BuildFederationConsentURL mints the Google OAuth consent URL the authenticated
+// user must visit to connect their Google account to a gcp_oauth-federated
+// connection. It performs the same connection lookup (access-control aware via
+// ctx), gcp_oauth guard, and single-use state creation as the
+// AuthorizeFederationOAuth HTTP handler, and is shared by that handler and the
+// in-process MCP exec path so both mint identical URLs without a self-HTTP
+// round trip.
+//
+// redirectBack is the URL the browser returns to after consent; pass "" (e.g.
+// from non-browser MCP callers) to default to the app root. Errors are the
+// sentinels above for known conditions, or a wrapped error for unexpected
+// failures, so callers can map them to the appropriate status.
+func BuildFederationConsentURL(ctx *storagev2.Context, nameOrID, redirectBack string) (string, error) {
+	if ctx.GetUserID() == "" || ctx.UserEmail == "" {
+		return "", ErrFederationNoUser
+	}
+
+	conn, err := models.GetConnectionByNameOrID(ctx, nameOrID)
+	if err != nil {
+		return "", fmt.Errorf("failed fetching connection: %w", err)
+	}
+	if conn == nil {
+		return "", ErrFederationConnectionNotFound
+	}
+
+	cfg, err := models.GetConnectionFederationConfig(models.DB, ctx.GetOrgID(), conn.ID)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			return "", ErrFederationNotConfigured
+		}
+		return "", fmt.Errorf("failed fetching federation config: %w", err)
+	}
+	if cfg.BuiltinProvider == nil || *cfg.BuiltinProvider != models.FederationProviderGCPOAuth {
+		return "", ErrFederationNotGCPOAuth
+	}
+
+	clientCfg, err := decodeFederationOAuthClient(cfg.AdminCredentialsEncrypted)
+	if err != nil {
+		return "", fmt.Errorf("failed loading oauth client config: %w", err)
+	}
+
+	if redirectBack == "" {
+		redirectBack = appconfig.Get().FullApiURL() + "/"
+	}
+
+	state := &models.FederationOAuthState{
+		ID:           uuid.NewString(),
+		OrgID:        ctx.GetOrgID(),
+		ConnectionID: conn.ID,
+		UserID:       ctx.GetUserID(),
+		UserEmail:    ctx.UserEmail,
+		RedirectURL:  redirectBack,
+	}
+	if err := models.CreateFederationOAuthState(models.DB, state); err != nil {
+		return "", fmt.Errorf("failed creating oauth state: %w", err)
+	}
+
+	conf := federationOAuthConfig(clientCfg, scopesFromConfig(cfg.ExtraConfig))
+	// AccessTypeOffline + prompt=consent forces Google to return a refresh
+	// token on every consent, even for a returning user. Without both, a
+	// second authorization returns only an access token and we would have no
+	// refresh token to persist.
+	return conf.AuthCodeURL(state.ID,
+		oauth2.AccessTypeOffline,
+		oauth2.SetAuthURLParam("prompt", "consent"),
+	), nil
+}
+
+// FederationConsentRequired reports whether running connectionID as userID
+// would be denied because the connection is federated with a per-user provider
+// (gcp_oauth) for which the user has not yet connected their account. When it
+// returns true the caller should surface the consent flow
+// (BuildFederationConsentURL) instead of opening a session and incurring its
+// side effects (audit rows, AI analysis, Jira tickets). A connection with no
+// federation config, or a non-gcp_oauth provider, never requires consent.
+func FederationConsentRequired(orgID, connectionID, userID string) (bool, error) {
+	cfg, err := models.GetConnectionFederationConfig(models.DB, orgID, connectionID)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if cfg.BuiltinProvider == nil || *cfg.BuiltinProvider != models.FederationProviderGCPOAuth {
+		return false, nil
+	}
+	if _, err := models.GetFederationUserCredential(models.DB, orgID, connectionID, userID); err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
+}
+
 // AuthorizeFederationOAuth
 //
 //	@Summary		Start the Google OAuth consent flow for a connection
@@ -91,40 +204,6 @@ func federationOAuthRedirectURI() string {
 //	@Router			/connections/{nameOrID}/federation/oauth/authorize [get]
 func AuthorizeFederationOAuth(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
-	if ctx.GetUserID() == "" || ctx.UserEmail == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"message": "an authenticated user is required to start the consent flow"})
-		return
-	}
-
-	conn, err := models.GetConnectionByNameOrID(ctx, c.Param("nameOrID"))
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching connection: %v", err)
-		return
-	}
-	if conn == nil {
-		c.JSON(http.StatusNotFound, gin.H{"message": "connection not found"})
-		return
-	}
-
-	cfg, err := models.GetConnectionFederationConfig(models.DB, ctx.GetOrgID(), conn.ID)
-	if err != nil {
-		if errors.Is(err, models.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"message": "federation not configured for this connection"})
-			return
-		}
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching federation config: %v", err)
-		return
-	}
-	if cfg.BuiltinProvider == nil || *cfg.BuiltinProvider != models.FederationProviderGCPOAuth {
-		c.JSON(http.StatusConflict, gin.H{"message": "the OAuth consent flow is only available for gcp_oauth federation"})
-		return
-	}
-
-	clientCfg, err := decodeFederationOAuthClient(cfg.AdminCredentialsEncrypted)
-	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed loading oauth client config: %v", err)
-		return
-	}
 
 	redirectBack, err := parseFederationRedirect(c)
 	if err != nil {
@@ -132,29 +211,21 @@ func AuthorizeFederationOAuth(c *gin.Context) {
 		return
 	}
 
-	state := &models.FederationOAuthState{
-		ID:           uuid.NewString(),
-		OrgID:        ctx.GetOrgID(),
-		ConnectionID: conn.ID,
-		UserID:       ctx.GetUserID(),
-		UserEmail:    ctx.UserEmail,
-		RedirectURL:  redirectBack,
+	authURL, err := BuildFederationConsentURL(ctx, c.Param("nameOrID"), redirectBack)
+	switch {
+	case err == nil:
+		c.JSON(http.StatusOK, openapi.FederationOAuthAuthorizeResponse{URL: authURL})
+	case errors.Is(err, ErrFederationNoUser):
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+	case errors.Is(err, ErrFederationConnectionNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"message": err.Error()})
+	case errors.Is(err, ErrFederationNotConfigured):
+		c.JSON(http.StatusNotFound, gin.H{"message": err.Error()})
+	case errors.Is(err, ErrFederationNotGCPOAuth):
+		c.JSON(http.StatusConflict, gin.H{"message": err.Error()})
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "%v", err)
 	}
-	if err := models.CreateFederationOAuthState(models.DB, state); err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating oauth state: %v", err)
-		return
-	}
-
-	conf := federationOAuthConfig(clientCfg, scopesFromConfig(cfg.ExtraConfig))
-	// AccessTypeOffline + prompt=consent forces Google to return a refresh
-	// token on every consent, even for a returning user. Without both, a
-	// second authorization returns only an access token and we would have no
-	// refresh token to persist.
-	authURL := conf.AuthCodeURL(state.ID,
-		oauth2.AccessTypeOffline,
-		oauth2.SetAuthURLParam("prompt", "consent"),
-	)
-	c.JSON(http.StatusOK, openapi.FederationOAuthAuthorizeResponse{URL: authURL})
 }
 
 // FederationOAuthCallback

--- a/gateway/api/mcpserver/federation.go
+++ b/gateway/api/mcpserver/federation.go
@@ -1,0 +1,53 @@
+package mcpserver
+
+import (
+	"github.com/hoophq/hoop/common/log"
+	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
+	"github.com/hoophq/hoop/gateway/clientexec"
+	"github.com/hoophq/hoop/gateway/federation"
+	"github.com/hoophq/hoop/gateway/storagev2"
+)
+
+// oauthRequiredEnvelope builds the actionable MCP response returned when a
+// gcp_oauth-federated connection requires the user to connect their Google
+// account before a session can run. It mints the consent URL in-process (no
+// self-HTTP); when URL minting fails the envelope still tells the user how to
+// connect via the web app so the underlying cause is never silently swallowed.
+//
+// An MCP server cannot open the user's browser, so the consent URL is returned
+// in the tool result for the agent to relay to the human.
+func oauthRequiredEnvelope(sc *storagev2.Context, connectionName string) map[string]any {
+	env := map[string]any{
+		"status":          "oauth_required",
+		"connection_name": connectionName,
+		"message": "This connection runs queries as your own Google identity and needs your Google " +
+			"account connected. Open consent_url in a browser to authorize, then run the command again.",
+		"next_step": "open consent_url, approve access, then retry the command",
+	}
+	consentURL, err := apiconnections.BuildFederationConsentURL(sc, connectionName, "")
+	if err != nil {
+		log.Warnf("mcp: failed building federation consent url for connection %q: %v", connectionName, err)
+		env["error"] = "could not build the Google consent link automatically; open the Hoop web app and " +
+			"connect your Google account for this connection, then retry"
+	} else {
+		env["consent_url"] = consentURL
+	}
+	return env
+}
+
+// federationConsentEnvelopeFromResponse returns an oauth_required envelope when
+// a clientexec response carries the gateway's stable "user not connected"
+// federation marker, and false otherwise. It is the response-stage safety net
+// for the session-open federation gate — e.g. the user disconnected their
+// account between the preflight check and the run, or a reviewed session hits
+// the gate — so callers fall through to their normal envelope when not matched.
+func federationConsentEnvelopeFromResponse(sc *storagev2.Context, resp *clientexec.Response) (map[string]any, bool) {
+	if resp == nil || resp.OutputStatus != "failed" {
+		return nil, false
+	}
+	name, ok := federation.ParseOAuthNotConnected(resp.Output)
+	if !ok {
+		return nil, false
+	}
+	return oauthRequiredEnvelope(sc, name), true
+}

--- a/gateway/api/mcpserver/tools_exec.go
+++ b/gateway/api/mcpserver/tools_exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	pb "github.com/hoophq/hoop/common/proto"
 	"github.com/hoophq/hoop/gateway/analytics"
+	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	sessionapi "github.com/hoophq/hoop/gateway/api/session"
 	"github.com/hoophq/hoop/gateway/appconfig"
@@ -72,6 +73,17 @@ func execHandler(ctx context.Context, _ *mcp.CallToolRequest, args execInput) (*
 	}
 	if conn == nil {
 		return errResult(fmt.Sprintf("connection %q not found or not accessible", args.ConnectionName)), nil, nil
+	}
+
+	// Preflight the per-user federation gate. A gcp_oauth-federated connection
+	// (e.g. BigQuery) runs as the user's own Google identity; if the user has
+	// not connected their account the session-open would be denied. Surface the
+	// consent flow now, before incurring exec side effects (audit row, AI
+	// analysis, Jira ticket creation).
+	if consentRequired, err := apiconnections.FederationConsentRequired(sc.GetOrgID(), conn.ID, sc.GetUserID()); err != nil {
+		return nil, nil, fmt.Errorf("failed checking federation consent status: %w", err)
+	} else if consentRequired {
+		return jsonResult(oauthRequiredEnvelope(sc, conn.Name))
 	}
 
 	trackClient := analytics.New()
@@ -236,6 +248,12 @@ func execHandler(ctx context.Context, _ *mcp.CallToolRequest, args execInput) (*
 
 	select {
 	case resp := <-respCh:
+		// Safety net for the session-open federation gate: if the user
+		// disconnected their account between the preflight and the run, the
+		// gate denies the session and tags the error with the stable marker.
+		if env, ok := federationConsentEnvelopeFromResponse(sc, resp); ok {
+			return jsonResult(env)
+		}
 		return execResponseToEnvelope(resp, sessionID)
 	case <-timeoutCtx.Done():
 		// Force the goroutine to unblock; its result will be persisted async.

--- a/gateway/api/mcpserver/tools_reviews.go
+++ b/gateway/api/mcpserver/tools_reviews.go
@@ -181,6 +181,13 @@ func reviewsExecuteHandler(ctx context.Context, _ *mcp.CallToolRequest, args rev
 
 	select {
 	case resp := <-respCh:
+		// Session-open federation gate: the user must connect their per-user
+		// account (gcp_oauth) before this approved query can run. Keep the
+		// review APPROVED (not EXECUTED) so it can be retried after consent.
+		if oauthEnv, ok := federationConsentEnvelopeFromResponse(sc, resp); ok {
+			reviewStatus = models.ReviewStatusApproved
+			return jsonResult(oauthEnv)
+		}
 		env := map[string]any{
 			"session_id":        resp.SessionID,
 			"output":            resp.Output,

--- a/gateway/federation/federation.go
+++ b/gateway/federation/federation.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hoophq/hoop/gateway/models"
@@ -32,6 +33,49 @@ import (
 // wrap it (fmt.Errorf("...: %w", federation.ErrUserNotConnected)) so the
 // human-readable context is preserved alongside the sentinel.
 var ErrUserNotConnected = errors.New("user has not connected an account for this connection")
+
+// OAuthNotConnectedCode is the stable, machine-readable marker the session-open
+// path embeds in the precondition error when a per-user federation provider
+// (gcp_oauth) has no stored credential for the calling user. Clients match on
+// this code — not the human-readable text — so the detection survives wording
+// changes. The full tag is rendered as
+// "[code=oauth_not_connected connection=<name>]".
+//
+// This constant is the single source of truth for the contract shared by the
+// producer (gateway/transport/client.go), the CLI (client/cmd), and the MCP
+// server (gateway/api/mcpserver). Do not duplicate it.
+const OAuthNotConnectedCode = "code=oauth_not_connected"
+
+// FormatOAuthNotConnected renders the stable, machine-readable tag the
+// session-open path appends to the precondition error when ErrUserNotConnected
+// is hit, embedding the connection name so clients can name the resource and
+// fetch its consent URL.
+func FormatOAuthNotConnected(connectionName string) string {
+	return fmt.Sprintf("[%s connection=%s]", OAuthNotConnectedCode, connectionName)
+}
+
+// ParseOAuthNotConnected reports whether errMsg carries the
+// OAuthNotConnectedCode marker and, when present, extracts the connection name
+// from the `connection=<name>` tag. It works whether errMsg is a raw rpc error
+// string or an HTTP error body that embeds it. ok is true whenever the code is
+// present, even if the connection name could not be recovered.
+func ParseOAuthNotConnected(errMsg string) (connectionName string, ok bool) {
+	if !strings.Contains(errMsg, OAuthNotConnectedCode) {
+		return "", false
+	}
+	const marker = "connection="
+	idx := strings.Index(errMsg, marker)
+	if idx == -1 {
+		return "", true
+	}
+	rest := errMsg[idx+len(marker):]
+	// The tag is rendered as "[code=oauth_not_connected connection=<name>]";
+	// the name ends at the first space or closing bracket.
+	if end := strings.IndexAny(rest, " ]"); end != -1 {
+		return strings.TrimSpace(rest[:end]), true
+	}
+	return strings.TrimSpace(rest), true
+}
 
 // Result is the resolved per-session output of a federation provider. Callers
 // must merge EnvVars into the connection's secret map (base64-encoding values)

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -531,8 +531,8 @@ func resolveFederationForSession(pctx *plugintypes.Context, stream *streamclient
 			// affordance instead of a raw error string.
 			if errors.Is(resolveErr, federation.ErrUserNotConnected) {
 				return status.Errorf(codes.FailedPrecondition,
-					"federation failed [code=oauth_not_connected connection=%s]: %v",
-					pctx.ConnectionName, resolveErr)
+					"federation failed %s: %v",
+					federation.FormatOAuthNotConnected(pctx.ConnectionName), resolveErr)
 			}
 			return status.Errorf(codes.FailedPrecondition, "federation failed: %v", resolveErr)
 		}


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Brings the per-user OAuth federation consent flow (`gcp_oauth`, e.g. BigQuery) to the
MCP server, and refactors the "user not connected" contract into a single shared source
of truth in `gateway/federation`.

Until now only the CLI (`hoop connect` / `hoop exec`) could detect a `gcp_oauth`-federated
connection the user hadn't connected yet and turn the raw `FailedPrecondition` error into
an actionable consent link. MCP agents calling `exec` or `reviews_execute` against such a
connection just got an opaque failure. Now the MCP server preflights the federation gate
**before** incurring exec side effects (audit row, AI analysis, Jira ticket) and returns an
`oauth_required` envelope with a `consent_url` the agent can relay to the human (an MCP
server can't open a browser itself).

Along the way the stable `oauth_not_connected` marker (constant + formatter + parser) and
the consent-URL minting logic are de-duplicated so the producer (transport), the CLI, and
the MCP server all share well-documented helpers instead of copy-pasted string matching.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Add `gateway/federation` as the single source of truth for the `oauth_not_connected` contract: `OAuthNotConnectedCode`, `FormatOAuthNotConnected()`, and `ParseOAuthNotConnected()`. Remove the duplicated constant/parser from `client/cmd/connect_federation_oauth.go`; `client/cmd/connect.go` and `client/cmd/exec.go` now consume the shared parser.
- `gateway/transport/client.go` now renders the precondition marker via `federation.FormatOAuthNotConnected()` instead of an inline format string.
- Extract consent-URL minting out of the HTTP handler into reusable `BuildFederationConsentURL(ctx, nameOrID, redirectBack)` with typed sentinel errors (`ErrFederationNoUser`, `ErrFederationConnectionNotFound`, `ErrFederationNotConfigured`, `ErrFederationNotGCPOAuth`); `AuthorizeFederationOAuth` maps the sentinels back to HTTP statuses. This lets the MCP path mint the same URL in-process with no self-HTTP round trip.
- New `gateway/api/mcpserver/federation.go`: `oauthRequiredEnvelope()` builds the actionable `oauth_required` MCP result (with `consent_url`, or a fallback "connect via the web app" message if URL minting fails), and `federationConsentEnvelopeFromResponse()` is the response-stage safety net for the session-open gate.
- `tools_exec.go`: preflight `FederationConsentRequired()` before exec so no side effects occur when consent is missing, plus the response-stage safety net for accounts disconnected mid-flight.
- `tools_reviews.go`: when an approved review hits the federation gate, keep the review `APPROVED` (not `EXECUTED`) so it can be retried after the user consents.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (no UI changes)
- **OS**: macOS (darwin)

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

<img width="754" height="625" alt="image" src="https://github.com/user-attachments/assets/8519127c-7365-47e8-bd2f-77bf0fac4103" />
<img width="754" height="625" alt="image" src="https://github.com/user-attachments/assets/f2b061fd-a292-40b6-8422-b6eeb23bb7c4" />

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Reviewer focus: the `oauth_not_connected` contract now has one producer
(`gateway/transport/client.go` via `FormatOAuthNotConnected`) and three consumers
(CLI, MCP, and the response-stage safety net) — worth confirming the marker format and
parser stay in lockstep. Also worth a look: the MCP exec preflight returns **before**
`analytics.New()`/`TrackRequest`, which is intentional (no exec happened, so no exec event
is emitted) but changes the early-return path.

No DB migrations, no new env vars, no analytics events added or removed.