### PR TITLE
fix(rdp): stop sharing one WASM parser instance across concurrent sessions

### DIFF
--- a/gateway/rdp/bitmap_parser.go
+++ b/gateway/rdp/bitmap_parser.go
@@ -1,35 +1,22 @@
 package rdp
 
 import (
-	"context"
-	"sync"
-
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/gateway/rdp/parser"
 )
 
-var (
-	globalParser     *parser.Parser
-	globalParserOnce sync.Once
-	globalParserErr  error
-)
-
-// InitParser initializes the global RDP bitmap parser
-// It should be called once at application startup
+// InitParser compiles the RDP bitmap parser WASM module once at startup so the
+// first RDP session does not pay the compile cost and a broken module is
+// detected early. It does NOT create a shared parser instance: each RDP session
+// creates its own isolated parser (the WASM module keeps per-instance mutable
+// state that is unsafe to share across concurrent sessions).
+//
+// It should be called once at application startup.
 func InitParser() error {
-	globalParserOnce.Do(func() {
-		ctx := context.Background()
-		globalParser, globalParserErr = parser.NewParser(ctx)
-		if globalParserErr != nil {
-			log.Errorf("failed to initialize RDP parser: %v", globalParserErr)
-		} else {
-			log.Debugf("RDP bitmap parser initialized successfully")
-		}
-	})
-	return globalParserErr
-}
-
-// GetParser returns the global parser instance
-func GetParser() *parser.Parser {
-	return globalParser
+	if err := parser.Warmup(); err != nil {
+		log.Errorf("failed to initialize RDP parser: %v", err)
+		return err
+	}
+	log.Debugf("RDP bitmap parser compiled successfully")
+	return nil
 }

