### PR TITLE
revert(rdp): remove line-level OCR cache from the PII guard

### DIFF
--- a/agentrs/src/piigate/analyze.rs
+++ b/agentrs/src/piigate/analyze.rs
@@ -7,55 +7,56 @@
 //! indistinguishable from full-frame analysis.
 
 use std::collections::HashMap;
+use std::hash::{Hash as _, Hasher as _};
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context as _;
 use async_trait::async_trait;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
 
-use super::bands::YBand;
+use super::bands::{split_bands, OcrChunk, YBand, DEFAULT_BAND_PADDING, MAX_CHUNK_ROWS};
 use super::metrics::LatencyAggregator;
-use super::ocr::{join_words, LineBox, OcrClient, Word};
+use super::ocr::{join_words, OcrClient, Word};
 use super::presidio::{analyze_text, AnalysisParams, PresidioClient, SnapshotResult};
 
-/// Per-LINE OCR result cache: recognition (rec) is the dominant cost, so we
-/// skip re-recognizing text lines whose recognition input is byte-identical to
-/// the last time that exact line was recognized.
+/// Per-window OCR result cache: skips re-OCR of a band whose pixels are
+/// byte-identical to the last time that exact window was OCR'd.
 ///
-/// Detection (det) still runs over the full dirty band every frame — it is
-/// cheap and finds the line boxes — so no line is ever missed at the
-/// segmentation stage. Only the per-line RECOGNITION is cached. On a typical
-/// edit (one line changes) this turns N rec calls into ~1.
+/// Live RDP produces a storm of tiny repaints (blinking carets, ticking
+/// clocks, focus rectangles) that re-dirty the same rows continuously. Without
+/// this cache every repaint re-OCRs the whole band, saturating the engine.
 ///
 /// Correctness is the priority over the speedup:
 ///
-/// - The key is the line's full-canvas position PLUS the SHA-256 the sidecar
-///   computed over the EXACT perspective crop recognition will see (see
-///   [`LineBox::crop_hash`]). The hash therefore covers precisely the pixels
-///   that determine the recognized text — not an axis-aligned approximation —
-///   so any change that would alter recognition changes the hash and forces a
-///   fresh rec. A changed line is NEVER reused (no PII slips through unread),
-///   and SHA-256 makes a stale-reuse collision cryptographically infeasible.
-/// - The cached value is the line's recognized [`Word`] (full-canvas coords),
-///   so a hit reproduces exactly the same word -> same Presidio text -> same
-///   detections. Persistent on-screen PII keeps being detected on every frame
-///   it remains visible; it is not "cleared" by a cache hit.
-/// - The cache is PERSISTENT across frames (unchanged lines stay cached) but
-///   bounded: each frame replaces it with exactly the lines detected this
-///   frame, so it tracks the current screen and cannot grow unbounded.
+/// - The key is the window geometry PLUS a hash of the window's exact pixel
+///   bytes. Any pixel change misses the cache and forces a fresh OCR, so a
+///   changed band is NEVER skipped (no PII can slip through unread).
+/// - The cached value is the OCR word list (window-local coordinates), so a
+///   hit reproduces exactly the same words -> same Presidio text -> same
+///   detections. Persistent PII therefore keeps being detected and redacted
+///   on every frame it remains on screen; it is not "cleared" by a cache hit.
+/// - A 64-bit non-crypto hash collision would reuse stale words for changed
+///   pixels. The window bytes are also length-checked via the geometry key,
+///   and the hash covers every byte; the residual collision probability over a
+///   session is negligible, and the failure mode degrades detection on a
+///   single frame (the next changed frame re-OCRs), it does not persistently
+///   blind the guard.
 #[derive(Default)]
-struct LineCache {
-    // (x0, y0, x1, y1, crop_sha256) -> the line's recognition outcome. The
-    // position is included so a hit also requires the same on-screen placement
-    // (a line that moved is re-analyzed in its new position). The value is an
-    // `Option<Word>`: `None` caches a line that recognized to nothing usable
-    // (blank line, icon, separator), so a stable empty line is a cache hit too
-    // and never forces a needless rec.
-    entries: HashMap<LineKey, Option<Word>>,
+struct OcrCache {
+    // (win_y0, win_y1, pixel_hash) -> window-local OCR words.
+    entries: HashMap<(usize, usize, u64), Arc<Vec<Word>>>,
 }
 
-/// Cache key: full-canvas bounding rect plus the SHA-256 (hex) of the exact
-/// recognition crop. Position + content together: same pixels at the same place.
-type LineKey = (usize, usize, usize, usize, String);
+/// Hashes a window's exact pixel bytes together with its dimensions. Two
+/// windows collide in the map only if geometry AND every pixel byte match.
+fn hash_window(crop: &[u8], width: usize, height: usize) -> u64 {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    width.hash(&mut h);
+    height.hash(&mut h);
+    crop.hash(&mut h);
+    h.finish()
+}
 
 /// The analysis stage the gate invokes per batch. A trait so tests can
 /// substitute a deterministic detector (the signature detector) for the real
@@ -79,10 +80,10 @@ pub struct BandAnalyzer {
     pub ocr: OcrClient,
     pub presidio: PresidioClient,
     pub params: AnalysisParams,
-    /// Per-line OCR result cache (see [`LineCache`]). Interior-mutable so
-    /// `analyze` keeps its `&self` signature; only ever locked briefly to read
-    /// hits or publish the new snapshot, never across an OCR/Presidio await.
-    cache: Mutex<LineCache>,
+    /// OCR result cache (see [`OcrCache`]). Interior-mutable so `analyze`
+    /// keeps its `&self` signature; only ever locked briefly to read a hit or
+    /// publish the new snapshot, never across an OCR/Presidio await.
+    cache: Mutex<OcrCache>,
     /// Shared per-session latency aggregator. The analyzer records the two
     /// network-bound stages (OCR, Presidio); the gate records compositing /
     /// redaction / end-to-end into the same instance, so one window summary
@@ -101,7 +102,7 @@ impl BandAnalyzer {
             ocr: OcrClient::new(&cfg.ocr_url)?,
             presidio: PresidioClient::new(&cfg.presidio_url)?,
             params: cfg.params.clone(),
-            cache: Mutex::new(LineCache::default()),
+            cache: Mutex::new(OcrCache::default()),
             metrics,
         })
     }
@@ -133,168 +134,153 @@ impl Analyzer for BandAnalyzer {
             }
         }
 
-        // Wall-clock for the whole OCR phase (det + per-line cache lookups +
-        // rec of changed lines), recorded into the shared latency window.
+        // Tall bands are split into chunks OCR'd in parallel; the chunk
+        // overlap follows the same padding policy as the dirty-band
+        // accumulator.
+        let pad = if self.params.band_padding == 0 {
+            DEFAULT_BAND_PADDING
+        } else {
+            self.params.band_padding
+        };
+        let chunks = split_bands(bands, MAX_CHUNK_ROWS, pad);
+
+        // Wall-clock for the whole OCR phase (cache lookups + parallel sidecar
+        // round-trips + collection), recorded into the shared latency window.
         let ocr_started = std::time::Instant::now();
 
-        // Per dirty band: run detection over the band, then for each detected
-        // line consult the per-line cache and recognize only the changed lines.
-        // Detection always runs (cheap, scales with band height), so no line is
-        // ever missed at segmentation; only the expensive recognition is cached.
+        let concurrency = if self.params.max_ocr_concurrency == 0 {
+            8usize.min(std::thread::available_parallelism().map_or(8, |n| n.get()))
+        } else {
+            self.params.max_ocr_concurrency
+        };
+        let semaphore = Arc::new(Semaphore::new(concurrency));
+        // Cancel sibling OCR work as soon as one chunk fails (matches Go's
+        // errgroup.WithContext): a failing batch fails open regardless, so
+        // burning sidecar capacity on the rest only worsens backlog pressure.
+        let cancel = CancellationToken::new();
+
+        // Each chunk owns a copy of its window rows: the framebuffer slice
+        // cannot be borrowed across spawned tasks (it is owned and reused by
+        // the gate's analysis loop). Chunk windows are bounded
+        // (MAX_CHUNK_ROWS + pad), so the copies are small. Indices preserve
+        // chunk order for stable text concatenation.
         //
