### PR TITLE
perf(rdp): skip re-analyzing byte-identical RDP repaints in PII guard

### DIFF
--- a/agentrs/src/piigate/canvas.rs
+++ b/agentrs/src/piigate/canvas.rs
@@ -69,7 +69,12 @@ pub fn to_rgba(src: &[u8], width: usize, height: usize, bpp: usize) -> Option<Ve
 }
 
 /// Draws a decoded RGBA bitmap patch onto the framebuffer at (dst_x, dst_y).
-/// Out-of-bounds regions are clipped.
+/// Out-of-bounds regions are clipped. Returns whether any pixel actually
+/// CHANGED: RDP routinely resends byte-identical tiles (idle repaints, cursor
+/// trails, unchanged backgrounds), and a paint that changes nothing has no new
+/// content to analyze. Reporting "unchanged" lets the caller skip marking the
+/// region dirty, so it is not needlessly re-OCR'd — this is safe because the
+/// shadow canvas already holds (and already analyzed) those exact pixels.
 #[allow(clippy::too_many_arguments)] // mirrors the Go CompositeBitmap contract
 pub fn composite_bitmap(
     fb: &mut [u8],
@@ -80,7 +85,8 @@ pub fn composite_bitmap(
     patch_h: usize,
     dst_x: usize,
     dst_y: usize,
-) {
+) -> bool {
+    let mut changed = false;
     for row in 0..patch_h {
         let fb_y = dst_y + row;
         if fb_y >= fb_height {
@@ -93,11 +99,13 @@ pub fn composite_bitmap(
             }
             let si = (row * patch_w + col) * 4;
             let di = (fb_y * fb_width + fb_x) * 4;
-            if si + 4 <= patch.len() && di + 4 <= fb.len() {
+            if si + 4 <= patch.len() && di + 4 <= fb.len() && fb[di..di + 4] != patch[si..si + 4] {
                 fb[di..di + 4].copy_from_slice(&patch[si..si + 4]);
+                changed = true;
             }
         }
     }
+    changed
 }
 
 /// A growable RGBA framebuffer that mirrors the client's screen. Shared
@@ -120,9 +128,18 @@ impl ShadowCanvas {
     }
 
     /// Decodes one bitmap patch and draws it, growing the canvas if the
-    /// patch extends beyond it. Returns false when the patch cannot be
-    /// composited (oversized extent or decode failure) — fail-open for that
-    /// region.
+    /// patch extends beyond it. Returns whether the canvas CHANGED (any pixel
+    /// differs, or the canvas grew) — the caller marks the region dirty only
+    /// then, so byte-identical RDP repaints are not needlessly re-OCR'd.
+    /// Returns false when the patch cannot be composited (oversized extent or
+    /// decode failure) — fail-open for that region — and also false for a
+    /// successful but pixel-identical paint (nothing new to analyze).
+    ///
+    /// Skipping unchanged paints is safe for the guard: the shadow canvas
+    /// already holds those exact pixels, which were analyzed when they first
+    /// appeared, so there is no unanalyzed content to leak. The PDU is still
+    /// forwarded by the caller regardless of this return — only the OCR/analysis
+    /// decision is affected.
     pub fn composite(&mut self, patch: &BitmapPatch) -> bool {
         // Checked: geometry is wire-format u16 today, but a malformed or
         // future-widened extent must fail-open for the region (skip), never
@@ -165,10 +182,13 @@ impl ShadowCanvas {
             return false;
         };
 
-        if right > self.w || bottom > self.h {
+        let grew = if right > self.w || bottom > self.h {
             self.grow(right, bottom);
-        }
-        composite_bitmap(
+            true
+        } else {
+            false
+        };
+        let changed = composite_bitmap(
             &mut self.fb,
             self.w,
             self.h,
@@ -178,7 +198,9 @@ impl ShadowCanvas {
             patch.x,
             patch.y,
         );
-        true
+        // A grow always exposes new canvas area, so treat it as changed even if
+        // the painted pixels happened to match the (zeroed) new region.
+        changed || grew
     }
 
     /// Reallocates the framebuffer to cover at least (width x height),
@@ -273,6 +295,52 @@ mod tests {
 
         // Oversized extent must be rejected.
         assert!(!c.composite(&patch(MAX_CANVAS_DIM - 1, 0, 2, 2, red)));
+    }
+
+    #[test]
+    fn composite_reports_changed_only_on_pixel_change() {
+        let mut c = ShadowCanvas::new("t");
+        let red = [0x00, 0x00, 0xff]; // BGR red
+
+        // First paint of a region changes pixels (and grows the canvas).
+        assert!(c.composite(&patch(0, 0, 4, 4, red)), "first paint must report changed");
+        // Repainting the SAME region with the SAME color changes nothing.
+        assert!(
+            !c.composite(&patch(0, 0, 4, 4, red)),
+            "byte-identical repaint must report unchanged"
+        );
+        // Repainting with a different color changes pixels again.
+        let blue = [0xff, 0x00, 0x00]; // BGR blue
+        assert!(
+            c.composite(&patch(0, 0, 4, 4, blue)),
+            "different color must report changed"
+        );
+        // And again the identical (now-blue) repaint is unchanged.
+        assert!(
+            !c.composite(&patch(0, 0, 4, 4, blue)),
+            "identical blue repaint must report unchanged"
+        );
+    }
+
+    #[test]
+    fn first_paint_of_zero_pixels_counts_as_changed() {
+        // The canvas starts zeroed. A first paint whose decoded RGBA happens to
+        // be black (0,0,0) is byte-identical to the zeroed framebuffer — but it
+        // is NEW to the client and MUST be treated as changed (so it gets
+        // analyzed), which the `grew` guard guarantees. If this ever returned
+        // false, black-on-black content could reach the client unanalyzed.
+        let mut c = ShadowCanvas::new("t");
+        let black = [0x00, 0x00, 0x00]; // BGR black -> RGBA (0,0,0,255)
+        assert!(
+            c.composite(&patch(0, 0, 4, 4, black)),
+            "first paint into new canvas area must be changed even if pixels are black"
+        );
+        // A second identical black paint over the same (now-black) region is a
+        // true no-op and is correctly skipped.
+        assert!(
+            !c.composite(&patch(0, 0, 4, 4, black)),
+            "identical black repaint over existing black must be unchanged"
+        );
     }
 
     #[test]

--- a/agentrs/src/piigate/metrics.rs
+++ b/agentrs/src/piigate/metrics.rs
@@ -123,6 +123,12 @@ struct Window {
     ocr_bytes: u64,           // total BMP bytes sent this window
     ocr_calls: usize,         // total OCR round-trips this window (cache misses)
     ocr_chunks: usize,        // total chunks this window (hits + misses)
+
+    // Composite paint accounting: how many bitmap paints actually changed
+    // pixels vs total paints. RDP resends many byte-identical tiles; a low
+    // changed/total ratio means most repaints are no-ops we now skip.
+    paints_total: u64,
+    paints_changed: u64,
 }
 
 impl Window {
@@ -201,6 +207,17 @@ impl LatencyAggregator {
         self.push(|w| w.composite.push(as_micros(d)));
     }
 
+    /// Records bitmap-paint accounting for one batch: total paints vs paints
+    /// that actually changed pixels. A low changed/total ratio quantifies how
+    /// many byte-identical RDP repaints are being skipped (i.e. OCR work
+    /// avoided).
+    pub fn record_paints(&self, total: u64, changed: u64) {
+        self.push(|w| {
+            w.paints_total += total;
+            w.paints_changed += changed;
+        });
+    }
+
     /// Records the redaction (PDU rewrite + pixel blanking) for one batch.
     pub fn record_redact(&self, d: Duration) {
         self.push(|w| w.redact.push(as_micros(d)));
@@ -275,6 +292,8 @@ impl LatencyAggregator {
             ocr_calls = w.ocr_calls,
             ocr_chunks = w.ocr_chunks,
             ocr_sent_kib = ocr_kib,
+            paints_total = w.paints_total,
+            paints_changed = w.paints_changed,
             "piigate latency: composite[{}] ocr[{}] ocr_server[{}] presidio[{}] redact[{}] total[{}]",
             summarize(&mut w.composite),
             summarize(&mut w.ocr),

--- a/agentrs/src/piigate/mod.rs
+++ b/agentrs/src/piigate/mod.rs
@@ -431,19 +431,29 @@ where
         let batch_started = std::time::Instant::now();
 
         let mut j = i;
+        let mut patches_total = 0usize;
+        let mut patches_changed = 0usize;
         let composite_started = std::time::Instant::now();
         while j < pdus.len() {
             if j > i && pdu_conflicts(dirty, &pdus[j]) {
                 break;
             }
             for p in &pdus[j].patches {
+                patches_total += 1;
+                // Only a paint that actually changed pixels (or grew the
+                // canvas) marks the region dirty — byte-identical RDP repaints
+                // carry no new content and must not trigger a re-OCR.
                 if canvas.composite(p) {
+                    patches_changed += 1;
                     dirty.add_rect(p.y, p.height);
                 }
             }
             j += 1;
         }
         shared.metrics.record_composite(composite_started.elapsed());
+        shared
+            .metrics
+            .record_paints(patches_total as u64, patches_changed as u64);
 
         let outcome = analyze_and_forward(shared, analyzer, sink, dirty, canvas, &pdus[i..j]).await;
         shared

--- a/agentrs/src/piigate/tests.rs
+++ b/agentrs/src/piigate/tests.rs
@@ -643,11 +643,13 @@ async fn flash_attack_never_leaks() {
     h.gate.close().await;
 }
 
-/// Every repaint of the same region within one ingest burst forces its own
-/// batch, so every intermediate state is analyzed — one analysis per
-/// overwrite generation.
+/// Byte-identical repaints of the same region carry no new content: they must
+/// still be FORWARDED (the client expects every PDU), but the gate skips
+/// re-analyzing pixels it already analyzed — RDP resends identical tiles
+/// constantly and re-OCRing them is pure waste. All five paints are the same
+/// WHITE rect, so exactly one analysis covers them.
 #[tokio::test]
-async fn overwrite_splits_and_analyzes_each_state() {
+async fn identical_repaints_forward_but_analyze_once() {
     let (det, calls) = SignatureDetector::new(40, 40, 8, 8);
     let h = new_test_gate(det);
 
@@ -657,9 +659,44 @@ async fn overwrite_splits_and_analyzes_each_state() {
     }
     h.gate.ingest(&burst);
 
-    wait_for("all clean repaints forwarded in order", || h.sink.bytes() == burst).await;
-    assert_eq!(calls.load(Ordering::SeqCst), 5, "each overwrite generation must be analyzed");
+    // Correctness preserved: every PDU is still delivered, in order.
+    wait_for("all repaints forwarded in order", || h.sink.bytes() == burst).await;
+    // Optimization: identical pixels are analyzed once, not five times.
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "identical repaints must collapse to a single analysis"
+    );
     assert_eq!(h.events.detections(), 0, "clean repaints must not detect");
+    h.gate.close().await;
+}
+
+/// Every repaint that actually CHANGES pixels still forces its own batch and is
+/// analyzed — the dirty-skip optimization must never collapse genuinely
+/// distinct screen states (that would be a leak). Alternating colors at a
+/// non-signature region change pixels every generation; each must be analyzed.
+#[tokio::test]
+async fn changed_repaints_analyze_each_state() {
+    let (det, calls) = SignatureDetector::new(40, 40, 8, 8);
+    let h = new_test_gate(det);
+
+    // Paint the same region alternating WHITE/MAGENTA away from the signature
+    // rect (signature is at 40,40; paint at 0,0) so each generation differs in
+    // pixels but never trips the detector.
+    let colors = [WHITE, MAGENTA, WHITE, MAGENTA, WHITE];
+    let mut burst = Vec::new();
+    for c in colors {
+        burst.extend_from_slice(&fast_path_bitmap_pdu(&[TestRect::new(0, 0, 8, 8, c)]));
+    }
+    h.gate.ingest(&burst);
+
+    wait_for("all changed repaints forwarded in order", || h.sink.bytes() == burst).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        colors.len() as i32,
+        "each pixel-changing generation must be analyzed"
+    );
+    assert_eq!(h.events.detections(), 0, "magenta away from the signature region must not detect");
     h.gate.close().await;
 }
 
@@ -690,6 +727,38 @@ async fn cross_batch_assembly_killed_on_completion() {
         }
     });
     assert!(!assembled, "LEAK: full signature visible in a client-renderable state");
+    h.gate.close().await;
+}
+
+/// The dirty-skip optimization must not create a leak across a
+/// changed -> identical-repaint -> changed-overwrite sequence. The signature
+/// is painted (changed, analyzed -> killed) so the identical repaint never even
+/// runs; this proves an identical repaint cannot be used to "refresh" PII past
+/// the guard, and that the first changed paint is always the one analyzed.
+#[tokio::test]
+async fn identical_repaint_of_pii_is_still_caught() {
+    let (det, calls) = SignatureDetector::new(40, 40, 8, 8);
+    let h = new_test_gate(det);
+
+    // First paint of the signature: changed -> dirtied -> analyzed -> killed.
+    // A second, byte-identical paint of the same signature would be skipped by
+    // the dirty optimization — but it can never leak, because the FIRST paint
+    // already triggers detection and drops the batch.
+    let sig = fast_path_bitmap_pdu(&[TestRect::new(40, 40, 8, 8, MAGENTA)]);
+    h.gate.ingest(&[sig.clone(), sig].concat());
+
+    wait_for("signature detected on first changed paint", || h.events.detections() == 1).await;
+    assert!(h.gate.killed(), "gate must kill on the PII paint");
+    assert!(calls.load(Ordering::SeqCst) >= 1, "the changed PII paint must be analyzed");
+
+    let mut leaked = false;
+    let mut oracle = ClientOracle::new();
+    oracle.consume(&h.sink.bytes(), |fb, w, hgt| {
+        if rect_is_color(fb, w, hgt, 40, 40, 8, 8, MAGENTA) {
+            leaked = true;
+        }
+    });
+    assert!(!leaked, "LEAK: signature reached a client-renderable state");
     h.gate.close().await;
 }
 

--- a/gateway/rdp/analyzer/worker.go
+++ b/gateway/rdp/analyzer/worker.go
@@ -300,14 +300,21 @@ func getCanvasDimensions(session *models.Session) (int, int) {
 	return w, h
 }
 
-// CompositeBitmap draws a decoded RGBA bitmap patch onto the full framebuffer at (dstX, dstY).
+// CompositeBitmap draws a decoded RGBA bitmap patch onto the full framebuffer
+// at (dstX, dstY) and reports whether any pixel actually CHANGED.
+//
+// RDP routinely resends byte-identical tiles (idle repaints, unchanged
+// backgrounds); a paint that changes nothing has no new content to analyze, so
+// the realtime gate uses the return value to skip marking that region dirty.
+// Callers that don't care (full-frame analysis, rdpbench) simply ignore it.
 //
 // Contract: framebuffer must be RGBA (4 bytes/pixel, top-down) with
 // len >= fbWidth*fbHeight*4, and patch must be RGBA with len >= patchW*patchH*4
 // (as produced by rle.ToRGBA / rle.DecompressToRGBA). Out-of-bounds regions are
 // clipped. The function does no locking: callers sharing the framebuffer across
 // goroutines must synchronize externally.
-func CompositeBitmap(framebuffer []byte, fbWidth, fbHeight int, patch []byte, patchW, patchH, dstX, dstY int) {
+func CompositeBitmap(framebuffer []byte, fbWidth, fbHeight int, patch []byte, patchW, patchH, dstX, dstY int) bool {
+	changed := false
 	for row := 0; row < patchH; row++ {
 		fbY := dstY + row
 		if fbY < 0 || fbY >= fbHeight {
@@ -323,13 +330,20 @@ func CompositeBitmap(framebuffer []byte, fbWidth, fbHeight int, patch []byte, pa
 			si := srcOff + col*4
 			di := dstOff + col*4
 			if si+3 < len(patch) && di+3 < len(framebuffer) {
-				framebuffer[di] = patch[si]
-				framebuffer[di+1] = patch[si+1]
-				framebuffer[di+2] = patch[si+2]
-				framebuffer[di+3] = patch[si+3]
+				if framebuffer[di] != patch[si] ||
+					framebuffer[di+1] != patch[si+1] ||
+					framebuffer[di+2] != patch[si+2] ||
+					framebuffer[di+3] != patch[si+3] {
+					framebuffer[di] = patch[si]
+					framebuffer[di+1] = patch[si+1]
+					framebuffer[di+2] = patch[si+2]
+					framebuffer[di+3] = patch[si+3]
+					changed = true
+				}
 			}
 		}
 	}
+	return changed
 }
 
 // SampleFramebuffer extracts every 64th scanline from the framebuffer for fast hashing.

--- a/gateway/rdp/piigate.go
+++ b/gateway/rdp/piigate.go
@@ -561,8 +561,17 @@ type shadowCanvas struct {
 }
 
 // composite decodes one bitmap patch and draws it, growing the canvas if the
-// patch extends beyond it. Returns false when the patch cannot be composited
-// (oversized extent or decode failure) — fail-open for that region.
+// patch extends beyond it. Returns whether the canvas CHANGED (any pixel
+// differs, or the canvas grew) — the caller marks the region dirty only then,
+// so byte-identical RDP repaints are not needlessly re-OCR'd. Returns false
+// when the patch cannot be composited (oversized extent or decode failure) —
+// fail-open for that region — and also false for a successful pixel-identical
+// paint (nothing new to analyze).
+//
+// Skipping unchanged paints is safe for the guard: the shadow canvas already
+// holds (and already analyzed) those exact pixels, so there is no unanalyzed
+// content to leak. The PDU is still forwarded regardless of this return — only
+// the OCR/analysis decision is affected.
 func (c *shadowCanvas) composite(bmp parser.BitmapRect, data []byte) bool {
 	right, bottom := int(bmp.X)+int(bmp.Width), int(bmp.Y)+int(bmp.Height)
 	if right > maxCanvasDim || bottom > maxCanvasDim {
@@ -580,11 +589,15 @@ func (c *shadowCanvas) composite(bmp parser.BitmapRect, data []byte) bool {
 		log.With("sid", c.sessionID).Debugf("piigate: bitmap decode error: %v", err)
 		return false
 	}
+	grew := false
 	if right > c.w || bottom > c.h {
 		c.grow(right, bottom)
+		grew = true
 	}
-	analyzer.CompositeBitmap(c.fb, c.w, c.h, rgba, int(bmp.Width), int(bmp.Height), int(bmp.X), int(bmp.Y))
-	return true
+	changed := analyzer.CompositeBitmap(c.fb, c.w, c.h, rgba, int(bmp.Width), int(bmp.Height), int(bmp.X), int(bmp.Y))
+	// A grow exposes new canvas area, so treat it as changed even if the
+	// painted pixels matched the (zeroed) new region.
+	return changed || grew
 }
 
 // grow reallocates the framebuffer to cover at least (width x height),

--- a/gateway/rdp/piigate_test.go
+++ b/gateway/rdp/piigate_test.go
@@ -595,6 +595,45 @@ func TestShadowCanvas_GrowPreservesContent(t *testing.T) {
 	}
 }
 
+// TestShadowCanvas_CompositeReportsChangedOnlyOnPixelChange: composite reports
+// true only when pixels actually change (or the canvas grows), so the gate
+// skips re-OCRing byte-identical RDP repaints.
+func TestShadowCanvas_CompositeReportsChangedOnlyOnPixelChange(t *testing.T) {
+	c := shadowCanvas{sessionID: "t"}
+	red := bytes.Repeat([]byte{0x00, 0x00, 0xff}, 16)  // BGR 4x4
+	blue := bytes.Repeat([]byte{0xff, 0x00, 0x00}, 16) // BGR 4x4
+
+	if !c.composite(parser.BitmapRect{X: 0, Y: 0, Width: 4, Height: 4, BitsPerPixel: 24}, red) {
+		t.Error("first paint must report changed")
+	}
+	if c.composite(parser.BitmapRect{X: 0, Y: 0, Width: 4, Height: 4, BitsPerPixel: 24}, red) {
+		t.Error("byte-identical repaint must report unchanged")
+	}
+	if !c.composite(parser.BitmapRect{X: 0, Y: 0, Width: 4, Height: 4, BitsPerPixel: 24}, blue) {
+		t.Error("different color must report changed")
+	}
+	if c.composite(parser.BitmapRect{X: 0, Y: 0, Width: 4, Height: 4, BitsPerPixel: 24}, blue) {
+		t.Error("identical blue repaint must report unchanged")
+	}
+}
+
+// TestShadowCanvas_FirstPaintOfZeroPixelsCountsAsChanged: the canvas starts
+// zeroed; a first paint whose decoded RGBA is black (0,0,0) is byte-identical
+// to the zeroed framebuffer but is NEW to the client and MUST be treated as
+// changed (so it is analyzed). The grow guard guarantees this — without it,
+// black-on-black content could reach the client unanalyzed.
+func TestShadowCanvas_FirstPaintOfZeroPixelsCountsAsChanged(t *testing.T) {
+	c := shadowCanvas{sessionID: "t"}
+	black := bytes.Repeat([]byte{0x00, 0x00, 0x00}, 16) // BGR 4x4 black
+
+	if !c.composite(parser.BitmapRect{X: 0, Y: 0, Width: 4, Height: 4, BitsPerPixel: 24}, black) {
+		t.Error("first paint into new canvas area must be changed even if pixels are black")
+	}
+	if c.composite(parser.BitmapRect{X: 0, Y: 0, Width: 4, Height: 4, BitsPerPixel: 24}, black) {
+		t.Error("identical black repaint over existing black must be unchanged")
+	}
+}
+
 // --- Adversarial leak tests -------------------------------------------------
 //
 // These prove the zero-leak pipeline property with a perfect detector
@@ -633,10 +672,43 @@ func TestPIIGate_FlashAttackNeverLeaks(t *testing.T) {
 	}
 }
 
-// TestPIIGate_OverwriteSplitsAndAnalyzesEachState: every repaint of the same
-// region within one ingest burst forces its own batch, so every intermediate
-// state is analyzed — one analysis per overwrite generation.
-func TestPIIGate_OverwriteSplitsAndAnalyzesEachState(t *testing.T) {
+// TestPIIGate_IdenticalRepaintOfPIIIsStillCaught: the dirty-skip optimization
+// must not let an identical repaint refresh PII past the guard. The signature
+// is painted (changed -> analyzed -> killed) so the identical repaint never even
+// runs; the first changed paint is always the one analyzed, and nothing leaks.
+func TestPIIGate_IdenticalRepaintOfPIIIsStillCaught(t *testing.T) {
+	h := &gateHarness{}
+	var calls atomic.Int32
+	gate := newTestGate(t, h, signatureDetector(&calls, 40, 40, 8, 8))
+
+	sig := fastPathBitmapPDU(t, testRect{40, 40, 8, 8, magenta})
+	gate.Ingest(append(append([]byte(nil), sig...), sig...))
+
+	waitFor(t, "signature detected on first changed paint", func() bool { return h.detections() == 1 })
+	if !gate.Killed() {
+		t.Error("gate must kill on the PII paint")
+	}
+	if got := calls.Load(); got < 1 {
+		t.Errorf("the changed PII paint must be analyzed: got %d analyses", got)
+	}
+
+	leaked := false
+	oracle := newClientOracle(t, func(fb []byte, _, _ int) {
+		if anyMagentaPixel(fb) {
+			leaked = true
+		}
+	})
+	oracle.consume(h.forwardedBytes())
+	if leaked {
+		t.Fatal("LEAK: signature reached a client-renderable state")
+	}
+}
+
+// TestPIIGate_IdenticalRepaintsForwardButAnalyzeOnce: byte-identical repaints
+// of the same region carry no new content — they must still be FORWARDED (the
+// client expects every PDU), but the gate skips re-analyzing pixels it already
+// analyzed. RDP resends identical tiles constantly and re-OCRing them is waste.
+func TestPIIGate_IdenticalRepaintsForwardButAnalyzeOnce(t *testing.T) {
 	h := &gateHarness{}
 	var calls atomic.Int32
 	gate := newTestGate(t, h, signatureDetector(&calls, 40, 40, 8, 8))
@@ -649,12 +721,45 @@ func TestPIIGate_OverwriteSplitsAndAnalyzesEachState(t *testing.T) {
 	}
 	gate.Ingest(burst)
 
-	waitFor(t, "all clean repaints forwarded in order", func() bool { return bytes.Equal(h.forwardedBytes(), want) })
-	if got := calls.Load(); got != 5 {
-		t.Errorf("each overwrite generation must be analyzed: got %d analyses, want 5", got)
+	// Correctness preserved: every PDU is still delivered, in order.
+	waitFor(t, "all repaints forwarded in order", func() bool { return bytes.Equal(h.forwardedBytes(), want) })
+	// Optimization: identical pixels are analyzed once, not five times.
+	if got := calls.Load(); got != 1 {
+		t.Errorf("identical repaints must collapse to a single analysis: got %d, want 1", got)
 	}
 	if h.detections() != 0 {
 		t.Errorf("clean repaints must not detect")
+	}
+}
+
+// TestPIIGate_ChangedRepaintsAnalyzeEachState: every repaint that actually
+// CHANGES pixels still forces its own batch and is analyzed — the dirty-skip
+// optimization must never collapse genuinely distinct screen states (that would
+// be a leak). Alternating colors at a non-signature region change pixels every
+// generation; each must be analyzed.
+func TestPIIGate_ChangedRepaintsAnalyzeEachState(t *testing.T) {
+	h := &gateHarness{}
+	var calls atomic.Int32
+	gate := newTestGate(t, h, signatureDetector(&calls, 40, 40, 8, 8))
+
+	// Paint the same region alternating white/magenta away from the signature
+	// rect (signature at 40,40; paint at 0,0) so each generation differs in
+	// pixels but never trips the detector.
+	colors := [][3]byte{white, magenta, white, magenta, white}
+	var burst, want []byte
+	for _, c := range colors {
+		pdu := fastPathBitmapPDU(t, testRect{0, 0, 8, 8, c})
+		burst = append(burst, pdu...)
+		want = append(want, pdu...)
+	}
+	gate.Ingest(burst)
+
+	waitFor(t, "all changed repaints forwarded in order", func() bool { return bytes.Equal(h.forwardedBytes(), want) })
+	if got := calls.Load(); got != int32(len(colors)) {
+		t.Errorf("each pixel-changing generation must be analyzed: got %d, want %d", got, len(colors))
+	}
+	if h.detections() != 0 {
+		t.Errorf("magenta away from the signature region must not detect")
 	}
 }
 


### PR DESCRIPTION
## Why

Production latency logs (#1555/#1557) proved **OCR dominates** the PII guard (~95% of batch time), and the OCR cache is **architecturally ineffective**: `composite()` marked a region dirty (→ OCR'd) on **every** bitmap paint. But RDP constantly resends **byte-identical tiles** (idle repaints, unchanged backgrounds), so unchanged content was re-OCR'd every frame — `ocr_calls ≈ ocr_chunks` (near-zero reuse) in the logs.

## What

`composite_bitmap` now compares before writing and reports whether any pixel **actually changed**. The gate marks a region dirty (→ analyzes/OCRs it) **only when it changed** (or the canvas grew). Unchanged paints are still **forwarded** — only analysis is skipped — so delivery is byte-for-byte unchanged.

Mirrored on both gates (agentrs Rust + gateway Go) so they enforce identically. `CompositeBitmap` (Go) now returns `bool`; the full-frame worker and rdpbench ignore it.

## Safety (security-critical guard)

Skipping analysis on identical pixels cannot leak PII:
- An unchanged paint's pixels are **already on the shadow canvas** and were analyzed when they first appeared — there is no unanalyzed content.
- A **first paint into newly grown canvas area is forced changed** (covers the black-on-zeroed-canvas edge).
- **Batch sealing is unaffected**: it keys on changed paints, which still dirty their band; the painted-then-overwritten protection (`flash_attack`/`cross_batch`) still holds.

## Verification

- `@review`: **no CRITICAL/HIGH**, security invariant verified path-by-path. Added the reviewer-requested regression tests (zero-pixel first paint; identical-PII-repaint-still-caught) on both sides.
- New `paints_total/paints_changed` metrics quantify the real skip rate in prod.
- 94 agentrs piigate tests + Go rdp suite pass; clippy + `go vet` clean.

Pure analysis-scheduling optimization; active only when `experimental.rdp_pii_guard` runs. No change to forwarded bytes or enforcement.

Automated by MisterMal