### PR TITLE
feat(rdp): windowed latency metrics for the PII guard hot path

### DIFF
--- a/agentrs/src/piigate/analyze.rs
+++ b/agentrs/src/piigate/analyze.rs
@@ -16,6 +16,7 @@ use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use super::bands::{split_bands, OcrChunk, YBand, DEFAULT_BAND_PADDING, MAX_CHUNK_ROWS};
+use super::metrics::LatencyAggregator;
 use super::ocr::{join_words, OcrClient, Word};
 use super::presidio::{analyze_text, AnalysisParams, PresidioClient, SnapshotResult};
 
@@ -83,17 +84,26 @@ pub struct BandAnalyzer {
     /// keeps its `&self` signature; only ever locked briefly to read a hit or
     /// publish the new snapshot, never across an OCR/Presidio await.
     cache: Mutex<OcrCache>,
+    /// Shared per-session latency aggregator. The analyzer records the two
+    /// network-bound stages (OCR, Presidio); the gate records compositing /
+    /// redaction / end-to-end into the same instance, so one window summary
+    /// covers the whole pipeline.
+    metrics: Arc<LatencyAggregator>,
 }
 
 impl BandAnalyzer {
     /// Builds the production analyzer from a resolved guard config (gateway
-    /// policy + agent-local endpoints).
-    pub fn from_config(cfg: &super::config::GuardConfig) -> anyhow::Result<Self> {
+    /// policy + agent-local endpoints), sharing `metrics` with the gate.
+    pub fn from_config(
+        cfg: &super::config::GuardConfig,
+        metrics: Arc<LatencyAggregator>,
+    ) -> anyhow::Result<Self> {
         Ok(Self {
             ocr: OcrClient::new(&cfg.ocr_url)?,
             presidio: PresidioClient::new(&cfg.presidio_url)?,
             params: cfg.params.clone(),
             cache: Mutex::new(OcrCache::default()),
+            metrics,
         })
     }
 }
@@ -133,6 +143,10 @@ impl Analyzer for BandAnalyzer {
             self.params.band_padding
         };
         let chunks = split_bands(bands, MAX_CHUNK_ROWS, pad);
+
+        // Wall-clock for the whole OCR phase (cache lookups + parallel sidecar
+        // round-trips + collection), recorded into the shared latency window.
+        let ocr_started = std::time::Instant::now();
 
         let concurrency = if self.params.max_ocr_concurrency == 0 {
             8usize.min(std::thread::available_parallelism().map_or(8, |n| n.get()))
@@ -212,6 +226,10 @@ impl Analyzer for BandAnalyzer {
                 }
             }
         }
+        // Record OCR phase wall-clock before any early return, so a slow or
+        // failing OCR sidecar (the most likely offender) still shows up in the
+        // latency window.
+        self.metrics.record_ocr(ocr_started.elapsed());
         if let Some(e) = first_err {
             return Err(e);
         }
@@ -250,7 +268,10 @@ impl Analyzer for BandAnalyzer {
         // Gate-close cancellation is handled at the mod.rs boundary (the
         // whole analyze() future is dropped), which aborts this Presidio
         // request via reqwest's drop — no inner select needed here.
-        analyze_text(&self.presidio, &text, &all_words, &self.params).await
+        let presidio_started = std::time::Instant::now();
+        let res = analyze_text(&self.presidio, &text, &all_words, &self.params).await;
+        self.metrics.record_presidio(presidio_started.elapsed());
+        res
     }
 }
 
@@ -371,7 +392,7 @@ mod tests {
             },
             policy: super::super::GatePolicy::Redact,
         };
-        BandAnalyzer::from_config(&cfg).unwrap()
+        BandAnalyzer::from_config(&cfg, Arc::new(LatencyAggregator::new("test"))).unwrap()
     }
 
     // A small framebuffer: width 64, height 64, RGBA. A band covers some rows.

