### PR TITLE
Add: fix the SSE long context

### DIFF
--- a/agent/controller/agent.go
+++ b/agent/controller/agent.go
@@ -77,6 +77,16 @@ type (
 		// cache and dial duplicate upstream SSH connections.
 		sshFlightGroup singleflight.Group
 
+		// httpProxyQueues holds one httpProxyPacketQueue per (sessionID,
+		// connectionID), keyed "sid:connID" like the connStore. The recv
+		// loop enqueues HttpProxyConnectionWrite packets here and a per-queue
+		// worker drains them in order, so a blocking upstream request never
+		// stalls packet dispatch (see processHttpProxyWriteServer). Entries
+		// are removed in sessionCleanup; they are intentionally NOT removed
+		// on TCPConnectionClose so a late packet cannot race a mid-drain
+		// worker into a second, concurrent worker for the same connection.
+		httpProxyQueues sync.Map
+
 		// gcpTokenSources caches one oauth2.TokenSource per session (keyed by
 		// gateway session ID) for claude-code connections that federate to
 		// Google Vertex AI. The source is built once from the connection's
@@ -312,6 +322,11 @@ func (a *Agent) Run() error {
 		// SessionClose is included so the recv loop is not blocked when
 		// it has to wait for an in-flight SSH handler to drain before
 		// running session cleanup.
+		//
+		// HttpProxyConnectionWrite stays inline: its handler only enqueues
+		// the packet into a per-connection FIFO drained by a worker
+		// goroutine (see processHttpProxyWriteServer), which keeps the
+		// recv loop free without giving up per-connection ordering.
 		if pkt.Type == pbagent.SSHConnectionWrite || pkt.Type == pbagent.SessionClose {
 			go a.processPacket(pkt)
 			continue
@@ -455,6 +470,15 @@ func (a *Agent) sessionCleanup(sessionID string) {
 		a.connStore.Del(key)
 		a.connWriteLocks.Delete(key)
 	}
+	// Drop the session's HTTP proxy packet queues. Iterated separately from
+	// the connStore because a queue can outlive its connStore entry (e.g. a
+	// connection whose first write failed and was deleted from the store).
+	a.httpProxyQueues.Range(func(key, _ any) bool {
+		if k, ok := key.(string); ok && strings.HasPrefix(k, sessionID+":") {
+			a.httpProxyQueues.Delete(key)
+		}
+		return true
+	})
 	// Drop any cached Vertex token source so the service-account-derived
 	// credential does not outlive the session in agent memory.
 	a.gcpTokenSources.Delete(sessionID)

--- a/agent/controller/httpproxy.go
+++ b/agent/controller/httpproxy.go
@@ -9,6 +9,7 @@ import (
 	libhoopaianalyzer "libhoop/aianalyzer"
 	redactortypes "libhoop/redactor/types"
 	"strings"
+	"sync"
 
 	"github.com/hoophq/hoop/agent/controller/featureflagstate"
 	"github.com/hoophq/hoop/common/log"
@@ -24,16 +25,86 @@ import (
 // common/grpc.MaxRecvMsgSize.
 const httpProxyResponseChunkSize = 1024 * 1024 * 4 // 4 MiB
 
+// httpProxyPacketQueue is a per-(sessionID, connectionID) FIFO of
+// HttpProxyConnectionWrite packets drained by a single on-demand worker
+// goroutine. See processHttpProxyWriteServer for the dispatch model.
+type httpProxyPacketQueue struct {
+	mu      sync.Mutex
+	packets []*pb.Packet
+	running bool
+}
+
+// push appends pkt and reports whether the caller must start a drain worker.
+// At most one caller observes true until that worker exits.
+func (q *httpProxyPacketQueue) push(pkt *pb.Packet) (startWorker bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.packets = append(q.packets, pkt)
+	if q.running {
+		return false
+	}
+	q.running = true
+	return true
+}
+
+// drain invokes handle on queued packets in arrival order and exits when the
+// queue is empty, so an idle connection does not hold a parked goroutine. The
+// running flag guarantees at most one worker per queue: it is cleared under
+// the same lock that observes emptiness, so a packet pushed after the last
+// drain always finds running=false and spawns a fresh worker, while a packet
+// pushed mid-drain is picked up by the current one.
+func (q *httpProxyPacketQueue) drain(handle func(*pb.Packet)) {
+	for {
+		q.mu.Lock()
+		if len(q.packets) == 0 {
+			q.running = false
+			q.mu.Unlock()
+			return
+		}
+		pkt := q.packets[0]
+		q.packets = q.packets[1:]
+		q.mu.Unlock()
+		handle(pkt)
+	}
+}
+
+// processHttpProxyWriteServer runs on the agent's packet recv loop. Handling a
+// proxied HTTP request is blocking: libhoop's Write performs the upstream
+// round-trip and does not return until response headers arrive, which for a
+// long-context LLM request can take minutes of time-to-first-byte. Processing
+// it inline would park the recv loop — stalling every other session on this
+// agent and, critically, preventing the TCPConnectionClose the gateway sends
+// when it abandons this same request from ever being dispatched: the
+// cancellation would deadlock against the request it is meant to cancel.
+//
+// Each packet is therefore appended to a per-(session, connection) FIFO
+// drained by a single worker goroutine. The recv loop never blocks, packets
+// for one connection keep their arrival order (required for chunked request
+// bodies and WebSocket frames), and connections proceed independently.
 func (a *Agent) processHttpProxyWriteServer(pkt *pb.Packet) {
+	sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
+	clientConnectionID := string(pkt.Spec[pb.SpecClientConnectionID])
+	if clientConnectionID == "" {
+		log.With("sid", sessionID).Info("connection not found in packet specfication")
+		a.sendClientSessionClose(sessionID, "http proxy connection id not found")
+		return
+	}
+	queueKey := fmt.Sprintf("%s:%s", sessionID, clientConnectionID)
+	obj, _ := a.httpProxyQueues.LoadOrStore(queueKey, &httpProxyPacketQueue{})
+	queue := obj.(*httpProxyPacketQueue)
+	if queue.push(pkt) {
+		go queue.drain(a.handleHttpProxyWrite)
+	}
+}
+
+// handleHttpProxyWrite performs the actual (blocking) request handling. It
+// must only be invoked from httpProxyPacketQueue.drain, which serializes
+// calls per (sessionID, connectionID).
+func (a *Agent) handleHttpProxyWrite(pkt *pb.Packet) {
 	sessionID := string(pkt.Spec[pb.SpecGatewaySessionID])
 	clientConnectionID := string(pkt.Spec[pb.SpecClientConnectionID])
 	proxyBaseURL := string(pkt.Spec[pb.SpecHttpProxyBaseUrl])
 	log := log.With("sid", sessionID, "conn", clientConnectionID)
-	if clientConnectionID == "" {
-		log.Info("connection not found in packet specfication")
-		a.sendClientSessionClose(sessionID, "http proxy connection id not found")
-		return
-	}
 	connParams := a.connectionParams(sessionID)
 	if connParams == nil {
 		log.Infof("connection params not found")
@@ -50,6 +121,7 @@ func (a *Agent) processHttpProxyWriteServer(pkt *pb.Packet) {
 			}
 			log.Infof("failed writing packet, err=%v", err)
 			_ = httpServer.Close()
+			a.connStore.Del(clientConnectionIDKey)
 			// Check if this is a guardrails error - these should close the session with the error message
 			if isGuardrailsError(err) {
 				log.Infof("guardrails validation failed, closing session: %v", err)
@@ -148,15 +220,24 @@ func (a *Agent) processHttpProxyWriteServer(pkt *pb.Packet) {
 		return
 	}
 
+	// Register the proxy before the first Write. Write blocks for the whole
+	// upstream round-trip, and while it is in flight the gateway may abandon
+	// the request (TCPConnectionClose) or end the session (SessionClose);
+	// those handlers cancel in-flight requests by looking the proxy up in the
+	// connStore and closing it, which cancels the proxy context and aborts the
+	// upstream call. Registering after Write (the previous behavior) made an
+	// in-flight first request — i.e. every plain HTTP request — uncancellable.
+	a.connStore.Set(clientConnectionIDKey, httpProxy)
+
 	// write the first packet when establishing the connection
 	if _, err := httpProxy.Write(pkt.Payload); err != nil {
 		// ErrWebSocketMode is not an error - it signals WebSocket mode was activated
 		if isWebSocketModeError(err) {
 			log.Infof("websocket mode activated on first request")
-			a.connStore.Set(clientConnectionIDKey, httpProxy)
 			return
 		}
 		log.Infof("failed writing first packet, err=%v", err)
+		a.connStore.Del(clientConnectionIDKey)
 		_ = httpProxy.Close()
 		// Check if this is a guardrails error - send the actual error message
 		if isGuardrailsError(err) {
@@ -167,7 +248,6 @@ func (a *Agent) processHttpProxyWriteServer(pkt *pb.Packet) {
 		a.sendClientTCPConnectionClose(sessionID, clientConnectionID)
 		return
 	}
-	a.connStore.Set(clientConnectionIDKey, httpProxy)
 }
 
 // isGuardrailsError checks if the error is a guardrails validation failure.

--- a/agent/controller/httpproxy_test.go
+++ b/agent/controller/httpproxy_test.go
@@ -1,0 +1,109 @@
+package controller
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	pb "github.com/hoophq/hoop/common/proto"
+)
+
+func newTestPacket(i int) *pb.Packet {
+	return &pb.Packet{Payload: []byte(fmt.Sprintf("pkt-%d", i))}
+}
+
+// Packets pushed before the worker starts must be handled in arrival order.
+func TestHttpProxyPacketQueueOrdering(t *testing.T) {
+	queue := &httpProxyPacketQueue{}
+	const total = 100
+
+	var startWorker int
+	for i := 0; i < total; i++ {
+		if queue.push(newTestPacket(i)) {
+			startWorker++
+		}
+	}
+	if startWorker != 1 {
+		t.Fatalf("expected exactly one push to request a worker, got %d", startWorker)
+	}
+
+	var handled []string
+	queue.drain(func(pkt *pb.Packet) { handled = append(handled, string(pkt.Payload)) })
+
+	if len(handled) != total {
+		t.Fatalf("expected %d handled packets, got %d", total, len(handled))
+	}
+	for i, payload := range handled {
+		if want := fmt.Sprintf("pkt-%d", i); payload != want {
+			t.Fatalf("packet %d handled out of order: got %s, want %s", i, payload, want)
+		}
+	}
+}
+
+// After a drain empties the queue and exits, the next push must request a new
+// worker; pushes while a worker is running must not.
+func TestHttpProxyPacketQueueWorkerRespawn(t *testing.T) {
+	queue := &httpProxyPacketQueue{}
+
+	if !queue.push(newTestPacket(0)) {
+		t.Fatal("first push on an idle queue must request a worker")
+	}
+	if queue.push(newTestPacket(1)) {
+		t.Fatal("push before the worker ran must not request a second worker")
+	}
+	queue.drain(func(*pb.Packet) {})
+
+	if !queue.push(newTestPacket(2)) {
+		t.Fatal("push after the worker exited must request a new worker")
+	}
+	queue.drain(func(*pb.Packet) {})
+}
+
+// Under concurrent push/drain cycles from a single producer (mirroring the
+// recv loop), every packet is handled exactly once, in order, and no two
+// handler invocations overlap.
+func TestHttpProxyPacketQueueSingleWorkerNoLoss(t *testing.T) {
+	queue := &httpProxyPacketQueue{}
+	const total = 1000
+
+	var (
+		wg         sync.WaitGroup
+		inHandler  atomic.Int32
+		handledMu  sync.Mutex
+		handled    []string
+		overlapped atomic.Bool
+	)
+	handle := func(pkt *pb.Packet) {
+		if inHandler.Add(1) > 1 {
+			overlapped.Store(true)
+		}
+		handledMu.Lock()
+		handled = append(handled, string(pkt.Payload))
+		handledMu.Unlock()
+		inHandler.Add(-1)
+	}
+
+	for i := 0; i < total; i++ {
+		if queue.push(newTestPacket(i)) {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				queue.drain(handle)
+			}()
+		}
+	}
+	wg.Wait()
+
+	if overlapped.Load() {
+		t.Fatal("two handler invocations overlapped: queue must serialize handling")
+	}
+	if len(handled) != total {
+		t.Fatalf("expected %d handled packets, got %d", total, len(handled))
+	}
+	for i, payload := range handled {
+		if want := fmt.Sprintf("pkt-%d", i); payload != want {
+			t.Fatalf("packet %d handled out of order: got %s, want %s", i, payload, want)
+		}
+	}
+}

--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -615,6 +615,7 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 		http.Error(w, "session expired", http.StatusUnauthorized)
 		return
 	case <-ctx.Done():
+		sess.notifyAgentConnectionClose(connectionID)
 		http.Error(w, "request send timeout", http.StatusGatewayTimeout)
 		return
 	}
@@ -626,6 +627,7 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 		http.Error(w, "session expired", http.StatusUnauthorized)
 		return
 	case <-time.After(httpTimeout):
+		sess.notifyAgentConnectionClose(connectionID)
 		http.Error(w, "request timeout", http.StatusGatewayTimeout)
 		return
 	case response, ok := <-responseChan:
@@ -688,6 +690,13 @@ func (sess *httpProxySession) writeBufferedResponse(
 ) {
 	log := log.With("sid", sess.sid, "conn", connectionID)
 
+	// Reassembling a large body from multiple packets can outlast the server's
+	// absolute WriteTimeout. Take over the write deadline and roll it forward
+	// per chunk (below) so a big response is not truncated mid-transfer, while
+	// a stalled client still trips the per-write deadline.
+	const bufferedWriteDeadline = 30 * time.Second
+	rc := http.NewResponseController(w)
+
 	for key, values := range resp.Header {
 		for _, value := range values {
 			w.Header().Add(key, value)
@@ -696,6 +705,10 @@ func (sess *httpProxySession) writeBufferedResponse(
 	w.WriteHeader(resp.StatusCode)
 
 	flusher, _ := w.(http.Flusher)
+
+	if err := rc.SetWriteDeadline(time.Now().Add(bufferedWriteDeadline)); err != nil {
+		log.Debugf("could not set write deadline for buffered response: %v", err)
+	}
 
 	// Body bytes carried by the first packet (resp.Body reads it after the
 	// headers). A premature EOF here is expected when Content-Length is larger
@@ -735,6 +748,7 @@ func (sess *httpProxySession) writeBufferedResponse(
 		case <-idleTimer.C:
 			log.Warnf("response reassembly aborted: idle timeout (%v) exceeded, written=%d/%d",
 				idleTimeout, bodyWritten, resp.ContentLength)
+			sess.notifyAgentConnectionClose(connectionID)
 			return
 		case data, ok := <-responseChan:
 			if !ok {
@@ -743,8 +757,12 @@ func (sess *httpProxySession) writeBufferedResponse(
 				return
 			}
 			if len(data) > 0 {
+				if err := rc.SetWriteDeadline(time.Now().Add(bufferedWriteDeadline)); err != nil {
+					log.Debugf("could not set write deadline for buffered chunk: %v", err)
+				}
 				if _, err := w.Write(data); err != nil {
 					log.Warnf("failed writing response body chunk: %v", err)
+					sess.notifyAgentConnectionClose(connectionID)
 					return
 				}
 				bodyWritten += int64(len(data))
@@ -779,8 +797,9 @@ func isSSEStreamingResponse(resp *http.Response) bool {
 // HTTP client, flushing after each one so events are delivered in real-time.
 //
 // The stream ends when the responseChan is closed (agent finished), the session
-// context is cancelled, or an idle timeout of 5 minutes is exceeded between
-// consecutive chunks.
+// context is cancelled, or the idle timeout is exceeded between consecutive
+// chunks. On abandonment (idle timeout or client write error) the agent is
+// notified so it stops relaying the upstream response into a dead channel.
 func (sess *httpProxySession) handleSSEStream(
 	w http.ResponseWriter,
 	resp *http.Response,
@@ -789,6 +808,19 @@ func (sess *httpProxySession) handleSSEStream(
 ) {
 	log := log.With("sid", sess.sid, "conn", connectionID, "type", "sse")
 	log.Infof("SSE stream detected, starting streaming relay")
+
+	// Take over the connection's deadlines from the http.Server. The server
+	// arms a single absolute ReadTimeout/WriteTimeout when the request is read;
+	// for an SSE relay that streams for minutes those deadlines would abort a
+	// perfectly healthy stream (observed as a "write ... i/o timeout" at the
+	// server WriteTimeout). We disable the read deadline (the request body was
+	// already fully consumed) and instead roll the write deadline forward per
+	// chunk below, so total stream duration is unbounded while a genuinely
+	// stuck client (one that stops draining) is still disconnected.
+	rc := http.NewResponseController(w)
+	if err := rc.SetReadDeadline(time.Time{}); err != nil {
+		log.Debugf("could not clear read deadline for SSE stream: %v", err)
+	}
 
 	// Copy response headers to the client
 	for key, values := range resp.Header {
@@ -815,6 +847,10 @@ func (sess *httpProxySession) handleSSEStream(
 	// Each chunk is a raw HTTP chunked-encoding fragment produced by the agent's
 	// httputil.NewChunkedWriter wrapping the gRPC streamWriter.
 	const sseIdleTimeout = 90 * time.Second
+	// Per-write deadline: an individual chunk (a few KB up to a few MB) must
+	// flush within this window. It is reset before every write, so it never
+	// bounds the total stream duration — only a wedged client trips it.
+	const sseWriteDeadline = 30 * time.Second
 	idleTimer := time.NewTimer(sseIdleTimeout)
 	defer idleTimer.Stop()
 
@@ -825,6 +861,7 @@ func (sess *httpProxySession) handleSSEStream(
 			return
 		case <-idleTimer.C:
 			log.Warnf("SSE stream ended: idle timeout (%v) exceeded", sseIdleTimeout)
+			sess.notifyAgentConnectionClose(connectionID)
 			return
 		case data, ok := <-responseChan:
 			if !ok {
@@ -833,8 +870,12 @@ func (sess *httpProxySession) handleSSEStream(
 				return
 			}
 
+			if err := rc.SetWriteDeadline(time.Now().Add(sseWriteDeadline)); err != nil {
+				log.Debugf("could not set write deadline for SSE chunk: %v", err)
+			}
 			if _, err := w.Write(data); err != nil {
 				log.Warnf("SSE stream ended: write error: %v", err)
+				sess.notifyAgentConnectionClose(connectionID)
 				return
 			}
 			if flusher != nil {
@@ -1123,6 +1164,35 @@ func (sess *httpProxySession) handleAgentResponses(server *HttpProxyServer, secr
 			// Unknown packet type, log and ignore
 			log.Debugf("unknown packet type received: %v, sid=%s", pkt.Type, sess.sid)
 		}
+	}
+}
+
+// notifyAgentConnectionClose asks the agent to tear down the upstream
+// connection identified by connectionID. The gateway calls this when it
+// abandons a request or stream before the agent signalled completion (client
+// disconnected, request/idle timeout, write error). Without it the agent keeps
+// relaying the upstream response into a response channel that no longer has a
+// reader — wasting the upstream connection (e.g. a Vertex SSE stream) and
+// spamming "no response channel found (response dropped)" on every late packet.
+//
+// The agent handles pbagent.TCPConnectionClose by closing the matching libhoop
+// proxy, which cancels the in-flight request context and aborts the upstream
+// body read. Best-effort: on a closing session the send may fail, but the
+// session teardown then performs the same cleanup.
+func (sess *httpProxySession) notifyAgentConnectionClose(connectionID string) {
+	if sess.closed.Load() || sess.streamClient == nil {
+		return
+	}
+	err := sess.streamClient.Send(&pb.Packet{
+		Type: pbagent.TCPConnectionClose,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(sess.sid),
+			pb.SpecClientConnectionID: []byte(connectionID),
+		},
+	})
+	if err != nil {
+		log.With("sid", sess.sid, "conn", connectionID).
+			Warnf("failed notifying agent to close connection: %v", err)
 	}
 }
 

--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -38,6 +38,19 @@ const (
 	// NOTE in the future we might want to support custom headers as well
 	proxyTokenHeader = "Authorization"
 	proxyTokenCookie = "hoop_proxy_token"
+
+	// requestChunkSize bounds the size of each gRPC packet emitted when
+	// forwarding a client request to the agent. Without chunking, a large
+	// request body (e.g. a long-context LLM prompt with base64 attachments)
+	// serializes into a single gRPC message; anything above
+	// common/grpc.MaxRecvMsgSize is rejected by the agent's receive layer with
+	// ResourceExhausted — a stream-fatal error that tears down the agent's
+	// entire Connect stream, dropping every session on that agent. The
+	// agent-side proxy buffers packets until Content-Length bytes arrive, so
+	// packet boundaries are transparent to it. Mirrors the agent's response
+	// chunking (agent/controller/httpproxy.go httpProxyResponseChunkSize) and
+	// must stay safely below common/grpc.MaxRecvMsgSize.
+	requestChunkSize = 1024 * 1024 * 4 // 4 MiB
 )
 
 var instanceStore sync.Map
@@ -584,15 +597,18 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 			sendErr <- fmt.Errorf("session closed")
 			return
 		}
-		err := sess.streamClient.Send(&pb.Packet{
-			Type:    pbagent.HttpProxyConnectionWrite,
-			Payload: []byte(rawRequest),
-			Spec: map[string][]byte{
-				pb.SpecGatewaySessionID:   []byte(sess.sid),
-				pb.SpecClientConnectionID: []byte(connectionID),
-				pb.SpecHttpProxyBaseUrl:   []byte(proxyBaseURL),
-			},
+		// Split the request across multiple sub-limit packets (see
+		// requestChunkSize). Chunks are written sequentially from this single
+		// goroutine, so they arrive at the agent in order even though other
+		// in-flight requests interleave their own packets on the shared
+		// stream. The chunked writer is deliberately not Closed: closing it
+		// would close the session's underlying gRPC stream.
+		streamWriter := pb.NewStreamWriter(sess.streamClient, pbagent.HttpProxyConnectionWrite, map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(sess.sid),
+			pb.SpecClientConnectionID: []byte(connectionID),
+			pb.SpecHttpProxyBaseUrl:   []byte(proxyBaseURL),
 		})
+		_, err := pb.NewChunkedWriter(streamWriter, requestChunkSize).Write([]byte(rawRequest))
 		sendErr <- err
 	}()
 


### PR DESCRIPTION
## 📝 Description

Long-lived HTTP-proxy streaming responses (Claude Code / Vertex AI SSE, large buffered bodies) were being cut off after ~90 seconds with `write ... i/o timeout`, followed by `no response channel found (response dropped)` spam. Root cause: the proxy's `http.Server` sets a single **absolute** `WriteTimeout` (90s) when the request is read, which bounds the *entire* response rather than being idle-based. Any stream that legitimately runs longer than 90s (an LLM completion with a large context) hits the deadline mid-flight and dies.

This PR stops the server-level deadline from killing healthy streams and notifies the agent to tear down the upstream connection when the gateway abandons a request/stream.

> **Requires a companion `libhoop` PR** — see Additional Notes.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- `handleSSEStream`: take over the connection deadlines via `http.NewResponseController` — clear the read deadline (request body is already consumed) and **roll a 30s write deadline forward per chunk**. Total stream duration is now unbounded (the real cap remains `sess.ctx`, tied to credential expiry); a client that stops draining is still disconnected within 30s.
- `writeBufferedResponse`: same rolling write deadline applied to large multi-packet body reassembly.
- New `notifyAgentConnectionClose(connectionID)` sends `pbagent.TCPConnectionClose` (same packet the Postgres proxy already uses) whenever the gateway gives up on a connection: SSE idle timeout, SSE/buffered write error, buffered idle timeout, and the request send/response timeouts. This releases the upstream connection and stops the "response dropped" log spam.
- Corrected a stale doc comment (`handleSSEStream` said "5 minutes" while the idle timeout constant was already 90s).

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a
- **OS**: macOS (dev)

### Tests performed:
- [x] Unit tests pass — `go test ./gateway/proxyproto/httpproxy/...` (ok)
- [ ] Integration tests pass
- [ ] Manual testing completed — reproduce with a Claude Code session over the httpproxy connection: confirm a >90s SSE completion streams to the end without `i/o timeout`, and that no `response dropped` warnings appear

`go vet` clean on the changed package; `go build ./gateway/...` and `go build ./agent/...` succeed.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**Requires a companion `libhoop` PR — do not merge this alone for the full fix.** The agent dispatches `HttpProxyConnectionWrite` synchronously in its single recv loop, and `handleSSEResponse` blocked for the whole stream, so the agent could not process the new `TCPConnectionClose` for that same connection until the stream ended on its own — making the notification a no-op. The libhoop change moves the SSE relay into a background goroutine (`relaySSEResponse`) so the dispatch loop stays free; `Close()` then cancels the request context and aborts the upstream body read. Guardrails violations mid-stream still emit `SendSessionClose` for the audit log (mirrors the existing WebSocket pumps).

Reviewers, please focus on:
- The 30s per-write deadline value — generous for flushing a few KB–MB chunk; only a wedged client trips it. Open to tuning.
- That `notifyAgentConnectionClose` is correctly guarded (`sess.closed` / nil stream) and best-effort.

Not gated behind a feature flag — this is a correctness fix to an existing path, not new behavior.