### PR TITLE
fix(httpproxy): prevent session stampede from leaking orphaned open sessions

### DIFF
--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/hoophq/hoop/gateway/proxyproto/grpckey"
 	"github.com/hoophq/hoop/gateway/transport/usertoken"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -43,11 +44,17 @@ var instanceStore sync.Map
 
 type HttpProxyServer struct {
 	sessionStore sync.Map // map[string]*httpProxySession
-	httpServer   *http.Server
-	listener     net.Listener
-	listenAddr   string
-	tlsConfig    *tls.Config
-	mutex        sync.RWMutex
+	// createGroup de-duplicates concurrent session creation per secretKeyHash.
+	// The session row is persisted the moment the gRPC stream connects (Save ->
+	// OnConnect), so a burst of first-requests for the same proxy token must
+	// share a single connect; otherwise each request opens its own stream and
+	// leaves an orphaned "open" session behind. Only one goroutine per key runs
+	// the creation; the rest block and reuse its result.
+	createGroup singleflight.Group
+	httpServer  *http.Server
+	listener    net.Listener
+	listenAddr  string
+	tlsConfig   *tls.Config
 }
 
 type httpProxySession struct {
@@ -307,7 +314,9 @@ func (s *HttpProxyServer) getSessionOrRelease(secretKeyHash string) (*httpProxyS
 		// Check if session context is still valid
 		if sess.ctx.Err() != nil {
 			log.Infof("http proxy session context error: %v, removing session for connection %s", sess.ctx.Err(), secretKeyHash)
-			s.sessionStore.Delete(secretKeyHash)
+			// Only evict this exact session; a concurrent creator may already
+			// have replaced it under the same key.
+			s.sessionStore.CompareAndDelete(secretKeyHash, sess)
 			return nil, fmt.Errorf("http proxy session context error: %v", sess.ctx.Err())
 		}
 		log.Debugf("http proxy session found for connection %s", secretKeyHash)
@@ -318,7 +327,7 @@ func (s *HttpProxyServer) getSessionOrRelease(secretKeyHash string) (*httpProxyS
 }
 
 func (s *HttpProxyServer) getOrCreateSession(secretKeyHash, correlationID string) (*httpProxySession, error) {
-	// First try to get existing valid session
+	// Fast path: reuse a live session without entering the singleflight group.
 	sess, err := s.getSessionOrRelease(secretKeyHash)
 	if err != nil {
 		return nil, err
@@ -327,6 +336,32 @@ func (s *HttpProxyServer) getOrCreateSession(secretKeyHash, correlationID string
 		return sess, nil
 	}
 
+	// Slow path: only one goroutine per secretKeyHash runs the creation; the
+	// rest block here and receive the same session. A burst of first-requests
+	// therefore opens a single gRPC stream (and a single audit session row)
+	// instead of one per request.
+	v, err, _ := s.createGroup.Do(secretKeyHash, func() (any, error) {
+		// Re-check inside the group: a previous leader may have created and
+		// stored the session in the window before singleflight forgot the key.
+		if sess, err := s.getSessionOrRelease(secretKeyHash); err != nil {
+			return nil, err
+		} else if sess != nil {
+			return sess, nil
+		}
+		return s.createSession(secretKeyHash, correlationID)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*httpProxySession), nil
+}
+
+// createSession validates the proxy-token credentials, opens a dedicated gRPC
+// stream to the gateway, performs the SessionOpen handshake and registers the
+// resulting session in sessionStore. It must only be called through
+// getOrCreateSession's singleflight group so concurrent first-requests for the
+// same secretKeyHash share a single stream instead of each opening one.
+func (s *HttpProxyServer) createSession(secretKeyHash, correlationID string) (*httpProxySession, error) {
 	// Validate credentials first
 	dba, err := getValidConnectionCredentials(secretKeyHash)
 	if err != nil {
@@ -466,21 +501,17 @@ func (s *HttpProxyServer) getOrCreateSession(secretKeyHash, correlationID string
 			_, _ = session.streamClient.Close()
 			log.Infof("http proxy session cleanup: stream closed, sid=%s", sid)
 		}
-		// Cleanup will be done by handleAgentResponses defer, but we also try here as backup
-		s.sessionStore.Delete(secretKeyHash)
+		// Only remove ourselves: CompareAndDelete guards against evicting a
+		// different session another goroutine registered under the same key,
+		// which would orphan the live session as a perpetual "open" row.
+		// Cleanup is also attempted by the handleAgentResponses defer.
+		s.sessionStore.CompareAndDelete(secretKeyHash, session)
 		log.Infof("http proxy session cleanup: session removed from store, sid=%s", sid)
 	}()
 
-	// Store session; in case of reace condition, the first one wins and we close the new one
-	s.mutex.Lock()
-	if existingSession, ok := s.sessionStore.Load(secretKeyHash); ok {
-		s.mutex.Unlock()
-		// Another goroutine created the session first, close this one
-		session.cancelFn("duplicate session, another session already exists")
-		return existingSession.(*httpProxySession), nil
-	}
+	// Register the session. singleflight guarantees we are the only creator for
+	// this secretKeyHash, so a plain Store cannot clobber a concurrent winner.
 	s.sessionStore.Store(secretKeyHash, session)
-	s.mutex.Unlock()
 
 	return session, nil
 }
@@ -999,7 +1030,9 @@ func (sess *httpProxySession) handleAgentResponses(server *HttpProxyServer, secr
 			return true
 		})
 
-		server.sessionStore.Delete(secretKeyHash)
+		// Ownership-aware removal: never evict a different session registered
+		// under the same key by a newer creator.
+		server.sessionStore.CompareAndDelete(secretKeyHash, sess)
 		log.Warnf("handleAgentResponses: session removed from store, sid=%s", sess.sid)
 	}()
 

--- a/gateway/proxyproto/httpproxy/httpproxy_test.go
+++ b/gateway/proxyproto/httpproxy/httpproxy_test.go
@@ -563,3 +563,90 @@ func TestResponseChannelBufferSize(t *testing.T) {
 		assert.Contains(t, body, fmt.Sprintf("chunk-%d", i))
 	}
 }
+
+// --- session reuse / ownership tests ----------------------------------------
+
+// TestGetOrCreateSessionConcurrentReuse verifies that when a live session
+// already exists for a proxy token, a burst of concurrent requests all reuse
+// that single session instead of each minting their own. This is the
+// steady-state half of the session-stampede fix: once a session is registered,
+// no concurrent caller creates a duplicate.
+func TestGetOrCreateSessionConcurrentReuse(t *testing.T) {
+	srv := &HttpProxyServer{}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	const key = "httpproxy-secret-hash"
+	existing := &httpProxySession{sid: "live-session", ctx: ctx}
+	srv.sessionStore.Store(key, existing)
+
+	const n = 64
+	var wg sync.WaitGroup
+	results := make([]*httpProxySession, n)
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = srv.getOrCreateSession(key, "")
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		require.NoErrorf(t, errs[i], "caller %d", i)
+		assert.Samef(t, existing, results[i], "caller %d must reuse the live session", i)
+	}
+}
+
+// TestGetSessionOrReleaseEvictsCancelledSession verifies a cancelled session is
+// never handed back and is evicted from the store, so the next caller mints a
+// fresh one instead of routing onto a dead stream.
+func TestGetSessionOrReleaseEvictsCancelledSession(t *testing.T) {
+	srv := &HttpProxyServer{}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(fmt.Errorf("expired"))
+
+	const key = "httpproxy-secret-hash"
+	dead := &httpProxySession{sid: "dead-session", ctx: ctx}
+	srv.sessionStore.Store(key, dead)
+
+	sess, err := srv.getSessionOrRelease(key)
+	require.Error(t, err)
+	assert.Nil(t, sess)
+
+	_, ok := srv.sessionStore.Load(key)
+	assert.False(t, ok, "cancelled session must be evicted from the store")
+}
+
+// TestSessionStoreCleanupIsOwnershipAware locks in the invariant the cleanup
+// paths rely on: a stale session removing itself (CompareAndDelete with its own
+// pointer) must never evict a newer session registered under the same key.
+// Without this, a cancelled duplicate's cleanup would orphan the live session
+// as a perpetual "open" row — the root cause of the leaked sessions.
+func TestSessionStoreCleanupIsOwnershipAware(t *testing.T) {
+	srv := &HttpProxyServer{}
+	const key = "httpproxy-secret-hash"
+
+	ctxA, cancelA := context.WithCancelCause(context.Background())
+	defer cancelA(nil)
+	ctxB, cancelB := context.WithCancelCause(context.Background())
+	defer cancelB(nil)
+	sessA := &httpProxySession{sid: "A", ctx: ctxA}
+	sessB := &httpProxySession{sid: "B", ctx: ctxB}
+
+	// B supersedes A under the same key.
+	srv.sessionStore.Store(key, sessA)
+	srv.sessionStore.Store(key, sessB)
+
+	// A's late cleanup must be a no-op for B.
+	srv.sessionStore.CompareAndDelete(key, sessA)
+	got, ok := srv.sessionStore.Load(key)
+	require.True(t, ok, "B must survive A's stale cleanup")
+	assert.Same(t, sessB, got)
+
+	// B removes only itself.
+	srv.sessionStore.CompareAndDelete(key, sessB)
+	_, ok = srv.sessionStore.Load(key)
+	assert.False(t, ok, "B must remove itself")
+}