--- a/agentrs/src/piigate/metrics.rs
+++ b/agentrs/src/piigate/metrics.rs
@@ -1,0 +1,424 @@
+//! Per-session latency aggregation for the PII guard hot path.
+//!
+//! The guard runs OCR + Presidio per held batch; on a busy RDP session that
+//! is many batches per second. Logging every batch would flood the agent log
+//! and is unreadable, so this module accumulates per-stage timings into a
+//! fixed time window (default 5s) and emits ONE summary line per window with
+//! count + avg/p50/p95/max for each stage. That is enough to find the
+//! dominant offender (OCR vs Presidio vs pixel compositing vs redaction)
+//! without per-batch spam.
+//!
+//! Design notes:
+//! - There is no background timer task. The window is flushed lazily on the
+//!   next record after it elapses, and once more on `flush_final` at gate
+//!   close. A guard that stops producing batches simply stops logging, and
+//!   nothing outlives the session — there is no task to cancel or leak.
+//! - Stages are recorded independently (`record_ocr`, `record_presidio`, …)
+//!   rather than as one combined per-batch struct, because the OCR/Presidio
+//!   timings are measured inside the analyzer while compositing/redaction/
+//!   end-to-end are measured by the gate loop around it. Decoupling the record
+//!   calls keeps each scope from having to thread a shared struct across the
+//!   analyzer/gate boundary.
+//! - All durations are stored as microseconds (`u64`) to keep the samples
+//!   compact and the percentile sort cheap; they are rendered as
+//!   floating-point milliseconds in the summary.
+
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use tracing::info;
+
+/// How long a window accumulates before it is summarized and reset.
+const WINDOW: Duration = Duration::from_secs(5);
+
+/// Hard cap on samples retained per stage within one window. A busy session
+/// can analyze many batches per second; without a cap a 5s window on a
+/// pathological stream could retain a huge sample vector (and a costlier
+/// percentile sort). Once the cap is hit, further samples for that stage are
+/// dropped — the percentiles become an estimate over the first `CAP` samples
+/// of the window, which is plenty to spot the dominant stage. Counts of
+/// dropped samples are not tracked: this is diagnostic, not billing.
+const MAX_SAMPLES_PER_STAGE: usize = 4096;
+
+/// One stage's samples within the current window.
+#[derive(Default)]
+struct StageSamples {
+    micros: Vec<u64>,
+}
+
+impl StageSamples {
+    fn push(&mut self, us: u64) {
+        // Zero-duration samples are excluded (a stage that did not run, or one
+        // that rounded below 1µs and carries no signal) so `n=` reflects real
+        // work and matches the Go side.
+        if us == 0 || self.micros.len() >= MAX_SAMPLES_PER_STAGE {
+            return;
+        }
+        self.micros.push(us);
+    }
+
+    /// Computes count/avg/p50/p95/max for the stage, or `None` if it never
+    /// ran this window. Consumes (sorts) the collected samples.
+    fn summarize(&mut self) -> Option<StageSummary> {
+        if self.micros.is_empty() {
+            return None;
+        }
+        self.micros.sort_unstable();
+        let n = self.micros.len();
+        let sum: u64 = self.micros.iter().copied().sum();
+        Some(StageSummary {
+            count: n,
+            avg_ms: (sum as f64 / n as f64) / 1000.0,
+            p50_ms: percentile(&self.micros, 0.50) / 1000.0,
+            p95_ms: percentile(&self.micros, 0.95) / 1000.0,
+            max_ms: (*self.micros.last().expect("non-empty") as f64) / 1000.0,
+        })
+    }
+}
+
+struct StageSummary {
+    count: usize,
+    avg_ms: f64,
+    p50_ms: f64,
+    p95_ms: f64,
+    max_ms: f64,
+}
+
+impl std::fmt::Display for StageSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "n={} avg={:.1}ms p50={:.1}ms p95={:.1}ms max={:.1}ms",
+            self.count, self.avg_ms, self.p50_ms, self.p95_ms, self.max_ms
+        )
+    }
+}
+
+/// Nearest-rank percentile over an already-sorted ascending slice. `q` in
+/// [0,1]. Returns microseconds as f64.
+fn percentile(sorted: &[u64], q: f64) -> f64 {
+    debug_assert!(!sorted.is_empty());
+    let rank = (q * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted[rank.min(sorted.len() - 1)] as f64
+}
+
+#[derive(Default)]
+struct Window {
+    started_at: Option<Instant>,
+    batches: usize,
+    detections: usize,
+    forwarded_bytes: u64,
+    composite: StageSamples,
+    ocr: StageSamples,
+    presidio: StageSamples,
+    redact: StageSamples,
+    total: StageSamples,
+}
+
+impl Window {
+    /// Whether anything has been recorded since the last flush.
+    fn is_empty(&self) -> bool {
+        self.started_at.is_none()
+    }
+
+    /// Marks the window start on the first record after a flush and returns
+    /// whether the window has now run for at least [`WINDOW`].
+    fn touch_and_elapsed(&mut self) -> bool {
+        match self.started_at {
+            None => {
+                self.started_at = Some(Instant::now());
+                false
+            }
+            Some(t) => t.elapsed() >= WINDOW,
+        }
+    }
+}
+
+/// Per-session latency aggregator. Cheap to clone-share via `Arc`; both the
+/// gate loop (compositing/redaction/total) and the analyzer (OCR/Presidio)
+/// record into the same instance, so one window covers the whole pipeline.
+pub struct LatencyAggregator {
+    session_id: String,
+    window: Mutex<Window>,
+}
+
+impl LatencyAggregator {
+    pub fn new(session_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            window: Mutex::new(Window::default()),
+        }
+    }
+
+    /// Records the OCR-phase wall-clock for one batch.
+    pub fn record_ocr(&self, d: Duration) {
+        self.push(|w| w.ocr.push(as_micros(d)));
+    }
+
+    /// Records the Presidio analyze HTTP call for one batch.
+    pub fn record_presidio(&self, d: Duration) {
+        self.push(|w| w.presidio.push(as_micros(d)));
+    }
+
+    /// Records PDU compositing (RLE decompress + pixel conversion) for one
+    /// batch.
+    pub fn record_composite(&self, d: Duration) {
+        self.push(|w| w.composite.push(as_micros(d)));
+    }
+
+    /// Records the redaction (PDU rewrite + pixel blanking) for one batch.
+    pub fn record_redact(&self, d: Duration) {
+        self.push(|w| w.redact.push(as_micros(d)));
+    }
+
+    /// Records the end-to-end batch latency (analysis start to forward/drop)
+    /// plus the batch's metadata. This is the per-batch anchor: it increments
+    /// the batch counter, so it must be called once per analyzed batch.
+    pub fn record_batch(&self, total: Duration, forwarded_bytes: u64, detection: bool) {
+        self.push(|w| {
+            w.batches += 1;
+            if detection {
+                w.detections += 1;
+            }
+            w.forwarded_bytes += forwarded_bytes;
+            w.total.push(as_micros(total));
+        });
+    }
+
+    /// Applies `f` to the current window. If the window has elapsed, the full
+    /// window is detached under the lock and then summarized + logged OUTSIDE
+    /// the lock, so the (sort + format + log) critical section never blocks
+    /// concurrent recorders.
+    fn push(&self, f: impl FnOnce(&mut Window)) {
+        let detached = {
+            let mut w = self.window.lock();
+            let elapsed = w.touch_and_elapsed();
+            f(&mut w);
+            if elapsed {
+                Some(std::mem::take(&mut *w))
+            } else {
+                None
+            }
+        };
+        if let Some(w) = detached {
+            self.log_window(w);
+        }
+    }
+
+    /// Emits a final summary at gate close so the last (partial) window is not
+    /// lost. A no-op if nothing was recorded since the last flush.
+    pub fn flush_final(&self) {
+        let detached = {
+            let mut w = self.window.lock();
+            if w.is_empty() {
+                None
+            } else {
+                Some(std::mem::take(&mut *w))
+            }
+        };
+        if let Some(w) = detached {
+            self.log_window(w);
+        }
+    }
+
+    /// Summarizes and logs a detached window. Must be called WITHOUT the lock
+    /// held.
+    fn log_window(&self, mut w: Window) {
+        let elapsed = w.started_at.map_or(Duration::ZERO, |t| t.elapsed());
+        let summarize = |s: &mut StageSamples| {
+            s.summarize()
+                .map(|sum| sum.to_string())
+                .unwrap_or_else(|| "n=0".to_string())
+        };
+        info!(
+            sid = %self.session_id,
+            window_s = elapsed.as_secs_f64(),
+            batches = w.batches,
+            detections = w.detections,
+            forwarded_kib = (w.forwarded_bytes / 1024),
+            "piigate latency: composite[{}] ocr[{}] presidio[{}] redact[{}] total[{}]",
+            summarize(&mut w.composite),
+            summarize(&mut w.ocr),
+            summarize(&mut w.presidio),
+            summarize(&mut w.redact),
+            summarize(&mut w.total),
+        );
+    }
+}
+
+/// Saturating microsecond conversion (a >584,000-year duration would be
+/// needed to overflow u64 micros, so saturation is purely defensive).
+fn as_micros(d: Duration) -> u64 {
+    d.as_micros().min(u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn percentile_nearest_rank() {
+        let s = [10u64, 20, 30, 40, 50];
+        assert_eq!(percentile(&s, 0.0), 10.0);
+        assert_eq!(percentile(&s, 0.5), 30.0);
+        assert_eq!(percentile(&s, 1.0), 50.0);
+        // p95 of 5 samples -> rank round(0.95*4)=round(3.8)=4 -> 50
+        assert_eq!(percentile(&s, 0.95), 50.0);
+    }
+
+    #[test]
+    fn percentile_single_sample() {
+        assert_eq!(percentile(&[42], 0.0), 42.0);
+        assert_eq!(percentile(&[42], 0.95), 42.0);
+        assert_eq!(percentile(&[42], 1.0), 42.0);
+    }
+
+    #[test]
+    fn summary_stats() {
+        let mut s = StageSamples::default();
+        for us in [1000u64, 2000, 3000, 4000] {
+            s.push(us);
+        }
+        let sum = s.summarize().expect("has samples");
+        assert_eq!(sum.count, 4);
+        assert!((sum.avg_ms - 2.5).abs() < 1e-9, "avg {}", sum.avg_ms);
+        assert_eq!(sum.max_ms, 4.0);
+    }
+
+    #[test]
+    fn empty_stage_has_no_summary() {
+        let mut s = StageSamples::default();
+        assert!(s.summarize().is_none());
+    }
+
+    #[test]
+    fn independent_stage_recording() {
+        let agg = LatencyAggregator::new("sid");
+        agg.record_ocr(Duration::from_millis(5));
+        agg.record_presidio(Duration::from_millis(3));
+        agg.record_batch(Duration::from_millis(9), 2048, false);
+        let w = agg.window.lock();
+        assert_eq!(w.ocr.micros.len(), 1);
+        assert_eq!(w.presidio.micros.len(), 1);
+        assert_eq!(w.total.micros.len(), 1);
+        // redact/composite were never recorded -> no samples.
+        assert!(w.redact.micros.is_empty());
+        assert!(w.composite.micros.is_empty());
+        assert_eq!(w.batches, 1);
+        assert_eq!(w.forwarded_bytes, 2048);
+    }
+
+    #[test]
+    fn detection_and_bytes_accumulate() {
+        let agg = LatencyAggregator::new("sid");
+        agg.record_batch(Duration::from_millis(1), 2048, true);
+        agg.record_batch(Duration::from_millis(1), 1024, false);
+        let w = agg.window.lock();
+        assert_eq!(w.batches, 2);
+        assert_eq!(w.detections, 1);
+        assert_eq!(w.forwarded_bytes, 3072);
+    }
+
+    #[test]
+    fn window_starts_lazily() {
+        // A fresh aggregator has no window start until the first record, so
+        // flush_final on an untouched aggregator is a no-op.
+        let agg = LatencyAggregator::new("sid");
+        assert!(agg.window.lock().is_empty());
+        agg.flush_final();
+        assert!(agg.window.lock().is_empty());
+        agg.record_ocr(Duration::from_millis(1));
+        assert!(!agg.window.lock().is_empty());
+    }
+
+    #[test]
+    fn flush_final_resets_window() {
+        let agg = LatencyAggregator::new("sid");
+        agg.record_batch(Duration::from_millis(1), 100, false);
+        agg.flush_final();
+        let w = agg.window.lock();
+        assert!(w.is_empty());
+        assert_eq!(w.batches, 0);
+    }
+
+    #[test]
+    fn as_micros_conversion() {
+        assert_eq!(as_micros(Duration::from_millis(1)), 1000);
+        assert_eq!(as_micros(Duration::ZERO), 0);
+    }
+
+    #[test]
+    fn zero_duration_excluded() {
+        let mut s = StageSamples::default();
+        s.push(0);
+        s.push(1000);
+        assert_eq!(s.micros.len(), 1, "zero-µs sample must be dropped");
+    }
+
+    #[test]
+    fn samples_capped_per_window() {
+        let mut s = StageSamples::default();
+        for _ in 0..(MAX_SAMPLES_PER_STAGE + 100) {
+            s.push(1000);
+        }
+        assert_eq!(s.micros.len(), MAX_SAMPLES_PER_STAGE);
+        // The summary still computes over the retained cap.
+        assert!(s.summarize().is_some());
+    }
+
+    /// A `MakeWriter` that appends every log line into a shared buffer so the
+    /// test can assert the aggregator actually emits a `tracing` line (not
+    /// just that it mutates state).
+    #[derive(Clone, Default)]
+    struct BufWriter(Arc<parking_lot::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for BufWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
+        type Writer = BufWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn flush_emits_log_line() {
+        let buf = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let writer = BufWriter(buf.clone());
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let agg = LatencyAggregator::new("sid-log-test");
+            agg.record_composite(Duration::from_micros(400));
+            agg.record_ocr(Duration::from_millis(58));
+            agg.record_presidio(Duration::from_millis(12));
+            agg.record_redact(Duration::from_millis(3));
+            agg.record_batch(Duration::from_millis(74), 8 * 1024 * 1024, true);
+            agg.flush_final();
+        });
+
+        let out = String::from_utf8(buf.lock().clone()).expect("utf8 log");
+        assert!(out.contains("piigate latency:"), "missing prefix in: {out}");
+        assert!(out.contains("sid-log-test"), "missing sid in: {out}");
+        assert!(out.contains("batches=1"), "missing batches in: {out}");
+        assert!(out.contains("detections=1"), "missing detections in: {out}");
+        // Each stage rendered with its summary.
+        for stage in ["composite[", "ocr[", "presidio[", "redact[", "total["] {
+            assert!(out.contains(stage), "missing {stage} in: {out}");
+        }
+        // OCR avg should reflect the 58ms sample.
+        assert!(out.contains("ocr[n=1 avg=58.0ms"), "wrong ocr summary in: {out}");
+    }
+}

