### PR TITLE
fix(mcp): stop session self-destruct causing 404

### DIFF
--- a/gateway/api/mcpserver/mcpserver.go
+++ b/gateway/api/mcpserver/mcpserver.go
@@ -12,10 +12,25 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// Sends MCP-level ping requests at this interval to keep idle sessions warm.
-// Without this, long-running tool handlers (e.g. reviews_wait) sit silently on
-// the wire long enough that intermediate layers tear down the connection.
-const mcpKeepAliveInterval = 30 * time.Second
+// mcpSessionTimeout bounds how long an *idle* MCP session is retained in the
+// server's in-memory session map before it is evicted. It is an inactivity
+// timer: the SDK pauses it for the duration of every in-flight request and
+// only resets it once the last request for a session finishes (see
+// sessionInfo.startPOST/endPOST in the go-sdk). An actively used session — or
+// one parked on a long-running wait tool — therefore never expires; only a
+// genuinely abandoned session is reclaimed, which keeps memory bounded on a
+// long-lived gateway without ever tearing a live client out from under itself.
+//
+// We intentionally do NOT use ServerOptions.KeepAlive. KeepAlive sends
+// server->client pings on the *standalone* SSE stream and, on the first ping
+// failure, destroys the whole session. Streamable-HTTP MCP clients that don't
+// hold a standalone GET stream open (Devin, Cursor) make every ping fail,
+// which evicted the session ~30s after it was created and surfaced to users as
+// "session terminated (404), need to re-initialize". Long-running tool calls
+// are instead kept warm by emitting progress notifications on the request's
+// own POST stream (see newWaitHeartbeat / waitUntil), which is the stream that
+// actually needs to stay alive.
+const mcpSessionTimeout = 30 * time.Minute
 
 type MCPServer struct {
 	handler *mcp.StreamableHTTPHandler
@@ -25,9 +40,7 @@ func New(releaseConnFn reviewapi.TransportReleaseConnectionFunc) *MCPServer {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "hoop",
 		Version: version.Get().Version,
-	}, &mcp.ServerOptions{
-		KeepAlive: mcpKeepAliveInterval,
-	})
+	}, nil)
 
 	registerConnectionTools(server)
 	registerGuardrailTools(server)
@@ -47,7 +60,7 @@ func New(releaseConnFn reviewapi.TransportReleaseConnectionFunc) *MCPServer {
 
 	handler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server { return server },
-		nil,
+		&mcp.StreamableHTTPOptions{SessionTimeout: mcpSessionTimeout},
 	)
 
 	return &MCPServer{handler: handler}