-        // Words are collected in detection order within each band and bands in
-        // top-to-bottom order, matching the previous reading order so Presidio
-        // sees the same text. A fresh cache snapshot is built from exactly the
-        // lines detected this frame (persistent across frames, but bounded to
-        // the current screen).
-        let mut all_words: Vec<Word> = Vec::new();
-        let mut new_cache = LineCache::default();
+        // Per chunk we first hash its exact pixels and consult the OCR cache.
+        // A hit reuses the cached window-local words (no OCR round-trip) — the
+        // repaint-storm fast path. A miss spawns an OCR task. Every chunk's
+        // window-local words (hit or freshly OCR'd) are recorded so this
+        // call's cache snapshot can be published at the end, byte-keyed.
+        let cache_key = |c: &OcrChunk, hash: u64| (c.win.y0, c.win.y1, hash);
+
+        // window-local words per chunk (the cache stores pre-shift words so a
+        // hit is independent of where own_words later places them).
+        let mut chunk_local: Vec<Option<Arc<Vec<Word>>>> = vec![None; chunks.len()];
+        let mut chunk_hash: Vec<u64> = vec![0; chunks.len()];
+        let mut handles = Vec::new();
+        {
+            let cache = self.cache.lock().expect("piigate: OCR cache poisoned");
+            for (idx, chunk) in chunks.iter().enumerate() {
+                let crop = fb[chunk.win.y0 * stride..chunk.win.y1 * stride].to_vec();
+                let win_height = chunk.win.height();
+                let hash = hash_window(&crop, fb_width, win_height);
+                chunk_hash[idx] = hash;
+                if let Some(words) = cache.entries.get(&cache_key(chunk, hash)) {
+                    // Cache hit: identical pixels were OCR'd before. Reuse the
+                    // words — persistent on-screen PII is therefore re-detected
+                    // every frame, never silently cleared by a hit.
+                    chunk_local[idx] = Some(words.clone());
+                    continue;
+                }
+                let ocr = self.ocr.clone();
+                let win = chunk.win;
+                let semaphore = semaphore.clone();
+                let cancel = cancel.clone();
+                handles.push(tokio::spawn(async move {
+                    let _permit = semaphore
+                        .acquire()
+                        .await
+                        .expect("piigate: OCR semaphore closed");
+                    if cancel.is_cancelled() {
+                        return Ok((idx, Vec::new(), 0.0, 0usize));
+                    }
+                    let extract = tokio::select! {
+                        res = ocr.extract(&crop, fb_width, win_height) => res.with_context(|| {
+                            format!("OCR failed on chunk [{},{})", win.y0, win.y1)
+                        })?,
+                        _ = cancel.cancelled() => return Ok((idx, Vec::new(), 0.0, 0usize)),
+                    };
+                    Ok::<_, anyhow::Error>((idx, extract.words, extract.server_ms, extract.request_bytes))
+                }));
+            }
+        }
+
+        // Collect the OCR'd (miss) chunks. On the first error, cancel the rest
+        // and propagate (the gate fails closed on an analyzer error).
+        //
+        // The chunks OCR in PARALLEL, so the per-batch number comparable to the
+        // OCR wall-clock is the SLOWEST chunk's sidecar inference time (the
+        // critical path), not the sum. If wall-clock >> max chunk inference,
+        // the gap is queueing/contention/transport, not the GPU. We also track
+        // bytes/calls/chunks to gauge payload size and cache effectiveness.
+        // Cache hits contribute nothing (no round-trip), which is the point.
+        let mut first_err = None;
         let mut server_ms_max = 0.0f64;
         let mut request_bytes_sum = 0usize;