--- a/gateway/rdp/parser/parser.go
+++ b/gateway/rdp/parser/parser.go
@@ -7,6 +7,8 @@ package parser
 import (
 	"context"
 	_ "embed"
+	"fmt"
+	"sync"
 
 	"github.com/hoophq/hoop/common/log"
 	"github.com/tetratelabs/wazero"
@@ -15,6 +17,58 @@ import (
 
 //go:embed rdp_parser.wasm
 var wasmBinary []byte
+
+// The WASM module keeps parse state in module-global memory (parsed bitmaps,
+// the bump allocator, and — critically — Fast-Path fragment reassembly state).
+// That state is per-instance, NOT safe to share across concurrent callers, so
+// every RDP session MUST get its own Parser instance. To avoid recompiling the
+// 50KB module on every session, the module is compiled ONCE into a shared,
+// immutable CompiledModule and each Parser is a cheap, fully isolated instance
+// (its own linear memory and globals) created from it.
+var (
+	sharedRuntime  wazero.Runtime
+	sharedCompiled wazero.CompiledModule
+	sharedInitErr  error
+	sharedInitOnce sync.Once
+)
+
+// initShared compiles the WASM module once for the whole process and registers
+// the host "env" module it imports. It is safe to call concurrently; only the
+// first call does the work. The shared runtime lives for the process lifetime
+// (like any compiled program) and is intentionally never closed.
+func initShared() error {
+	sharedInitOnce.Do(func() {
+		// Use a background context: the shared runtime and compiled module
+		// outlive any single request/session, so they must not be tied to a
+		// cancelable caller context.
+		ctx := context.Background()
+		runtime := wazero.NewRuntime(ctx)
+
+		if _, err := runtime.NewHostModuleBuilder("env").
+			NewFunctionBuilder().WithFunc(logString).Export("log").
+			Instantiate(ctx); err != nil {
+			_ = runtime.Close(ctx)
+			sharedInitErr = fmt.Errorf("failed instantiating host module: %w", err)
+			return
+		}
+
+		compiled, err := runtime.CompileModule(ctx, wasmBinary)
+		if err != nil {
+			_ = runtime.Close(ctx)
+			sharedInitErr = fmt.Errorf("failed compiling rdp parser wasm: %w", err)
+			return
+		}
+
+		sharedRuntime = runtime
+		sharedCompiled = compiled
+	})
+	return sharedInitErr
+}
+
+// Warmup compiles the WASM module ahead of time so the first session does not
+// pay the compile cost and a broken module fails fast at startup. Optional:
+// NewParser triggers the same one-time compile lazily.
+func Warmup() error { return initShared() }
 
 // BitmapRect represents a bitmap rectangle extracted from RDP stream
 type BitmapRect struct {
@@ -30,11 +84,11 @@ type BitmapRect struct {
 	Compressed   bool   // True if data is RLE compressed
 }
 
-// Parser wraps the WASM RDP parser
+// Parser wraps one isolated instance of the WASM RDP parser. It is NOT safe for
+// concurrent use: confine each Parser to a single goroutine (one per session).
 type Parser struct {
-	ctx     context.Context
-	runtime wazero.Runtime
-	module  api.Module
+	ctx    context.Context
+	module api.Module
 
 	// Exported functions
 	fnParserVersion  api.Function
@@ -77,25 +131,27 @@ func logString(ctx context.Context, m api.Module, level, offset, byteCount uint3
 	}
 }
 
-// NewParser creates a new RDP parser instance
+// NewParser creates a new, fully isolated RDP parser instance. Each instance
+// has its own WASM linear memory and globals, so distinct instances are safe to
+// use concurrently from different goroutines (one per RDP session). A single
+// instance is NOT safe for concurrent use and must be confined to one goroutine
+// (or externally synchronized), because it carries mutable per-instance parse
+// and fragment-reassembly state.
+//
+// The provided ctx is retained and used for every subsequent WASM call on this
+// instance; pass a context that outlives the parser (e.g. context.Background()
+// or context.WithoutCancel) so a canceled request context does not disable the
+// parser mid-session.
 func NewParser(ctx context.Context) (*Parser, error) {
-	// Create a new runtime
-	runtime := wazero.NewRuntime(ctx)
-	// Instantiate a Go-defined module named "env" that exports a function to
-	// log to the console.
-	_, err := runtime.NewHostModuleBuilder("env").
-		NewFunctionBuilder().WithFunc(logString).Export("log").
-		Instantiate(ctx)
-	if err != nil {
-		runtime.Close(ctx)
+	if err := initShared(); err != nil {
 		return nil, err
 	}
 
-	// Instantiate the WASM module
-	module, err := runtime.Instantiate(ctx, wasmBinary)
+	// Anonymous instance (empty name): lets us instantiate the same compiled
+	// module many times, each in its own sandbox. See wazero ModuleConfig.WithName.
+	module, err := sharedRuntime.InstantiateModule(ctx, sharedCompiled, wazero.NewModuleConfig().WithName(""))
 	if err != nil {
-		runtime.Close(ctx)
-		return nil, err
+		return nil, fmt.Errorf("failed instantiating rdp parser module: %w", err)
 	}
 
 	// Get exported functions
@@ -113,32 +169,29 @@ func NewParser(ctx context.Context) (*Parser, error) {
 	deallocate := module.ExportedFunction("deallocate")
 
 	if fnParserVersion == nil || fnParseRdpOutput == nil || fnGetBitmapCount == nil ||
-		fnGetBitmap == nil || fnGetBitmapData == nil || fnGetError == nil || fnClearParsed == nil ||
-		fnGetPduSize == nil || allocate == nil || deallocate == nil {
-		module.Close(ctx)
-		runtime.Close(ctx)
-		return nil, err
+		fnGetBitmap == nil || fnGetBitmapData == nil || fnGetError == nil || fnGetErrorLen == nil ||
+		fnClearParsed == nil || fnGetPduSize == nil || allocate == nil || deallocate == nil {
+		_ = module.Close(ctx)
+		return nil, fmt.Errorf("rdp parser module is missing required exports")
 	}
 
 	// Get memory
 	memory := module.ExportedMemory("memory")
 	if memory == nil {
-		module.Close(ctx)
-		runtime.Close(ctx)
-		return nil, err
+		_ = module.Close(ctx)
+		return nil, fmt.Errorf("rdp parser module is missing exported memory")
 	}
 
-	// Call initModule
-	_, err = initModule.Call(ctx)
-	if err != nil {
-		module.Close(ctx)
-		runtime.Close(ctx)
-		return nil, err
+	// Reactor modules expose _initialize instead of _start; run it explicitly.
+	if initModule != nil {
+		if _, err = initModule.Call(ctx); err != nil {
+			_ = module.Close(ctx)
+			return nil, fmt.Errorf("failed initializing rdp parser module: %w", err)
+		}
 	}
 
 	return &Parser{
 		ctx:              ctx,
-		runtime:          runtime,
 		module:           module,
 		fnParserVersion:  fnParserVersion,
 		fnParseRdpOutput: fnParseRdpOutput,
@@ -155,9 +208,13 @@ func NewParser(ctx context.Context) (*Parser, error) {
 	}, nil
 }
 
-// Close releases the parser resources
+// Close releases this parser instance. The shared runtime and compiled module
+// are process-lifetime and are intentionally not closed here.
 func (p *Parser) Close() error {
-	return p.runtime.Close(p.ctx)
+	if p.module == nil {
+		return nil
+	}
+	return p.module.Close(p.ctx)
 }
 
 // Version returns the parser version
@@ -188,7 +245,7 @@ func (p *Parser) GetPduSize(data []byte) (uint32, error) {
 
 	// Write data to the allocated WASM memory
 	if !p.memory.Write(dataPtr, data) {
-		return 0, err
+		return 0, fmt.Errorf("rdp parser memory write out of range: ptr=%d size=%d", dataPtr, len(data))
 	}
 
 	// Call get_pdu_size
@@ -222,7 +279,7 @@ func (p *Parser) Parse(data []byte) (*ParseResult, error) {
 
 	// Write data to the allocated WASM memory
 	if !p.memory.Write(dataPtr, data) {
-		return nil, err
+		return nil, fmt.Errorf("rdp parser memory write out of range: ptr=%d size=%d", dataPtr, len(data))
 	}
 
 	// Call parse_rdp_output
@@ -280,14 +337,14 @@ func (p *Parser) getBitmap(index uint32) (BitmapRect, error) {
 
 	ptr := uint32(results[0])
 	if ptr == 0 {
-		return BitmapRect{}, err
+		return BitmapRect{}, fmt.Errorf("rdp parser returned null bitmap pointer for index %d", index)
 	}
 
 	// Read BitmapRect struct from memory (26 bytes)
 	const bitmapSize = 26
 	buf, ok := p.memory.Read(ptr, bitmapSize)
 	if !ok {
-		return BitmapRect{}, err
+		return BitmapRect{}, fmt.Errorf("rdp parser bitmap struct read out of range: ptr=%d", ptr)
 	}
 
 	compressed := uint16(buf[22]) | uint16(buf[23])<<8

--- a/gateway/rdp/parser_concurrency_test.go
+++ b/gateway/rdp/parser_concurrency_test.go
@@ -1,0 +1,158 @@
+package rdp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/hoophq/hoop/gateway/rdp/parser"
+)
+
+// TestParserInstancesAreIsolatedAcrossConcurrentSessions is the DEP-47
+// regression test. The WASM parser keeps per-instance mutable state (parsed
+// bitmaps, bump allocator and Fast-Path fragment reassembly); the session
+// recorder used to share ONE global instance across every concurrent RDP
+// session, so interleaved sessions corrupted each other's state — leading to
+// out-of-bounds reads and intermittent gateway crashes.
+//
+// This test runs many concurrent "sessions", each with its own parser
+// instance, interleaving complete and fragmented Fast-Path bitmap PDUs, and
+// verifies every session decodes exactly its own bitmaps. Run with -race.
+func TestParserInstancesAreIsolatedAcrossConcurrentSessions(t *testing.T) {
+	const sessions = 8
+	const rounds = 25
+
+	// Distinct per-session rect geometry so cross-instance state bleed would
+	// surface as wrong coordinates/dimensions, not just as a race report.
+	pduFor := func(session int) []byte {
+		return fastPathBitmapPDU(t, testRect{
+			x: 8 * session, y: 4 * session, w: 8 + session, h: 8, bgr: white,
+		})
+	}
+	fragmentsFor := func(session int) [][]byte {
+		return fragmentedFastPathBitmapPDU(t, 3, testRect{
+			x: 8*session + 1, y: 4*session + 2, w: 8 + session, h: 8, bgr: magenta,
+		})
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, sessions)
+	for s := 0; s < sessions; s++ {
+		wg.Add(1)
+		go func(session int) {
+			defer wg.Done()
+
+			p, err := parser.NewParser(context.Background())
+			if err != nil {
+				errCh <- fmt.Errorf("session %d: NewParser: %w", session, err)
+				return
+			}
+			defer p.Close()
+
+			complete := pduFor(session)
+			frags := fragmentsFor(session)
+
+			for r := 0; r < rounds; r++ {
+				// Complete PDU: must yield exactly one bitmap with this
+				// session's geometry.
+				res, err := p.Parse(complete)
+				if err != nil {
+					errCh <- fmt.Errorf("session %d round %d: parse: %w", session, r, err)
+					return
+				}
+				if len(res.Bitmaps) != 1 {
+					errCh <- fmt.Errorf("session %d round %d: got %d bitmaps, want 1", session, r, len(res.Bitmaps))
+					return
+				}
+				bmp := res.Bitmaps[0]
+				if int(bmp.X) != 8*session || int(bmp.Y) != 4*session || int(bmp.Width) != 8+session {
+					errCh <- fmt.Errorf("session %d round %d: got rect (%d,%d %dx%d), want (%d,%d %dx8) — cross-session state bleed",
+						session, r, bmp.X, bmp.Y, bmp.Width, bmp.Height, 8*session, 4*session, 8+session)
+					return
+				}
+				if data := p.GetBitmapData(bmp); len(data) != int(bmp.DataLen) || len(data) == 0 {
+					errCh <- fmt.Errorf("session %d round %d: bitmap data len %d, want %d", session, r, len(data), bmp.DataLen)
+					return
+				}
+
+				// Fragmented PDU: reassembly state is per-instance; the final
+				// fragment must yield this session's rect. Feed fragments one
+				// by one, as the wire delivers them.
+				for i, frag := range frags {
+					res, err = p.Parse(frag)
+					if err != nil {
+						errCh <- fmt.Errorf("session %d round %d: parse frag %d: %w", session, r, i, err)
+						return
+					}
+					if i < len(frags)-1 && len(res.Bitmaps) != 0 {
+						errCh <- fmt.Errorf("session %d round %d: frag %d yielded %d bitmaps before Last", session, r, i, len(res.Bitmaps))
+						return
+					}
+				}
+				if len(res.Bitmaps) != 1 {
+					errCh <- fmt.Errorf("session %d round %d: reassembly yielded %d bitmaps, want 1", session, r, len(res.Bitmaps))
+					return
+				}
+				bmp = res.Bitmaps[0]
+				if int(bmp.X) != 8*session+1 || int(bmp.Y) != 4*session+2 {
+					errCh <- fmt.Errorf("session %d round %d: reassembled rect (%d,%d), want (%d,%d) — fragment state bleed",
+						session, r, bmp.X, bmp.Y, 8*session+1, 4*session+2)
+					return
+				}
+			}
+			errCh <- nil
+		}(s)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestParserGetPduSizeConcurrent exercises the framing helper concurrently on
+// isolated instances — the recorder calls GetPduSize on every server->client
+// chunk, so this is the hottest path of the old shared-instance race.
+func TestParserGetPduSizeConcurrent(t *testing.T) {
+	const sessions = 8
+	const rounds = 200
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, sessions)
+	for s := 0; s < sessions; s++ {
+		wg.Add(1)
+		go func(session int) {
+			defer wg.Done()
+			p, err := parser.NewParser(context.Background())
+			if err != nil {
+				errCh <- fmt.Errorf("session %d: NewParser: %w", session, err)
+				return
+			}
+			defer p.Close()
+
+			pdu := fastPathBitmapPDU(t, testRect{x: session, y: session, w: 8, h: 8, bgr: white})
+			for r := 0; r < rounds; r++ {
+				size, err := p.GetPduSize(pdu)
+				if err != nil {
+					errCh <- fmt.Errorf("session %d round %d: GetPduSize: %w", session, r, err)
+					return
+				}
+				if int(size) != len(pdu) {
+					errCh <- fmt.Errorf("session %d round %d: GetPduSize=%d, want %d", session, r, size, len(pdu))
+					return
+				}
+			}
+			errCh <- nil
+		}(s)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/gateway/rdp/recorder.go
+++ b/gateway/rdp/recorder.go
@@ -1,6 +1,7 @@
 package rdp
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -82,7 +83,18 @@ func NewRDPSessionRecorder(
 		connectionSub: connectionSub,
 		labels:        make(map[string]string),
 		startTime:     time.Now().UTC(),
-		parser:        GetParser(),
+	}
+
+	// Each recorder gets its own isolated parser instance. The WASM parser keeps
+	// per-instance mutable state (parsed bitmaps, bump allocator, and Fast-Path
+	// fragment reassembly), so sharing one instance across concurrent RDP
+	// sessions corrupts that state and crashes the gateway. Use a background
+	// context so a canceled request context never disables the parser mid-session.
+	p, err := parser.NewParser(context.Background())
+	if err != nil {
+		log.With("sid", sessionID).Errorf("failed to create RDP parser, recording will store no bitmaps: %v", err)
+	} else {
+		r.parser = p
 	}
 
 	// Create temp file for streaming events
@@ -114,7 +126,7 @@ func (r *RDPSessionRecorder) RecordOutput(data []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.closed || len(data) == 0 {
+	if r.closed || len(data) == 0 || r.parser == nil {
 		return
 	}
 
@@ -268,6 +280,12 @@ func (r *RDPSessionRecorder) Close(err error) {
 	if len(r.outputBuffer) > 0 {
 		r.parseAndStorePDU(r.outputBuffer)
 		r.outputBuffer = nil
+	}
+
+	// Release this session's isolated WASM parser instance.
+	if r.parser != nil {
+		_ = r.parser.Close()
+		r.parser = nil
 	}
 
 	if r.tmpFile == nil {

--- a/gateway/rdp/recorder_parser_test.go
+++ b/gateway/rdp/recorder_parser_test.go
@@ -41,6 +41,73 @@ func TestRecorderDegradedNilParserPaths(t *testing.T) {
 	r.Close(nil)
 }
 
+// TestRecorderPipelineExtractsBitmapsFromWire is the recorder happy-path test:
+// raw server->client wire bytes go through framing (GetPduSize), WASM parsing,
+// bitmap extraction and land as JSONL events in the temp file — with the new
+// per-session parser instance. Covers chunked delivery (a PDU split across
+// RecordOutput calls, exercising the tail buffer) and Fast-Path fragment
+// reassembly (state that is per-instance in the WASM module).
+func TestRecorderPipelineExtractsBitmapsFromWire(t *testing.T) {
+	r := NewRDPSessionRecorder("sid-pipeline", "org", "uid", "user", "mail", "conn", "")
+	if r.parser == nil || r.tmpFile == nil {
+		t.Fatal("recorder must have its own parser and temp file")
+	}
+	tmpName := r.tmpFile.Name()
+	t.Cleanup(func() {
+		_ = r.parser.Close()
+		_ = r.tmpFile.Close()
+		_ = os.Remove(tmpName)
+	})
+
+	// 1. One complete PDU delivered whole.
+	r.RecordOutput(fastPathBitmapPDU(t, testRect{x: 16, y: 8, w: 10, h: 6, bgr: white}))
+	if r.bitmapCount != 1 {
+		t.Fatalf("after complete PDU: bitmapCount=%d, want 1", r.bitmapCount)
+	}
+
+	// 2. The same kind of PDU split byte-wise across two RecordOutput calls:
+	// the first chunk must sit in the tail buffer, the second completes it.
+	pdu := fastPathBitmapPDU(t, testRect{x: 32, y: 16, w: 12, h: 4, bgr: magenta})
+	r.RecordOutput(pdu[:len(pdu)/2])
+	if r.bitmapCount != 1 {
+		t.Fatalf("half a PDU must not yield a bitmap, bitmapCount=%d", r.bitmapCount)
+	}
+	r.RecordOutput(pdu[len(pdu)/2:])
+	if r.bitmapCount != 2 {
+		t.Fatalf("after completing split PDU: bitmapCount=%d, want 2", r.bitmapCount)
+	}
+
+	// 3. A bitmap update fragmented across three Fast-Path PDUs: only the
+	// Last fragment yields the bitmap (reassembly state inside this
+	// recorder's own WASM instance).
+	for _, frag := range fragmentedFastPathBitmapPDU(t, 3, testRect{x: 48, y: 24, w: 14, h: 6, bgr: white}) {
+		r.RecordOutput(frag)
+	}
+	if r.bitmapCount != 3 {
+		t.Fatalf("after fragmented PDU: bitmapCount=%d, want 3", r.bitmapCount)
+	}
+
+	// Canvas dimension tracking follows the furthest extents seen.
+	if int(r.maxWidth) != 48+14 || int(r.maxHeight) != 24+6 {
+		t.Fatalf("canvas extents = %dx%d, want %dx%d", r.maxWidth, r.maxHeight, 48+14, 24+6)
+	}
+
+	// The temp file must contain one JSONL event per bitmap.
+	raw, err := os.ReadFile(tmpName)
+	if err != nil {
+		t.Fatalf("reading temp file: %v", err)
+	}
+	lines := 0
+	for _, b := range raw {
+		if b == '\n' {
+			lines++
+		}
+	}
+	if lines != 3 {
+		t.Fatalf("temp file has %d events, want 3", lines)
+	}
+}
+
 // TestRecorderOwnsIsolatedParserInstances ensures every recorder gets its own
 // parser instance (never a shared one) and that concurrent recorders parse
 // their own streams correctly under -race — the DEP-47 crash was recorders

--- a/gateway/rdp/recorder_parser_test.go
+++ b/gateway/rdp/recorder_parser_test.go
@@ -1,0 +1,85 @@
+package rdp
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestRecorderDegradedNilParserPaths covers the recorder's degraded mode: when
+// per-session parser creation fails, the recorder must keep working with a nil
+// parser — RecordOutput and Close must be safe no-ops for bitmap parsing, never
+// a panic (DEP-47 hardening).
+func TestRecorderDegradedNilParserPaths(t *testing.T) {
+	r := &RDPSessionRecorder{
+		sessionID: "test-nil-parser",
+		labels:    map[string]string{},
+		startTime: time.Now().UTC(),
+		// parser and tmpFile intentionally nil: parser creation failure +
+		// temp-file creation failure is the worst-case degraded recorder.
+	}
+
+	pdu := fastPathBitmapPDU(t, testRect{x: 0, y: 0, w: 8, h: 8, bgr: white})
+
+	// Must not panic and must not accumulate an unbounded buffer.
+	for i := 0; i < 3; i++ {
+		r.RecordOutput(pdu)
+	}
+	if len(r.outputBuffer) != 0 {
+		t.Fatalf("nil-parser recorder must not buffer output, got %d bytes", len(r.outputBuffer))
+	}
+
+	// parseAndStorePDU with nil parser/tmpFile must be a no-op.
+	r.parseAndStorePDU(pdu)
+	if r.bitmapCount != 0 {
+		t.Fatalf("nil-parser recorder must not record bitmaps, got %d", r.bitmapCount)
+	}
+
+	// Close must be safe and idempotent in degraded mode.
+	r.Close(nil)
+	r.Close(nil)
+}
+
+// TestRecorderOwnsIsolatedParserInstances ensures every recorder gets its own
+// parser instance (never a shared one) and that concurrent recorders parse
+// their own streams correctly under -race — the DEP-47 crash was recorders
+// sharing one WASM instance across sessions.
+func TestRecorderOwnsIsolatedParserInstances(t *testing.T) {
+	const recorders = 4
+	made := make([]*RDPSessionRecorder, recorders)
+	for i := range made {
+		made[i] = NewRDPSessionRecorder("sid", "org", "uid", "user", "mail", "conn", "")
+		if made[i].parser == nil {
+			t.Fatal("recorder must own a parser instance")
+		}
+		if made[i].tmpFile != nil {
+			// Do not let Close reach the DB persistence path in this unit test.
+			name := made[i].tmpFile.Name()
+			_ = made[i].tmpFile.Close()
+			made[i].tmpFile = nil
+			t.Cleanup(func() { _ = os.Remove(name) })
+		}
+	}
+	for i := 0; i < recorders; i++ {
+		for j := i + 1; j < recorders; j++ {
+			if made[i].parser == made[j].parser {
+				t.Fatal("recorders must not share a parser instance")
+			}
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i, r := range made {
+		wg.Add(1)
+		go func(i int, r *RDPSessionRecorder) {
+			defer wg.Done()
+			pdu := fastPathBitmapPDU(t, testRect{x: 8 * i, y: 4 * i, w: 8, h: 8, bgr: white})
+			for round := 0; round < 20; round++ {
+				r.RecordOutput(pdu)
+			}
+			r.Close(nil)
+		}(i, r)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem (DEP-47)

The gateway intermittently crashed/wedged during active RDP usage — the whole HTTP endpoint refused connections for ~1 minute (k8s pod restart), then recovered. Reported against tryrunops.

## Root cause

`RDPSessionRecorder` shared **one global WASM parser instance across every concurrent RDP session**. The parser module keeps mutable state in its linear memory — parsed bitmaps, a bump allocator, and cross-call Fast-Path **fragment reassembly** state — and wazero module instances are not safe for concurrent calls. Overlapping sessions corrupted each other's reassembly state and allocator, producing out-of-bounds reads that crashed or wedged the gateway.

Empirically confirmed: driving a single shared instance from 8 goroutines **hangs indefinitely** under `-race`; isolated per-session instances pass cleanly.

## Fix

- **Compile once, instantiate per session** (wazero's documented pattern): the module is compiled once per process (shared `Runtime` + `CompiledModule` behind `sync.Once`); each session gets a cheap, fully isolated anonymous instance with its own linear memory and globals.
- Each recorder owns and closes its parser instance; degrades safely (no panic, no buffering) if creation fails.
- The PII gate's per-session parser stops recompiling the module per session (same semantics, less CPU).
- `InitParser` becomes a startup compile warmup; the shared `GetParser` accessor is removed.
- Hardening: all required WASM exports validated at construction; masked nil-error returns in `GetPduSize`/`Parse`/`getBitmap` now return real errors.

## Tests

- 8 concurrent per-session instances, interleaved complete + fragmented bitmap PDUs with per-session distinct geometry (cross-instance state bleed would fail assertions), under `-race`
- `GetPduSize` framing hot path, concurrent, under `-race`
- Recorder wire→bitmap pipeline end to end: tail buffering (PDU split across `RecordOutput` calls), fragment reassembly, JSONL event stream, canvas extents
- Recorder degraded mode (nil parser): no panic, idempotent Close
- Full gateway suite: 33 packages, 0 failures

## Validation note

The trigger condition is **two or more concurrent RDP sessions**. Recommended staging smoke test: open 2+ RDP sessions, use them for several minutes, confirm the gateway stays up and a recorded session replays correctly. Wire format and the `BitmapEvent`/replay schema are unchanged.

Fixes DEP-47

Automated by MisterMal