--- a/gateway/api/mcpserver/poll.go
+++ b/gateway/api/mcpserver/poll.go
@@ -40,10 +40,16 @@ func resolveWaitTimeout(seconds int) time.Duration {
 // fn is invoked once eagerly so an already-terminal state returns
 // immediately without a poll-interval delay. On timeout, fn is invoked one
 // more time so the response reflects the most recent state.
+//
+// onTick, if non-nil, is invoked with the elapsed time after every poll that
+// leaves the wait still pending. It is used to emit a heartbeat on the request
+// stream (see newWaitHeartbeat) so the long-poll HTTP connection is not torn
+// down by intermediate proxies or clients. onTick must not block.
 func waitUntil[T any](
 	ctx context.Context,
 	timeout time.Duration,
 	fn func() (T, bool, error),
+	onTick func(elapsed time.Duration),
 ) (T, bool, time.Duration, error) {
 	started := time.Now()
 
@@ -71,6 +77,9 @@ func waitUntil[T any](
 			val, done, err = fn()
 			if err != nil || done {
 				return val, false, time.Since(started), err
+			}
+			if onTick != nil {
+				onTick(time.Since(started))
 			}
 		}
 	}

--- a/gateway/api/mcpserver/poll_test.go
+++ b/gateway/api/mcpserver/poll_test.go
@@ -35,7 +35,7 @@ func TestWaitUntil_AlreadyDone(t *testing.T) {
 	val, timedOut, waited, err := waitUntil(context.Background(), 5*time.Second, func() (string, bool, error) {
 		calls++
 		return "ready", true, nil
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestWaitUntil_DoneAfterFewTicks(t *testing.T) {
 	val, timedOut, _, err := waitUntil(context.Background(), 30*time.Second, func() (int, bool, error) {
 		calls++
 		return calls, calls >= flipAt, nil
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestWaitUntil_Timeout(t *testing.T) {
 	val, timedOut, waited, err := waitUntil(context.Background(), timeout, func() (string, bool, error) {
 		calls++
 		return "still-pending", false, nil
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestWaitUntil_FnErrorPropagates(t *testing.T) {
 	sentinel := errors.New("db blew up")
 	val, _, _, err := waitUntil(context.Background(), 30*time.Second, func() (string, bool, error) {
 		return "", false, sentinel
-	})
+	}, nil)
 	if !errors.Is(err, sentinel) {
 		t.Errorf("expected sentinel error, got %v", err)
 	}
@@ -119,7 +119,7 @@ func TestWaitUntil_CtxCancelled(t *testing.T) {
 	_, timedOut, waited, err := waitUntil(ctx, 30*time.Second, func() (string, bool, error) {
 		calls++
 		return "pending", false, nil
-	})
+	}, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}
@@ -128,6 +128,50 @@ func TestWaitUntil_CtxCancelled(t *testing.T) {
 	}
 	if waited > 5*time.Second {
 		t.Errorf("expected fast cancellation, waited %v", waited)
+	}
+}
+
+func TestWaitUntil_OnTickFiresPerPendingPoll(t *testing.T) {
+	calls := 0
+	flipAt := 4
+	var ticks []time.Duration
+	_, timedOut, _, err := waitUntil(context.Background(), 30*time.Second,
+		func() (int, bool, error) {
+			calls++
+			return calls, calls >= flipAt, nil
+		},
+		func(elapsed time.Duration) { ticks = append(ticks, elapsed) },
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if timedOut {
+		t.Errorf("expected timedOut=false")
+	}
+	// Eager call (pending) and the terminal poll do not tick; every pending
+	// poll in between does. With flipAt=4: eager + 3 ticker polls, the last of
+	// which is terminal, so 2 ticks fire.
+	if want := flipAt - 2; len(ticks) != want {
+		t.Fatalf("expected %d heartbeat ticks, got %d", want, len(ticks))
+	}
+	for i := 1; i < len(ticks); i++ {
+		if ticks[i] <= ticks[i-1] {
+			t.Errorf("expected monotonically increasing elapsed, got %v then %v", ticks[i-1], ticks[i])
+		}
+	}
+}
+
+func TestWaitUntil_OnTickNotCalledWhenAlreadyDone(t *testing.T) {
+	ticked := false
+	_, _, _, err := waitUntil(context.Background(), 5*time.Second,
+		func() (string, bool, error) { return "ready", true, nil },
+		func(time.Duration) { ticked = true },
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ticked {
+		t.Errorf("expected no heartbeat tick for an already-terminal state")
 	}
 }
 
@@ -140,7 +184,7 @@ func TestWaitUntil_FnErrorDuringPoll(t *testing.T) {
 			return "pending", false, nil
 		}
 		return "", false, sentinel
-	})
+	}, nil)
 	if !errors.Is(err, sentinel) {
 		t.Errorf("expected sentinel from poll iteration, got %v", err)
 	}

--- a/gateway/api/mcpserver/progress.go
+++ b/gateway/api/mcpserver/progress.go
@@ -1,0 +1,55 @@
+package mcpserver
+
+import (
+	"context"
+	"time"
+
+	"github.com/hoophq/hoop/common/log"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newWaitHeartbeat builds a waitUntil tick callback that emits MCP progress
+// notifications on the request's own POST stream while a long-running wait tool
+// (reviews_wait, sessions_wait_analysis) polls.
+//
+// Why this exists: the streamable-HTTP POST that carries a wait tool call sits
+// silent for as long as the wait runs. Intermediate proxies and some MCP
+// clients tear down an HTTP request that produces no bytes for ~60-120s.
+// Emitting a notification on that same request stream every poll interval keeps
+// the connection alive. The notification rides ctx — the handler context the
+// SDK tagged with the incoming request ID — so it is routed to this request's
+// POST stream rather than the standalone SSE stream that the broken
+// ServerOptions.KeepAlive used to ping (see mcpserver.go for that history).
+//
+// Progress notifications are part of the MCP spec and are only meaningful when
+// the client opted in by sending a progressToken with the request. When no
+// token is present we return nil and waitUntil runs without a heartbeat: the
+// session still survives (it is held alive by the in-flight POST), and the wait
+// simply relies on its timeout. We never send unsolicited progress
+// notifications, which keeps the behavior spec-compliant across every client.
+func newWaitHeartbeat(ctx context.Context, req *mcp.CallToolRequest, total time.Duration) func(elapsed time.Duration) {
+	if req == nil || req.Session == nil || req.Params == nil {
+		return nil
+	}
+	token := req.Params.GetProgressToken()
+	if token == nil {
+		return nil
+	}
+
+	ss := req.Session
+	totalSeconds := total.Seconds()
+	return func(elapsed time.Duration) {
+		// Best-effort: a heartbeat delivery failure must never abort the wait,
+		// so we only log it. Progress is reported in seconds elapsed, which is
+		// monotonically increasing as the spec requires.
+		err := ss.NotifyProgress(ctx, &mcp.ProgressNotificationParams{
+			ProgressToken: token,
+			Progress:      elapsed.Seconds(),
+			Total:         totalSeconds,
+			Message:       "waiting for completion",
+		})
+		if err != nil {
+			log.Debugf("mcp: wait heartbeat notification failed: %v", err)
+		}
+	}
+}

--- a/gateway/api/mcpserver/session_lifecycle_test.go
+++ b/gateway/api/mcpserver/session_lifecycle_test.go
@@ -1,0 +1,110 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// These tests reproduce the "session terminated (404), need to re-initialize"
+// failure that Devin/Cursor hit, and prove our fix resolves it — without a
+// gateway, Postgres, or a real client.
+//
+// The trigger has two ingredients, both reproduced here:
+//   - The MCP client does NOT keep a standalone GET SSE stream open
+//     (StreamableClientTransport.DisableStandaloneSSE = true). Devin/Cursor
+//     behave this way; the go-sdk's own client does not, which is why
+//     `hoop admin mcp` never reproduced the bug.
+//   - The server pings on a timer (ServerOptions.KeepAlive). With no standalone
+//     stream to carry it, every ping fails and the SDK closes the whole
+//     session, so the next tool call returns 404 ErrSessionMissing.
+
+type pingArgs struct{}
+
+// newTestMCP starts an in-memory streamable MCP server exposing a single
+// "ping" tool, configured with the given server/handler options, and returns a
+// connected client session. The client mimics Devin/Cursor by never opening a
+// standalone SSE stream.
+func newTestMCP(t *testing.T, serverOpts *mcp.ServerOptions, handlerOpts *mcp.StreamableHTTPOptions) *mcp.ClientSession {
+	t.Helper()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "hoop-test", Version: "test"}, serverOpts)
+	mcp.AddTool(server, &mcp.Tool{Name: "ping", Description: "returns pong"},
+		func(ctx context.Context, _ *mcp.CallToolRequest, _ pingArgs) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "pong"}}}, nil, nil
+		})
+
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, handlerOpts)
+	httpServer := httptest.NewServer(handler)
+	t.Cleanup(httpServer.Close)
+
+	ctx := context.Background()
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:             httpServer.URL,
+		DisableStandaloneSSE: true, // <- the Devin/Cursor condition
+	}
+	session, err := mcp.NewClient(&mcp.Implementation{Name: "devin-like", Version: "test"}, nil).
+		Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func callPing(ctx context.Context, s *mcp.ClientSession) error {
+	_, err := s.CallTool(ctx, &mcp.CallToolParams{Name: "ping"})
+	return err
+}
+
+// TestKeepAlive_ReproducesSessionTermination demonstrates the ORIGINAL bug:
+// with ServerOptions.KeepAlive set and a client that holds no standalone
+// stream, the session is torn down between calls and the second call fails.
+// This guards against anyone reintroducing KeepAlive.
+func TestKeepAlive_ReproducesSessionTermination(t *testing.T) {
+	ctx := context.Background()
+	// Short keepalive so the test is fast; production used 30s.
+	session := newTestMCP(t, &mcp.ServerOptions{KeepAlive: 100 * time.Millisecond}, nil)
+
+	if err := callPing(ctx, session); err != nil {
+		t.Fatalf("first call should succeed while the session is fresh, got: %v", err)
+	}
+
+	// Let at least one keepalive ping fire and fail (no standalone stream).
+	time.Sleep(400 * time.Millisecond)
+
+	err := callPing(ctx, session)
+	if err == nil {
+		t.Fatal("expected the second call to fail after the keepalive killed the session, but it succeeded")
+	}
+	if !errors.Is(err, mcp.ErrSessionMissing) {
+		t.Errorf("expected ErrSessionMissing (the 404 surfaced to the client), got: %v", err)
+	}
+}
+
+// TestProductionConfig_SurvivesIdleGap proves the FIX: with our production
+// transport configuration (no KeepAlive; an inactivity SessionTimeout) the same
+// Devin-like client can sit idle across what used to be the keepalive window
+// and still call tools — no 404, no re-initialize.
+func TestProductionConfig_SurvivesIdleGap(t *testing.T) {
+	ctx := context.Background()
+	// Mirror mcpserver.New: no ServerOptions.KeepAlive, inactivity SessionTimeout
+	// on the handler. A generous timeout that will not fire during the test.
+	session := newTestMCP(t, nil, &mcp.StreamableHTTPOptions{SessionTimeout: mcpSessionTimeout})
+
+	if err := callPing(ctx, session); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	// Idle far longer than the old 100ms-1-tick failure window above.
+	time.Sleep(500 * time.Millisecond)
+
+	if err := callPing(ctx, session); err != nil {
+		t.Fatalf("second call after idle gap should succeed with the fix, got: %v", err)
+	}
+}