--- a/agentrs/src/piigate/mod.rs
+++ b/agentrs/src/piigate/mod.rs
@@ -44,6 +44,7 @@ pub mod capabilities;
 pub mod canvas;
 pub mod config;
 pub mod framing;
+pub mod metrics;
 pub mod ocr;
 pub mod presidio;
 pub mod report;
@@ -64,6 +65,7 @@ use analyze::Analyzer;
 use bands::DirtyBands;
 use canvas::{ShadowCanvas, MAX_CANVAS_DIM};
 use framing::{pdu_size, BitmapPatch, FastPathParser};
+use metrics::LatencyAggregator;
 use presidio::SnapshotResult;
 
 /// Caps the per-session backlog awaiting analysis (PDU bytes plus their
@@ -169,6 +171,10 @@ struct GateShared {
     cancel: CancellationToken,
     events: mpsc::UnboundedSender<GateEvent>,
     policy: GatePolicy,
+    /// Per-session latency aggregator, shared with the analyzer so one window
+    /// summary spans the whole pipeline (compositing here, OCR/Presidio in the
+    /// analyzer, redaction here).
+    metrics: Arc<LatencyAggregator>,
 }
 
 /// The hold-and-release valve. Create with [`PiiGate::spawn`]; feed
@@ -191,6 +197,7 @@ impl PiiGate {
         events: mpsc::UnboundedSender<GateEvent>,
         band_padding: usize,
         policy: GatePolicy,
+        metrics: Arc<LatencyAggregator>,
     ) -> Self
     where
         W: AsyncWrite + Unpin + Send + 'static,
