### PR TITLE
Add Google Vertex AI provider for Claude Code connections 

### DIFF
--- a/agent/controller/agent.go
+++ b/agent/controller/agent.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	
 
 	"github.com/getsentry/sentry-go"
 	"github.com/hoophq/hoop/agent/config"
@@ -77,6 +76,15 @@ type (
 		// it, async-dispatched goroutines could each miss the connStore
 		// cache and dial duplicate upstream SSH connections.
 		sshFlightGroup singleflight.Group
+
+		// gcpTokenSources caches one oauth2.TokenSource per session (keyed by
+		// gateway session ID) for claude-code connections that federate to
+		// Google Vertex AI. The source is built once from the connection's
+		// service-account key and reused for the life of the session so the
+		// bearer is minted lazily and auto-refreshed by the oauth2 library
+		// shortly before expiry — rather than re-minted on every proxied
+		// request. Entries are removed in sessionCleanup.
+		gcpTokenSources sync.Map
 	}
 	connEnv struct {
 		scheme             string
@@ -94,9 +102,15 @@ type (
 		connectionString   string
 		httpProxyRemoteURL string
 		httpProxyHeaders   map[string]string
-		awsRegion          string
-		awsSecretAccessKey string
-		awsAccessKeyID     string
+		// gcpServiceAccountJSON carries the GCP service-account key configured
+		// on a claude-code connection that federates to Google Vertex AI. When
+		// present (and the experimental.claude_code_vertex flag is on) the agent
+		// mints a short-lived OAuth bearer from it and injects it as the upstream
+		// Authorization header. Empty for every other connection.
+		gcpServiceAccountJSON string
+		awsRegion             string
+		awsSecretAccessKey    string
+		awsAccessKeyID        string
 
 		kubernetesClusterURL         string
 		kubernetesToken              string
@@ -440,6 +454,9 @@ func (a *Agent) sessionCleanup(sessionID string) {
 		a.connStore.Del(key)
 		a.connWriteLocks.Delete(key)
 	}
+	// Drop any cached Vertex token source so the service-account-derived
+	// credential does not outlive the session in agent memory.
+	a.gcpTokenSources.Delete(sessionID)
 }
 
 func (a *Agent) sendClientSessionClose(sessionID string, errMsg string) {
@@ -738,9 +755,10 @@ func parseConnectionEnvVars(envVars map[string]any, connType pb.ConnectionType) 
 		postgresSSLMode:   envVarS.Getenv("SSLMODE"),
 		options:           envVarS.Getenv("OPTIONS"),
 		// this option is only used by mongodb at the momento
-		connectionString:   envVarS.Getenv("CONNECTION_STRING"),
-		httpProxyRemoteURL: envVarS.Getenv("REMOTE_URL"),
-		httpProxyHeaders:   httpProxyHeaders,
+		connectionString:      envVarS.Getenv("CONNECTION_STRING"),
+		httpProxyRemoteURL:    envVarS.Getenv("REMOTE_URL"),
+		httpProxyHeaders:      httpProxyHeaders,
+		gcpServiceAccountJSON: envVarS.Getenv("GCP_SERVICE_ACCOUNT_JSON"),
 
 		kubernetesClusterURL:         envVarS.Getenv("KUBERNETES_CLUSTER_URL"),
 		kubernetesToken:              envVarS.Getenv("KUBERNETES_BEARER_TOKEN"),

--- a/agent/controller/gcpvertex.go
+++ b/agent/controller/gcpvertex.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// claudeCodeVertexFlag gates the claude-code → Google Vertex AI federation.
+// When off, the agent never mints GCP tokens for a claude-code connection and
+// leaves the request headers untouched.
+const claudeCodeVertexFlag = "experimental.claude_code_vertex"
+
+// gcpVertexScope is the OAuth scope minted bearers carry. cloud-platform is the
+// scope Vertex AI prediction calls require (roles/aiplatform.user).
+const gcpVertexScope = "https://www.googleapis.com/auth/cloud-platform"
+
+// gcpVertexBearer returns a valid GCP OAuth access token for the session,
+// minted from the connection's service-account key (saJSON).
+//
+// The oauth2.TokenSource built from the service-account key is cached per
+// session in a.gcpTokenSources and reused across every proxied request, so the
+// token is minted lazily on first use and transparently refreshed by the oauth2
+// library shortly before it expires. This is what lets a long-lived Claude Code
+// session keep working past the ~1h token TTL without re-opening the session.
+//
+// google.CredentialsFromJSON only parses the key (no network I/O); the network
+// round-trip to Google's token endpoint happens inside TokenSource.Token().
+func (a *Agent) gcpVertexBearer(sessionID, saJSON string) (string, error) {
+	ts, ok := a.gcpTokenSources.Load(sessionID)
+	if !ok {
+		creds, err := google.CredentialsFromJSON(context.Background(), []byte(saJSON), gcpVertexScope)
+		if err != nil {
+			return "", fmt.Errorf("invalid gcp service account credentials: %w", err)
+		}
+		// LoadOrStore guards against two concurrent requests for the same
+		// session each building a source: the first stored wins and both
+		// share its token cache.
+		ts, _ = a.gcpTokenSources.LoadOrStore(sessionID, creds.TokenSource)
+	}
+
+	tokenSource, isTokenSource := ts.(oauth2.TokenSource)
+	if !isTokenSource {
+		return "", fmt.Errorf("unexpected cached token source type %T", ts)
+	}
+	token, err := tokenSource.Token()
+	if err != nil {
+		return "", fmt.Errorf("failed minting gcp access token: %w", err)
+	}
+	return token.AccessToken, nil
+}
+
+// removeHeader deletes a proxy header by name, case-insensitively. The header
+// map is built from connection env vars (e.g. "HEADER_X_API_KEY"), so the exact
+// casing is whatever was stored; this guards against a stale key surviving when
+// the Vertex bearer supersedes a connection's static API-key header.
+func removeHeader(headers map[string]string, name string) {
+	for k := range headers {
+		if strings.EqualFold(k, name) {
+			delete(headers, k)
+		}
+	}
+}

--- a/agent/controller/httpproxy.go
+++ b/agent/controller/httpproxy.go
@@ -10,6 +10,7 @@ import (
 	redactortypes "libhoop/redactor/types"
 	"strings"
 
+	"github.com/hoophq/hoop/agent/controller/featureflagstate"
 	"github.com/hoophq/hoop/common/log"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
@@ -102,6 +103,23 @@ func (a *Agent) processHttpProxyWriteServer(pkt *pb.Packet) {
 		}
 		connenv.httpProxyHeaders["HEADER_AUTHORIZATION"] = connenv.kubernetesToken
 		connenv.httpProxyHeaders["insecure"] = fmt.Sprintf("%v", connenv.kubernetesInsecureSkipVerify)
+	}
+
+	// Google Vertex AI federation for claude-code connections: when the
+	// connection carries a service-account key and the feature is enabled,
+	// mint a short-lived OAuth bearer and inject it as the upstream
+	// Authorization header so Claude Code (running in Vertex mode) reaches
+	// Vertex as the connection's GCP identity. The bearer supersedes any
+	// static API-key header configured on the connection.
+	if connenv.gcpServiceAccountJSON != "" && featureflagstate.IsEnabled(claudeCodeVertexFlag) {
+		token, err := a.gcpVertexBearer(sessionID, connenv.gcpServiceAccountJSON)
+		if err != nil {
+			log.Infof("failed obtaining gcp vertex credentials, err=%v", err)
+			a.sendClientSessionClose(sessionID, fmt.Sprintf("failed obtaining GCP credentials: %v", err))
+			return
+		}
+		removeHeader(connenv.httpProxyHeaders, "HEADER_X_API_KEY")
+		connenv.httpProxyHeaders["HEADER_AUTHORIZATION"] = "Bearer " + token
 	}
 
 	// Build the per-connection AI session analyzer from the gateway-resolved

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/crypto v0.52.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.81.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -144,7 +145,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/api v0.283.0 // indirect
 	google.golang.org/genproto v0.0.0-20260610212136-7ab31c22f7ad // indirect

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -88,6 +88,7 @@ github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
@@ -209,6 +210,7 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgm
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -387,6 +389,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/client/cmd/claude.go
+++ b/client/cmd/claude.go
@@ -53,30 +53,41 @@ func runClaudeConfigure(connectionName string) {
 	baseURL := fmt.Sprintf("%s://%s:%s", scheme, creds.Hostname, creds.Port)
 	proxyToken := creds.ProxyToken
 
-	if err := updateClaudeSettings(baseURL, proxyToken, claudeSettingsFile); err != nil {
+	settings := claudeSettings{
+		baseURL:       baseURL,
+		proxyToken:    proxyToken,
+		vertexProject: creds.VertexProjectID,
+		vertexRegion:  creds.VertexRegion,
+	}
+	if err := updateClaudeSettings(settings, claudeSettingsFile); err != nil {
 		printErrorAndExit("failed to update Claude settings: %s", err.Error())
 	}
 
 	path, _ := claudeSettingsFilePath(claudeSettingsFile)
-	printClaudeConfigureSuccess(path, connectionName, baseURL, proxyToken)
+	printClaudeConfigureSuccess(path, connectionName, settings)
 }
 
-func printClaudeConfigureSuccess(settingsPath, connectionName, baseURL, token string) {
+func printClaudeConfigureSuccess(settingsPath, connectionName string, settings claudeSettings) {
 	labelStyle := lipgloss.NewStyle().Faint(true).Width(14)
 	valueStyle := lipgloss.NewStyle()
 	successStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10"))
 
 	// truncate token for display
-	displayToken := token
-	if len(token) > 24 {
-		displayToken = token[:24] + "..."
+	displayToken := settings.proxyToken
+	if len(displayToken) > 24 {
+		displayToken = displayToken[:24] + "..."
 	}
 
 	fmt.Println()
 	fmt.Printf("  %s %s\n", successStyle.Render("✓"), styles.Fainted("%s updated", settingsPath))
 	fmt.Println()
 	fmt.Printf("  %s%s\n", labelStyle.Render("Connection"), valueStyle.Render(connectionName))
-	fmt.Printf("  %s%s\n", labelStyle.Render("Base URL"), valueStyle.Render(baseURL))
+	if settings.isVertex() {
+		fmt.Printf("  %s%s\n", labelStyle.Render("Provider"), valueStyle.Render("Google Vertex AI"))
+		fmt.Printf("  %s%s\n", labelStyle.Render("Project"), valueStyle.Render(settings.vertexProject))
+		fmt.Printf("  %s%s\n", labelStyle.Render("Region"), valueStyle.Render(settings.vertexRegion))
+	}
+	fmt.Printf("  %s%s\n", labelStyle.Render("Base URL"), valueStyle.Render(settings.baseURL))
 	fmt.Printf("  %s%s\n", labelStyle.Render("Token"), valueStyle.Render(displayToken))
 	fmt.Println()
 	fmt.Println(styles.Fainted("  Claude Code requests are now routed through hoop."))
@@ -87,9 +98,11 @@ func printClaudeConfigureSuccess(settingsPath, connectionName, baseURL, token st
 }
 
 type activeCredentials struct {
-	Hostname   string `json:"hostname"`
-	Port       string `json:"port"`
-	ProxyToken string `json:"proxy_token"`
+	Hostname        string `json:"hostname"`
+	Port            string `json:"port"`
+	ProxyToken      string `json:"proxy_token"`
+	VertexProjectID string `json:"vertex_project_id"`
+	VertexRegion    string `json:"vertex_region"`
 }
 
 type credentialsEnvelope struct {

--- a/client/cmd/claudesettings.go
+++ b/client/cmd/claudesettings.go
@@ -20,10 +20,42 @@ func claudeSettingsFilePath(override string) (string, error) {
 	return filepath.Join(home, claudeSettingsPath), nil
 }
 
-// updateClaudeSettings merges ANTHROPIC_BASE_URL (and optionally ANTHROPIC_CUSTOM_HEADERS)
-// into ~/.claude/settings.json, preserving all other existing keys.
-// If proxyToken is empty, ANTHROPIC_CUSTOM_HEADERS is removed from the env section.
-func updateClaudeSettings(baseURL, proxyToken, settingsFile string) error {
+// claudeSettings is the resolved set of values written into the Claude Code
+// settings env block for a connection. When vertexProject is set the connection
+// federates to Google Vertex AI and the Vertex-mode env keys are emitted;
+// otherwise the standard Anthropic-mode keys are used.
+type claudeSettings struct {
+	baseURL       string
+	proxyToken    string
+	vertexProject string
+	vertexRegion  string
+}
+
+func (s claudeSettings) isVertex() bool { return s.vertexProject != "" }
+
+// vertexEnvKeys are the env keys that only make sense in Vertex mode. They are
+// stripped when writing an Anthropic-mode connection so switching a connection
+// back and forth never leaves stale keys behind.
+var vertexEnvKeys = []string{
+	"CLAUDE_CODE_USE_VERTEX",
+	"ANTHROPIC_VERTEX_PROJECT_ID",
+	"CLOUD_ML_REGION",
+	"ANTHROPIC_VERTEX_BASE_URL",
+}
+
+// updateClaudeSettings merges the hoop-managed env keys into
+// ~/.claude/settings.json, preserving all other existing keys.
+//
+//   - Anthropic mode sets ANTHROPIC_BASE_URL (+ ANTHROPIC_CUSTOM_HEADERS when a
+//     proxy token is present) and strips any Vertex-mode keys.
+//   - Vertex mode sets CLAUDE_CODE_USE_VERTEX, ANTHROPIC_VERTEX_PROJECT_ID,
+//     CLOUD_ML_REGION and ANTHROPIC_VERTEX_BASE_URL (so Claude Code talks the
+//     Vertex protocol to the hoop proxy) and strips ANTHROPIC_BASE_URL.
+//
+// In both modes the proxy token rides in ANTHROPIC_CUSTOM_HEADERS as the
+// Authorization header; the gateway authenticates it and the agent swaps in the
+// real upstream credential.
+func updateClaudeSettings(s claudeSettings, settingsFile string) error {
 	path, err := claudeSettingsFilePath(settingsFile)
 	if err != nil {
 		return err
@@ -40,9 +72,22 @@ func updateClaudeSettings(baseURL, proxyToken, settingsFile string) error {
 	if env == nil {
 		env = map[string]any{}
 	}
-	env["ANTHROPIC_BASE_URL"] = baseURL
-	if proxyToken != "" {
-		env["ANTHROPIC_CUSTOM_HEADERS"] = "Authorization: " + proxyToken
+
+	if s.isVertex() {
+		delete(env, "ANTHROPIC_BASE_URL")
+		env["CLAUDE_CODE_USE_VERTEX"] = "1"
+		env["ANTHROPIC_VERTEX_PROJECT_ID"] = s.vertexProject
+		env["CLOUD_ML_REGION"] = s.vertexRegion
+		env["ANTHROPIC_VERTEX_BASE_URL"] = s.baseURL
+	} else {
+		for _, k := range vertexEnvKeys {
+			delete(env, k)
+		}
+		env["ANTHROPIC_BASE_URL"] = s.baseURL
+	}
+
+	if s.proxyToken != "" {
+		env["ANTHROPIC_CUSTOM_HEADERS"] = "Authorization: " + s.proxyToken
 	} else {
 		delete(env, "ANTHROPIC_CUSTOM_HEADERS")
 	}

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -96,6 +96,13 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentAgent},
 	},
+	"experimental.claude_code_vertex": {
+		Name:        "experimental.claude_code_vertex",
+		Description: "Allow claude-code connections to authenticate against Google Vertex AI: the connection stores a GCP service-account key and the agent mints a short-lived, auto-refreshing OAuth bearer that it injects as the upstream Authorization header while transparently proxying Claude Code traffic to Vertex. Claude Code runs in Vertex mode (CLAUDE_CODE_USE_VERTEX) pointed at the hoop proxy. When off, the Vertex provider is hidden in the connection form and the agent does not mint GCP tokens.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentGateway, ComponentAgent},
+	},
 }
 
 // All returns every registered flag, sorted by name.

--- a/gateway/api/connections/connection_credentials.go
+++ b/gateway/api/connections/connection_credentials.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/hoophq/hoop/common/apiutils"
+	"github.com/hoophq/hoop/common/featureflag"
 	"github.com/hoophq/hoop/common/keys"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/common/proto"
@@ -892,17 +893,42 @@ func buildConnectionCredentialsResponse(
 				"subdomain": "` + browserWildcardCommand + `"
 			}`
 		base.ConnectionType = proto.ConnectionType(connectionType).String()
-		base.ConnectionCredentials = &openapi.HttpProxyConnectionInfo{
+		info := &openapi.HttpProxyConnectionInfo{
 			Hostname:   host,
 			Port:       serverPort,
 			ProxyToken: secretKey,
 			Command:    jsonCommandsString,
 		}
+		// For a claude-code connection federated to Google Vertex AI, surface
+		// the GCP project/region so `hoop claude configure` can emit the
+		// Vertex-mode client env. Gated by the experimental flag so a deploy
+		// with the feature off never advertises Vertex settings.
+		if conn.SubType.String == proto.ConnectionTypeClaudeCode.String() &&
+			featureflag.IsEnabled(cred.OrgID, "experimental.claude_code_vertex") {
+			info.VertexProjectID = decodeConnectionEnv(conn, "GCP_PROJECT_ID")
+			info.VertexRegion = decodeConnectionEnv(conn, "GCP_REGION")
+		}
+		base.ConnectionCredentials = info
 	default:
 		return nil
 	}
 
 	return &base
+}
+
+// decodeConnectionEnv returns the plaintext value of a connection env-var
+// secret (stored base64-encoded under the "envvar:NAME" key), or "" when the
+// key is absent or undecodable.
+func decodeConnectionEnv(conn *models.Connection, name string) string {
+	enc := conn.Envs[fmt.Sprintf("envvar:%s", name)]
+	if enc == "" {
+		return ""
+	}
+	decoded, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		return ""
+	}
+	return string(decoded)
 }
 
 func isConnectionTypeConfigured(connType proto.ConnectionType) bool {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -2469,6 +2469,14 @@ type HttpProxyConnectionInfo struct {
 	ProxyToken string `json:"proxy_token"`
 	// The command to access the HTTP proxy instance
 	Command string `json:"command"`
+	// VertexProjectID is set only for claude-code connections federated to
+	// Google Vertex AI (experimental.claude_code_vertex). It is the GCP project
+	// `hoop claude configure` writes to ANTHROPIC_VERTEX_PROJECT_ID so Claude
+	// Code runs in Vertex mode against the hoop proxy. Empty otherwise.
+	VertexProjectID string `json:"vertex_project_id,omitempty"`
+	// VertexRegion is the GCP region (CLOUD_ML_REGION) for the Vertex-federated
+	// claude-code connection. Empty for non-Vertex connections.
+	VertexRegion string `json:"vertex_region,omitempty"`
 }
 
 type PostgresConnectionInfo struct {

--- a/webapp/src/webapp/connections/native_client_access/custom_credential_views.cljs
+++ b/webapp/src/webapp/connections/native_client_access/custom_credential_views.cljs
@@ -23,12 +23,25 @@
   (let [hostname (:hostname connection_credentials)
         port (:port connection_credentials)
         proxy-token (:proxy_token connection_credentials)
+        vertex-project (:vertex_project_id connection_credentials)
+        vertex-region (:vertex_region connection_credentials)
+        vertex? (boolean (seq vertex-project))
         protocol (-> js/window .-location .-protocol)
         base-url (str protocol "//" hostname ":" port)
         custom-headers (str "Authorization: " proxy-token)
-        build-json-content (fn [base-url custom-headers]
-                             {:env {:ANTHROPIC_BASE_URL base-url
-                                    :ANTHROPIC_CUSTOM_HEADERS custom-headers}})]
+        ;; Vertex mode forwards the full Vertex path through hoop, so the base
+        ;; URL must keep the `/v1` segment the Anthropic Vertex SDK appends
+        ;; `/projects/...` to. The gateway proxy preserves the request path
+        ;; verbatim, so `/v1` has to come from the client base URL.
+        json-content (if vertex?
+                       {:env {:CLAUDE_CODE_USE_VERTEX "1"
+                              :CLAUDE_CODE_SKIP_VERTEX_AUTH "1"
+                              :ANTHROPIC_VERTEX_PROJECT_ID vertex-project
+                              :CLOUD_ML_REGION vertex-region
+                              :ANTHROPIC_VERTEX_BASE_URL (str base-url "/v1")
+                              :ANTHROPIC_AUTH_TOKEN proxy-token}}
+                       {:env {:ANTHROPIC_BASE_URL base-url
+                              :ANTHROPIC_CUSTOM_HEADERS custom-headers}})]
     [:<>
 
      ;; Anthropic API URL
@@ -52,17 +65,15 @@
        [:> Text {:size "2" :weight "regular" :class "text-[--gray-11]"}
         "Modify the following values accordingly. If you have more settings, you can leave them, you only need to modify "
         [:> Text {:as "span" :size "2" :weight "bold" :class "text-[--gray-11]"}
-         "ANTHROPIC_BASE_URL"]
+         (if vertex? "ANTHROPIC_VERTEX_BASE_URL" "ANTHROPIC_BASE_URL")]
         " and "
         [:> Text {:as "span" :size "2" :weight "bold" :class "text-[--gray-11]"}
-         "ANTHROPIC_CUSTOM_HEADERS"]
+         (if vertex? "ANTHROPIC_AUTH_TOKEN" "ANTHROPIC_CUSTOM_HEADERS")]
         "."]]
       [logs/new-container
        {:status :success
         :id "anthropic-authorization-header"
-        :logs [:pre (js/JSON.stringify (clj->js (build-json-content
-                                                 base-url
-                                                 custom-headers)) nil 2)]}]
+        :logs [:pre (js/JSON.stringify (clj->js json-content) nil 2)]}]
       [:> Box {:class "pt-1"}
        [:> Text {:size "2" :weight "regular" :class "text-[--gray-11]"}
         "Or run this command to apply automatically:"]

--- a/webapp/src/webapp/connections/views/setup/events/db_events.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/db_events.cljs
@@ -533,3 +533,8 @@
  (fn [db [_ enabled?]]
    (assoc-in db [:connection-setup :claude-code-credentials :insecure] (boolean enabled?))))
 
+(rf/reg-event-db
+ :connection-setup/update-claude-code-provider
+ (fn [db [_ provider]]
+   (assoc-in db [:connection-setup :claude-code-credentials :provider] provider)))
+

--- a/webapp/src/webapp/connections/views/setup/events/process_form.cljs
+++ b/webapp/src/webapp/connections/views/setup/events/process_form.cljs
@@ -16,6 +16,17 @@
            :value (resource-process-form/extract-value value connection-method (keyword key) secrets-provider)})
         headers))
 
+(defn claude-code-vertex-remote-url
+  "Builds the Google Vertex AI host the agent proxies claude-code traffic to,
+  from the configured GCP region. A blank or \"global\" region resolves to the
+  global endpoint; any other region uses the regional endpoint. The hostname
+  pattern matches Vertex AI's documented endpoints."
+  [region]
+  (let [r (str/trim (or region ""))]
+    (if (or (str/blank? r) (= r "global"))
+      "https://aiplatform.googleapis.com"
+      (str "https://" r "-aiplatform.googleapis.com"))))
+
 ;; Create a new connection
 (defn get-api-connection-type [ui-type subtype]
   (cond
@@ -181,14 +192,31 @@
                                               (str insecure-value)
                                               (if insecure-value "true" "false")))
 
-                             ;; For claude-code, include the HEADER_X_API_KEY in the base env vars
+                             ;; For claude-code, the emitted env vars depend on
+                             ;; the provider: the Anthropic API key path uses a
+                             ;; static HEADER_X_API_KEY, while the Google Vertex
+                             ;; AI path stores a service-account key (the agent
+                             ;; mints the upstream bearer) and derives REMOTE_URL
+                             ;; from the GCP region.
+                             claude-code-provider (let [p (get credentials :provider)]
+                                                    (if (map? p) (:value p) (or p "anthropic")))
                              base-env-vars (if (= connection-subtype "claude-code")
-                                             (let [api-key-value (get credentials :HEADER_X_API_KEY)
-                                                   api-key (resource-process-form/extract-value api-key-value connection-method :HEADER_X_API_KEY secrets-provider)]
-                                               (filterv #(not (str/blank? (:value %)))
-                                                        [{:key "REMOTE_URL" :value remote-url}
-                                                         {:key "HEADER_X_API_KEY" :value api-key}
-                                                         {:key "INSECURE" :value insecure-str}]))
+                                             (if (= claude-code-provider "vertex")
+                                               (let [region (resource-process-form/extract-value (get credentials :GCP_REGION) connection-method :GCP_REGION secrets-provider)
+                                                     project (resource-process-form/extract-value (get credentials :GCP_PROJECT_ID) connection-method :GCP_PROJECT_ID secrets-provider)
+                                                     sa-json (resource-process-form/extract-value (get credentials :GCP_SERVICE_ACCOUNT_JSON) connection-method :GCP_SERVICE_ACCOUNT_JSON secrets-provider)]
+                                                 (filterv #(not (str/blank? (:value %)))
+                                                          [{:key "REMOTE_URL" :value (claude-code-vertex-remote-url region)}
+                                                           {:key "GCP_SERVICE_ACCOUNT_JSON" :value sa-json}
+                                                           {:key "GCP_PROJECT_ID" :value project}
+                                                           {:key "GCP_REGION" :value region}
+                                                           {:key "INSECURE" :value insecure-str}]))
+                                               (let [api-key-value (get credentials :HEADER_X_API_KEY)
+                                                     api-key (resource-process-form/extract-value api-key-value connection-method :HEADER_X_API_KEY secrets-provider)]
+                                                 (filterv #(not (str/blank? (:value %)))
+                                                          [{:key "REMOTE_URL" :value remote-url}
+                                                           {:key "HEADER_X_API_KEY" :value api-key}
+                                                           {:key "INSECURE" :value insecure-str}])))
                                              ;; MCP (and any http proxy) keeps its Authorization
                                              ;; token in network-credentials, not the headers list,
                                              ;; so it is not shown/edited as a plain header. Emit it
@@ -426,15 +454,25 @@
                  (boolean insecure-value))}))
 
 (defn extract-claude-code-credentials
-  "Retrieves and normalizes remote_url, API key and insecure flag from secrets for claude-code credentials"
+  "Retrieves and normalizes claude-code credentials from secrets. Detects the
+  provider: a connection carrying GCP service-account/project/region secrets is
+  Google Vertex AI; otherwise it is the Anthropic API."
   [credentials]
   (let [remote-url-value (get credentials "REMOTE_URL")
         normalized-remote-url (connection-method/normalize-credential-value remote-url-value)
         api-key-value (get credentials "HEADER_X_API_KEY")
         normalized-api-key (connection-method/normalize-credential-value api-key-value)
+        sa-json-value (get credentials "GCP_SERVICE_ACCOUNT_JSON")
+        project-value (get credentials "GCP_PROJECT_ID")
+        region-value (get credentials "GCP_REGION")
+        vertex? (boolean (or sa-json-value project-value region-value))
         insecure-value (get credentials "INSECURE")]
     {:remote_url normalized-remote-url
      :HEADER_X_API_KEY normalized-api-key
+     :provider (if vertex? "vertex" "anthropic")
+     :GCP_SERVICE_ACCOUNT_JSON (connection-method/normalize-credential-value sa-json-value)
+     :GCP_PROJECT_ID (connection-method/normalize-credential-value project-value)
+     :GCP_REGION (connection-method/normalize-credential-value region-value)
      :insecure (if (string? insecure-value)
                  (= insecure-value "true")
                  (boolean insecure-value))}))
@@ -535,6 +573,13 @@
                         (let [headers (process-connection-envvars (:secret connection) "envvar")
                               remote-url? #(= (:key %) "REMOTE_URL")
                               insecure? #(= (:key %) "INSECURE")
+                              ;; claude-code Vertex secrets are edited through
+                              ;; dedicated form fields, not the generic headers
+                              ;; list, so keep them out of it.
+                              claude-code-vertex-key? #(contains? #{"GCP_SERVICE_ACCOUNT_JSON"
+                                                                    "GCP_PROJECT_ID"
+                                                                    "GCP_REGION"}
+                                                                  (:key %))
                               header? #(str/starts-with? % "HEADER_")
                               processed-headers (mapv (fn [{:keys [key value]}]
                                                         {:key (if (header? key)
@@ -543,7 +588,8 @@
                                                          :value value})
                                                       (->> headers
                                                            (remove remote-url?)
-                                                           (remove insecure?)))]
+                                                           (remove insecure?)
+                                                           (remove claude-code-vertex-key?)))]
                           processed-headers))
 
         connection-type (:type connection)

--- a/webapp/src/webapp/resources/configure_role/claude_code_edit.cljs
+++ b/webapp/src/webapp/resources/configure_role/claude_code_edit.cljs
@@ -1,6 +1,6 @@
 (ns webapp.resources.configure-role.claude-code-edit
   (:require
-   ["@radix-ui/themes" :refer [Box Flex Heading Switch Text]]
+   ["@radix-ui/themes" :refer [Box Callout Flex Heading Switch Text]]
    [re-frame.core :as rf]
    [reagent.core :as r]
    [webapp.components.forms :as forms]
@@ -8,10 +8,22 @@
    [webapp.connections.views.setup.configuration-inputs :as configuration-inputs]
    [webapp.connections.views.setup.connection-method :as connection-method]))
 
+(defn- credential-value
+  "Reads a claude-code credential field tolerating both the {:value ...} map
+  shape (used when the value is sourced from a secrets manager) and a plain
+  string. Returns default-value when the field is absent/blank."
+  [credentials k default-value]
+  (let [v (get credentials k)]
+    (cond
+      (map? v) (or (:value v) default-value)
+      (and (string? v) (not= v "")) v
+      :else default-value)))
+
 (defn claude-code-edit-form []
   (let [credentials (rf/subscribe [:connection-setup/claude-code-credentials])
         connection-method (rf/subscribe [:connection-setup/connection-method])
-        env-vars (rf/subscribe [:connection-setup/environment-variables])]
+        env-vars (rf/subscribe [:connection-setup/environment-variables])
+        vertex-flag? (rf/subscribe [:feature-flag/enabled? "experimental.claude_code_vertex"])]
     (fn []
       (r/with-let
         [initialized? (atom false)]
@@ -19,17 +31,23 @@
         (let [show-selector? (= @connection-method "secrets-manager")
               all-env-vars @env-vars
               x-api-key-env (some #(when (= (:key %) "X_API_KEY") %) all-env-vars)
-              remote-url-value (if (map? (:remote_url @credentials))
-                                 (:value (:remote_url @credentials))
-                                 (or (:remote_url @credentials) "https://api.anthropic.com"))
-              api-key-value (if (map? (:HEADER_X_API_KEY @credentials))
-                              (:value (:HEADER_X_API_KEY @credentials))
-                              (or (:HEADER_X_API_KEY @credentials)
-                                  (when x-api-key-env
-                                    (if (map? (:value x-api-key-env))
-                                      (:value (:value x-api-key-env))
-                                      (:value x-api-key-env)))
-                                  ""))
+              provider (credential-value @credentials :provider "anthropic")
+              vertex? (= provider "vertex")
+              ;; The Vertex option is shown when the feature is enabled, or when
+              ;; an already-Vertex connection is being edited on a gateway where
+              ;; the flag happens to be off, so the form never hides existing
+              ;; configuration.
+              show-vertex-option? (or @vertex-flag? vertex?)
+              remote-url-value (credential-value @credentials :remote_url "https://api.anthropic.com")
+              api-key-value (or (credential-value @credentials :HEADER_X_API_KEY nil)
+                                (when x-api-key-env
+                                  (if (map? (:value x-api-key-env))
+                                    (:value (:value x-api-key-env))
+                                    (:value x-api-key-env)))
+                                "")
+              project-value (credential-value @credentials :GCP_PROJECT_ID "")
+              region-value (credential-value @credentials :GCP_REGION "us-east5")
+              sa-json-value (credential-value @credentials :GCP_SERVICE_ACCOUNT_JSON "")
               insecure-value (let [raw-insecure (:insecure @credentials)]
                                (cond
                                  (boolean? raw-insecure) raw-insecure
@@ -61,28 +79,72 @@
             [:> Box {:class "space-y-radix-4"}
              [:> Heading {:size "4" :weight "bold"} "Basic info"]
 
-             [forms/input
-              {:label "Anthropic API URL"
-               :placeholder "https://api.anthropic.com"
-               :required true
-               :value remote-url-value
-               :on-change #(rf/dispatch [:connection-setup/update-claude-code-credentials
-                                         "remote_url"
-                                         (-> % .-target .-value)])
-               :start-adornment (when show-selector?
-                                  [connection-method/source-selector "remote_url"])}]
+             (when show-vertex-option?
+               [forms/select
+                {:label "Provider"
+                 :options [{:text "Anthropic API" :value "anthropic"}
+                           {:text "Google Vertex AI" :value "vertex"}]
+                 :selected provider
+                 :on-change #(rf/dispatch [:connection-setup/update-claude-code-provider %])}])
 
-             [forms/input
-              {:label "Anthropic API Key"
-               :placeholder "sk-ant-..."
-               :required true
-               :type "password"
-               :value api-key-value
-               :on-change #(rf/dispatch [:connection-setup/update-claude-code-credentials
-                                         "HEADER_X_API_KEY"
-                                         (-> % .-target .-value)])
-               :start-adornment (when show-selector?
-                                  [connection-method/source-selector "HEADER_X_API_KEY"])}]]
+             (if vertex?
+               [:<>
+                [:> Callout.Root {:size "1" :color "gray"}
+                 [:> Callout.Text
+                  "Claude Code runs in Vertex mode against hoop. hoop mints a short-lived "
+                  "token from the service account below and proxies requests to Google Vertex AI."]]
+
+                [forms/input
+                 {:label "GCP Region"
+                  :placeholder "us-east5"
+                  :required true
+                  :value region-value
+                  :on-change #(rf/dispatch [:connection-setup/update-claude-code-credentials
+                                            "GCP_REGION"
+                                            (-> % .-target .-value)])}]
+
+                [forms/input
+                 {:label "GCP Project ID"
+                  :placeholder "my-gcp-project"
+                  :required true
+                  :value project-value
+                  :on-change #(rf/dispatch [:connection-setup/update-claude-code-credentials
+                                            "GCP_PROJECT_ID"
+                                            (-> % .-target .-value)])}]
+
+                [forms/textarea
+                 {:label "Service Account JSON"
+                  :placeholder "{\n  \"type\": \"service_account\",\n  ...\n}"
+                  :required true
+                  :rows 8
+                  :value sa-json-value
+                  :on-change #(rf/dispatch [:connection-setup/update-claude-code-credentials
+                                            "GCP_SERVICE_ACCOUNT_JSON"
+                                            (-> % .-target .-value)])}]]
+
+               [:<>
+                [forms/input
+                 {:label "Anthropic API URL"
+                  :placeholder "https://api.anthropic.com"
+                  :required true
+                  :value remote-url-value
+                  :on-change #(rf/dispatch [:connection-setup/update-claude-code-credentials
+                                            "remote_url"
+                                            (-> % .-target .-value)])
+                  :start-adornment (when show-selector?
+                                     [connection-method/source-selector "remote_url"])}]
+
+                [forms/input
+                 {:label "Anthropic API Key"
+                  :placeholder "sk-ant-..."
+                  :required true
+                  :type "password"
+                  :value api-key-value
+                  :on-change #(rf/dispatch [:connection-setup/update-claude-code-credentials
+                                            "HEADER_X_API_KEY"
+                                            (-> % .-target .-value)])
+                  :start-adornment (when show-selector?
+                                     [connection-method/source-selector "HEADER_X_API_KEY"])}]])]
 
             [configuration-inputs/http-headers-section]
 

--- a/webapp/src/webapp/resources/setup/events/process_form.cljs
+++ b/webapp/src/webapp/resources/setup/events/process_form.cljs
@@ -42,13 +42,61 @@
       :else
       final-value)))
 
+(defn- raw-credential-value
+  "Returns the plain string held by a role credential, unwrapping the
+  {:value :source} secrets-manager shape."
+  [v]
+  (cond
+    (map? v) (str (:value v ""))
+    (nil? v) ""
+    :else (str v)))
+
+(defn claude-code-vertex-remote-url
+  "Builds the Google Vertex AI host the agent proxies claude-code traffic to,
+  from the configured GCP region. A blank or \"global\" region resolves to the
+  global endpoint; any other region uses the regional endpoint."
+  [region]
+  (let [r (str/trim (or region ""))]
+    (if (or (str/blank? r) (= r "global"))
+      "https://aiplatform.googleapis.com"
+      (str "https://" r "-aiplatform.googleapis.com"))))
+
+(defn claude-code-secret-credentials
+  "Builds the credential map emitted for a claude-code role. The UI-only
+  \"provider\" marker and the inactive provider's fields are dropped so they
+  never leak into the connection secret. For the Google Vertex AI provider the
+  regional Vertex host is derived into REMOTE_URL (forced to manual-input so it
+  is never treated as a secret reference)."
+  [credentials]
+  (let [provider (raw-credential-value (get credentials "provider"))
+        insecure (get credentials "insecure" false)]
+    (if (= provider "vertex")
+      ;; The Vertex fields are entered as literal values (no source-selector),
+      ;; so they are forced to manual-input — otherwise a role configured for a
+      ;; secrets manager would prefix them as secret references.
+      {"REMOTE_URL" {:value (claude-code-vertex-remote-url
+                             (raw-credential-value (get credentials "GCP_REGION")))
+                     :source "manual-input"}
+       "GCP_SERVICE_ACCOUNT_JSON" {:value (raw-credential-value (get credentials "GCP_SERVICE_ACCOUNT_JSON"))
+                                   :source "manual-input"}
+       "GCP_PROJECT_ID" {:value (raw-credential-value (get credentials "GCP_PROJECT_ID"))
+                         :source "manual-input"}
+       "GCP_REGION" {:value (raw-credential-value (get credentials "GCP_REGION"))
+                     :source "manual-input"}
+       "insecure" insecure}
+      {"remote_url" (get credentials "remote_url")
+       "HEADER_X_API_KEY" (get credentials "HEADER_X_API_KEY")
+       "insecure" insecure})))
+
 (defn process-role-secret
   "Process role credentials into secret format with base64 encoding"
   [role]
   (let [subtype (:subtype role)
         connection-method (:connection-method role)
         secrets-provider (or (:secrets-manager-provider role) "vault-kv1")
-        credentials (:credentials role)
+        credentials (if (= subtype "claude-code")
+                      (claude-code-secret-credentials (:credentials role))
+                      (:credentials role))
         metadata-credentials (:metadata-credentials role)
         env-vars (or (:environment-variables role) [])
         config-files (or (:configuration-files role) [])

--- a/webapp/src/webapp/resources/setup/roles_step.cljs
+++ b/webapp/src/webapp/resources/setup/roles_step.cljs
@@ -1,6 +1,6 @@
 (ns webapp.resources.setup.roles-step
   (:require
-   ["@radix-ui/themes" :refer [Box Button Flex Grid Heading Link Separator Text Switch]]
+   ["@radix-ui/themes" :refer [Box Button Callout Flex Grid Heading Link Separator Text Switch]]
    ["lucide-react" :refer [ArrowUpRight Check Plus ShieldCheck Trash2]]
    [clojure.string :as cs]
    [re-frame.core :as rf]
@@ -210,34 +210,45 @@
        [:> Text {:as "p" :size "2" :class "text-[--gray-11]"}
         "Skip SSL certificate verification for HTTPS connections."]]]]))
 
+(defn- claude-code-cred-display
+  "Display value for a claude-code create-form field, unwrapping the
+  {:value :source} secrets-manager shape into a plain string."
+  [credentials k]
+  (let [v (get credentials k "")]
+    (if (map? v) (or (:value v) "") v)))
+
 (defn claude-code-role-form [role-index]
   (let [credentials (rf/subscribe [:resource-setup/role-credentials role-index])
-        connection-method (rf/subscribe [:resource-setup/role-connection-method role-index])]
+        connection-method (rf/subscribe [:resource-setup/role-connection-method role-index])
+        vertex-flag? (rf/subscribe [:feature-flag/enabled? "experimental.claude_code_vertex"])]
     (fn [role-index]
-      (let [api-url-value (get @credentials "remote_url" "")
-            api-key-value (get @credentials "HEADER_X_API_KEY" "")
+      (let [creds @credentials
+            provider (let [p (claude-code-cred-display creds "provider")]
+                       (if (empty? p) "anthropic" p))
+            vertex? (= provider "vertex")
+            ;; Show the Vertex option when the feature is enabled, or when the
+            ;; role is already set to Vertex (so it never hides existing config).
+            show-vertex-option? (or @vertex-flag? vertex?)
+            api-url-value (claude-code-cred-display creds "remote_url")
+            api-key-value (claude-code-cred-display creds "HEADER_X_API_KEY")
+            region-value (claude-code-cred-display creds "GCP_REGION")
+            project-value (claude-code-cred-display creds "GCP_PROJECT_ID")
+            sa-json-value (claude-code-cred-display creds "GCP_SERVICE_ACCOUNT_JSON")
             show-selector? (= @connection-method "secrets-manager")
-            handle-api-url-change (fn [e]
-                                    (let [new-value (-> e .-target .-value)]
-                                      (rf/dispatch [:resource-setup->update-role-credentials
-                                                    role-index
-                                                    "remote_url"
-                                                    new-value])))
-            handle-api-key-change (fn [e]
-                                    (let [new-value (-> e .-target .-value)]
-                                      (rf/dispatch [:resource-setup->update-role-credentials
-                                                    role-index
-                                                    "HEADER_X_API_KEY"
-                                                    new-value])))]
+            update-cred (fn [k]
+                          (fn [e]
+                            (rf/dispatch [:resource-setup->update-role-credentials
+                                          role-index k (-> e .-target .-value)])))]
 
-        ;; Initialize default values
-        (when (empty? api-url-value)
+        ;; Initialize default values. REMOTE_URL is only relevant for the
+        ;; Anthropic provider; Vertex derives it from the region at submit time.
+        (when (and (not vertex?) (empty? api-url-value))
           (rf/dispatch [:resource-setup->update-role-credentials
                         role-index
                         "remote_url"
                         "https://api.anthropic.com"]))
 
-        (when (nil? (get credentials "insecure"))
+        (when (nil? (get creds "insecure"))
           (rf/dispatch [:resource-setup->update-role-credentials
                         role-index
                         "insecure"
@@ -247,28 +258,66 @@
          [:> Box {:class "space-y-radix-4"}
           [:> Heading {:size "3"} "Basic info"]
 
-          [forms/input {:label "Anthropic API URL"
-                        :placeholder "https://api.anthropic.com"
-                        :value (if (empty? api-url-value) "https://api.anthropic.com" api-url-value)
-                        :required true
-                        :type "text"
-                        :on-change handle-api-url-change
-                        :start-adornment (when show-selector?
-                                           [connection-method/source-selector role-index "remote_url"])}]
+          (when show-vertex-option?
+            [forms/select
+             {:label "Provider"
+              :options [{:text "Anthropic API" :value "anthropic"}
+                        {:text "Google Vertex AI" :value "vertex"}]
+              :selected provider
+              :on-change #(rf/dispatch [:resource-setup->update-role-credentials
+                                        role-index "provider" %])}])
 
-          [forms/input {:label "Anthropic API Key"
-                        :placeholder "sk-ant-..."
-                        :value api-key-value
-                        :required true
-                        :type "password"
-                        :on-change handle-api-key-change
-                        :start-adornment (when show-selector?
-                                           [connection-method/source-selector role-index "HEADER_X_API_KEY"])}]]
+          (if vertex?
+            [:<>
+             [:> Callout.Root {:size "1" :color "gray"}
+              [:> Callout.Text
+               "Claude Code runs in Vertex mode against hoop. hoop mints a short-lived "
+               "token from the service account below and proxies requests to Google Vertex AI."]]
+
+             [forms/input {:label "GCP Region"
+                           :placeholder "us-east5"
+                           :value region-value
+                           :required true
+                           :type "text"
+                           :on-change (update-cred "GCP_REGION")}]
+
+             [forms/input {:label "GCP Project ID"
+                           :placeholder "my-gcp-project"
+                           :value project-value
+                           :required true
+                           :type "text"
+                           :on-change (update-cred "GCP_PROJECT_ID")}]
+
+             [forms/textarea {:label "Service Account JSON"
+                              :placeholder "{\n  \"type\": \"service_account\",\n  ...\n}"
+                              :value sa-json-value
+                              :required true
+                              :rows 8
+                              :on-change (update-cred "GCP_SERVICE_ACCOUNT_JSON")}]]
+
+            [:<>
+             [forms/input {:label "Anthropic API URL"
+                           :placeholder "https://api.anthropic.com"
+                           :value (if (empty? api-url-value) "https://api.anthropic.com" api-url-value)
+                           :required true
+                           :type "text"
+                           :on-change (update-cred "remote_url")
+                           :start-adornment (when show-selector?
+                                              [connection-method/source-selector role-index "remote_url"])}]
+
+             [forms/input {:label "Anthropic API Key"
+                           :placeholder "sk-ant-..."
+                           :value api-key-value
+                           :required true
+                           :type "password"
+                           :on-change (update-cred "HEADER_X_API_KEY")
+                           :start-adornment (when show-selector?
+                                              [connection-method/source-selector role-index "HEADER_X_API_KEY"])}]])]
 
          [configuration-inputs/http-headers-section role-index]
 
          [:> Flex {:align "center" :gap "3"}
-          [:> Switch {:checked (get credentials "insecure" false)
+          [:> Switch {:checked (get creds "insecure" false)
                       :size "3"
                       :onCheckedChange #(rf/dispatch [:resource-setup->update-role-credentials
                                                       role-index


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Adds Google Vertex AI as an authentication provider for `claude-code` connections. A connection can now hold a single connection-level GCP identity (service account key, project, region); the agent mints and auto-refreshes a GCP OAuth2 bearer per request and injects it as the upstream `Authorization` header, so Claude Code can run in Vertex mode against the hoop HTTP proxy without any local `gcloud` auth. The same connection-level token is used for every user of the connection.

The whole feature is gated behind the experimental feature flag `experimental.claude_code_vertex` (default `false`), so a fresh deployment ships with everything off and existing Anthropic-API `claude-code` connections are unaffected.

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- **Feature flag**: register `experimental.claude_code_vertex` (gateway + agent), default off (`common/featureflag/featureflag.go`).
- **Agent token minting** (`agent/controller/gcpvertex.go`, `agent.go`): build an auto-refreshing `oauth2.TokenSource` from the connection's `GCP_SERVICE_ACCOUNT_JSON`, cached per session in a `sync.Map` and cleaned up on session teardown.
- **Agent HTTP proxy** (`agent/controller/httpproxy.go`): when the flag is on and the connection carries a service-account key, strip any `X-Api-Key` and set `Authorization: Bearer <gcp-token>` on the upstream Vertex request.
- **Gateway credentials API** (`gateway/api/openapi/types.go`, `connection_credentials.go`): surface `vertex_project_id` / `vertex_region` on `HttpProxyConnectionInfo` for Vertex-federated `claude-code` connections (flag-gated, `omitempty`).
- **Connect modal** (`custom_credential_views.cljs`): render the Vertex `settings.json` env block (`CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_SKIP_VERTEX_AUTH`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`, `ANTHROPIC_VERTEX_BASE_URL` with the required `/v1` suffix, `ANTHROPIC_AUTH_TOKEN`) when the connection is Vertex; falls back to the existing Anthropic block otherwise.
- **Connection create/edit forms** (`roles_step.cljs`, `claude_code_edit.cljs`, setup `process_form.cljs` / `db_events.cljs`): add a Provider selector (Anthropic API | Google Vertex AI) with GCP region / project / service-account-JSON fields, flag-gated, plus form processing and extract-on-edit.
- **CLI** (`client/cmd/claude.go`, `claudesettings.go`): `hoop claude configure` emits Vertex-mode client env when the connection is Vertex.
- **Deps** (`agent/go.mod`, `go.sum`): add `golang.org/x/oauth2/google` for service-account token sourcing.

## 🧪 Testing

Validated the end-to-end Vertex path against a real project (`claude-vertex-project-id`, region `global`, model `claude-opus-4-8`):

- Confirmed a direct `:rawPredict` call to Vertex returns `200` with a valid Claude completion.
- Reproduced and root-caused the proxied `404`: the agent forwards the client request path verbatim (only scheme+host of `REMOTE_URL` are used), so the `/v1` API-version segment must come from the client base URL. Fixed by emitting `ANTHROPIC_VERTEX_BASE_URL` with the `/v1` suffix in the connect modal.
- Verified `CLAUDE_CODE_SKIP_VERTEX_AUTH=1` is required for Claude Code to skip local GCP auth and route through the gateway, and that the gateway strips the `Bearer ` prefix from the proxy token (`gateway/proxyproto/httpproxy/httpproxy.go`).

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

Connect modal now shows the Vertex-mode `~/.claude/settings.json` block for Vertex-federated `claude-code` connections (with `/v1`, `CLAUDE_CODE_SKIP_VERTEX_AUTH`, and `ANTHROPIC_AUTH_TOKEN`).
<img width="1243" height="1162" alt="image" src="https://github.com/user-attachments/assets/41a97820-d3e5-489a-83c9-d5e7399f04ec" />
<img width="1008" height="1455" alt="image" src="https://github.com/user-attachments/assets/f030e9a6-f5b4-4daa-909f-de2c31c139a0" />
<img width="1096" height="710" alt="image" src="https://github.com/user-attachments/assets/f6e70862-4ec6-4b0c-ba27-f982d8de419b" />
## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- **Gated & off by default**: every new code path checks `experimental.claude_code_vertex`; existing Anthropic-API `claude-code` connections are untouched.
- **Reviewer focus / known follow-up**: the connect-modal JSON is the working, recommended path. The `hoop claude configure` CLI Vertex branch (`client/cmd/claudesettings.go`) still emits `ANTHROPIC_VERTEX_BASE_URL` **without** the `/v1` suffix, does **not** emit `CLAUDE_CODE_SKIP_VERTEX_AUTH=1`, and carries the token in `ANTHROPIC_CUSTOM_HEADERS` instead of `ANTHROPIC_AUTH_TOKEN` — so it would reproduce the `404` we fixed in the UI. This should be brought to parity (and `CLAUDE_CODE_SKIP_VERTEX_AUTH` added to the strip list) before relying on the CLI command shown in the same modal.
- **Security**: the GCP service-account key is connection-level config; the same minted bearer is shared by all users of the connection (by design — single connection-level identity).


