### PR TITLE
feat(rdp): surface OCR sidecar inference time in PII guard metrics

### DIFF
--- a/agentrs/src/piigate/analyze.rs
+++ b/agentrs/src/piigate/analyze.rs
@@ -201,35 +201,56 @@ impl Analyzer for BandAnalyzer {
                         .await
                         .expect("piigate: OCR semaphore closed");
                     if cancel.is_cancelled() {
-                        return Ok((idx, Vec::new()));
+                        return Ok((idx, Vec::new(), 0.0, 0usize));
                     }
-                    let words = tokio::select! {
+                    let extract = tokio::select! {
                         res = ocr.extract(&crop, fb_width, win_height) => res.with_context(|| {
                             format!("OCR failed on chunk [{},{})", win.y0, win.y1)
                         })?,
-                        _ = cancel.cancelled() => return Ok((idx, Vec::new())),
+                        _ = cancel.cancelled() => return Ok((idx, Vec::new(), 0.0, 0usize)),
                     };
-                    Ok::<_, anyhow::Error>((idx, words))
+                    Ok::<_, anyhow::Error>((idx, extract.words, extract.server_ms, extract.request_bytes))
                 }));
             }
         }
 
         // Collect the OCR'd (miss) chunks. On the first error, cancel the rest
         // and propagate (the gate fails closed on an analyzer error).
+        //
+        // The chunks OCR in PARALLEL, so the per-batch number comparable to the
+        // OCR wall-clock is the SLOWEST chunk's sidecar inference time (the
+        // critical path), not the sum. If wall-clock >> max chunk inference,
+        // the gap is queueing/contention/transport, not the GPU. We also track
+        // bytes/calls/chunks to gauge payload size and cache effectiveness.
+        // Cache hits contribute nothing (no round-trip), which is the point.
         let mut first_err = None;
+        let mut server_ms_max = 0.0f64;
+        let mut request_bytes_sum = 0usize;
+        let mut ocr_calls = 0usize;
         for h in handles {
             match h.await.context("piigate: OCR task panicked")? {
-                Ok((idx, words)) => chunk_local[idx] = Some(Arc::new(words)),
+                Ok((idx, words, server_ms, request_bytes)) => {
+                    chunk_local[idx] = Some(Arc::new(words));
+                    if request_bytes > 0 {
+                        if server_ms > server_ms_max {
+                            server_ms_max = server_ms;
+                        }
+                        request_bytes_sum += request_bytes;
+                        ocr_calls += 1;
+                    }
+                }
                 Err(e) => {
                     cancel.cancel();
                     first_err = first_err.or(Some(e));
                 }
             }
         }
-        // Record OCR phase wall-clock before any early return, so a slow or
-        // failing OCR sidecar (the most likely offender) still shows up in the
-        // latency window.
+        // Record OCR phase wall-clock and the sidecar-internal breakdown before
+        // any early return, so a slow or failing OCR sidecar (the most likely
+        // offender) still shows up in the latency window.
         self.metrics.record_ocr(ocr_started.elapsed());
+        self.metrics
+            .record_ocr_detail(server_ms_max, request_bytes_sum as u64, ocr_calls, chunks.len());
         if let Some(e) = first_err {
             return Err(e);
         }