@@ -210,6 +217,7 @@ impl PiiGate {
             cancel: CancellationToken::new(),
             events,
             policy,
+            metrics,
         });
 
         let task = tokio::spawn(analysis_loop(
@@ -349,6 +357,22 @@ fn enqueue(st: &mut GateState, pdu: GatePdu) {
 async fn analysis_loop<W>(
     shared: Arc<GateShared>,
     analyzer: Arc<dyn Analyzer>,
+    sink: W,
+    dirty: DirtyBands,
+    canvas: ShadowCanvas,
+) where
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    run_analysis_loop(&shared, &*analyzer, sink, dirty, canvas).await;
+    // Emit the final (partial) latency window on every exit path — kill,
+    // forward failure, cancellation, or normal close — so the last few
+    // seconds of measurements are never silently dropped.
+    shared.metrics.flush_final();
+}
+
+async fn run_analysis_loop<W>(
+    shared: &GateShared,
+    analyzer: &dyn Analyzer,
     mut sink: W,
     mut dirty: DirtyBands,
     mut canvas: ShadowCanvas,
@@ -372,7 +396,7 @@ async fn analysis_loop<W>(
                 }
             };
             let Some(pdus) = pdus else { break };
-            if !process_pdus(&shared, &*analyzer, &mut sink, &mut dirty, &mut canvas, pdus).await {
+            if !process_pdus(shared, analyzer, &mut sink, &mut dirty, &mut canvas, pdus).await {
                 return;
             }
         }
@@ -401,7 +425,13 @@ where
 {
     let mut i = 0;
     while i < pdus.len() {
+        // End-to-end batch timer: from compositing the first PDU through the
+        // forward/drop decision. This is the latency the gate adds to the
+        // client stream.
+        let batch_started = std::time::Instant::now();
+
         let mut j = i;
+        let composite_started = std::time::Instant::now();
         while j < pdus.len() {
             if j > i && pdu_conflicts(dirty, &pdus[j]) {
                 break;
@@ -413,12 +443,30 @@ where
             }
             j += 1;
         }
-        if !analyze_and_forward(shared, analyzer, sink, dirty, canvas, &pdus[i..j]).await {
+        shared.metrics.record_composite(composite_started.elapsed());
+
+        let outcome = analyze_and_forward(shared, analyzer, sink, dirty, canvas, &pdus[i..j]).await;
+        shared
+            .metrics
+            .record_batch(batch_started.elapsed(), outcome.forwarded_bytes, outcome.detection);
+        if !outcome.proceed {
             return false;
         }
         i = j;
     }
     true
+}
+
+/// The result of analyzing and forwarding one batch.
+struct BatchOutcome {
+    /// Whether the analysis loop should continue (false = exit: kill, forward
+    /// failure, or cancellation).
+    proceed: bool,
+    /// Bytes written downstream for this batch (0 when the batch was dropped
+    /// or the session killed without forwarding).
+    forwarded_bytes: u64,
+    /// Whether this batch contained a PII detection.
+    detection: bool,
 }
 
 /// Reports whether any of the PDU's patches would touch rows already dirtied
@@ -437,7 +485,7 @@ async fn analyze_and_forward<W>(
     dirty: &mut DirtyBands,
     canvas: &mut ShadowCanvas,
     batch: &[GatePdu],
-) -> bool
+) -> BatchOutcome
 where
     W: AsyncWrite + Unpin,
 {
@@ -458,7 +506,9 @@ where
         // HTTP requests) — a hung OCR sidecar must never wedge teardown.
         let res = tokio::select! {
             res = analyzer.analyze(&canvas.fb, canvas.w, canvas.h, &bands) => res,
-            _ = shared.cancel.cancelled() => return false,
+            _ = shared.cancel.cancelled() => {
+                return BatchOutcome { proceed: false, forwarded_bytes: 0, detection: false };
+            }
         };
         match res {
             Err(e) => {
@@ -487,7 +537,7 @@ where
                 if !already_down {
                     let _ = shared.events.send(GateEvent::AnalysisError);
                 }
-                return false;
+                return BatchOutcome { proceed: false, forwarded_bytes: 0, detection: false };
             }
             Ok(res) if res.is_detection() => {
                 return on_detection(shared, sink, canvas, batch, res).await;
@@ -496,7 +546,15 @@ where
         }
     }
 
-    forward_batch(shared, sink, batch).await
+    let batch_bytes: u64 = batch.iter().map(|p| p.data.len() as u64).sum();
+    let proceed = forward_batch(shared, sink, batch).await;
+    BatchOutcome {
+        proceed,
+        // On a forward failure nothing useful reached the client; count the
+        // batch as forwarded only when the write succeeded.
+        forwarded_bytes: if proceed { batch_bytes } else { 0 },
+        detection: false,
+    }
 }
 
 /// Handles a detection according to the gate policy. Returns false when the
@@ -508,13 +566,14 @@ async fn on_detection<W>(
     canvas: &ShadowCanvas,
     batch: &[GatePdu],
     res: SnapshotResult,
-) -> bool
+) -> BatchOutcome
 where
     W: AsyncWrite + Unpin,
 {
     let policy = shared.policy;
 
     if policy.redacts() {
+        let redact_started = std::time::Instant::now();
         // Hold-and-rewrite, SELECTIVELY. For each held PDU:
         //   - A PDU whose bitmap patches do NOT overlap any detection is
         //     forwarded UNMODIFIED — this preserves the legitimate screen
@@ -609,8 +668,12 @@ where
                 bpp,
             ));
         }