-        let mut lines_total = 0usize;
-        let mut lines_recognized = 0usize;
-
-        for band in bands {
-            let band_h = band.y1 - band.y0;
-            // Crop the band's full-width rows (band-local image) for det/rec.
-            let band_rgba = fb[band.y0 * stride..band.y1 * stride].to_vec();
-
-            let det = self
-                .ocr
-                .detect(&band_rgba, fb_width, band_h)
-                .await
-                .with_context(|| format!("OCR detect failed on band [{},{})", band.y0, band.y1))?;
-            if det.server_ms > server_ms_max {
-                server_ms_max = det.server_ms;
-            }
-
-            // For each detected line, look it up in the cache by its
-            // recognition-crop hash + full-canvas position. Hits reuse the
-            // cached word; misses are collected for a single rec call on this
-            // band.
-            //
-            // `miss_boxes` are band-local (for the rec request); `slots` records
-            // per-detection whether the line was a hit (with its word) or a miss
-            // (with its miss-box index), so cached and freshly-recognized words
-            // are reassembled in detection order. `keys[i]` is the full-canvas
-            // cache key for detection i, or None if the line is uncacheable.
-            #[derive(Clone)]
-            enum Slot {
-                Cached(Option<Word>), // None = cached blank line
-                Miss(usize),          // index into miss_boxes
-            }
-            let mut slots: Vec<Slot> = Vec::with_capacity(det.boxes.len());
-            let mut miss_boxes: Vec<LineBox> = Vec::new();
-            let mut keys: Vec<Option<LineKey>> = Vec::with_capacity(det.boxes.len());
-
-            {
-                let cache = self.cache.lock().expect("piigate: line cache poisoned");
-                for line in &det.boxes {
-                    lines_total += 1;
-                    // Position in full-canvas coords (for placement + cache
-                    // position component); content validity comes from the
-                    // sidecar-computed crop hash, not these bounds.
-                    let (bx0, by0, bx1, by1) = line.bounds(); // band-local
-                    let key: LineKey = (
-                        bx0,
-                        by0 + band.y0,
-                        bx1,
-                        by1 + band.y0,
-                        line.crop_hash.clone(),
-                    );
-                    keys.push(Some(key.clone()));
-                    if let Some(word) = cache.entries.get(&key) {
-                        // Cache hit: this exact line (position + recognition
-                        // pixels) was recognized before. Reuse its word —
-                        // persistent PII is re-detected every frame, never
-                        // cleared by a hit.
-                        slots.push(Slot::Cached(word.clone()));
-                    } else {
-                        slots.push(Slot::Miss(miss_boxes.len()));
-                        miss_boxes.push(line.clone());
+        let mut ocr_calls = 0usize;
+        for h in handles {
+            match h.await.context("piigate: OCR task panicked")? {
+                Ok((idx, words, server_ms, request_bytes)) => {
+                    chunk_local[idx] = Some(Arc::new(words));
+                    if request_bytes > 0 {
+                        if server_ms > server_ms_max {
+                            server_ms_max = server_ms;
+                        }
+                        request_bytes_sum += request_bytes;
+                        ocr_calls += 1;
                     }
                 }
-            }
-
-            // Recognize the changed lines in a single rec call (band-local
-            // boxes; the sidecar crops and recognizes, returning full-image
-            // coords within the band).
-            let rec_words = if miss_boxes.is_empty() {
-                Vec::new()
-            } else {
-                let rec = self
-                    .ocr
-                    .recognize(&band_rgba, fb_width, band_h, &miss_boxes)
-                    .await
-                    .with_context(|| {
-                        format!("OCR recognize failed on band [{},{})", band.y0, band.y1)
-                    })?;
-                // Fail closed on a cardinality mismatch: /rec must return exactly
-                // one word per requested box. A short response would otherwise
-                // silently drop detected lines from analysis (unanalyzed pixels
-                // reaching the client) — never acceptable in a fail-closed gate.
-                if rec.words.len() != miss_boxes.len() {
-                    anyhow::bail!(
-                        "OCR recognize returned {} words for {} boxes on band [{},{})",
-                        rec.words.len(),
-                        miss_boxes.len(),
-                        band.y0,
-                        band.y1
-                    );
-                }
-                if rec.server_ms > server_ms_max {
-                    server_ms_max = rec.server_ms;
-                }
-                request_bytes_sum += rec.request_bytes;
-                lines_recognized += miss_boxes.len();
-                rec.words
-            };
-
-            // Reassemble recognition outcomes in detection order, shifting
-            // band-local Y into full-canvas space, and publish each line into
-            // the new cache. A line may recognize to nothing usable (`None`):
-            // it still occupies a slot (preserving box↔word alignment) and is
-            // cached as blank, but contributes no word to Presidio and no
-            // redaction box.
-            for (det_idx, slot) in slots.into_iter().enumerate() {
-                let word: Option<Word> = match slot {
-                    Slot::Cached(w) => w, // already full-canvas (or None)
-                    Slot::Miss(mi) => {
-                        // rec returns one slot per requested box, in order
-                        // (cardinality validated above, so the index is valid).
-                        rec_words[mi].clone().map(|mut w| {
-                            w.top += band.y0; // band-local -> full-canvas
-                            w
-                        })
-                    }
-                };
-                if let Some(key) = &keys[det_idx] {
-                    new_cache.entries.insert(key.clone(), word.clone());
-                }
-                if let Some(w) = word {
-                    all_words.push(w);
+                Err(e) => {
+                    cancel.cancel();
+                    first_err = first_err.or(Some(e));
                 }
             }
         }
-
-        // Record OCR phase wall-clock + the sidecar-internal breakdown and the
-        // line-cache effectiveness before any early return.
+        // Record OCR phase wall-clock and the sidecar-internal breakdown before
+        // any early return, so a slow or failing OCR sidecar (the most likely
+        // offender) still shows up in the latency window.
         self.metrics.record_ocr(ocr_started.elapsed());
-        self.metrics.record_ocr_detail(
-            server_ms_max,
-            request_bytes_sum as u64,
-            lines_recognized,
-            lines_total,
-        );
-        self.metrics.record_lines(lines_total as u64, lines_recognized as u64);
-
-        // Publish the new cache snapshot (replace, not merge): the cache now
-        // holds exactly the lines on screen this frame, so it tracks the screen
-        // and stays bounded.
-        {
-            let mut cache = self.cache.lock().expect("piigate: line cache poisoned");
-            *cache = new_cache;
+        self.metrics
+            .record_ocr_detail(server_ms_max, request_bytes_sum as u64, ocr_calls, chunks.len());
+        if let Some(e) = first_err {
+            return Err(e);
         }
+
+        // Publish this call's cache snapshot: only the windows analyzed now,
+        // keyed by geometry+hash. Replacing (not merging) bounds the cache to
+        // the current dirty set and naturally evicts windows no longer dirty.
+        {
+            let mut cache = self.cache.lock().expect("piigate: OCR cache poisoned");
+            cache.entries.clear();
+            for (idx, chunk) in chunks.iter().enumerate() {
+                if let Some(words) = &chunk_local[idx] {
+                    cache
+                        .entries
+                        .insert(cache_key(chunk, chunk_hash[idx]), words.clone());
+                }
+            }
+        }
+
+        // Shift each chunk's window-local words into full-screen space and
+        // keep only the lines the chunk owns (overlap seams deduplicated),
+        // preserving top-to-bottom order across chunks.
+        let all_words: Vec<Word> = chunks
+            .iter()
+            .enumerate()
+            .flat_map(|(idx, chunk)| {
+                let local = chunk_local[idx].as_ref().expect("every chunk resolved");
+                own_words(local.as_ref().clone(), *chunk)
+            })
+            .collect();
 
         if all_words.is_empty() {
             return Ok(SnapshotResult::default());
@@ -310,39 +296,52 @@ impl Analyzer for BandAnalyzer {
     }
 }
 
+/// Shifts word coordinates into full-screen space and keeps only the words
+/// the chunk owns, so overlap regions are not duplicated.
+fn own_words(words: Vec<Word>, chunk: OcrChunk) -> Vec<Word> {
+    words
+        .into_iter()
+        .map(|mut w| {
+            w.top += chunk.win.y0;
+            w
+        })
+        .filter(|w| chunk.owns(w.top, w.height))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn line_box_bounds_axis_aligned() {
-        let b = LineBox {
-            quad: [[4.0, 24.0], [206.0, 24.0], [206.0, 58.0], [4.0, 58.0]],
-            crop_hash: "deadbeef".into(),
+    fn own_words_offsets_and_filters() {
+        let chunk = OcrChunk {
+            win: YBand { y0: 232, y1: 536 },
+            own: YBand { y0: 256, y1: 512 },
         };
-        assert_eq!(b.bounds(), (4, 24, 206, 58));
+        let mk = |top: usize| Word {
+            text: "w".into(),
+            left: 0,
+            top,
+            width: 10,
+            height: 12,
+            conf: 90.0,
+        };
+        // Band-local top 30 → screen 262, center 268 ∈ [256,512): owned.
+        // Band-local top 10 → screen 242, center 248 < 256: not owned.
+        let out = own_words(vec![mk(30), mk(10)], chunk);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].top, 262);
     }
 
-    #[test]
-    fn line_box_bounds_ceils_max_floors_min() {
-        // Fractional detector output: min floored, max ceiled so the bounds
-        // never exclude a partially-covered edge pixel.
-        let b = LineBox {
-            quad: [[4.4, 24.6], [205.2, 24.6], [205.2, 57.1], [4.4, 57.1]],
-            crop_hash: "x".into(),
-        };
-        assert_eq!(b.bounds(), (4, 24, 206, 58));
-    }
-
-    // ---- Per-line OCR cache correctness -----------------------------------
+    // ---- OCR cache (content-dedup) correctness ----------------------------
     //
-    // These drive a REAL BandAnalyzer against a stub sidecar (/det + /rec) and
-    // stub Presidio so the production line-cache path is exercised end to end.
-    // The stub counts REC calls (the cached stage) and lines recognized; the
-    // assertions prove the security-critical invariants: an unchanged line
-    // skips rec (the speedup) while ANY changed line is always re-recognized
-    // (no PII slips through), and a cache hit still yields the same word
-    // (persistent on-screen PII keeps being detected).
+    // These drive a REAL BandAnalyzer against stub OCR + Presidio HTTP servers
+    // so the production cache path is exercised end to end. The stub counts
+    // OCR calls; the assertions prove the security-critical invariants:
+    // unchanged pixels skip OCR (the speedup) while changed pixels are ALWAYS
+    // re-OCR'd (no PII slips through), and a cache hit still yields the same
+    // words (persistent on-screen PII keeps being detected).
 
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -354,63 +353,22 @@ mod tests {
 
     #[derive(Clone)]
     struct StubState {
-        // Number of /rec calls and total boxes recognized.
-        rec_calls: Arc<AtomicUsize>,
-        rec_boxes: Arc<AtomicUsize>,
-        // The single word the stub "reads" per detected box; drives Presidio.
+        ocr_calls: Arc<AtomicUsize>,
+        // The single word the stub OCR "reads"; its text drives Presidio.
         word_text: Arc<std::sync::Mutex<String>>,
     }
 
-    // Stub /det: returns ONE line box covering the top-left of the band, with a
-    // crop_hash derived from the box's pixels in the sent BMP. Mirrors the real
-    // sidecar contract: the hash changes iff the recognition pixels change, so
-    // the agent's per-line cache hits on identical content and misses on a
-    // change. We hash the box region of the decoded image (the stub sends a BMP
-    // identical to the real client) so a changed pixel inside [4,4]-(44,16)
-    // produces a different hash.
-    async fn stub_det(body: axum::body::Bytes) -> Json<Value> {
-        let hash = stub_crop_hash(&body);
+    async fn stub_ocr(State(s): State<StubState>, _body: axum::body::Bytes) -> Json<Value> {
+        s.ocr_calls.fetch_add(1, Ordering::SeqCst);
+        let text = s.word_text.lock().unwrap().clone();
         Json(json!({
             "duration_ms": 1.0,
-            "boxes": [{
-                "quad": [[4.0, 4.0], [44.0, 4.0], [44.0, 16.0], [4.0, 16.0]],
-                "crop_hash": hash,
-            }],
+            "words": [{ "text": text, "conf": 95.0, "x": 4, "y": 4, "w": 40, "h": 12 }],
         }))
     }
 
-    // Hash the box region [4,4)-(44,16) out of a 24bpp bottom-up BMP body,
-    // approximating what the real sidecar does (hash the exact recognition
-    // crop). Good enough for the cache tests: identical body -> identical hash,
-    // a changed pixel in the region -> different hash.
-    fn stub_crop_hash(bmp: &[u8]) -> String {
-        use std::hash::{Hash as _, Hasher as _};
-        // BMP pixel data starts at offset 54 (BITMAPFILEHEADER+INFOHEADER).
-        // The stub frames are tiny (64x*); just hash the whole pixel area — any
-        // pixel change anywhere changes it, which is a superset of "box region
-        // changed" and keeps the test's changed->miss invariant exact. Rendered
-        // as 64-char hex so it passes the agent's SHA-256 format validation.
-        let mut h = std::collections::hash_map::DefaultHasher::new();
-        bmp.get(54..).unwrap_or(bmp).hash(&mut h);
-        let v = h.finish();
-        format!("{v:016x}{v:016x}{v:016x}{v:016x}")
-    }
-
-    // Stub /rec: returns one word per requested box, counting the call.
-    async fn stub_rec(State(s): State<StubState>, body: axum::body::Bytes) -> Json<Value> {
-        s.rec_calls.fetch_add(1, Ordering::SeqCst);
-        let req: Value = serde_json::from_slice(&body).unwrap();
-        let boxes = req.get("boxes").and_then(|b| b.as_array()).cloned().unwrap_or_default();
-        s.rec_boxes.fetch_add(boxes.len(), Ordering::SeqCst);
-        let text = s.word_text.lock().unwrap().clone();
-        let words: Vec<Value> = boxes
-            .iter()
-            .map(|_| json!({ "text": text, "conf": 95.0, "x": 4, "y": 4, "w": 40, "h": 12 }))
-            .collect();
-        Json(json!({ "duration_ms": 1.0, "words": words }))
-    }
-
-    // Stub Presidio: flags the substring "SSN" as US_SSN, else nothing.
+    // Stub Presidio: flags the substring "SSN" as US_SSN, else nothing. Lets a
+    // test assert detections survive a cache hit without a real analyzer.
     async fn stub_analyze(body: axum::body::Bytes) -> Json<Value> {
         let req: Value = serde_json::from_slice(&body).unwrap();
         let text = req.get("text").and_then(|t| t.as_str()).unwrap_or("");
@@ -422,26 +380,17 @@ mod tests {
         Json(json!([]))
     }
 
-    struct Stub {
-        base: String,
-        rec_calls: Arc<AtomicUsize>,
-        rec_boxes: Arc<AtomicUsize>,
-        word_text: Arc<std::sync::Mutex<String>>,
-    }
-
-    /// Spawns the stub sidecar (/det, /rec) + Presidio (/analyze).
-    async fn spawn_stub() -> Stub {
-        let rec_calls = Arc::new(AtomicUsize::new(0));
-        let rec_boxes = Arc::new(AtomicUsize::new(0));
+    /// Spawns the stub servers and returns (base_url, ocr_call_counter,
+    /// settable_word_text). One axum app serves both /ocr and /analyze.
+    async fn spawn_stub() -> (String, Arc<AtomicUsize>, Arc<std::sync::Mutex<String>>) {
+        let ocr_calls = Arc::new(AtomicUsize::new(0));
         let word_text = Arc::new(std::sync::Mutex::new("hello world".to_string()));
         let state = StubState {
-            rec_calls: rec_calls.clone(),
-            rec_boxes: rec_boxes.clone(),
+            ocr_calls: ocr_calls.clone(),
             word_text: word_text.clone(),
         };
         let app = Router::new()
-            .route("/det", post(stub_det))
-            .route("/rec", post(stub_rec))
+            .route("/ocr", post(stub_ocr))
             .route("/analyze", post(stub_analyze))
             .with_state(state);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -449,12 +398,7 @@ mod tests {
         tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        Stub {
-            base: format!("http://{addr}"),
-            rec_calls,
-            rec_boxes,
-            word_text,
-        }
+        (format!("http://{addr}"), ocr_calls, word_text)
     }
 
     fn analyzer_for(base: &str) -> BandAnalyzer {
@@ -478,212 +422,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unchanged_line_skips_rec_on_second_analyze() {
-        let stub = spawn_stub().await;
-        let analyzer = analyzer_for(&stub.base);
+    async fn unchanged_pixels_skip_ocr_on_second_analyze() {
+        let (base, ocr_calls, _txt) = spawn_stub().await;
+        let analyzer = analyzer_for(&base);
         let (w, h) = (64usize, 64usize);
         let fb = make_fb(w, h, 0xff);
         let bands = vec![YBand { y0: 0, y1: 32 }];
 
         let _ = analyzer.analyze(&fb, w, h, &bands).await.unwrap();
-        let after_first = stub.rec_boxes.load(Ordering::SeqCst);
-        assert!(after_first >= 1, "first analyze must recognize the detected line");
+        let after_first = ocr_calls.load(Ordering::SeqCst);
+        assert!(after_first >= 1, "first analyze must OCR the band");
 
-        // Identical framebuffer -> det finds the same line, same pixels -> cache
-        // hit -> NO new rec (det still runs, but rec is skipped).
+        // Identical framebuffer + identical bands -> cache hit -> no new OCR.
         let _ = analyzer.analyze(&fb, w, h, &bands).await.unwrap();
         assert_eq!(
-            stub.rec_boxes.load(Ordering::SeqCst),
+            ocr_calls.load(Ordering::SeqCst),
             after_first,
-            "unchanged line must NOT trigger another rec call"
+            "unchanged pixels must NOT trigger another OCR call"
         );
     }
 
     #[tokio::test]
-    async fn changed_line_forces_rerec() {
-        let stub = spawn_stub().await;
-        let analyzer = analyzer_for(&stub.base);
+    async fn changed_pixels_force_reocr() {
+        let (base, ocr_calls, _txt) = spawn_stub().await;
+        let analyzer = analyzer_for(&base);
         let (w, h) = (64usize, 64usize);
         let bands = vec![YBand { y0: 0, y1: 32 }];
 
         let fb1 = make_fb(w, h, 0xff);
         let _ = analyzer.analyze(&fb1, w, h, &bands).await.unwrap();
-        let after_first = stub.rec_boxes.load(Ordering::SeqCst);
+        let after_first = ocr_calls.load(Ordering::SeqCst);
 
-        // A changed pixel INSIDE the detected line's rect (the stub box is
-        // [4,4]-[44,16]) must miss the cache and re-recognize: a changed line is
-        // NEVER reused (no unread PII).
+        // A single changed pixel in the band must miss the cache and re-OCR:
+        // a changed band is NEVER skipped (no unread PII).
         let mut fb2 = fb1.clone();
-        fb2[8 * w * 4 + 10 * 4] ^= 0xff; // row 8, col 10 -> inside [4,4)-(44,16)
+        fb2[10 * w * 4 + 20] ^= 0xff;
         let _ = analyzer.analyze(&fb2, w, h, &bands).await.unwrap();
         assert!(
-            stub.rec_boxes.load(Ordering::SeqCst) > after_first,
-            "a changed line MUST trigger a fresh rec (no stale words)"
+            ocr_calls.load(Ordering::SeqCst) > after_first,
+            "changed pixels MUST trigger a fresh OCR (no stale words)"
         );
     }
 
     #[tokio::test]
     async fn persistent_pii_still_detected_on_cache_hit() {
-        let stub = spawn_stub().await;
-        *stub.word_text.lock().unwrap() = "my SSN is here".to_string();
-        let analyzer = analyzer_for(&stub.base);
+        let (base, ocr_calls, txt) = spawn_stub().await;
+        *txt.lock().unwrap() = "my SSN is here".to_string();
+        let analyzer = analyzer_for(&base);
         let (w, h) = (64usize, 64usize);
         let fb = make_fb(w, h, 0xff);
         let bands = vec![YBand { y0: 0, y1: 32 }];
 
         let r1 = analyzer.analyze(&fb, w, h, &bands).await.unwrap();
         assert!(r1.is_detection(), "first frame detects the SSN");
-        let after_first = stub.rec_boxes.load(Ordering::SeqCst);
+        let after_first = ocr_calls.load(Ordering::SeqCst);
 
-        // Same pixels next frame: rec is skipped (cache hit) BUT the SSN must
+        // Same pixels next frame: OCR is skipped (cache hit) BUT the SSN must
         // still be detected — a persistent on-screen secret is re-flagged, not
         // silently cleared by the cache.
         let r2 = analyzer.analyze(&fb, w, h, &bands).await.unwrap();
-        assert_eq!(
-            stub.rec_boxes.load(Ordering::SeqCst),
-            after_first,
-            "cache hit: no re-rec"
-        );
+        assert_eq!(ocr_calls.load(Ordering::SeqCst), after_first, "cache hit: no re-OCR");
         assert!(
             r2.is_detection(),
             "persistent PII must remain detected on a cache hit"
-        );
-    }
-
-    #[tokio::test]
-    async fn rec_call_count_reflects_caching() {
-        // Two analyses of the identical frame: exactly one rec CALL total (the
-        // first); the second is fully served from the line cache.
-        let stub = spawn_stub().await;
-        let analyzer = analyzer_for(&stub.base);
-        let (w, h) = (64usize, 64usize);
-        let fb = make_fb(w, h, 0xff);
-        let bands = vec![YBand { y0: 0, y1: 32 }];
-
-        analyzer.analyze(&fb, w, h, &bands).await.unwrap();
-        analyzer.analyze(&fb, w, h, &bands).await.unwrap();
-        assert_eq!(
-            stub.rec_calls.load(Ordering::SeqCst),
-            1,
-            "second identical frame must issue no rec call (full cache hit)"
-        );
-    }
-
-    // A /det that returns two boxes but a /rec that returns only one word: the
-    // analyzer must FAIL (fail-closed), never silently drop the second line.
-    async fn stub_det_two(_body: axum::body::Bytes) -> Json<Value> {
-        // Two distinct, well-formed (64-hex) crop hashes.
-        let ha = "a".repeat(64);
-        let hb = "b".repeat(64);
-        Json(json!({
-            "duration_ms": 1.0,
-            "boxes": [
-                {"quad": [[4.0,4.0],[44.0,4.0],[44.0,16.0],[4.0,16.0]], "crop_hash": ha},
-                {"quad": [[4.0,20.0],[44.0,20.0],[44.0,30.0],[4.0,30.0]], "crop_hash": hb},
-            ],
-        }))
-    }
-    async fn stub_rec_one(_body: axum::body::Bytes) -> Json<Value> {
-        Json(json!({
-            "duration_ms": 1.0,
-            "words": [{ "text": "only-one", "conf": 95.0, "x": 4, "y": 4, "w": 40, "h": 12 }],
-        }))
-    }
-    async fn stub_analyze_empty(_body: axum::body::Bytes) -> Json<Value> {
-        Json(json!([]))
-    }
-
-    #[tokio::test]
-    async fn rec_cardinality_mismatch_fails_closed() {
-        let app = Router::new()
-            .route("/det", post(stub_det_two))
-            .route("/rec", post(stub_rec_one))
-            .route("/analyze", post(stub_analyze_empty));
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-        let analyzer = analyzer_for(&format!("http://{addr}"));
-        let (w, h) = (64usize, 64usize);
-        let fb = make_fb(w, h, 0xff);
-        let bands = vec![YBand { y0: 0, y1: 32 }];
-
-        let res = analyzer.analyze(&fb, w, h, &bands).await;
-        assert!(
-            res.is_err(),
-            "a /rec returning fewer words than boxes must fail the analysis (fail-closed), not drop lines"
-        );
-    }
-
-    // Regression for the "bottom half of the screen vanished" bug: RapidOCR's
-    // recognizer legitimately returns an EMPTY string for a detected box that
-    // holds no readable text (a blank row, an icon, a separator). /rec keeps
-    // that as an empty slot (positional contract: one entry per box), and the
-    // agent must turn it into a `None` word — NOT drop it. Dropping made the
-    // word count fall one short of the box count, tripping the fail-closed
-    // cardinality check and killing that band's forwarding, which on a real
-    // desktop blanked the lower portion of the screen.
-    async fn stub_rec_one_empty(_body: axum::body::Bytes) -> Json<Value> {
-        // Correct CARDINALITY (two entries for two boxes) but the second box
-        // recognized to empty text — exactly what the engine emits for a blank
-        // line. Must be accepted, not treated as a mismatch.
-        Json(json!({
-            "duration_ms": 1.0,
-            "words": [
-                { "text": "real text", "conf": 95.0, "x": 4, "y": 4,  "w": 40, "h": 12 },
-                { "text": "",          "conf": 0.0,  "x": 4, "y": 20, "w": 40, "h": 10 },
-            ],
-        }))
-    }
-
-    #[tokio::test]
-    async fn empty_recognition_is_kept_as_blank_slot_not_dropped() {
-        let app = Router::new()
-            .route("/det", post(stub_det_two)) // two detected boxes
-            .route("/rec", post(stub_rec_one_empty)) // second recognizes empty
-            .route("/analyze", post(stub_analyze_empty));
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-        let analyzer = analyzer_for(&format!("http://{addr}"));
-        let (w, h) = (64usize, 64usize);
-        let fb = make_fb(w, h, 0xff);
-        let bands = vec![YBand { y0: 0, y1: 32 }];
-
-        // Must succeed: the empty second line is a `None` slot, the count still
-        // matches the box count, nothing is dropped, the band forwards normally.
-        let res = analyzer.analyze(&fb, w, h, &bands).await;
-        assert!(
-            res.is_ok(),
-            "an empty recognition must be kept as a blank slot, not dropped (which would fail-close and blank the band): {res:?}"
-        );
-
-        // A second identical frame is a full cache hit, including the blank
-        // line: the `None` outcome is cached too, so no needless re-rec.
-        analyzer.analyze(&fb, w, h, &bands).await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn moved_line_is_reanalyzed_not_reused() {
-        // Same pixels (same crop_hash from the stub) but the analyzer keys also
-        // on POSITION. A first frame caches the line at band [0,32); analyzing a
-        // band at a different y-range must NOT reuse it (the position component
-        // of the key differs), so rec runs again.
-        let stub = spawn_stub().await;
-        let analyzer = analyzer_for(&stub.base);
-        let (w, h) = (64usize, 96usize);
-        let fb = make_fb(w, h, 0xff);
-
-        analyzer.analyze(&fb, w, h, &[YBand { y0: 0, y1: 32 }]).await.unwrap();
-        let after_first = stub.rec_boxes.load(Ordering::SeqCst);
-        // Different band position -> different full-canvas key -> miss -> re-rec.
-        analyzer.analyze(&fb, w, h, &[YBand { y0: 40, y1: 72 }]).await.unwrap();
-        assert!(
-            stub.rec_boxes.load(Ordering::SeqCst) > after_first,
-            "a line at a new screen position must be re-recognized, not reused"
         );
     }
 }

--- a/agentrs/src/piigate/metrics.rs
+++ b/agentrs/src/piigate/metrics.rs
@@ -129,12 +129,6 @@ struct Window {
     // changed/total ratio means most repaints are no-ops we now skip.
     paints_total: u64,
     paints_changed: u64,
-
-    // Per-line OCR cache accounting: total detected lines vs lines actually
-    // recognized (cache misses). A low recognized/total ratio means the line
-    // cache served most lines from a prior frame (the rec-cost saving).
-    lines_total: u64,
-    lines_recognized: u64,
 }
 
 impl Window {
@@ -224,17 +218,6 @@ impl LatencyAggregator {
         });
     }
 
-    /// Records per-line OCR cache accounting for one batch: total detected
-    /// lines vs lines actually recognized (cache misses). A low recognized/total
-    /// ratio means the line cache is serving most lines from a prior frame —
-    /// the recognition-cost saving.
-    pub fn record_lines(&self, total: u64, recognized: u64) {
-        self.push(|w| {
-            w.lines_total += total;
-            w.lines_recognized += recognized;
-        });
-    }
-
     /// Records the redaction (PDU rewrite + pixel blanking) for one batch.
     pub fn record_redact(&self, d: Duration) {
         self.push(|w| w.redact.push(as_micros(d)));
@@ -311,8 +294,6 @@ impl LatencyAggregator {
             ocr_sent_kib = ocr_kib,
             paints_total = w.paints_total,
             paints_changed = w.paints_changed,
-            lines_total = w.lines_total,
-            lines_recognized = w.lines_recognized,
             "piigate latency: composite[{}] ocr[{}] ocr_server[{}] presidio[{}] redact[{}] total[{}]",
             summarize(&mut w.composite),
             summarize(&mut w.ocr),

--- a/agentrs/src/piigate/ocr.rs
+++ b/agentrs/src/piigate/ocr.rs
@@ -14,8 +14,7 @@
 use std::time::Duration;
 
 use anyhow::Context as _;
-use base64::Engine as _;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 /// One recognized token with its bounding box in full-image pixel space.
 /// `conf` follows the tesseract convention (0-100) like the Go analyzer.
@@ -110,82 +109,6 @@ pub struct OcrExtract {
     pub request_bytes: usize,
 }
 
-/// A detected text line: a 4-point quad in the sent image's pixel space exactly
-/// as the sidecar's detector produced it, plus `crop_hash` — the SHA-256 of the
-/// EXACT perspective-cropped pixels recognition will see for this line.
-///
-/// The agent keys its per-line OCR cache on `crop_hash` (with the quad geometry
-/// for diagnostics/placement), so a line is reused only when the exact
-/// recognition input recurs. Because the hash is computed by the sidecar over
-/// the same `get_rotate_crop_image` crop that `/rec` recognizes, "unchanged
-/// hash" provably means "recognition would see identical pixels" — there is no
-/// bbox-vs-quad gap through which a changed line could reuse a stale word.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LineBox {
-    /// Four [x, y] points (top-left, top-right, bottom-right, bottom-left).
-    pub quad: [[f32; 2]; 4],
-    /// SHA-256 (hex) of the perspective-cropped recognition pixels.
-    pub crop_hash: String,
-}
-
-impl LineBox {
-    /// Axis-aligned bounding rect (x0, y0, x1, y1) in image pixels, clamped to
-    /// non-negative. Used only for placing the resulting word / redaction box,
-    /// never for the cache validity check (that uses `crop_hash`).
-    pub fn bounds(&self) -> (usize, usize, usize, usize) {
-        let xs = self.quad.iter().map(|p| p[0]);
-        let ys = self.quad.iter().map(|p| p[1]);
-        let x0 = xs.clone().fold(f32::INFINITY, f32::min).max(0.0).floor() as usize;
-        let y0 = ys.clone().fold(f32::INFINITY, f32::min).max(0.0).floor() as usize;
-        let x1 = xs.fold(f32::NEG_INFINITY, f32::max).max(0.0).ceil() as usize;
-        let y1 = ys.fold(f32::NEG_INFINITY, f32::max).max(0.0).ceil() as usize;
-        (x0, y0, x1, y1)
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct DetServerBox {
-    quad: [[f32; 2]; 4],
-    crop_hash: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct DetServerResponse {
-    duration_ms: f64,
-    boxes: Vec<DetServerBox>,
-}
-
-/// Result of a detection-only call: the line boxes plus the sidecar's
-/// self-reported inference time.
-#[derive(Debug)]
-pub struct DetResult {
-    pub boxes: Vec<LineBox>,
-    pub server_ms: f64,
-}
-
-#[derive(Debug, Serialize)]
-struct RecRequest {
-    image: String, // base64 of the same image det was run on
-    boxes: Vec<[[f32; 2]; 4]>,
-}
-
-/// Result of a recognition-only call: EXACTLY one slot per requested box, in
-/// the same order, in full-image coordinates. A slot is `None` when that box
-/// recognized to nothing usable (empty/whitespace text, or geometry the agent
-/// rejects) — a legitimate result for a blank line, an icon, or a separator.
-///
-/// The 1:1 positional alignment is load-bearing: the per-line cache pairs each
-/// detected box with its recognition outcome, and the analyzer fails closed on
-/// a count mismatch. Recognition outcomes must therefore never be *dropped*
-/// (which would silently misalign boxes and words); an unusable result becomes
-/// `None` in place, preserving the slot.
-#[derive(Debug)]
-pub struct RecResult {
-    pub words: Vec<Option<Word>>,
-    pub server_ms: f64,
-    pub request_bytes: usize,
-}
-
 /// Bounds the response body read: even a pathological full-screen of dense
 /// text is far below this.
 const MAX_OCR_RESPONSE_BYTES: usize = 8 << 20;
@@ -255,145 +178,6 @@ impl OcrClient {
             request_bytes,
         })
     }
-
-    /// Detection only: returns the text-line boxes for a top-down RGBA image.
-    /// Boxes are in the sent image's pixel space; the caller uses them to decide
-    /// which lines changed (per-line OCR cache) and recognizes only those via
-    /// [`recognize`](Self::recognize).
-    pub async fn detect(&self, rgba: &[u8], width: usize, height: usize) -> anyhow::Result<DetResult> {
-        let bmp = encode_bmp(rgba, width, height);
-        let resp = self
-            .client
-            .post(format!("{}/det", self.base_url))
-            .header("Content-Type", "application/octet-stream")
-            .body(bmp)
-            .send()
-            .await
-            .context("ocr: det request failed")?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.bytes().await.unwrap_or_default();
-            let snippet = String::from_utf8_lossy(&body[..body.len().min(512)]).to_string();
-            anyhow::bail!("ocr: det returned status {status}: {}", snippet.trim());
-        }
-        let body = resp.bytes().await.context("ocr: failed to read det response")?;
-        if body.len() > MAX_OCR_RESPONSE_BYTES {
-            anyhow::bail!("ocr: det response exceeds {MAX_OCR_RESPONSE_BYTES} bytes");
-        }
-        let out: DetServerResponse =
-            serde_json::from_slice(&body).context("ocr: invalid det response")?;
-
-        Ok(DetResult {
-            boxes: out
-                .boxes
-                .into_iter()
-                .map(|b| {
-                    // The crop_hash is the security-critical cache validity
-                    // token. Reject a malformed one (wrong length / non-hex)
-                    // rather than trust it: a constant or empty hash from a
-                    // misbehaving sidecar could otherwise cause a wrong reuse.
-                    if !is_sha256_hex(&b.crop_hash) {
-                        anyhow::bail!("ocr: det returned a malformed crop_hash");
-                    }
-                    Ok(LineBox {
-                        quad: b.quad,
-                        crop_hash: b.crop_hash,
-                    })
-                })
-                .collect::<anyhow::Result<Vec<_>>>()?,
-            server_ms: out.duration_ms,
-        })
-    }
-
-    /// Recognition only: recognizes the given line boxes against `rgba` (the
-    /// SAME image `detect` was run on). The sidecar crops each box with the same
-    /// perspective transform as the combined pipeline, so the text is identical
-    /// to what `/ocr` would have produced. Returns one word per box, in order,
-    /// in full-image coordinates.
-    pub async fn recognize(
-        &self,
-        rgba: &[u8],
-        width: usize,
-        height: usize,
-        boxes: &[LineBox],
-    ) -> anyhow::Result<RecResult> {
-        if boxes.is_empty() {
-            return Ok(RecResult { words: Vec::new(), server_ms: 0.0, request_bytes: 0 });
-        }
-        let want = boxes.len();
-        let bmp = encode_bmp(rgba, width, height);
-        let req = RecRequest {
-            image: base64::engine::general_purpose::STANDARD.encode(&bmp),
-            boxes: boxes.iter().map(|b| b.quad).collect(),
-        };
-        let payload = serde_json::to_vec(&req).context("ocr: encode rec request")?;
-        let request_bytes = payload.len();
-        let resp = self
-            .client
-            .post(format!("{}/rec", self.base_url))
-            .header("Content-Type", "application/json")
-            .body(payload)
-            .send()
-            .await
-            .context("ocr: rec request failed")?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.bytes().await.unwrap_or_default();
-            let snippet = String::from_utf8_lossy(&body[..body.len().min(512)]).to_string();
-            anyhow::bail!("ocr: rec returned status {status}: {}", snippet.trim());
-        }
-        let body = resp.bytes().await.context("ocr: failed to read rec response")?;
-        if body.len() > MAX_OCR_RESPONSE_BYTES {
-            anyhow::bail!("ocr: rec response exceeds {MAX_OCR_RESPONSE_BYTES} bytes");
-        }
-        let out: OcrServerResponse =
-            serde_json::from_slice(&body).context("ocr: invalid rec response")?;
-
-        // The /rec contract is positional: the sidecar must return exactly one
-        // entry per requested box, in order. Enforce it at the boundary so a
-        // protocol violation is a clear error here rather than a misaligned
-        // box/word pairing downstream. Empty/unusable recognitions are kept as
-        // `None` slots by `validate_words_positional` — never dropped.
-        if out.words.len() != want {
-            anyhow::bail!(
-                "ocr: rec returned {} entries for {} boxes (positional contract violated)",
-                out.words.len(),
-                want
-            );
-        }
-
-        Ok(RecResult {
-            words: validate_words_positional(out.words, width, height),
-            server_ms: out.duration_ms,
-            request_bytes,
-        })
-    }
-}
-
-/// Whether `s` is a well-formed SHA-256 hex digest: exactly 64 lowercase hex
-/// characters. The per-line cache validity depends on this token, so a
-/// malformed value from a misbehaving sidecar must be rejected (fail closed),
-/// never used as a cache key.
-fn is_sha256_hex(s: &str) -> bool {
-    s.len() == 64 && s.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-}
-
-#[cfg(test)]
-mod hash_tests {
-    use super::is_sha256_hex;
-
-    #[test]
-    fn sha256_hex_validation() {
-        assert!(is_sha256_hex(&"a".repeat(64)));
-        assert!(is_sha256_hex(&"0123456789abcdef".repeat(4)));
-        assert!(!is_sha256_hex(""), "empty rejected");
-        assert!(!is_sha256_hex(&"a".repeat(63)), "too short rejected");
-        assert!(!is_sha256_hex(&"a".repeat(65)), "too long rejected");
-        assert!(!is_sha256_hex(&"A".repeat(64)), "uppercase rejected");
-        assert!(!is_sha256_hex(&"g".repeat(64)), "non-hex rejected");
-    }
 }
 
 /// Validates and normalizes raw server tokens before they enter the analyzer
@@ -403,59 +187,39 @@ mod hash_tests {
 /// confidence is clamped to 0..1 and rescaled to the 0-100 Word convention.
 fn validate_words(raw: Vec<OcrServerWord>, width: usize, height: usize) -> Vec<Word> {
     raw.into_iter()
-        .filter_map(|w| validate_word(w, width, height))
+        .filter_map(|w| {
+            let text = w.text.trim();
+            if text.is_empty() {
+                return None;
+            }
+            if !w.conf.is_finite() || w.conf < 0.0 {
+                return None;
+            }
+            if w.x < 0 || w.y < 0 || w.w <= 0 || w.h <= 0 {
+                return None;
+            }
+            let (x, y, ww, hh) = (w.x as usize, w.y as usize, w.w as usize, w.h as usize);
+            // Reject tokens that fall outside the submitted image. The
+            // sidecar is a separate (untrusted) process: absurd coordinates
+            // would otherwise produce off-canvas bounding boxes and overflow
+            // the bbox merge in analyze_text. The Go engine does not
+            // bounds-check, but the agent-side sidecar runs in the customer
+            // network and warrants the stricter contract — words it drops
+            // here are off-screen anyway.
+            if x >= width || y >= height || ww > width - x || hh > height - y {
+                return None;
+            }
+            Some(Word {
+                text: text.to_string(),
+                left: x,
+                top: y,
+                width: ww,
+                height: hh,
+                // Server confidence is 0..1; Word.conf is 0-100.
+                conf: w.conf.min(1.0) * 100.0,
+            })
+        })
         .collect()
-}
-
-/// Positional sibling of [`validate_words`] for the `/rec` path: returns one
-/// slot per input word, in order, with the same per-word sanitization but
-/// WITHOUT dropping. An unusable entry (empty text, bad confidence, degenerate
-/// or off-canvas geometry) becomes `None` in place rather than collapsing the
-/// vector — preserving the box↔word alignment the per-line cache relies on.
-fn validate_words_positional(
-    raw: Vec<OcrServerWord>,
-    width: usize,
-    height: usize,
-) -> Vec<Option<Word>> {
-    raw.into_iter()
-        .map(|w| validate_word(w, width, height))
-        .collect()
-}
-
-/// Sanitizes a single raw sidecar word, returning `None` if it is unusable.
-/// Shared by the dropping (`/ocr`, `/det` discovery) and positional (`/rec`)
-/// validators so both apply identical rules — only their handling of `None`
-/// differs (drop vs. keep-as-empty-slot).
-fn validate_word(w: OcrServerWord, width: usize, height: usize) -> Option<Word> {
-    let text = w.text.trim();
-    if text.is_empty() {
-        return None;
-    }
-    if !w.conf.is_finite() || w.conf < 0.0 {
-        return None;
-    }
-    if w.x < 0 || w.y < 0 || w.w <= 0 || w.h <= 0 {
-        return None;
-    }
-    let (x, y, ww, hh) = (w.x as usize, w.y as usize, w.w as usize, w.h as usize);
-    // Reject tokens that fall outside the submitted image. The sidecar is a
-    // separate (untrusted) process: absurd coordinates would otherwise produce
-    // off-canvas bounding boxes and overflow the bbox merge in analyze_text.
-    // The Go engine does not bounds-check, but the agent-side sidecar runs in
-    // the customer network and warrants the stricter contract — words rejected
-    // here are off-screen anyway.
-    if x >= width || y >= height || ww > width - x || hh > height - y {
-        return None;
-    }
-    Some(Word {
-        text: text.to_string(),
-        left: x,
-        top: y,
-        width: ww,
-        height: hh,
-        // Server confidence is 0..1; Word.conf is 0-100.
-        conf: w.conf.min(1.0) * 100.0,
-    })
 }
 
 #[cfg(test)]
@@ -492,25 +256,6 @@ mod tests {
         assert_eq!(kept[0].text, "ok"); // trimmed
         assert_eq!(kept[1].text, "clamp");
         assert_eq!(kept[1].conf, 100.0); // 5.0 clamped to 1.0 → 100
-    }
-
-    #[test]
-    fn positional_validation_keeps_one_slot_per_word() {
-        // Same inputs as the dropping validator, but positional: every input
-        // gets a slot; unusable ones become `None` IN PLACE (no collapse), so
-        // the i-th result still corresponds to the i-th requested /rec box.
-        let raw = vec![
-            OcrServerWord { text: "ok".into(), conf: 0.9, x: 0, y: 0, w: 10, h: 10 },
-            OcrServerWord { text: "".into(), conf: 0.0, x: 0, y: 0, w: 5, h: 5 }, // blank line
-            OcrServerWord { text: "bad".into(), conf: f64::NAN, x: 0, y: 0, w: 5, h: 5 },
-            OcrServerWord { text: "two".into(), conf: 0.8, x: 1, y: 1, w: 4, h: 4 },
-        ];
-        let slots = validate_words_positional(raw, 100, 100);
-        assert_eq!(slots.len(), 4, "one slot per input, never dropped");
-        assert_eq!(slots[0].as_ref().unwrap().text, "ok");
-        assert!(slots[1].is_none(), "empty text -> None slot, not removed");
-        assert!(slots[2].is_none(), "NaN conf -> None slot, not removed");
-        assert_eq!(slots[3].as_ref().unwrap().text, "two");
     }
 
     #[test]

--- a/scripts/dev/ocr-poc/server_rapidocr.py
+++ b/scripts/dev/ocr-poc/server_rapidocr.py
@@ -28,8 +28,6 @@ Run locally without Docker (CPU):
 """
 
 import asyncio
-import base64
-import hashlib
 import logging
 import os
 import time
@@ -39,8 +37,6 @@ import numpy as np
 import onnxruntime
 from fastapi import FastAPI, Request, Response
 from rapidocr import RapidOCR
-from rapidocr.ch_ppocr_rec.typings import TextRecInput
-from rapidocr.utils.process_img import get_rotate_crop_image
 
 from device_policy import cuda_device_count, resolve_device
 
@@ -116,115 +112,6 @@ async def ocr(request: Request):
 
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, _run_ocr, img)
-
-
-def _run_det(img) -> dict:
-    """Detection only: return the text-line quad boxes for an image, each with a
-    content hash of the EXACT pixels recognition will see. The agent uses these
-    to decide which lines changed (per-line OCR cache) and re-runs recognition
-    only on the changed ones via /rec.
-
-    Boxes are returned as 4-point quads in full-image pixel coordinates, exactly
-    as RapidOCR's detector produces them, so /rec can reproduce the identical
-    crop with get_rotate_crop_image (no fidelity loss versus the combined /ocr
-    path).
-
-    crop_hash is the SHA-256 of the recognition crop produced by
-    get_rotate_crop_image for this box — i.e. the very pixels /rec will feed to
-    the recognizer. The agent keys its per-line cache on this hash, so a line is
-    reused ONLY when the exact recognition input recurs. Hashing the perspective
-    crop (not an axis-aligned bbox) closes the gap where a changed quad could
-    share a bbox: if recognition would see different pixels, the hash differs
-    and the line is re-recognized. SHA-256 makes a stale-reuse collision
-    cryptographically infeasible, upholding the guard's invariant."""
-    start = time.perf_counter()
-    result = ENGINE.text_det(img)
-    duration_ms = (time.perf_counter() - start) * 1000.0
-    boxes = []
-    if getattr(result, "boxes", None) is not None:
-        for box in result.boxes:
-            arr = np.array(box, dtype=np.float32)
-            crop = get_rotate_crop_image(img, arr)
-            crop_hash = hashlib.sha256(np.ascontiguousarray(crop).tobytes()).hexdigest()
-            boxes.append(
-                {
-                    "quad": [[float(p[0]), float(p[1])] for p in box],
-                    "crop_hash": crop_hash,
-                }
-            )
-    return {"duration_ms": duration_ms, "boxes": boxes}
-
-
-def _run_rec(img, boxes) -> dict:
-    """Recognition only: crop each provided quad box from the image (using the
-    same perspective crop as the combined pipeline) and recognize it. Returns
-    one word per box, in full-image coordinates, in the SAME order as `boxes`.
-
-    The agent calls this only for the boxes whose pixels changed since the last
-    frame; unchanged lines are served from its cache. Cropping happens here (not
-    on the agent) so the recognized text is byte-for-byte what /ocr would have
-    produced for the same box."""
-    start = time.perf_counter()
-    words = []
-    if boxes:
-        crops = []
-        bounds = []
-        for box in boxes:
-            arr = np.array(box, dtype=np.float32)
-            crops.append(get_rotate_crop_image(img, arr))
-            xs = [p[0] for p in box]
-            ys = [p[1] for p in box]
-            bounds.append((int(min(xs)), int(min(ys)), int(max(xs)), int(max(ys))))
-        rec_out = ENGINE.text_rec(TextRecInput(img=crops))
-        txts = rec_out.txts or []
-        scores = rec_out.scores or []
-        for i, (x0, y0, x1, y1) in enumerate(bounds):
-            text = txts[i] if i < len(txts) else ""
-            conf = float(scores[i]) if i < len(scores) else 0.0
-            words.append(
-                {
-                    "text": text,
-                    "conf": conf,
-                    "x": x0,
-                    "y": y0,
-                    "w": x1 - x0,
-                    "h": y1 - y0,
-                }
-            )
-    duration_ms = (time.perf_counter() - start) * 1000.0
-    return {"duration_ms": duration_ms, "words": words}
-
-
-@app.post("/det")
-async def det(request: Request):
-    body = await request.body()
-    img = cv2.imdecode(np.frombuffer(body, dtype=np.uint8), cv2.IMREAD_COLOR)
-    if img is None:
-        return Response(status_code=400, content="undecodable image")
-
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, _run_det, img)
-
-
-@app.post("/rec")
-async def rec(request: Request):
-    # JSON: { "image": "<base64 of the same image det was run on>",
-    #         "boxes": [ [[x,y],[x,y],[x,y],[x,y]], ... ] }
-    payload = await request.json()
-    image_b64 = payload.get("image")
-    boxes = payload.get("boxes") or []
-    if not image_b64:
-        return Response(status_code=400, content="missing image")
-    try:
-        raw = base64.b64decode(image_b64)
-    except Exception:
-        return Response(status_code=400, content="invalid base64 image")
-    img = cv2.imdecode(np.frombuffer(raw, dtype=np.uint8), cv2.IMREAD_COLOR)
-    if img is None:
-        return Response(status_code=400, content="undecodable image")
-
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, _run_rec, img, boxes)
 
 
 def warmup() -> None:


### PR DESCRIPTION
Reverts the line-level OCR cache (#1563) and its follow-up fix (#1566).

## Why

The cache split the single `/ocr` call into `/det` + `/rec` to re-recognize only the lines whose pixels were unchanged since the previous frame. That only wins when on-screen text is **pixel-stable** frame to frame.

On real interactive sessions (scrolling, redraws, animation) almost every line changes every frame. Live metrics from the deployed GPU agent:

| Metric | Observed | Meaning |
|--------|----------|---------|
| `lines_recognized` / `lines_total` | 151/173, 177/194 | ~85-90% cache **miss** — near-zero reuse |
| `paints_changed` / `paints_total` | 442/442, 351/351 | every paint genuinely changes pixels |
| `ocr_sent_kib` | 15-21 MB/window | band bitmap encoded + sent **twice** (`/det` then `/rec`) |
| `ocr` wall-clock | 460-1180ms | up from ~224ms pre-cache |

So on dynamic content the split design is **pure overhead** vs. the original single call: double BMP encode, double round-trip, double bytes, to do work one `/ocr` call already did. Net result is a clear latency regression — the gate felt much slower.

## What

Restores the proven single-`/ocr` pipeline. `analyze.rs` and `ocr.rs` are byte-identical to the pre-cache baseline (#1557); the sidecar is back to `/healthz` + `/ocr` only.

- Fail-closed behavior and all other guard properties unchanged.
- 94 piigate tests pass (back to the pre-cache suite); clippy clean.
- The line-cache ADR (#1562) is intentionally **kept** as a record of the approach and why it did not hold up in practice.

Reviewed: no dangling references to the removed `/det`, `/rec`, `LineCache`, `crop_hash`, `RecResult`, `DetResult`; restored path preserves fail-closed analysis.

Automated by MisterMal