--- a/agentrs/src/piigate/metrics.rs
+++ b/agentrs/src/piigate/metrics.rs
@@ -113,6 +113,16 @@ struct Window {
     presidio: StageSamples,
     redact: StageSamples,
     total: StageSamples,
+
+    // OCR-internal breakdown: the sidecar's self-reported inference time
+    // (server_ms) per batch, the bytes sent, and the OCR call count. The gap
+    // between `ocr` wall-clock and `ocr_server` is queueing/contention/
+    // transport — this is what tells us whether the GPU is slow or the
+    // requests are piling up.
+    ocr_server: StageSamples, // server_ms summed per batch, stored as micros
+    ocr_bytes: u64,           // total BMP bytes sent this window
+    ocr_calls: usize,         // total OCR round-trips this window (cache misses)
+    ocr_chunks: usize,        // total chunks this window (hits + misses)
 }
 
 impl Window {
@@ -153,6 +163,31 @@ impl LatencyAggregator {
     /// Records the OCR-phase wall-clock for one batch.
     pub fn record_ocr(&self, d: Duration) {
         self.push(|w| w.ocr.push(as_micros(d)));
+    }
+
+    /// Records the OCR-internal breakdown for one batch. `server_ms_max` is the
+    /// SLOWEST chunk's sidecar-reported inference time (the parallel critical
+    /// path — directly comparable to the OCR wall-clock; a large wall-clock −
+    /// server_max gap means queueing/contention, not GPU cost). `bytes` is the
+    /// total BMP bytes sent, `calls` the OCR round-trips (cache misses), and
+    /// `chunks` the total chunks (hits + misses) so cache effectiveness is
+    /// visible.
+    pub fn record_ocr_detail(&self, server_ms_max: f64, bytes: u64, calls: usize, chunks: usize) {
+        self.push(|w| {
+            // Stored as micros to share StageSamples' percentile machinery.
+            // Coerce non-finite/negative sidecar values to 0: malformed
+            // telemetry must never poison the window, and this is best-effort
+            // diagnostics, not enforcement.
+            let server_us = if server_ms_max.is_finite() && server_ms_max > 0.0 {
+                (server_ms_max * 1000.0) as u64
+            } else {
+                0
+            };
+            w.ocr_server.push(server_us);
+            w.ocr_bytes += bytes;
+            w.ocr_calls += calls;
+            w.ocr_chunks += chunks;
+        });
     }
 
     /// Records the Presidio analyze HTTP call for one batch.
@@ -230,15 +265,20 @@ impl LatencyAggregator {
                 .map(|sum| sum.to_string())
                 .unwrap_or_else(|| "n=0".to_string())
         };
+        let ocr_kib = w.ocr_bytes / 1024;
         info!(
             sid = %self.session_id,
             window_s = elapsed.as_secs_f64(),
             batches = w.batches,
             detections = w.detections,
             forwarded_kib = (w.forwarded_bytes / 1024),
-            "piigate latency: composite[{}] ocr[{}] presidio[{}] redact[{}] total[{}]",
+            ocr_calls = w.ocr_calls,
+            ocr_chunks = w.ocr_chunks,
+            ocr_sent_kib = ocr_kib,
+            "piigate latency: composite[{}] ocr[{}] ocr_server[{}] presidio[{}] redact[{}] total[{}]",
             summarize(&mut w.composite),
             summarize(&mut w.ocr),
+            summarize(&mut w.ocr_server),
             summarize(&mut w.presidio),
             summarize(&mut w.redact),
             summarize(&mut w.total),
@@ -349,6 +389,33 @@ mod tests {
     }
 
     #[test]
+    fn ocr_detail_coerces_bad_server_ms() {
+        let agg = LatencyAggregator::new("sid");
+        agg.record_ocr_detail(f64::NAN, 100, 1, 1);
+        agg.record_ocr_detail(f64::INFINITY, 100, 1, 1);
+        agg.record_ocr_detail(-5.0, 100, 1, 1);
+        // All three are non-finite/negative -> coerced to 0 -> excluded by
+        // StageSamples::push, so no server samples, but bytes/calls/chunks
+        // still accumulate.
+        let w = agg.window.lock();
+        assert!(w.ocr_server.micros.is_empty(), "bad server_ms must not be sampled");
+        assert_eq!(w.ocr_bytes, 300);
+        assert_eq!(w.ocr_calls, 3);
+        assert_eq!(w.ocr_chunks, 3);
+    }
+
+    #[test]
+    fn ocr_detail_records_valid_server_ms() {
+        let agg = LatencyAggregator::new("sid");
+        agg.record_ocr_detail(12.5, 2048, 2, 4);
+        let w = agg.window.lock();
+        assert_eq!(w.ocr_server.micros, vec![12500]);
+        assert_eq!(w.ocr_bytes, 2048);
+        assert_eq!(w.ocr_calls, 2);
+        assert_eq!(w.ocr_chunks, 4);
+    }
+
+    #[test]
     fn zero_duration_excluded() {
         let mut s = StageSamples::default();
         s.push(0);
@@ -403,6 +470,7 @@ mod tests {
             let agg = LatencyAggregator::new("sid-log-test");
             agg.record_composite(Duration::from_micros(400));
             agg.record_ocr(Duration::from_millis(58));
+            agg.record_ocr_detail(40.0, 512 * 1024, 3, 4);
             agg.record_presidio(Duration::from_millis(12));
             agg.record_redact(Duration::from_millis(3));
             agg.record_batch(Duration::from_millis(74), 8 * 1024 * 1024, true);
@@ -415,10 +483,14 @@ mod tests {
         assert!(out.contains("batches=1"), "missing batches in: {out}");
         assert!(out.contains("detections=1"), "missing detections in: {out}");
         // Each stage rendered with its summary.
-        for stage in ["composite[", "ocr[", "presidio[", "redact[", "total["] {
+        for stage in ["composite[", "ocr[", "ocr_server[", "presidio[", "redact[", "total["] {
             assert!(out.contains(stage), "missing {stage} in: {out}");
         }
-        // OCR avg should reflect the 58ms sample.
+        // OCR wall-clock avg should reflect the 58ms sample.
         assert!(out.contains("ocr[n=1 avg=58.0ms"), "wrong ocr summary in: {out}");
+        // OCR sidecar inference (server_ms) should reflect the 40ms sample.
+        assert!(out.contains("ocr_server[n=1 avg=40.0ms"), "wrong ocr_server summary in: {out}");
+        assert!(out.contains("ocr_calls=3"), "missing ocr_calls in: {out}");
+        assert!(out.contains("ocr_chunks=4"), "missing ocr_chunks in: {out}");
     }
 }

--- a/agentrs/src/piigate/ocr.rs
+++ b/agentrs/src/piigate/ocr.rs
@@ -93,9 +93,20 @@ struct OcrServerWord {
 
 #[derive(Debug, Deserialize)]
 struct OcrServerResponse {
-    #[allow(dead_code)]
     duration_ms: f64,
     words: Vec<OcrServerWord>,
+}
+
+/// Result of one OCR call: the recognized words plus diagnostics used by the
+/// latency aggregator to separate sidecar inference time from the wall-clock
+/// the agent observes (the gap is queueing/contention/transport).
+#[derive(Debug)]
+pub struct OcrExtract {
+    pub words: Vec<Word>,
+    /// The sidecar's self-reported inference time for this request.
+    pub server_ms: f64,
+    /// BMP bytes sent to the sidecar for this request.
+    pub request_bytes: usize,
 }
 
 /// Bounds the response body read: even a pathological full-screen of dense
@@ -135,8 +146,9 @@ impl OcrClient {
         rgba: &[u8],
         width: usize,
         height: usize,
-    ) -> anyhow::Result<Vec<Word>> {
+    ) -> anyhow::Result<OcrExtract> {
         let bmp = encode_bmp(rgba, width, height);
+        let request_bytes = bmp.len();
         let resp = self
             .client
             .post(format!("{}/ocr", self.base_url))
@@ -160,7 +172,11 @@ impl OcrClient {
         let out: OcrServerResponse =
             serde_json::from_slice(&body).context("ocr: invalid server response")?;
 
-        Ok(validate_words(out.words, width, height))
+        Ok(OcrExtract {
+            words: validate_words(out.words, width, height),
+            server_ms: out.duration_ms,
+            request_bytes,
+        })
     }
 }
 


### PR DESCRIPTION
## Why

Production latency logs (from #1555) showed **OCR dominates** the PII guard hot path: ~340ms avg, p50 ~210ms, **p95 up to 1.8s**, ~95% of total batch time. The huge p95/max tail points to queueing/contention rather than raw inference — but we can't prove it without the sidecar's own timing.

## What

Surface the OCR sidecar's self-reported `duration_ms` (already parsed, previously `#[allow(dead_code)]`) alongside the agent-measured wall-clock. The 5s window line gains:

- `ocr_server[...]` — the **slowest parallel chunk's** sidecar inference time (the critical path, directly comparable to `ocr` wall-clock).
- `ocr_calls` / `ocr_chunks` — OCR round-trips vs total chunks (cache effectiveness).
- `ocr_sent_kib` — BMP payload size.

**Interpretation**: if `ocr` wall-clock ≫ `ocr_server`, the bottleneck is queueing/contention (likely the 4 uvicorn workers fighting over one T4) → fix is concurrency/batching. If `ocr_server` ≈ `ocr`, it's raw inference → fix is smaller model / fewer pixels / bigger GPU.

## Safety

- `OcrClient::extract` now returns `OcrExtract { words, server_ms, request_bytes }`; `validate_words` output is byte-identical to before, OCR cache unaffected, cancellation/error paths unchanged.
- Non-finite/negative sidecar values coerced to 0 (malformed telemetry can't poison the window).
- Reviewed with `@review`: all findings LOW, no enforcement change. 90 piigate tests pass (+ new edge-case tests), clippy clean.

Diagnostic-only; active only when `experimental.rdp_pii_guard` runs.

Automated by MisterMal