+        // Redaction (PDU rewrite + pixel blanking) is complete; the remaining
+        // cost is just the downstream write, timed as part of the batch total.
+        shared.metrics.record_redact(redact_started.elapsed());
+        let wire_bytes = wire.len() as u64;
         if !forward_bytes(shared, sink, &wire).await {
-            return false;
+            return BatchOutcome { proceed: false, forwarded_bytes: 0, detection: true };
         }
         let _ = shared.events.send(GateEvent::Detection(res));
 
@@ -621,9 +684,10 @@ where
             st.queue.clear();
             st.queued_bytes = 0;
             st.tail.clear();
-            return false;
+            return BatchOutcome { proceed: false, forwarded_bytes: wire_bytes, detection: true };
         }
-        return true; // Redact: keep guarding.
+        // Redact: keep guarding.
+        return BatchOutcome { proceed: true, forwarded_bytes: wire_bytes, detection: true };
     }
 
     // Kill: drop the held batch and terminate. Terminal-state transition
@@ -639,7 +703,7 @@ where
         already
     };
     if already_down {
-        return false;
+        return BatchOutcome { proceed: false, forwarded_bytes: 0, detection: true };
     }
     warn!(
         sid = %shared.session_id,
@@ -647,7 +711,8 @@ where
         res.counts
     );
     let _ = shared.events.send(GateEvent::Detection(res));
-    false
+    // Kill: the held batch was dropped, nothing forwarded.
+    BatchOutcome { proceed: false, forwarded_bytes: 0, detection: true }
 }
 
 /// Delivers cleared PDUs downstream, coalescing them into bounded chunks

--- a/agentrs/src/piigate/tests.rs
+++ b/agentrs/src/piigate/tests.rs
@@ -19,6 +19,7 @@ use super::analyze::Analyzer;
 use super::bands::YBand;
 use super::canvas::ShadowCanvas;
 use super::framing::{pdu_size, FastPathParser};
+use super::metrics::LatencyAggregator;
 use super::presidio::{EntityDetection, SnapshotResult};
 use super::testpdu::*;
 use super::{GateEvent, GatePolicy, PiiGate, MAX_HELD_BYTES};
@@ -104,7 +105,15 @@ fn new_test_gate_with_policy(analyzer: Arc<dyn Analyzer>, policy: GatePolicy) ->
         }
     });
     let sink = TestSink::default();
-    let gate = PiiGate::spawn("sid-test", analyzer, sink.clone(), tx, 0, policy);
+    let gate = PiiGate::spawn(
+        "sid-test",
+        analyzer,
+        sink.clone(),
+        tx,
+        0,
+        policy,
+        Arc::new(LatencyAggregator::new("sid-test")),
+    );
     Harness { gate, sink, events }
 }
 
@@ -572,7 +581,15 @@ async fn close_cancels_stalled_write() {
     let sink = BlockingSink {
         entered: entered.clone(),
     };
-    let gate = PiiGate::spawn("sid-test", analyzer, sink, tx, 0, GatePolicy::Kill);
+    let gate = PiiGate::spawn(
+        "sid-test",
+        analyzer,
+        sink,
+        tx,
+        0,
+        GatePolicy::Kill,
+        Arc::new(LatencyAggregator::new("sid-test")),
+    );
 
     // A non-bitmap PDU goes straight to forward, where the sink stalls.
     gate.ingest(&tpkt_pdu(&[0x01, 0x02]));

--- a/agentrs/src/proxy.rs
+++ b/agentrs/src/proxy.rs
@@ -8,6 +8,7 @@ use tracing::{info, warn};
 use typed_builder::TypedBuilder;
 
 use crate::piigate::config::GuardConfig;
+use crate::piigate::metrics::LatencyAggregator;
 use crate::piigate::report::ViolationReport;
 use crate::piigate::{analyze::BandAnalyzer, GateEvent, PiiGate};
 
@@ -93,8 +94,12 @@ where
         // transparently would be a silent enforcement bypass — refuse the
         // session instead. (Endpoint presence was already validated in
         // GuardConfig::resolve; a failure here is a client-construction error.)
+        // One latency aggregator per session, shared by the analyzer
+        // (OCR/Presidio timings) and the gate (compositing/redaction/total) so
+        // a single 5s window summary covers the whole pipeline.
+        let metrics = Arc::new(LatencyAggregator::new(self.session_id.clone()));
         let analyzer = Arc::new(
-            BandAnalyzer::from_config(&guard)
+            BandAnalyzer::from_config(&guard, metrics.clone())
                 .context("piigate: failed to build analyzer for a delegated-guard session")?,
         );
 
@@ -106,6 +111,7 @@ where
             events_tx,
             guard.params.band_padding,
             guard.policy,
+            metrics,
         ));
         info!(sid = %self.session_id, "piigate: realtime PII guard active (agent-side, hold-and-release)");
 

--- a/gateway/rdp/piigate.go
+++ b/gateway/rdp/piigate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/hoophq/hoop/common/featureflag"
@@ -164,6 +165,10 @@ type PIIGate struct {
 	// released, never states still queued behind a batch seal.
 	canvas shadowCanvas
 	dirty  *analyzer.DirtyBands
+
+	// Per-session latency aggregator: records compositing/OCR/Presidio/total
+	// per batch and logs a windowed summary (see piigate_metrics.go).
+	metrics *piiLatencyAggregator
 }
 
 // NewPIIGate creates a gate and starts its analysis goroutine. Callers must
