### PR TITLE
fix(gateway): do not treat empty guardrail rules as configured guardrails

### DIFF
--- a/gateway/transport/agent_guardrails_test.go
+++ b/gateway/transport/agent_guardrails_test.go
@@ -91,6 +91,80 @@ func TestConnectionTypeSupportsGuardRails(t *testing.T) {
 	}
 }
 
+func TestEncodeGuardRailRules(t *testing.T) {
+	t.Run("nil rules yield no payload", func(t *testing.T) {
+		payload, err := encodeGuardRailRules(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if payload != nil {
+			t.Fatalf("expected nil payload, got %q", string(payload))
+		}
+	})
+
+	// services.GetGuardRailRulesForConnection fabricates "[]" rule sets for
+	// connections WITHOUT guardrails. These must not produce a payload —
+	// otherwise the fail-closed admission check (DEP-48) refuses ruleless
+	// sessions on types without guardrail enforcement.
+	t.Run("fabricated empty-array rules yield no payload", func(t *testing.T) {
+		payload, err := encodeGuardRailRules(&models.ConnectionGuardRailRules{
+			GuardRailInputRules:  []byte("[]"),
+			GuardRailOutputRules: []byte("[]"),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if payload != nil {
+			t.Fatalf("expected nil payload for empty rules, got %q", string(payload))
+		}
+	})
+
+	t.Run("absent rule columns yield no payload", func(t *testing.T) {
+		payload, err := encodeGuardRailRules(&models.ConnectionGuardRailRules{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if payload != nil {
+			t.Fatalf("expected nil payload, got %q", string(payload))
+		}
+	})
+
+	t.Run("real rules yield a payload", func(t *testing.T) {
+		inputRules := []byte(`[{"items":[{"type":"deny_words_list","words":["DENYWORD"]}]}]`)
+		payload, err := encodeGuardRailRules(&models.ConnectionGuardRailRules{
+			GuardRailInputRules:  inputRules,
+			GuardRailOutputRules: []byte("[]"),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(payload) == 0 {
+			t.Fatal("expected non-empty payload")
+		}
+		var decoded struct {
+			InputRules  []json.RawMessage `json:"input_rules"`
+			OutputRules []json.RawMessage `json:"output_rules"`
+		}
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			t.Fatalf("payload is not valid JSON: %v", err)
+		}
+		if len(decoded.InputRules) != 1 {
+			t.Fatalf("expected 1 input rule, got %d", len(decoded.InputRules))
+		}
+		if len(decoded.OutputRules) != 0 {
+			t.Fatalf("expected no output rules, got %d", len(decoded.OutputRules))
+		}
+	})
+
+	t.Run("invalid rules yield an error", func(t *testing.T) {
+		if _, err := encodeGuardRailRules(&models.ConnectionGuardRailRules{
+			GuardRailInputRules: []byte("{bad-json"),
+		}); err == nil {
+			t.Fatal("expected error for invalid rules JSON")
+		}
+	})
+}
+
 func TestBuildLegacyGuardRailErrorMessage_InvalidPayload(t *testing.T) {
 	msg, ok := buildLegacyGuardRailErrorMessage([]byte("{bad-json"))
 	if ok || msg != "" {

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -276,12 +276,25 @@ func getGuardRailsRulesForConnection(pctx *plugintypes.Context) (json.RawMessage
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed obtaining guard rail rules, err=%v", err)
 	}
+	return encodeGuardRailRules(connGuardRailRules)
+}
 
+// encodeGuardRailRules turns the connection's stored guardrail rules into the
+// JSON payload shipped to the agent (AgentConnectionParams.GuardRailRules).
+// It returns nil — meaning "no guardrails" — when the connection has no rules
+// to enforce. Emptiness MUST be judged by rule count, not slice nil-ness:
+// services.GetGuardRailRulesForConnection fabricates "[]" (JSON empty array)
+// rule sets for connections without guardrails, and json.Unmarshal turns "[]"
+// into an empty NON-nil slice. A nil-ness check made every ruleless
+// connection look guarded, which the fail-closed admission check (DEP-48)
+// then refused for connection types without guardrail enforcement.
+func encodeGuardRailRules(connGuardRailRules *models.ConnectionGuardRailRules) (json.RawMessage, error) {
 	if connGuardRailRules == nil {
 		return nil, nil
 	}
 
 	var inputRules, outputRules []guardrails.DataRules
+	var err error
 
 	// decode input rules
 	if connGuardRailRules.GuardRailInputRules != nil {
@@ -297,8 +310,8 @@ func getGuardRailsRulesForConnection(pctx *plugintypes.Context) (json.RawMessage
 		}
 	}
 
-	// check if there are no rules
-	if inputRules == nil && outputRules == nil {
+	// no rules to enforce -> no guardrail payload
+	if len(inputRules) == 0 && len(outputRules) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Summary
Regression from #1573 (DEP-48): connecting to MySQL/MSSQL/MongoDB connections **without any guardrails** failed with:

```
rpc error: code = FailedPrecondition desc = this connection has guardrails configured, but connection type "mysql" does not support guardrail enforcement; ...
```

## Root cause
- `services.GetGuardRailRulesForConnection` fabricates `"[]"` (JSON empty array) rule sets for connections without guardrails.
- `guardrails.Decode("[]")` yields an empty **non-nil** slice.
- The emptiness check in the transport layer was nil-ness based (`inputRules == nil && outputRules == nil`), so ruleless connections marshaled `{"input_rules":[],"output_rules":[]}`.
- The DEP-48 fail-closed admission check counts any non-empty payload as "guardrails configured" and refused the session.

Before #1573 this latent flaw only shipped a harmless empty payload to the agent; the fail-closed check turned it into a session refusal for every ruleless connection of an unenforceable type.

## Fix
- Judge emptiness by rule count (`len(...) == 0`), so no-rules connections produce a nil payload (the agent-side `guardrails.Validate` already no-ops on empty rule data).
- Extract the encoding into a pure `encodeGuardRailRules` function and pin the regression with unit tests (fabricated `"[]"` sets, nil/absent columns, real rules, invalid JSON).
- DEP-48 semantics are preserved: connections with real rules still produce a payload and are still refused on unenforceable types.

## Validation
- `go test ./gateway/transport/... ./gateway/guardrails/...` passes.
- New `TestEncodeGuardRailRules` covers the exact regression case.

Automated by MisterMal