### PR TITLE
ci: auto-deploy released versions to remaining hoopcloud envs (ENG-476)

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -17,9 +17,11 @@ name: Auto Deploy
 # Canary ordering (mirrors infra's "Deploy All Instances"):
 #   - Demo environments (appdemo, hoopdemo) and the sandbox canary deploy in
 #     parallel as soon as the release succeeds.
-#   - Customer environments (tryrunops) deploy only after the sandbox deploy
-#     succeeds, so a broken release is caught on sandbox before it reaches a
-#     customer. A failing demo never blocks a customer deploy.
+#   - Customer and production environments (tryrunops, enjoei, rdstation, unico,
+#     dock, multitenant) deploy only after the sandbox deploy succeeds, so a
+#     broken release is caught on sandbox before it reaches a customer or the
+#     production cloud. They then roll out in parallel with each other. A
+#     failing demo never blocks a customer deploy.
 # Each deploy reuses the local composite action .github/actions/deploy-app,
 # which dispatches infra's "Deploy By App" and waits for it to finish.
 on:
@@ -100,15 +102,18 @@ jobs:
 
   deploy-customers:
     name: Deploy ${{ matrix.app }}
-    # Gate customer environments on the sandbox canary specifically: they only
-    # deploy once sandbox has upgraded successfully. (resolve-version is also
+    # Gate customer and production environments on the sandbox canary
+    # specifically: they only deploy once sandbox has upgraded successfully,
+    # then roll out in parallel with each other. (resolve-version is also
     # needed here to read its version output.)
     needs: [resolve-version, deploy-canary]
     runs-on: ubuntu-latest
     strategy:
+      # Independent namespaces — if one fails, still attempt the others and let
+      # each report its own status.
       fail-fast: false
       matrix:
-        app: [tryrunops]
+        app: [tryrunops, enjoei, rdstation, unico, dock, multitenant]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/deploy-app


### PR DESCRIPTION
## 📝 Description

Expands the auto-deploy pipeline to cover every `hoopcloud` environment that exists in `hoophq/infra` but was not yet auto-deployed on release. Previously the pipeline only deployed `appdemo`, `hoopdemo` (demos), `sandbox` (canary) and `tryrunops` (customer). This adds the remaining five: `enjoei`, `rdstation`, `unico`, `dock` and `multitenant`.

## 🔗 Related Issue

[ENG-476 — Expand the auto-deploy pipeline to other environments](https://linear.app/hoophq/issue/ENG-476/expand-the-auto-deploy-pipeline-to-other-environments-we-already-have)

## 🚀 Type of Change

- [x] 🔧 Build configuration change

## 📋 Changes Made

- Extend the `deploy-customers` matrix in `.github/workflows/auto-deploy.yml` from `[tryrunops]` to `[tryrunops, enjoei, rdstation, unico, dock, multitenant]`.
- Update the header and job comments so the documented canary ordering stays accurate.

## 🧪 Testing

No application code is touched — this is a GitHub Actions workflow change. Validated the workflow YAML parses cleanly, and confirmed each new environment already has the infra resources `deploy-by-app.yml` requires (a `hoopcloud/<app>/values.yml` and the `hoop/self-hosted/<app>` secret convention), so no infra changes are needed.

### Tests performed:
- [x] Workflow YAML validated
- [x] Verified `hoopcloud/<app>/values.yml` exists in `hoophq/infra` for all five new envs

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

The rollout faithfully mirrors infra's "Deploy All Instances" (`deploy.yml`), where these same six environments all use `needs: [deploy-sandbox]`:

```
Hoop Release succeeds
   ├─ deploy-demos (parallel, no gate):  appdemo, hoopdemo
   └─ deploy-canary:                     sandbox
         └─ deploy-customers (parallel after sandbox passes):
               tryrunops, enjoei, rdstation, unico, dock, multitenant
```

Heads-up for reviewers: `multitenant` is the **production multi-tenant cloud** — it now auto-deploys on every release. It is protected behind the `sandbox` canary gate (a broken release fails on sandbox before any customer/prod env upgrades), and `fail-fast: false` keeps one failing namespace from aborting the others.
