### PR TITLE
fix(gateway): refuse guarded sessions Presidio cannot enforce

### DIFF
--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -437,6 +437,16 @@ func (c Config) GcpDLPJsonCredentials() string         { return c.gcpDLPJsonCred
 func (c Config) DlpProvider() string                   { return c.dlpProvider }
 func (c Config) DlpMode() string                       { return c.dlpMode }
 func (c Config) HasRedactCredentials() bool            { return c.hasRedactCredentials }
+
+// HasGuardrailProvider reports whether the server is configured with a DLP
+// provider capable of enforcing guardrails. Guardrails are evaluated exclusively
+// through MSPresidio, so this requires the mspresidio provider with both the
+// analyzer and anonymizer URLs configured. It is intentionally stricter than
+// HasRedactCredentials (which is also true for GCP), because GCP cannot enforce
+// guardrails.
+func (c Config) HasGuardrailProvider() bool {
+	return c.dlpProvider == "mspresidio" && c.msPresidioAnalyzerURL != "" && c.msPresidioAnonymizerURL != ""
+}
 func (c Config) MSPresidioAnalyzerURL() string         { return c.msPresidioAnalyzerURL }
 func (c Config) MSPresidioAnomymizerURL() string       { return c.msPresidioAnonymizerURL }
 func (c Config) PgUsername() string                    { return c.pgCred.username }

--- a/gateway/transport/agent_guardrails_test.go
+++ b/gateway/transport/agent_guardrails_test.go
@@ -61,6 +61,36 @@ func TestBuildLegacyGuardRailErrorMessage(t *testing.T) {
 	}
 }
 
