### PR TITLE
fix(rdp): keep empty OCR line recognitions as blank slots in PII guard

### DIFF
--- a/agentrs/src/piigate/analyze.rs
+++ b/agentrs/src/piigate/analyze.rs
@@ -44,10 +44,13 @@ use super::presidio::{analyze_text, AnalysisParams, PresidioClient, SnapshotResu
 ///   frame, so it tracks the current screen and cannot grow unbounded.
 #[derive(Default)]
 struct LineCache {
-    // (x0, y0, x1, y1, crop_sha256) -> the line's recognized word. The position
-    // is included so a hit also requires the same on-screen placement (a line
-    // that moved is re-analyzed in its new position).
-    entries: HashMap<LineKey, Word>,
+    // (x0, y0, x1, y1, crop_sha256) -> the line's recognition outcome. The
+    // position is included so a hit also requires the same on-screen placement
+    // (a line that moved is re-analyzed in its new position). The value is an
+    // `Option<Word>`: `None` caches a line that recognized to nothing usable
+    // (blank line, icon, separator), so a stable empty line is a cache hit too
+    // and never forces a needless rec.
+    entries: HashMap<LineKey, Option<Word>>,
 }
 
 /// Cache key: full-canvas bounding rect plus the SHA-256 (hex) of the exact
@@ -177,8 +180,8 @@ impl Analyzer for BandAnalyzer {
             // cache key for detection i, or None if the line is uncacheable.
             #[derive(Clone)]
             enum Slot {
-                Cached(Word),
-                Miss(usize), // index into miss_boxes
+                Cached(Option<Word>), // None = cached blank line
+                Miss(usize),          // index into miss_boxes
             }
             let mut slots: Vec<Slot> = Vec::with_capacity(det.boxes.len());
             let mut miss_boxes: Vec<LineBox> = Vec::new();
@@ -247,23 +250,30 @@ impl Analyzer for BandAnalyzer {
                 rec.words
             };
 
-            // Reassemble words in detection order, shifting band-local Y into
-            // full-canvas space, and publish each line into the new cache.
+            // Reassemble recognition outcomes in detection order, shifting
+            // band-local Y into full-canvas space, and publish each line into
+            // the new cache. A line may recognize to nothing usable (`None`):
+            // it still occupies a slot (preserving box↔word alignment) and is
+            // cached as blank, but contributes no word to Presidio and no
+            // redaction box.
             for (det_idx, slot) in slots.into_iter().enumerate() {
-                let word = match slot {
-                    Slot::Cached(w) => w, // already full-canvas
+                let word: Option<Word> = match slot {
+                    Slot::Cached(w) => w, // already full-canvas (or None)
                     Slot::Miss(mi) => {
-                        // rec returns one word per requested box, in order
+                        // rec returns one slot per requested box, in order
                         // (cardinality validated above, so the index is valid).
-                        let mut w = rec_words[mi].clone();
-                        w.top += band.y0; // band-local -> full-canvas
-                        w
+                        rec_words[mi].clone().map(|mut w| {
+                            w.top += band.y0; // band-local -> full-canvas
+                            w
+                        })
                     }
                 };
                 if let Some(key) = &keys[det_idx] {
                     new_cache.entries.insert(key.clone(), word.clone());
                 }
-                all_words.push(word);
+                if let Some(w) = word {
+                    all_words.push(w);
+                }
             }
         }
 
@@ -604,6 +614,56 @@ mod tests {
             res.is_err(),
             "a /rec returning fewer words than boxes must fail the analysis (fail-closed), not drop lines"
         );
+    }
+
+    // Regression for the "bottom half of the screen vanished" bug: RapidOCR's
+    // recognizer legitimately returns an EMPTY string for a detected box that
+    // holds no readable text (a blank row, an icon, a separator). /rec keeps
+    // that as an empty slot (positional contract: one entry per box), and the
+    // agent must turn it into a `None` word — NOT drop it. Dropping made the
+    // word count fall one short of the box count, tripping the fail-closed
+    // cardinality check and killing that band's forwarding, which on a real
+    // desktop blanked the lower portion of the screen.
+    async fn stub_rec_one_empty(_body: axum::body::Bytes) -> Json<Value> {
+        // Correct CARDINALITY (two entries for two boxes) but the second box
+        // recognized to empty text — exactly what the engine emits for a blank
+        // line. Must be accepted, not treated as a mismatch.
+        Json(json!({
+            "duration_ms": 1.0,
+            "words": [
+                { "text": "real text", "conf": 95.0, "x": 4, "y": 4,  "w": 40, "h": 12 },
+                { "text": "",          "conf": 0.0,  "x": 4, "y": 20, "w": 40, "h": 10 },
+            ],
+        }))
+    }
+
+    #[tokio::test]
+    async fn empty_recognition_is_kept_as_blank_slot_not_dropped() {
+        let app = Router::new()
+            .route("/det", post(stub_det_two)) // two detected boxes
+            .route("/rec", post(stub_rec_one_empty)) // second recognizes empty
+            .route("/analyze", post(stub_analyze_empty));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let analyzer = analyzer_for(&format!("http://{addr}"));
+        let (w, h) = (64usize, 64usize);
+        let fb = make_fb(w, h, 0xff);
+        let bands = vec![YBand { y0: 0, y1: 32 }];
+
+        // Must succeed: the empty second line is a `None` slot, the count still
+        // matches the box count, nothing is dropped, the band forwards normally.
+        let res = analyzer.analyze(&fb, w, h, &bands).await;
+        assert!(
+            res.is_ok(),
+            "an empty recognition must be kept as a blank slot, not dropped (which would fail-close and blank the band): {res:?}"
+        );
+
+        // A second identical frame is a full cache hit, including the blank
+        // line: the `None` outcome is cached too, so no needless re-rec.
+        analyzer.analyze(&fb, w, h, &bands).await.unwrap();
     }
 
     #[tokio::test]

--- a/agentrs/src/piigate/ocr.rs
+++ b/agentrs/src/piigate/ocr.rs
@@ -169,11 +169,19 @@ struct RecRequest {
     boxes: Vec<[[f32; 2]; 4]>,
 }
 
-/// Result of a recognition-only call: one word per requested box, in the same
-/// order, in full-image coordinates.
+/// Result of a recognition-only call: EXACTLY one slot per requested box, in
+/// the same order, in full-image coordinates. A slot is `None` when that box
+/// recognized to nothing usable (empty/whitespace text, or geometry the agent
+/// rejects) — a legitimate result for a blank line, an icon, or a separator.
+///
+/// The 1:1 positional alignment is load-bearing: the per-line cache pairs each
+/// detected box with its recognition outcome, and the analyzer fails closed on
+/// a count mismatch. Recognition outcomes must therefore never be *dropped*
+/// (which would silently misalign boxes and words); an unusable result becomes
+/// `None` in place, preserving the slot.
 #[derive(Debug)]
 pub struct RecResult {
-    pub words: Vec<Word>,
+    pub words: Vec<Option<Word>>,
     pub server_ms: f64,
     pub request_bytes: usize,
 }
@@ -313,6 +321,7 @@ impl OcrClient {
         if boxes.is_empty() {
             return Ok(RecResult { words: Vec::new(), server_ms: 0.0, request_bytes: 0 });
         }
+        let want = boxes.len();
         let bmp = encode_bmp(rgba, width, height);
         let req = RecRequest {
             image: base64::engine::general_purpose::STANDARD.encode(&bmp),
@@ -342,8 +351,21 @@ impl OcrClient {
         let out: OcrServerResponse =
             serde_json::from_slice(&body).context("ocr: invalid rec response")?;
 
+        // The /rec contract is positional: the sidecar must return exactly one
+        // entry per requested box, in order. Enforce it at the boundary so a
+        // protocol violation is a clear error here rather than a misaligned
+        // box/word pairing downstream. Empty/unusable recognitions are kept as
+        // `None` slots by `validate_words_positional` — never dropped.
+        if out.words.len() != want {
+            anyhow::bail!(
+                "ocr: rec returned {} entries for {} boxes (positional contract violated)",
+                out.words.len(),
+                want
+            );
+        }
+
         Ok(RecResult {
-            words: validate_words(out.words, width, height),
+            words: validate_words_positional(out.words, width, height),
             server_ms: out.duration_ms,
             request_bytes,
         })
@@ -381,39 +403,59 @@ mod hash_tests {
 /// confidence is clamped to 0..1 and rescaled to the 0-100 Word convention.
 fn validate_words(raw: Vec<OcrServerWord>, width: usize, height: usize) -> Vec<Word> {
     raw.into_iter()
-        .filter_map(|w| {
-            let text = w.text.trim();
-            if text.is_empty() {
-                return None;
-            }
-            if !w.conf.is_finite() || w.conf < 0.0 {
-                return None;
-            }
-            if w.x < 0 || w.y < 0 || w.w <= 0 || w.h <= 0 {
-                return None;
-            }
-            let (x, y, ww, hh) = (w.x as usize, w.y as usize, w.w as usize, w.h as usize);
-            // Reject tokens that fall outside the submitted image. The
-            // sidecar is a separate (untrusted) process: absurd coordinates
-            // would otherwise produce off-canvas bounding boxes and overflow
-            // the bbox merge in analyze_text. The Go engine does not
-            // bounds-check, but the agent-side sidecar runs in the customer
-            // network and warrants the stricter contract — words it drops
-            // here are off-screen anyway.
-            if x >= width || y >= height || ww > width - x || hh > height - y {
-                return None;
-            }
-            Some(Word {
-                text: text.to_string(),
-                left: x,
-                top: y,
-                width: ww,
-                height: hh,
-                // Server confidence is 0..1; Word.conf is 0-100.
-                conf: w.conf.min(1.0) * 100.0,
-            })
-        })
+        .filter_map(|w| validate_word(w, width, height))
         .collect()
+}
+
+/// Positional sibling of [`validate_words`] for the `/rec` path: returns one
+/// slot per input word, in order, with the same per-word sanitization but
+/// WITHOUT dropping. An unusable entry (empty text, bad confidence, degenerate
+/// or off-canvas geometry) becomes `None` in place rather than collapsing the
+/// vector — preserving the box↔word alignment the per-line cache relies on.
+fn validate_words_positional(
+    raw: Vec<OcrServerWord>,
+    width: usize,
+    height: usize,
+) -> Vec<Option<Word>> {
+    raw.into_iter()
+        .map(|w| validate_word(w, width, height))
+        .collect()
+}
+
+/// Sanitizes a single raw sidecar word, returning `None` if it is unusable.
+/// Shared by the dropping (`/ocr`, `/det` discovery) and positional (`/rec`)
+/// validators so both apply identical rules — only their handling of `None`
+/// differs (drop vs. keep-as-empty-slot).
+fn validate_word(w: OcrServerWord, width: usize, height: usize) -> Option<Word> {
+    let text = w.text.trim();
+    if text.is_empty() {
+        return None;
+    }
+    if !w.conf.is_finite() || w.conf < 0.0 {
+        return None;
+    }
+    if w.x < 0 || w.y < 0 || w.w <= 0 || w.h <= 0 {
+        return None;
+    }
+    let (x, y, ww, hh) = (w.x as usize, w.y as usize, w.w as usize, w.h as usize);
+    // Reject tokens that fall outside the submitted image. The sidecar is a
+    // separate (untrusted) process: absurd coordinates would otherwise produce
+    // off-canvas bounding boxes and overflow the bbox merge in analyze_text.
+    // The Go engine does not bounds-check, but the agent-side sidecar runs in
+    // the customer network and warrants the stricter contract — words rejected
+    // here are off-screen anyway.
+    if x >= width || y >= height || ww > width - x || hh > height - y {
+        return None;
+    }
+    Some(Word {
+        text: text.to_string(),
+        left: x,
+        top: y,
+        width: ww,
+        height: hh,
+        // Server confidence is 0..1; Word.conf is 0-100.
+        conf: w.conf.min(1.0) * 100.0,
+    })
 }
 
 #[cfg(test)]
@@ -450,6 +492,25 @@ mod tests {
         assert_eq!(kept[0].text, "ok"); // trimmed
         assert_eq!(kept[1].text, "clamp");
         assert_eq!(kept[1].conf, 100.0); // 5.0 clamped to 1.0 → 100
+    }
+
+    #[test]
+    fn positional_validation_keeps_one_slot_per_word() {
+        // Same inputs as the dropping validator, but positional: every input
+        // gets a slot; unusable ones become `None` IN PLACE (no collapse), so
+        // the i-th result still corresponds to the i-th requested /rec box.
+        let raw = vec![
+            OcrServerWord { text: "ok".into(), conf: 0.9, x: 0, y: 0, w: 10, h: 10 },
+            OcrServerWord { text: "".into(), conf: 0.0, x: 0, y: 0, w: 5, h: 5 }, // blank line
+            OcrServerWord { text: "bad".into(), conf: f64::NAN, x: 0, y: 0, w: 5, h: 5 },
+            OcrServerWord { text: "two".into(), conf: 0.8, x: 1, y: 1, w: 4, h: 4 },
+        ];
+        let slots = validate_words_positional(raw, 100, 100);
+        assert_eq!(slots.len(), 4, "one slot per input, never dropped");
+        assert_eq!(slots[0].as_ref().unwrap().text, "ok");
+        assert!(slots[1].is_none(), "empty text -> None slot, not removed");
+        assert!(slots[2].is_none(), "NaN conf -> None slot, not removed");
+        assert_eq!(slots[3].as_ref().unwrap().text, "two");
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

After deploying the line-level OCR cache (#1563), the **bottom half of the RDP screen disappeared** — consistently, on every session/relogin.

## Root cause

Live logs showed:
```
piigate: analysis failed, failing closed (dropping batch, terminating):
OCR recognize returned 32 words for 33 boxes on band [296,920)
```

Band `[296,920)` is the bottom region. The chain:

1. `/det` detects 33 lines in the bottom band.
2. The agent sends all 33 to `/rec`. The recognizer reads one as **empty text** (a blank row / icon / separator — entirely normal).
3. The agent ran `/rec` output through `validate_words`, which **drops empty-text entries** (correct for `/ocr`, fatal for `/rec`).
4. 33 boxes → 32 words → the fail-closed cardinality check (correctly) fires and **drops the whole band**, killing its forwarding.
5. Top band renders, bottom band always dropped → bottom half gone, every time.

The fail-closed check was right; the bug was **violating `/rec`'s positional contract** by dropping a slot.

## Fix (agent-side only)

`/rec` is positional — result `i` belongs to box `i` — so an unusable recognition must never be dropped.

- `recognize()` → `validate_words_positional` returning `Vec<Option<Word>>`: one slot per box, `None` for empty/invalid, **never dropped**. Also enforces exactly N entries at the HTTP boundary, so a genuine protocol violation still errors immediately (fail-closed preserved).
- Per-line cache value is `Option<Word>`, so a stable blank line is a cache hit (no needless re-rec).
- `analyze()` reassembles by slot: `None` → no Presidio text, no redaction box, but the slot still exists and is cached. Changed lines are still always re-recognized (key = position + `crop_hash`), so no PII slips through.
- Shared per-word sanitization extracted to `validate_word` (one rule set for `/ocr`, `/det`, `/rec`).

## Tests

- `empty_recognition_is_kept_as_blank_slot_not_dropped` — reproduces the vanished-band bug (fails before, passes after).
- `positional_validation_keeps_one_slot_per_word` — locks the `Vec<Option<Word>>` contract.
- 112 agentrs tests pass; clippy clean on changed files.

The sidecar was already correct (it returns N positional entries with empty strings), so this is purely the agent binary — needs a new image to deploy.

Automated by MisterMal