### PR DESCRIPTION

> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Fixes leaked "open" audit session rows in the HTTP proxy caused by a session-creation stampede. When a burst of concurrent first-requests arrived for the same proxy token, each request opened its own gRPC stream (and persisted its own session row via `Save -> OnConnect`) before racing to register in `sessionStore`. The losers were closed, but their already-persisted session rows were orphaned as perpetual "open" sessions. Additionally, the unconditional `sessionStore.Delete(secretKeyHash)` in the cleanup paths could evict a *newer* live session registered under the same key, orphaning it too.

The fix replaces the mutex + first-one-wins registration with `singleflight.Group`, so only one goroutine per `secretKeyHash` ever runs session creation — a burst of first-requests shares a single gRPC stream and a single audit row. All cleanup paths now use ownership-aware `CompareAndDelete` so a stale session's cleanup can never evict a live session it doesn't own.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- De-duplicate concurrent session creation per `secretKeyHash` with `singleflight.Group` in `getOrCreateSession`, extracting the creation logic into a dedicated `createSession` method — a burst of first-requests now opens exactly one gRPC stream and one audit session row.
- Re-check for an existing live session inside the singleflight callback to cover the window where a previous leader stored the session before singleflight forgot the key.
- Replace all unconditional `sessionStore.Delete` calls (cancelled-session eviction, session cleanup defer, `handleAgentResponses` defer) with ownership-aware `sessionStore.CompareAndDelete`, so a stale session's cleanup never evicts a newer live session under the same key.
- Remove the now-unneeded `mutex` field and the first-one-wins duplicate-session registration race handling.
- Add regression tests: concurrent session reuse under burst load, cancelled-session eviction, and ownership-aware cleanup semantics.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (gateway/backend change)
- **OS**: macOS (darwin)

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

New tests in `gateway/proxyproto/httpproxy/httpproxy_test.go`:
- `TestGetOrCreateSessionConcurrentReuse` — 64 concurrent callers all reuse a single live session.
- `TestGetSessionOrReleaseEvictsCancelledSession` — cancelled sessions are never handed back and are evicted.
- `TestSessionStoreCleanupIsOwnershipAware` — a stale session's cleanup cannot evict a newer session under the same key.

Run with `make test-oss` (or `go test ./gateway/proxyproto/httpproxy/...`).

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Reviewers may want to focus on the singleflight re-check inside `createGroup.Do` and the `CompareAndDelete` semantics in the two cleanup defers — these are the paths that previously raced. Label: `patch`.

Note: I checked the checklist boxes based on the diff itself (tests included, code commented), but I haven't actually run the tests — you may want to run go test ./gateway/proxyproto/httpproxy/... before opening the PR, or I can run them now if you'd like.