--- a/gateway/api/mcpserver/tools_reviews.go
+++ b/gateway/api/mcpserver/tools_reviews.go
@@ -341,7 +341,7 @@ func makeReviewsUpdateHandler(releaseConnFn reviewapi.TransportReleaseConnection
 	}
 }
 
-func reviewsWaitHandler(ctx context.Context, _ *mcp.CallToolRequest, args reviewsWaitInput) (*mcp.CallToolResult, any, error) {
+func reviewsWaitHandler(ctx context.Context, req *mcp.CallToolRequest, args reviewsWaitInput) (*mcp.CallToolResult, any, error) {
 	sc := storageContextFrom(ctx)
 	if sc == nil {
 		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
@@ -368,7 +368,8 @@ func reviewsWaitHandler(ctx context.Context, _ *mcp.CallToolRequest, args review
 		return reviewsWaitResult(initial, false, 0), nil, nil
 	}
 
-	rev, timedOut, waited, err := waitUntil(ctx, resolveWaitTimeout(args.TimeoutSeconds),
+	timeout := resolveWaitTimeout(args.TimeoutSeconds)
+	rev, timedOut, waited, err := waitUntil(ctx, timeout,
 		func() (*models.Review, bool, error) {
 			r, err := models.GetReviewByIdOrSid(orgID, args.ID)
 			if err != nil {
@@ -378,7 +379,8 @@ func reviewsWaitHandler(ctx context.Context, _ *mcp.CallToolRequest, args review
 				return nil, false, models.ErrNotFound
 			}
 			return r, isReviewTerminal(r.Status), nil
-		})
+		},
+		newWaitHeartbeat(ctx, req, timeout))
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			if rev == nil {

--- a/gateway/api/mcpserver/tools_sessions.go
+++ b/gateway/api/mcpserver/tools_sessions.go
@@ -268,7 +268,7 @@ func sessionsGetAnalysisHandler(ctx context.Context, _ *mcp.CallToolRequest, arg
 	})
 }
 
-func sessionsWaitAnalysisHandler(ctx context.Context, _ *mcp.CallToolRequest, args sessionsWaitAnalysisInput) (*mcp.CallToolResult, any, error) {
+func sessionsWaitAnalysisHandler(ctx context.Context, req *mcp.CallToolRequest, args sessionsWaitAnalysisInput) (*mcp.CallToolResult, any, error) {
 	sc := storageContextFrom(ctx)
 	if sc == nil {
 		return nil, nil, fmt.Errorf("unauthorized: missing auth context")
@@ -295,14 +295,16 @@ func sessionsWaitAnalysisHandler(ctx context.Context, _ *mcp.CallToolRequest, ar
 		return sessionsWaitAnalysisResult(initial, false, 0), nil, nil
 	}
 
-	sess, timedOut, waited, err := waitUntil(ctx, resolveWaitTimeout(args.TimeoutSeconds),
+	timeout := resolveWaitTimeout(args.TimeoutSeconds)
+	sess, timedOut, waited, err := waitUntil(ctx, timeout,
 		func() (*models.Session, bool, error) {
 			s, err := models.GetSessionByID(sc.OrgID, args.ID)
 			if err != nil {
 				return nil, false, err
 			}
 			return s, s.AIAnalysis != nil, nil
-		})
+		},
+		newWaitHeartbeat(ctx, req, timeout))
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			if sess == nil {


### PR DESCRIPTION
## 📝 Description

MCP sessions were being destroyed about 30 seconds after creation for clients that do not keep a standalone SSE stream open (Devin, Cursor). The next tool call then failed with `transport error: failed to send request: session terminated (404). need to re-initialize`. The symptom was "works once, fails on the next call".

Root cause: the MCP server set `ServerOptions.KeepAlive`. This makes the go-sdk send server→client pings on the **standalone** SSE stream and close the **entire session** on the first ping failure. Clients that don't hold that stream open fail every ping, so the session is evicted and every subsequent request returns 404. The ping also never travelled on the stream doing the actual work, so it never protected long-running tool calls in the first place.

## 🔗 Related Issue

N/A

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Removed `ServerOptions.KeepAlive` from the MCP server, since it pinged the wrong stream and destroyed sessions on ping failure.
- Added an inactivity-based `SessionTimeout` (30m) on the handler. The SDK pauses this timer for every in-flight request, so active sessions and long-running waits never expire; only genuinely abandoned sessions are reclaimed, keeping memory bounded.
- Kept long-running waits warm the correct way: emit MCP progress notifications on the request's own POST stream from the `waitUntil` poll loop, gated on the client having sent a `progressToken` (no unsolicited notifications). Wired into `reviews_wait` and `sessions_wait_analysis`.
- Added a deterministic, gateway-free regression test that reproduces the 404 with a Devin-style client and proves the fix.

## 🧪 Testing

Reproduced and verified with the real go-sdk, without a gateway, Postgres, or a live client:

- `TestKeepAlive_ReproducesSessionTermination` drives a client that does not open a standalone SSE stream (`DisableStandaloneSSE=true`) against a server with `KeepAlive` set, and asserts the second call fails with `ErrSessionMissing` — the exact 404. Guards against reintroducing `KeepAlive`.
- `TestProductionConfig_SurvivesIdleGap` runs the same client against the production transport config and asserts an idle gap no longer breaks the next call.

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
