### PR TITLE
fix(webapp): restore connection metadata download in release build

### DIFF
--- a/webapp/scripts/download-connection-metadata.sh
+++ b/webapp/scripts/download-connection-metadata.sh
@@ -31,62 +31,62 @@ else
     echo "  Using unauthenticated request (no token)"
 fi
 
-# HTTP_CODE=$(curl "${CURL_ARGS[@]}" \
-#      "https://api.github.com/repos/$ORG/$REPO/contents/$FILE")
+HTTP_CODE=$(curl "${CURL_ARGS[@]}" \
+     "https://api.github.com/repos/$ORG/$REPO/contents/$FILE")
 
-# echo "HTTP Status: $HTTP_CODE"
+echo "HTTP Status: $HTTP_CODE"
 
-# # Check if download was successful
-# if [ -f "$OUTPUT_DIR/$OUTPUT_FILE" ]; then
-#     FILE_SIZE=$(wc -c < "$OUTPUT_DIR/$OUTPUT_FILE" | tr -d ' ')
-#     echo "✓ Download complete: $OUTPUT_DIR/$OUTPUT_FILE"
-#     echo "  File size: $FILE_SIZE bytes"
-    
-#     # Check HTTP status code
-#     if [ "$HTTP_CODE" -ne 200 ]; then
-#         echo "⚠ Warning: HTTP Status $HTTP_CODE (expected 200)"
-#         echo "  Response content:"
-#         head -n 5 "$OUTPUT_DIR/$OUTPUT_FILE" | sed 's/^/    /'
-        
-#         # Handle specific error codes
-#         case $HTTP_CODE in
-#             429)
-#                 echo ""
-#                 echo "ERROR: Rate limit exceeded (429 Too Many Requests)"
-#                 echo "  • GitHub API limit: 60 requests/hour (unauthenticated)"
-#                 ;;
-#             403)
-#                 echo ""
-#                 echo "ERROR: Forbidden (403)"
-#                 echo "  • Possible rate limit or access restriction"
-#                 ;;
-#             404)
-#                 echo ""
-#                 echo "ERROR: Not Found (404)"
-#                 echo "  • Check if file path is correct: $FILE"
-#                 echo "  • Repository: $ORG/$REPO"
-#                 ;;
-#         esac
-#         exit 1
-#     fi
-    
-#     # Validate JSON if jq is installed
-#     if command -v jq &> /dev/null; then
-#         JQ_ERROR=$(jq empty "$OUTPUT_DIR/$OUTPUT_FILE" 2>&1)
-#         if [ $? -eq 0 ]; then
-#             CONNECTION_COUNT=$(jq '.connections | length' "$OUTPUT_DIR/$OUTPUT_FILE" 2>/dev/null || echo "0")
-#             echo "✓ JSON valid (connections: $CONNECTION_COUNT)"
-#         else
-#             echo "ERROR: Invalid JSON file"
-#             echo "  jq error:"
-#             echo "$JQ_ERROR" | sed 's/^/    /'
-#             exit 1
-#         fi
-#     else
-#         echo "⚠ Warning: jq not installed, skipping JSON validation"
-#     fi
-# else
-#     echo "ERROR: Download failed - file not created"
-#     echo "  Expected: $OUTPUT_DIR/$OUTPUT_FILE"
-#     exit 1
-# fi
+# Check if download was successful
+if [ -f "$OUTPUT_DIR/$OUTPUT_FILE" ]; then
+    FILE_SIZE=$(wc -c < "$OUTPUT_DIR/$OUTPUT_FILE" | tr -d ' ')
+    echo "✓ Download complete: $OUTPUT_DIR/$OUTPUT_FILE"
+    echo "  File size: $FILE_SIZE bytes"
+
+    # Check HTTP status code
+    if [ "$HTTP_CODE" -ne 200 ]; then
+        echo "⚠ Warning: HTTP Status $HTTP_CODE (expected 200)"
+        echo "  Response content:"
+        head -n 5 "$OUTPUT_DIR/$OUTPUT_FILE" | sed 's/^/    /'
+
+        # Handle specific error codes
+        case $HTTP_CODE in
+            429)
+                echo ""
+                echo "ERROR: Rate limit exceeded (429 Too Many Requests)"
+                echo "  • GitHub API limit: 60 requests/hour (unauthenticated)"
+                ;;
+            403)
+                echo ""
+                echo "ERROR: Forbidden (403)"
+                echo "  • Possible rate limit or access restriction"
+                ;;
+            404)
+                echo ""
+                echo "ERROR: Not Found (404)"
+                echo "  • Check if file path is correct: $FILE"
+                echo "  • Repository: $ORG/$REPO"
+                ;;
+        esac
+        exit 1
+    fi
+
+    # Validate JSON if jq is installed
+    if command -v jq &> /dev/null; then
+        JQ_ERROR=$(jq empty "$OUTPUT_DIR/$OUTPUT_FILE" 2>&1)
+        if [ $? -eq 0 ]; then
+            CONNECTION_COUNT=$(jq '.connections | length' "$OUTPUT_DIR/$OUTPUT_FILE" 2>/dev/null || echo "0")
+            echo "✓ JSON valid (connections: $CONNECTION_COUNT)"
+        else
+            echo "ERROR: Invalid JSON file"
+            echo "  jq error:"
+            echo "$JQ_ERROR" | sed 's/^/    /'
+            exit 1
+        fi
+    else
+        echo "⚠ Warning: jq not installed, skipping JSON validation"
+    fi
+else
+    echo "ERROR: Download failed - file not created"
+    echo "  Expected: $OUTPUT_DIR/$OUTPUT_FILE"
+    exit 1
+fi


### PR DESCRIPTION
## 📝 Description

The Resource Catalog stopped loading roles on `sandbox` and `demo`: `https://<host>/data/connections-metadata.json` returns the SPA `index.html` instead of the connections JSON.

**Root cause:** PR #1537 accidentally commented out the `curl` download in `webapp/scripts/download-connection-metadata.sh`. That file is gitignored and produced solely by this script at build time, so every release since #1537 ships without `/data/connections-metadata.json`. The gateway's static middleware then misses the file and falls through to the SPA catch-all (`gateway/api/server.go:151`), returning `index.html`.

Sandbox and demo broke because auto-deploy (#1536) bumped them onto the latest release; app/use stayed on the pre-#1537 release and keep working.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- Restore the `curl` download (and the HTTP-status / JSON-validation guards) in `webapp/scripts/download-connection-metadata.sh`, so the release build fetches the file again and fails loudly on a bad download.

## 🧪 Testing

Ran the restored script locally:

```
HTTP Status: 200
✓ Download complete: resources/public/data/connections-metadata.json
  File size: 83085 bytes
✓ JSON valid (connections: 32)
```