### PR TITLE
fix(webapp): restore SAML login in React shell (ENG-501)

### DIFF
--- a/webapp_v2/src/pages/Auth/Login/index.jsx
+++ b/webapp_v2/src/pages/Auth/Login/index.jsx
@@ -93,7 +93,7 @@ function Login() {
         setAuthMethod(method)
 
         if (method !== 'local') {
-          redirectToIdp()
+          redirectToIdp(method)
         }
       } catch (err) {
         console.error('Failed to fetch server info:', err)
@@ -106,11 +106,14 @@ function Login() {
     fetchAuthMethod()
   }, [isAuthenticated])
 
-  const redirectToIdp = async (options = {}) => {
+  const redirectToIdp = async (method, options = {}) => {
     setLoading(true)
     try {
       const callbackUrl = `${window.location.origin}/auth/callback`
-      const loginUrl = await authService.getLoginUrl(callbackUrl, options)
+      const loginUrl =
+        method === 'saml'
+          ? await authService.getSamlLoginUrl(callbackUrl, options)
+          : await authService.getLoginUrl(callbackUrl, options)
       window.location.replace(loginUrl)
     } catch (err) {
       setError('Failed to initialize login')
@@ -169,7 +172,7 @@ function Login() {
         <Alert color="red" mb="md">
           {error}
         </Alert>
-        <Button fullWidth onClick={() => redirectToIdp({ promptLogin: true })} loading={loading}>
+        <Button fullWidth onClick={() => redirectToIdp(authMethod, { promptLogin: true })} loading={loading}>
           Try again
         </Button>
       </AuthCard>

--- a/webapp_v2/src/services/auth.js
+++ b/webapp_v2/src/services/auth.js
@@ -4,6 +4,7 @@ const AUTH_ENDPOINTS = {
   LOCAL_LOGIN: '/localauth/login',
   LOCAL_REGISTER: '/localauth/register',
   IDPS_LOGIN: '/login',
+  SAML_LOGIN: '/saml/login',
   SIGNUP: '/signup',
   USER: '/userinfo',
   SERVER_INFO: '/serverinfo',
@@ -58,6 +59,24 @@ export const authService = {
     params.append('redirect', callbackUrl);
 
     const response = await api.get(`${AUTH_ENDPOINTS.IDPS_LOGIN}?${params.toString()}`);
+    return response.data.login_url;
+  },
+
+  // Get SAML login URL (for SAML 2.0 identity providers)
+  // Calls GET /saml/login?redirect=<callbackUrl> and returns login_url from response
+  async getSamlLoginUrl(callbackUrl, options = {}) {
+    const { promptLogin = false } = options;
+
+    const params = new URLSearchParams();
+
+    // SAML's equivalent of the OIDC re-authentication prompt
+    if (promptLogin) {
+      params.append('force_authn', 'true');
+    }
+
+    params.append('redirect', callbackUrl);
+
+    const response = await api.get(`${AUTH_ENDPOINTS.SAML_LOGIN}?${params.toString()}`);
     return response.data.login_url;
   },
 


### PR DESCRIPTION
## 📝 Description

Restores SAML login in the React webapp. On a gateway configured with `auth_method: "saml"`, users could not sign in — the login page showed **"Failed to initialize login"** and `GET /api/login` returned **403 `{"message":"OIDC provider not configured"}`**.

The React login page only knew the OIDC login endpoint: any non-local auth method was routed to `GET /api/login`. SAML has its own endpoint (`GET /api/saml/login`) that the React app never called — this path existed in the legacy ClojureScript login (`:auth->get-saml-link`) but was dropped in the React shell migration (#1427). OIDC providers (Google, Entra, Auth0, …) were unaffected; only SAML 2.0 was broken.

Reported by a self-hosted customer (OneLogin IdP) after upgrading to 1.96.0. Affects every release with the React login shell (verified absent through 1.104.4 and `main`).

## 🔗 Related Issue

ENG-501 — https://linear.app/hoophq/issue/ENG-501

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- `services/auth.js`: add `SAML_LOGIN: '/saml/login'` and `getSamlLoginUrl(callbackUrl, options)` (mirrors `getLoginUrl`; maps the "Try again" re-auth prompt to SAML `force_authn=true`).
- `pages/Auth/Login/index.jsx`: `redirectToIdp(method, options)` dispatches to `getSamlLoginUrl` when `method === 'saml'`, otherwise the OIDC path. Both call sites pass the method explicitly (the initial effect can't read the `authMethod` state — `setAuthMethod` is async).

## 🧪 Testing

No backend change needed: `GET /api/saml/login` returns `{login_url}` (same shape as OIDC), and `POST /api/saml/callback` already sets the `hoop_access_token` cookie and redirects to `login.Redirect` — identical to OIDC — so the existing React `/auth/callback` completes the flow.

### Test Configuration:
- **Browser(s)**: Chrome/Firefox
- **OS**: macOS / Linux

### Tests performed:
- [x] Manual testing completed — `npm run build` passes; SAML login page now redirects to the IdP instead of 403ing; OIDC (Google) and local logins unchanged.
- [ ] Unit tests pass
- [ ] Integration tests pass

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- **Out of scope (follow-up):** `Login/index.jsx` routes to `/setup` when `setup_required && method !== 'oidc'`. A brand-new SAML install (zero users) would land on `/setup` instead of SAML SSO, even though the gateway SAML callback self-provisions the first user as admin like OIDC. Not changed here to keep the fix surgical — likely the condition should also exempt `saml`.
- Two pre-existing eslint errors in `Login/index.jsx` (`'err' unused` in the `redirectToIdp`/`handleSignup` catch blocks) are untouched by this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
