### PR TITLE
feat(agent): gate SSH guardrails behind feature flags and report violations

### DIFF
--- a/agent/controller/ssh.go
+++ b/agent/controller/ssh.go
@@ -5,10 +5,30 @@ import (
 	"fmt"
 	"io"
 	"libhoop"
+	redactortypes "libhoop/redactor/types"
+	"strings"
 
+	"github.com/hoophq/hoop/agent/controller/featureflagstate"
 	"github.com/hoophq/hoop/common/log"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
+)
+
+// sshGuardrailsFlag gates exec-command input and session-channel output
+// guardrails on native SSH connections. sshInputGuardrailsFlag independently
+// gates best-effort guardrails on interactive shell stdin (keystroke line
+// reconstruction). When both are off, the agent passes no guardrails/DLP
+// options to the proxy, so no validation runs and the connection behaves
+// exactly as before.
+const (
+	sshGuardrailsFlag      = "experimental.ssh_guardrails"
+	sshInputGuardrailsFlag = "experimental.ssh_input_guardrails"
+
+	// Proxy option keys mirroring libhoop's proxyssh contract: they tell the
+	// proxy which guardrails concern to enforce (the redactor client itself is
+	// built whenever either flag is on).
+	optSSHGuardrailsExecOutput = "ssh_guardrails_exec_output"
+	optSSHGuardrailsInput      = "ssh_guardrails_input"
 )
 
 func (a *Agent) processSSHProtocol(pkt *pb.Packet) {
@@ -83,6 +103,23 @@ func (a *Agent) processSSHProtocol(pkt *pb.Packet) {
 			"authorized_server_keys": connenv.authorizedSSHKeys,
 			"connection_id":          clientConnectionID,
 		}
+		// Guardrails enforcement for SSH is split across two independent feature
+		// flags: one for exec-command input + session output, one for best-effort
+		// interactive-shell stdin. Build the redactor client (and thread the DLP
+		// options through) when EITHER is enabled, then tell the proxy which
+		// concern to enforce. With both off no options are set, no redactor
+		// client is built, and the proxy runs without validation (unchanged).
+		execOutputEnabled := featureflagstate.IsEnabled(sshGuardrailsFlag)
+		inputEnabled := featureflagstate.IsEnabled(sshInputGuardrailsFlag)
+		if execOutputEnabled || inputEnabled {
+			addGuardRailsOpts(opts, connParams)
+			if execOutputEnabled {
+				opts[optSSHGuardrailsExecOutput] = "true"
+			}
+			if inputEnabled {
+				opts[optSSHGuardrailsInput] = "true"
+			}
+		}
 		proxy, proxyErr := libhoop.NewSSHProxy(context.Background(), streamClient, opts)
 		if proxyErr != nil {
 			return nil, fmt.Errorf("failed initializing SSH proxy connection: %v", proxyErr)
@@ -91,6 +128,18 @@ func (a *Agent) processSSHProtocol(pkt *pb.Packet) {
 		proxy.Run(func(_ int, errMsg string) {
 			a.connStore.Del(clientConnectionIDKey)
 			a.connWriteLocks.Delete(clientConnectionIDKey)
+			// When the proxy blocked the session on a guardrails violation it
+			// records the matched rules. Surface them as structured info so the
+			// gateway persists them and the user sees the "Blocked by ...
+			// Guardrails Rules" message instead of a generic error.
+			if gr, ok := proxy.(interface {
+				GuardRailsViolation() []redactortypes.GuardRailsInfo
+			}); ok {
+				if info := gr.GuardRailsViolation(); len(info) > 0 {
+					a.sendClientSessionCloseWithGuardRailsInfo(sid, "", internalExitCode, info)
+					return
+				}
+			}
 			a.sendClientSessionClose(sid, errMsg)
 		})
 
@@ -124,4 +173,29 @@ func (a *Agent) processSSHProtocol(pkt *pb.Packet) {
 		log.With("sid", sid, "conn", clientConnectionID).Errorf(errMsg)
 		a.sendClientSessionClose(sid, errMsg)
 	}
+}
+
+// addGuardRailsOpts threads the DLP/guardrails connection options into the SSH
+// proxy options, mirroring the keys used by the database proxies. libhoop uses
+// these to build a redactor client that the SSH proxy invokes for guardrails
+// validation only (it does not redact SSH traffic). A DLP provider
+// (Presidio/GCP) must be configured for guardrails rules to be enforced.
+func addGuardRailsOpts(opts map[string]string, connParams *pb.AgentConnectionParams) {
+	var dataMaskingEntityTypesData string
+	if connParams.DataMaskingEntityTypesData != nil {
+		dataMaskingEntityTypesData = string(connParams.DataMaskingEntityTypesData)
+	}
+	var guardRailRules string
+	if connParams.GuardRailRules != nil {
+		guardRailRules = string(connParams.GuardRailRules)
+	}
+	opts["dlp_provider"] = connParams.DlpProvider
+	opts["dlp_mode"] = connParams.DlpMode
+	opts["mspresidio_analyzer_url"] = connParams.DlpPresidioAnalyzerURL
+	opts["mspresidio_anonymizer_url"] = connParams.DlpPresidioAnonymizerURL
+	opts["dlp_gcp_credentials"] = connParams.DlpGcpRawCredentialsJSON
+	opts["dlp_info_types"] = strings.Join(connParams.DLPInfoTypes, ",")
+	opts["dlp_masking_character"] = "#"
+	opts["data_masking_entity_data"] = dataMaskingEntityTypesData
+	opts["guard_rail_rules"] = guardRailRules
 }

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -82,6 +82,20 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentGateway},
 	},