+func TestConnectionTypeSupportsGuardRails(t *testing.T) {
+	supported := []pb.ConnectionType{
+		pb.ConnectionTypePostgres,
+		pb.ConnectionTypeOracleDB,
+		pb.ConnectionTypeHttpProxy,
+		pb.ConnectionTypeSSH,
+		pb.ConnectionTypeCommandLine,
+	}
+	for _, ct := range supported {
+		if !connectionTypeSupportsGuardRails(ct) {
+			t.Errorf("expected connection type %q to support guardrails", ct)
+		}
+	}
+
+	// MySQL, MSSQL and MongoDB proxies do not evaluate guardrails yet, so a
+	// guarded session of these types must be refused (fail closed), not run
+	// unguarded (DEP-48).
+	unsupported := []pb.ConnectionType{
+		pb.ConnectionTypeMySQL,
+		pb.ConnectionTypeMSSQL,
+		pb.ConnectionTypeMongoDB,
+		pb.ConnectionTypeTCP,
+	}
+	for _, ct := range unsupported {
+		if connectionTypeSupportsGuardRails(ct) {
+			t.Errorf("expected connection type %q to NOT support guardrails", ct)
+		}
+	}
+}
+
 func TestBuildLegacyGuardRailErrorMessage_InvalidPayload(t *testing.T) {
 	msg, ok := buildLegacyGuardRailErrorMessage([]byte("{bad-json"))
 	if ok || msg != "" {

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -317,6 +317,31 @@ func getGuardRailsRulesForConnection(pctx *plugintypes.Context) (json.RawMessage
 	return guardRailRulesJsonData, nil
 }
 
+// connectionTypeSupportsGuardRails reports whether the agent-side proxy for the
+// given connection type actually evaluates guardrail rules. It is a session-open
+// admission policy: guarded sessions are only admitted for types with real
+// enforcement in libhoop. Guardrails are enforced for PostgreSQL, Oracle, HTTP
+// proxy, SSH and command-line (terminal console and exec, including the DB exec
+// drivers, which resolve to the command-line type). MySQL, MSSQL and MongoDB
+// native proxies do not yet evaluate guardrails, so a guarded session of those
+// types would run unguarded — we fail closed at session-open rather than
+// silently ignoring the configured rules (DEP-48).
+//
+// IMPORTANT: this list mirrors enforcement support in libhoop. When guardrail
+// evaluation is added to another protocol proxy there, add its type here.
+func connectionTypeSupportsGuardRails(connType pb.ConnectionType) bool {
+	switch connType {
+	case pb.ConnectionTypePostgres,
+		pb.ConnectionTypeOracleDB,
+		pb.ConnectionTypeHttpProxy,
+		pb.ConnectionTypeSSH,
+		pb.ConnectionTypeCommandLine:
+		return true
+	default:
+		return false
+	}
+}
+
 func getAnalyzerMetricsRulesForConnection() (json.RawMessage, error) {
 	rules := []redactor.DataMaskingEntityData{
 		{
@@ -478,6 +503,37 @@ func (s *Server) processClientPacket(stream *streamclient.ProxyStream, pkt *pb.P
 			if err != nil {
 				log.With("sid", pctx.SID, "connection", pctx.ConnectionName).Errorf(err.Error())
 				return err
+			}
+
+			// Fail closed: guardrails are enforced exclusively through Presidio and
+			// only for connection types whose agent proxy actually evaluates them.
+			// If a connection has guardrail rules but the server has no Presidio
+			// provider configured, OR the connection type cannot enforce guardrails,
+			// the request would run unguarded and blocked queries would pass through.
+			// Refuse the session at open time with a clear error instead (DEP-48).
+			//
+			// ClientVerbPlainExec is intentionally exempt (the enclosing branch):
+			// plain-exec is a gateway-internal verb gated by a per-process secret in
+			// the auth interceptor (see interceptors/auth: plain-exec-key). It is
+			// only used for gateway-generated introspection scripts (connection
+			// test, database explorer, MCP schema) and never carries user-authored
+			// input, so guardrail rules are not fetched nor enforced for it — the
+			// same long-standing behavior as DLP redaction, which is also disabled
+			// for plain-exec sessions.
+			if len(guardRailRulesJsonData) > 0 {
+				logCtx := log.With("sid", pctx.SID, "connection", pctx.ConnectionName)
+				if !s.AppConfig.HasGuardrailProvider() {
+					logCtx.Warnf("refusing session: connection has guardrail rules but no Presidio provider is configured to enforce them")
+					return status.Errorf(codes.FailedPrecondition,
+						"this connection has guardrails configured, but the server has no Presidio (data masking) provider configured to enforce them; "+
+							"contact your administrator to configure Presidio")
+				}
+				if connType := pctx.ProtoConnectionType(); !connectionTypeSupportsGuardRails(connType) {
+					logCtx.Warnf("refusing session: connection type %q does not support guardrail enforcement", connType)
+					return status.Errorf(codes.FailedPrecondition,
+						"this connection has guardrails configured, but connection type %q does not support guardrail enforcement; "+
+							"remove the guardrails from this connection or use a supported connection type", connType)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

Guardrails are enforced exclusively through Presidio in the agent, and only for connection types whose proxy actually evaluates them. Sessions on guarded connections could still open — and run **unguarded** — when no Presidio provider was configured, or when the connection type has no guardrail enforcement (mysql, mssql, mongodb).

## Changes

Fail closed at session-open with `FailedPrecondition` when a connection has guardrail rules and either:

- **no Presidio provider is configured** — new `HasGuardrailProvider()` accessor (requires `DLP_PROVIDER=mspresidio` plus both analyzer/anonymizer URLs; stricter than `HasRedactCredentials`, which is also true for GCP), or
- **the connection type has no agent-side guardrail enforcement** — new `connectionTypeSupportsGuardRails` admission check (allowed: postgres, oracledb, httpproxy, ssh, command-line).

`plain-exec` sessions remain exempt: the verb is gateway-internal (gated by a per-process secret in the auth interceptor) and only runs fixed introspection scripts, mirroring the existing DLP exemption.

Complements hoophq/libhoop#83, which makes the agent-side enforcement fail closed for the runtime "Presidio unreachable" case.

Fixes DEP-48

Automated by MisterMal