@@ -197,6 +202,7 @@ func NewPIIGate(ctx context.Context, cfg PIIGateConfig) (*PIIGate, error) {
 		notify:  make(chan struct{}, 1),
 		done:    make(chan struct{}),
 		cancel:  cancel,
+		metrics: newPIILatencyAggregator(cfg.SessionID),
 	}
 	if cfg.analyzeOverride != nil {
 		g.analyze = cfg.analyzeOverride
@@ -310,6 +316,9 @@ func (g *PIIGate) signal() {
 // limit.
 func (g *PIIGate) analysisLoop(ctx context.Context) {
 	defer close(g.done)
+	// Emit the final (partial) latency window on every exit path so the last
+	// few seconds of measurements are never silently dropped.
+	defer g.metrics.flushFinal()
 	for {
 		select {
 		case <-ctx.Done():
@@ -358,7 +367,12 @@ func (g *PIIGate) takePending() ([]gatePDU, bool) {
 func (g *PIIGate) processPDUs(ctx context.Context, pdus []gatePDU) bool {
 	i := 0
 	for i < len(pdus) {
+		// End-to-end batch timer: from compositing the first PDU through the
+		// forward/drop decision — the latency the gate adds to the stream.
+		batchStart := time.Now()
+
 		j := i
+		compositeStart := time.Now()
 		for j < len(pdus) {
 			if j > i && g.pduConflicts(pdus[j]) {
 				break
@@ -366,12 +380,36 @@ func (g *PIIGate) processPDUs(ctx context.Context, pdus []gatePDU) bool {
 			g.compositePDU(pdus[j])
 			j++
 		}
-		if !g.analyzeAndForward(ctx, pdus[i:j]) {
+		compositeDur := time.Since(compositeStart)
+
+		outcome := g.analyzeAndForward(ctx, pdus[i:j])
+		g.metrics.recordBatch(
+			compositeDur, outcome.ocrDur, outcome.presidioDur, time.Since(batchStart),
+			outcome.forwardedBytes, outcome.detection,
+		)
+		if !outcome.proceed {
 			return false
 		}
 		i = j
 	}
 	return true
+}
+
+// batchOutcome is the result of analyzing and forwarding one batch, plus the
+// per-stage timings the latency aggregator records.
+type batchOutcome struct {
+	// proceed reports whether the analysis loop should continue (false = exit:
+	// kill, forward failure, or cancellation).
+	proceed bool
+	// forwardedBytes is the wire bytes written downstream for this batch (0
+	// when dropped/killed).
+	forwardedBytes int64
+	// detection reports whether this batch contained PII.
+	detection bool
+	// ocrDur/presidioDur are the analyzer's per-stage timings (0 when the
+	// batch dirtied nothing and analysis was skipped).
+	ocrDur      time.Duration
+	presidioDur time.Duration
 }
 
 // pduConflicts reports whether any of the PDU's patches would touch rows
@@ -397,24 +435,41 @@ func (g *PIIGate) compositePDU(pdu gatePDU) {
 }
 
 // analyzeAndForward analyzes the current shadow framebuffer state (if the
-// batch dirtied anything) and forwards the batch on clearance. Returns false
-// when the loop must exit.
-func (g *PIIGate) analyzeAndForward(ctx context.Context, batch []gatePDU) bool {
+// batch dirtied anything) and forwards the batch on clearance. The returned
+// batchOutcome drives the loop (proceed) and feeds the latency aggregator
+// (per-stage timings, forwarded bytes, detection).
+func (g *PIIGate) analyzeAndForward(ctx context.Context, batch []gatePDU) batchOutcome {
+	var out batchOutcome
 	bands := g.takeBands()
 	if len(bands) > 0 {
 		res, err := g.analyze(
 			ctx, g.canvas.fb, g.canvas.w, g.canvas.h, bands,
 			g.cfg.SessionID, 0, 0, g.cfg.Presidio, g.cfg.Params,
 		)
+		// res carries the per-stage timings even on error (they are recorded
+		// before the early return inside the analyzer), so a slow or failing
+		// OCR/Presidio — the likely offender — still shows up in the window.
+		//
+		// SnapshotResult.{OCRDuration,PresidioDuration} are part of the
+		// realtime gate's instrumentation contract (populated by
+		// analyzer.AnalyzeFramebufferBands on every path, including errors and
+		// empty-OCR). A nil res (defensive: the analyzer always returns
+		// non-nil today) simply loses this batch's OCR/Presidio attribution,
+		// never a panic.
+		if res != nil {
+			out.ocrDur = res.OCRDuration
+			out.presidioDur = res.PresidioDuration
+		}
 		switch {
 		case err != nil:
 			if ctx.Err() != nil {
-				return false
+				return out
 			}
 			// Fail open: forwarding beats freezing the session on an
 			// analyzer hiccup (PoC policy; see type doc).
 			log.With("sid", g.cfg.SessionID).Warnf("piigate: analysis failed, failing open: %v", err)
 		case len(res.Counts) > 0:
+			out.detection = true
 			// Terminal-state transition under the lock: if an overload (or
 			// Close) already terminated the gate while this analysis was in
 			// flight, the session is going down anyway — do not fire a
@@ -427,14 +482,20 @@ func (g *PIIGate) analyzeAndForward(ctx context.Context, batch []gatePDU) bool {
 			g.tail = nil
 			g.mu.Unlock()
 			if alreadyDown {
-				return false
+				return out
 			}
 			log.With("sid", g.cfg.SessionID).Warnf("piigate: PII detected (%v), dropping held batch and terminating session", res.Counts)
 			g.cfg.OnDetection(res)
-			return false
+			return out
 		}
 	}
-	return g.forwardBatch(batch)
+	out.proceed = g.forwardBatch(batch)
+	if out.proceed {
+		for _, p := range batch {
+			out.forwardedBytes += int64(len(p.data))
+		}
+	}
+	return out
 }
 
 // takeBands drains the dirty-band accumulator, clamped to the framebuffer.

--- a/gateway/rdp/piigate_metrics.go
+++ b/gateway/rdp/piigate_metrics.go
@@ -1,0 +1,200 @@
+package rdp
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/hoophq/hoop/common/log"
+)
+
+// piiLatencyWindow is how long the gateway-side PII gate accumulates per-stage
+// timings before emitting one summary log line and resetting. The gate runs
+// OCR + Presidio per held batch (many batches per second on a busy session),
+// so per-batch logging would flood the gateway log; a windowed summary is
+// enough to find the dominant offender (OCR vs Presidio vs compositing)
+// without the spam.
+//
+// Note: the gateway-side gate is KILL-ONLY (it has no redaction path —
+// redaction is an agent-side policy, see agentrs/src/piigate). There is
+// therefore deliberately no redact stage here; redact latency is attributed
+// only in the agentrs aggregator. The agentrs summary line carries an extra
+// redact[...] field for that reason.
+const piiLatencyWindow = 5 * time.Second
+
+// piiMaxSamplesPerStage hard-caps samples retained per stage within one
+// window. A busy session can analyze many batches per second; without a cap a
+// 5s window on a pathological stream could retain a huge sample vector (and a
+// costlier percentile sort). Once the cap is hit, further samples for that
+// stage are dropped — the percentiles become an estimate over the first
+// piiMaxSamplesPerStage samples of the window, which is plenty to spot the
+// dominant stage. This is diagnostic, not billing.
+const piiMaxSamplesPerStage = 4096
+
+// piiStageSamples collects one stage's durations (in microseconds) within the
+// current window.
+type piiStageSamples struct {
+	micros []int64
+}
+
+func (s *piiStageSamples) push(d time.Duration) {
+	// Non-positive samples are excluded (a stage that did not run, or one that
+	// rounded below 1µs and carries no signal). Bounded by the per-stage cap.
+	if d <= 0 || len(s.micros) >= piiMaxSamplesPerStage {
+		return
+	}
+	s.micros = append(s.micros, d.Microseconds())
+}
+
+// summarize returns "n=… avg=…ms p50=…ms p95=…ms max=…ms" for the stage, or
+// "n=0" when it never ran this window. It sorts the samples in place.
+func (s *piiStageSamples) summarize() string {
+	if len(s.micros) == 0 {
+		return "n=0"
+	}
+	sort.Slice(s.micros, func(i, j int) bool { return s.micros[i] < s.micros[j] })
+	n := len(s.micros)
+	var sum int64
+	for _, v := range s.micros {
+		sum += v
+	}
+	avgMs := float64(sum) / float64(n) / 1000.0
+	maxMs := float64(s.micros[n-1]) / 1000.0
+	return fmt.Sprintf("n=%d avg=%.1fms p50=%.1fms p95=%.1fms max=%.1fms",
+		n, avgMs, percentileMs(s.micros, 0.50), percentileMs(s.micros, 0.95), maxMs)
+}
+
+// percentileMs is the nearest-rank percentile (q in [0,1]) over an
+// already-sorted ascending micros slice, returned as milliseconds.
+func percentileMs(sorted []int64, q float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	rank := int(q*float64(len(sorted)-1) + 0.5)
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return float64(sorted[rank]) / 1000.0
+}
+
+// piiLatencyAggregator accumulates per-stage timings for one gateway-side PII
+// gate session and logs a windowed summary. Safe for concurrent use; in
+// practice every record call comes from the single analysis goroutine, but the
+// mutex keeps the final flush race-free.
+type piiLatencyAggregator struct {
+	sessionID string
+
+	mu             sync.Mutex
+	startedAt      time.Time // zero until the first record after a flush
+	batches        int
+	detections     int
+	forwardedBytes int64
+	composite      piiStageSamples
+	ocr            piiStageSamples
+	presidio       piiStageSamples
+	total          piiStageSamples
+}
+
+func newPIILatencyAggregator(sessionID string) *piiLatencyAggregator {
+	return &piiLatencyAggregator{sessionID: sessionID}
+}
+
+// recordBatch records one analyzed batch: its per-stage timings, the bytes
+// forwarded (0 when dropped/killed), and whether it was a detection. This is
+// the per-batch anchor — call it exactly once per analyzed batch. It flushes
+// the window when [piiLatencyWindow] has elapsed.
+func (a *piiLatencyAggregator) recordBatch(
+	composite, ocr, presidio, total time.Duration,
+	forwardedBytes int64,
+	detection bool,
+) {
+	a.mu.Lock()
+	elapsed := false
+	if a.startedAt.IsZero() {
+		a.startedAt = time.Now()
+	} else if time.Since(a.startedAt) >= piiLatencyWindow {
+		elapsed = true
+	}
+
+	a.batches++
+	if detection {
+		a.detections++
+	}
+	a.forwardedBytes += forwardedBytes
+	a.composite.push(composite)
+	a.ocr.push(ocr)
+	a.presidio.push(presidio)
+	a.total.push(total)
+
+	// Detach the window under the lock and log it outside, so the (sort +
+	// format + log) work never blocks concurrent recorders.
+	var detached *piiLatencyAggregator
+	if elapsed {
+		detached = a.detachLocked()
+	}
+	a.mu.Unlock()
+	if detached != nil {
+		detached.logWindow()
+	}
+}
+
+// flushFinal emits the last (partial) window at gate close so the final few
+// seconds of measurements are not lost. A no-op when nothing was recorded
+// since the last flush.
+func (a *piiLatencyAggregator) flushFinal() {
+	a.mu.Lock()
+	var detached *piiLatencyAggregator
+	if a.batches > 0 {
+		detached = a.detachLocked()
+	}
+	a.mu.Unlock()
+	if detached != nil {
+		detached.logWindow()
+	}
+}
+
+// detachLocked snapshots the current window into a standalone aggregator and
+// resets the live one. The caller must hold a.mu.
+func (a *piiLatencyAggregator) detachLocked() *piiLatencyAggregator {
+	d := &piiLatencyAggregator{
+		sessionID:      a.sessionID,
+		startedAt:      a.startedAt,
+		batches:        a.batches,
+		detections:     a.detections,
+		forwardedBytes: a.forwardedBytes,
+		composite:      a.composite,
+		ocr:            a.ocr,
+		presidio:       a.presidio,
+		total:          a.total,
+	}
+	a.reset()
+	return d
+}
+
+// logWindow summarizes and logs a detached window. Must be called WITHOUT the
+// lock held (a detached aggregator is not shared, so it needs no locking).
+func (a *piiLatencyAggregator) logWindow() {
+	var windowS float64
+	if !a.startedAt.IsZero() {
+		windowS = time.Since(a.startedAt).Seconds()
+	}
+	log.With("sid", a.sessionID).Infof(
+		"piigate latency (gateway): window_s=%.1f batches=%d detections=%d forwarded_kib=%d "+
+			"composite[%s] ocr[%s] presidio[%s] total[%s]",
+		windowS, a.batches, a.detections, a.forwardedBytes/1024,
+		a.composite.summarize(), a.ocr.summarize(),
+		a.presidio.summarize(), a.total.summarize(),
+	)
+}
+
+func (a *piiLatencyAggregator) reset() {
+	a.startedAt = time.Time{}
+	a.batches = 0
+	a.detections = 0
+	a.forwardedBytes = 0
+	a.composite = piiStageSamples{}
+	a.ocr = piiStageSamples{}
+	a.presidio = piiStageSamples{}
+	a.total = piiStageSamples{}
+}

--- a/gateway/rdp/piigate_metrics_test.go
+++ b/gateway/rdp/piigate_metrics_test.go
@@ -1,0 +1,114 @@
+package rdp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPercentileMs_NearestRank(t *testing.T) {
+	s := []int64{10000, 20000, 30000, 40000, 50000} // micros
+	cases := []struct {
+		q    float64
+		want float64 // ms
+	}{
+		{0.0, 10.0},
+		{0.5, 30.0},
+		{1.0, 50.0},
+		{0.95, 50.0}, // rank round(0.95*4)=round(3.8)=4 -> 50ms
+	}
+	for _, c := range cases {
+		if got := percentileMs(s, c.q); got != c.want {
+			t.Errorf("percentileMs(q=%.2f) = %.1f, want %.1f", c.q, got, c.want)
+		}
+	}
+}
+
+func TestPercentileMs_Empty(t *testing.T) {
+	if got := percentileMs(nil, 0.5); got != 0 {
+		t.Errorf("percentileMs(empty) = %.1f, want 0", got)
+	}
+}
+
+func TestStageSamples_SummarizeEmpty(t *testing.T) {
+	var s piiStageSamples
+	if got := s.summarize(); got != "n=0" {
+		t.Errorf("summarize(empty) = %q, want %q", got, "n=0")
+	}
+}
+
+func TestStageSamples_PushIgnoresNonPositive(t *testing.T) {
+	var s piiStageSamples
+	s.push(0)
+	s.push(-1 * time.Millisecond)
+	s.push(2 * time.Millisecond)
+	if len(s.micros) != 1 {
+		t.Fatalf("expected 1 sample, got %d", len(s.micros))
+	}
+	if s.micros[0] != 2000 {
+		t.Errorf("expected 2000us, got %d", s.micros[0])
+	}
+}
+
+func TestStageSamples_CappedPerWindow(t *testing.T) {
+	var s piiStageSamples
+	for i := 0; i < piiMaxSamplesPerStage+100; i++ {
+		s.push(time.Millisecond)
+	}
+	if len(s.micros) != piiMaxSamplesPerStage {
+		t.Errorf("samples = %d, want cap %d", len(s.micros), piiMaxSamplesPerStage)
+	}
+	if s.summarize() == "n=0" {
+		t.Error("capped stage should still summarize")
+	}
+}
+
+func TestAggregator_RecordBatchAccumulates(t *testing.T) {
+	a := newPIILatencyAggregator("sid")
+	a.recordBatch(time.Millisecond, 5*time.Millisecond, 3*time.Millisecond, 9*time.Millisecond, 2048, true)
+	a.recordBatch(time.Millisecond, 0, 0, 2*time.Millisecond, 1024, false)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.batches != 2 {
+		t.Errorf("batches = %d, want 2", a.batches)
+	}
+	if a.detections != 1 {
+		t.Errorf("detections = %d, want 1", a.detections)
+	}
+	if a.forwardedBytes != 3072 {
+		t.Errorf("forwardedBytes = %d, want 3072", a.forwardedBytes)
+	}
+	// OCR ran once (second batch had 0 -> skipped); total ran twice.
+	if len(a.ocr.micros) != 1 {
+		t.Errorf("ocr samples = %d, want 1", len(a.ocr.micros))
+	}
+	if len(a.total.micros) != 2 {
+		t.Errorf("total samples = %d, want 2", len(a.total.micros))
+	}
+}
+
+func TestAggregator_StartsLazilyAndFlushResets(t *testing.T) {
+	a := newPIILatencyAggregator("sid")
+	if !a.startedAt.IsZero() {
+		t.Fatal("startedAt should be zero before first record")
+	}
+	a.recordBatch(0, 0, 0, time.Millisecond, 100, false)
+	if a.startedAt.IsZero() {
+		t.Fatal("startedAt should be set after first record")
+	}
+	a.flushFinal()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.batches != 0 || !a.startedAt.IsZero() {
+		t.Errorf("flushFinal should reset window: batches=%d startedAtZero=%v", a.batches, a.startedAt.IsZero())
+	}
+}
+
+func TestAggregator_FlushFinalNoopWhenEmpty(t *testing.T) {
+	a := newPIILatencyAggregator("sid")
+	// Should not panic and should leave the window empty.
+	a.flushFinal()
+	if a.batches != 0 {
+		t.Errorf("batches = %d, want 0", a.batches)
+	}
+}


### PR DESCRIPTION
## Problem

RDP sessions through the PII guard are slow even on the GPU node, and there's no visibility into which pipeline stage dominates per-frame latency (compositing vs OCR vs Presidio vs redaction).

## Change

Adds self-aggregating, **logs-only** latency instrumentation to the PII guard hot path on both sides:

- **agentrs (Rust)** — `LatencyAggregator` per session: composite / ocr / presidio / redact / total.
- **gateway (Go)** — mirror aggregator (reuses the OCR/Presidio durations already in `SnapshotResult`). Kill-only gate, so no redact stage there.

Per-stage timings are aggregated into **5s windows** and emitted as one summary line (`n/avg/p50/p95/max`), so a busy session never floods the log. Samples are **capped per stage** and the summary is computed + logged **outside the aggregator lock** to keep the hot path cheap.

Sample line:
```
piigate latency: composite[n=42 avg=0.4ms ...] ocr[n=40 avg=58ms p95=120ms ...] presidio[n=40 avg=12ms ...] redact[n=1 ...] total[n=42 avg=74ms ...] batches=42 detections=1 forwarded_kib=8123
```

## Why logs-only
agentrs has no telemetry exporter and the gateway's OTel/Honeycomb wiring is gateway-only; a unified spans pipeline would need new agent egress + secrets. Out of scope for "find the offender."

## Verification
- Reviewed with `@review`: **no enforcement-path regression** (the `bool -> outcome struct` refactor preserves every kill/redact/fail-closed/fail-open decision); addressed findings (sample cap, flush-outside-lock, zero-duration skip, docs).
- Both log lines confirmed emitting via captured-output tests.
- 87 agentrs piigate tests + Go rdp suite + new aggregator/log tests pass; `go vet` + `clippy` clean.

Pure instrumentation, active only when `experimental.rdp_pii_guard` runs. No behavior change.

Automated by MisterMal