+	"experimental.ssh_guardrails": {
+		Name:        "experimental.ssh_guardrails",
+		Description: "Enforce guardrails on native SSH connections: exec commands are validated against input rules before they run, and session-channel output (interactive shell/exec) is validated against output rules before it reaches the client. Port-forward (direct-tcpip) channels are not inspected. Interactive shell stdin is validated separately by experimental.ssh_input_guardrails. Requires a DLP provider (Presidio/GCP) to be configured.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentAgent},
+	},
+	"experimental.ssh_input_guardrails": {
+		Name:        "experimental.ssh_input_guardrails",
+		Description: "Best-effort guardrails on interactive SSH shell stdin: each command line typed on a session shell is reconstructed and validated against input rules before the Enter that submits it is forwarded; a match blocks the command and ends the session. Reconstruction is approximate — shell history recall, tab-completion and cursor editing can bypass it — so treat it as advisory and pair it with experimental.ssh_guardrails (output rules) for defense in depth. Only interactive shells are inspected (not exec, sftp or port-forwards). Requires a DLP provider (Presidio/GCP) to be configured.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentAgent},
+	},
 }
 
 // All returns every registered flag, sorted by name.

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -84,14 +84,14 @@ var catalog = map[string]Flag{
 	},
 	"experimental.ssh_guardrails": {
 		Name:        "experimental.ssh_guardrails",
-		Description: "Enforce guardrails on native SSH connections: exec commands are validated against input rules before they run, and session-channel output (interactive shell/exec) is validated against output rules before it reaches the client. Port-forward (direct-tcpip) channels are not inspected. Interactive shell stdin is validated separately by experimental.ssh_input_guardrails. Requires a DLP provider (Presidio/GCP) to be configured.",
+		Description: "Enforce guardrails on native SSH connections: exec commands are validated against input rules before they run, and session-channel output (interactive shell/exec) is validated against output rules before it reaches the client. Port-forward (direct-tcpip) channels are not inspected. Interactive shell stdin is validated separately by experimental.ssh_input_guardrails. Requires a DLP provider (Presidio) to be configured.",
 		Default:     false,
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentAgent},
 	},
 	"experimental.ssh_input_guardrails": {
 		Name:        "experimental.ssh_input_guardrails",
-		Description: "Best-effort guardrails on interactive SSH shell stdin: each command line typed on a session shell is reconstructed and validated against input rules before the Enter that submits it is forwarded; a match blocks the command and ends the session. Reconstruction is approximate — shell history recall, tab-completion and cursor editing can bypass it — so treat it as advisory and pair it with experimental.ssh_guardrails (output rules) for defense in depth. Only interactive shells are inspected (not exec, sftp or port-forwards). Requires a DLP provider (Presidio/GCP) to be configured.",
+		Description: "Best-effort guardrails on interactive SSH shell stdin: each command line typed on a session shell is reconstructed and validated against input rules before the Enter that submits it is forwarded; a match blocks the command and ends the session. Reconstruction is approximate — shell history recall, tab-completion and cursor editing can bypass it — so treat it as advisory and pair it with experimental.ssh_guardrails (output rules) for defense in depth. Only interactive shells are inspected (not exec, sftp or port-forwards). Requires a DLP provider (Presidio) to be configured.",
 		Default:     false,
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentAgent},


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

<!-- Label: minor -->

## 📝 Description

Wires the new libhoop SSH guardrails into the agent, gated behind two **experimental feature flags that both default to `false`**. With both off, the agent passes no guardrails/DLP options to the SSH proxy, no redactor client is built, and native SSH connections behave exactly as before.

- `experimental.ssh_guardrails` — validates exec-command **input** against input rules and session-channel **output** (interactive shell/exec) against output rules.
- `experimental.ssh_input_guardrails` — best-effort guardrails on interactive shell **stdin** (per-line keystroke reconstruction).

When a guardrail blocks a session, the agent now surfaces the matched rules as structured info so the gateway persists them and the user sees the `Blocked by the following Hoop Guardrails Rules: ...` message instead of a generic close.

Requires a DLP provider (Presidio/GCP) to be configured for rules to be enforced.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Register `experimental.ssh_guardrails` and `experimental.ssh_input_guardrails` in the feature-flag catalog (`common/featureflag/featureflag.go`), both `ComponentAgent`, default `false`, experimental stability.
- In `processSSHProtocol` (`agent/controller/ssh.go`), build the redactor client and thread DLP/guardrails options into the proxy **only** when at least one flag is enabled, then pass per-concern opts (`ssh_guardrails_exec_output`, `ssh_guardrails_input`) telling the proxy what to enforce.
- On session close, type-assert the proxy for `GuardRailsViolation()` and, when a violation was recorded, call `sendClientSessionCloseWithGuardRailsInfo` so the matched rules reach the gateway/user; otherwise fall back to the existing `sendClientSessionClose`.
- Add `addGuardRailsOpts` helper that mirrors the DLP option keys already used by the database proxies.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: macOS / Linux agent

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

Manual: with `experimental.ssh_guardrails` on and a Presidio deny-words rule configured, `hoop connect <ssh>` then `cat docker-compose.yml` is blocked and the terminal shows the `Blocked by ... Guardrails Rules` message; with both flags off the connection behaves unchanged; `direct-tcpip` port-forwards are never inspected.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Depends on the companion `libhoop` PR (SSH proxy guardrails). Both flags are off by default, so this is safe to merge ahead of enabling them per-org.