### PR TITLE
fix: build agent OCR images as root, restore hoop runtime user

### DIFF
--- a/.github/workflows/agent-ocr-build.yml
+++ b/.github/workflows/agent-ocr-build.yml
@@ -1,0 +1,93 @@
+# Build-only smoke check for the agent OCR images.
+#
+# The release workflow (release.yml) is the ONLY place these Dockerfiles are
+# otherwise built — they derive FROM the just-published hoophq/hoop:<tag>
+# image, which does not exist at PR time. That gap let a broken Dockerfile
+# reach main and fail the post-merge release publish (the base image runs as
+# the unprivileged 'hoop' user, and apt-get failed at first real build).
+#
+# This workflow closes the gap: on PRs touching the OCR image inputs it
+# builds the same Dockerfiles against the latest released base image, with
+# the same platform matrix as the release jobs (CPU: amd64+arm64, GPU:
+# amd64-only), without pushing. 'latest' is acceptable here — this is a
+# smoke build for Dockerfile correctness, not a reproducible artifact; the
+# release build still pins the exact tag.
+name: Agent OCR Image Build
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile.agent-ocr'
+      - 'Dockerfile.agent-ocr-gpu'
+      - 'scripts/dev/ocr-poc/device_policy.py'
+      - 'scripts/dev/ocr-poc/server_rapidocr.py'
+      - 'scripts/dev/ocr-poc/entrypoint-embedded.sh'
+      - '.github/workflows/agent-ocr-build.yml'
+
+jobs:
+  build-agent-ocr:
+    name: Build Agent OCR Image (CPU)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build (CPU, multiarch, no push)
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.agent-ocr
+          context: '.'
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
+          push: false
+          build-args: |
+            HOOP_IMAGE=hoophq/hoop:latest
+      # Multiarch builds cannot be --load'ed; rebuild amd64 from the warm
+      # buildx cache to run the runtime-privilege assertion below.
+      - name: Build (CPU, amd64, load for runtime check)
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.agent-ocr
+          context: '.'
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          push: false
+          load: true
+          tags: hoop-agent-ocr:pr-smoke
+          build-args: |
+            HOOP_IMAGE=hoophq/hoop:latest
+      # The base image runs as the unprivileged 'hoop' user (uid 10001) and
+      # the OCR Dockerfiles escalate to root for setup — assert the runtime
+      # user was restored so a missing 'USER hoop' can never ship.
+      - name: Verify runtime user is unprivileged
+        run: |
+          uid="$(docker run --rm --entrypoint id hoop-agent-ocr:pr-smoke -u)"
+          echo "runtime uid: ${uid}"
+          test "${uid}" = "10001"
+
+  build-agent-ocr-gpu:
+    name: Build Agent OCR Image (GPU)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build (GPU, amd64-only, no push)
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.agent-ocr-gpu
+          context: '.'
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          push: false
+          build-args: |
+            HOOP_IMAGE=hoophq/hoop:latest

--- a/Dockerfile.agent-ocr
+++ b/Dockerfile.agent-ocr
@@ -18,6 +18,10 @@ FROM ${HOOP_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# The hoop base image drops to the unprivileged 'hoop' user; package
+# installation below needs root. The runtime user is restored after setup.
+USER root
+
 # Python + native libs RapidOCR's opencv dependency links (imdecode only,
 # but the module still loads them). Kept minimal; no build toolchain.
 RUN apt-get update -y && \
@@ -41,6 +45,12 @@ COPY scripts/dev/ocr-poc/device_policy.py /opt/ocr/device_policy.py
 COPY scripts/dev/ocr-poc/server_rapidocr.py /opt/ocr/server_rapidocr.py
 COPY scripts/dev/ocr-poc/entrypoint-embedded.sh /opt/ocr/entrypoint-embedded.sh
 RUN chmod 755 /opt/ocr/entrypoint-embedded.sh
+
+# Drop back to the base image's unprivileged runtime user. Everything under
+# /opt/ocr-venv and /opt/ocr stays root-owned and world-readable — the engine
+# only reads them at runtime (models ship inside the rapidocr wheel, so
+# nothing is downloaded or written after build).
+USER hoop
 
 # The agent reaches the bundled engine on loopback by default. Operators only
 # need to set MSPRESIDIO_ANALYZER_URL to enable guarding — no extra container.

--- a/Dockerfile.agent-ocr-gpu
+++ b/Dockerfile.agent-ocr-gpu
@@ -22,6 +22,10 @@ FROM ${HOOP_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# The hoop base image drops to the unprivileged 'hoop' user; package
+# installation below needs root. The runtime user is restored after setup.
+USER root
+
 # Python + native libs RapidOCR's opencv dependency links. The CUDA userspace
 # runtime libraries are NOT bundled by the onnxruntime-gpu wheel — they are
 # installed explicitly below as nvidia-*-cu12 wheels. The driver itself is
@@ -76,6 +80,12 @@ COPY scripts/dev/ocr-poc/device_policy.py /opt/ocr/device_policy.py
 COPY scripts/dev/ocr-poc/server_rapidocr.py /opt/ocr/server_rapidocr.py
 COPY scripts/dev/ocr-poc/entrypoint-embedded.sh /opt/ocr/entrypoint-embedded.sh
 RUN chmod 755 /opt/ocr/entrypoint-embedded.sh
+
+# Drop back to the base image's unprivileged runtime user. Everything under
+# /opt/ocr-venv, /opt/cuda-libs and /opt/ocr stays root-owned and
+# world-readable — the engine only reads them at runtime (models ship inside
+# the rapidocr wheel, so nothing is downloaded or written after build).
+USER hoop
 
 ENV RDP_OCR_SERVER_URL="http://127.0.0.1:18868"
 ENV OCR_PORT=18868


### PR DESCRIPTION
## Summary
The post-merge release publish of the agent OCR images failed (`Publish Agent OCR Image (CPU)`/`(GPU)`) with:

```
E: List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)
```

Root cause: the hoop base image ends with `USER hoop` (uid 10001), so the derived OCR Dockerfiles ran `apt-get`/`pip` setup unprivileged. The PR that introduced them was green because these images are only built in `release.yml` — `FROM` the just-published `hoophq/hoop:<tag>`, which doesn't exist at PR time — so the release run was the first build ever attempted.

## Changes
- `Dockerfile.agent-ocr` / `Dockerfile.agent-ocr-gpu`: `USER root` for the setup steps, `USER hoop` restored after — runtime privileges unchanged.
- New `.github/workflows/agent-ocr-build.yml`: PR-time build-only smoke check (path-filtered) that builds both flavors against `hoophq/hoop:latest` with the release platform matrix (CPU amd64+arm64, GPU amd64), plus a runtime assertion that the image still runs as uid 10001.

## Validation
- Local `docker build` of the CPU flavor against `hoophq/hoop:1.108.3` (arm64 — the platform that failed in CI) succeeds.
- Running the container: OCR engine becomes healthy as user `hoop` (rapidocr bundles its models in the wheel — no runtime writes) and exits cleanly.
- The new smoke workflow triggers on this PR itself and validates both flavors, including the GPU one.

Fixes DEP-52

Automated by MisterMal