### PR TITLE
test(gateway): agent↔gateway transport integration harness (DEP-39)

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -33,14 +33,13 @@ jobs:
       - name: Checkout Hoop
         uses: actions/checkout@v3
 
-      # Integration tests drive the real controller.Agent — and the real
-      # gateway gRPC transport (gateway/integration/transport) — against real
-      # upstream containers via libhoop. The OSS _libhoop stub returns "missing
-      # protocol hoop library for X" for every protocol, so we need the
-      # enterprise libhoop checked out at ./libhoop. The Makefile's libhoop-map
-      # target tries to overwrite this with a symlink, but `rm libhoop || true`
-      # is a no-op against a non-empty directory — the checkout wins. Matches
-      # the build jobs in pullrequest-release.yml.
+      # Integration tests drive the real controller.Agent against real upstream
+      # containers via libhoop. The OSS _libhoop stub returns "missing protocol
+      # hoop library for X" for every protocol, so we need the enterprise
+      # libhoop checked out at ./libhoop. The Makefile's libhoop-map target
+      # tries to overwrite this with a symlink, but `rm libhoop || true` is a
+      # no-op against a non-empty directory — the checkout wins. Matches the
+      # build jobs in pullrequest-release.yml.
       - name: Checkout libhoop
         uses: actions/checkout@v3
         with:
@@ -65,6 +64,46 @@ jobs:
       # https://golang.testcontainers.org/system_requirements/
       - name: Integration Test
         run: make test-integration
+
+  transport-test:
+    name: Transport Integration Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      # The transport harness drives the real gateway gRPC transport end to end
+      # (real agent controller + real Postgres). Its PostgreSQL protocol
+      # round-trip needs the enterprise libhoop proxy — the OSS _libhoop stub
+      # returns "missing protocol hoop library" and that one test skips. Same
+      # ./libhoop checkout trick as the Integration Test job (libhoop-map's
+      # `rm libhoop || true` is a no-op against this non-empty directory).
+      #
+      # This runs as its own job (not folded into Integration Test) so its
+      # Postgres containers do not contend on one runner with the heavy agent
+      # suite's containers, which caused timeouts when the two ran in parallel.
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.26.0'
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Transport Integration Test
+        run: make test-transport
 
   gateway-smoke-test:
     name: Gateway Smoke Test

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -33,13 +33,14 @@ jobs:
       - name: Checkout Hoop
         uses: actions/checkout@v3
 
-      # Integration tests drive the real controller.Agent against real upstream
-      # containers via libhoop. The OSS _libhoop stub returns "missing protocol
-      # hoop library for X" for every protocol, so we need the enterprise
-      # libhoop checked out at ./libhoop. The Makefile's libhoop-map target
-      # tries to overwrite this with a symlink, but `rm libhoop || true` is a
-      # no-op against a non-empty directory — the checkout wins. Matches the
-      # build jobs in pullrequest-release.yml.
+      # Integration tests drive the real controller.Agent — and the real
+      # gateway gRPC transport (gateway/integration/transport) — against real
+      # upstream containers via libhoop. The OSS _libhoop stub returns "missing
+      # protocol hoop library for X" for every protocol, so we need the
+      # enterprise libhoop checked out at ./libhoop. The Makefile's libhoop-map
+      # target tries to overwrite this with a symlink, but `rm libhoop || true`
+      # is a no-op against a non-empty directory — the checkout wins. Matches
+      # the build jobs in pullrequest-release.yml.
       - name: Checkout libhoop
         uses: actions/checkout@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -87,16 +87,29 @@ test-oss: libhoop-map generate-wasm
 test-enterprise: libhoop-map generate-wasm
 	env CGO_ENABLED=0 go test -json -v github.com/hoophq/hoop/...
 
+# Integration tests drive the real controller.Agent and the real gateway gRPC
+# transport against upstream containers via libhoop. Both suites need the
+# enterprise libhoop (the OSS _libhoop stub returns "missing protocol hoop
+# library" for every protocol) — the CI job checks it out at ./libhoop. The
+# transport suite skips only its protocol round-trip on the OSS stub.
 test-integration: libhoop-map generate-wasm
-	env CGO_ENABLED=1 go test -tags integration -race -v -timeout 10m -count=1 ./agent/integration/...
+	env CGO_ENABLED=1 go test -tags integration -race -v -timeout 10m -count=1 ./agent/integration/... ./gateway/integration/transport/...
+
+# Agent↔gateway transport harness only (subset of test-integration). Runs
+# against the real gRPC transport; the PG round-trip needs the enterprise
+# libhoop proxy and skips on the OSS stub, so the rest still run locally.
+test-transport: libhoop-map generate-wasm
+	env CGO_ENABLED=1 go test -tags integration -race -v -timeout 8m -count=1 ./gateway/integration/transport/...
 
 # Gateway smoke tests only exercise the HTTP API / model / auth layers. They
 # need libhoop-map (OSS _libhoop stub satisfies the imports) but not a fresh
 # WASM build: gateway/rdp/parser embeds the committed rdp_parser.wasm via
 # go:embed, so the artifact already exists at build time. Skipping
-# generate-wasm keeps this target independent of the Rust toolchain.
+# generate-wasm keeps this target independent of the Rust toolchain. The path
+# is non-recursive on purpose: the transport suite (a subdir) needs the
+# enterprise libhoop and runs under test-integration instead.
 test-gateway: libhoop-map
-	env CGO_ENABLED=0 go test -tags integration -v -timeout 8m -count=1 ./gateway/integration/...
+	env CGO_ENABLED=0 go test -tags integration -v -timeout 8m -count=1 ./gateway/integration/
 
 generate-openapi-docs: libhoop-map
 	cd ./gateway/ && go run github.com/swaggo/swag/cmd/swag@v1.16.3 init -g api/server.go -o api/openapi/autogen --outputTypes go --markdownFiles api/openapi/docs/ --parseDependency
@@ -270,4 +283,4 @@ publish-sentry-sourcemaps:
 	tar -xvf ${DIST_FOLDER}/webapp.tar.gz
 	sentry-cli sourcemaps upload --release=$$(cat ./version.txt) ./public/js/app.js.map --org hoopdev --project webapp
 
-.PHONY: run-dev run-dev-postgres build-dev-webapp test-enterprise test-oss test test-integration test-gateway generate-openapi-docs build-go build-dev-client build-webapp build-helm-chart build-gateway-bundle extract-webapp publish release-s3 release-s3-latest release-s3-cf-templates-latest release-s3-cf-templates-latest swag-fmt build-rust-darwin-all build-rust-linux-all build-rust-single build-empty-folder build-dev-rust install-rust merge-artifacts generate-wasm build-hsh-tunneld build-hsh-tunneld-all build-release-checksums stage-release-scripts
+.PHONY: run-dev run-dev-postgres build-dev-webapp test-enterprise test-oss test test-integration test-transport test-gateway generate-openapi-docs build-go build-dev-client build-webapp build-helm-chart build-gateway-bundle extract-webapp publish release-s3 release-s3-latest release-s3-cf-templates-latest release-s3-cf-templates-latest swag-fmt build-rust-darwin-all build-rust-linux-all build-rust-single build-empty-folder build-dev-rust install-rust merge-artifacts generate-wasm build-hsh-tunneld build-hsh-tunneld-all build-release-checksums stage-release-scripts

--- a/Makefile
+++ b/Makefile
@@ -87,17 +87,18 @@ test-oss: libhoop-map generate-wasm
 test-enterprise: libhoop-map generate-wasm
 	env CGO_ENABLED=0 go test -json -v github.com/hoophq/hoop/...
 
-# Integration tests drive the real controller.Agent and the real gateway gRPC
-# transport against upstream containers via libhoop. Both suites need the
-# enterprise libhoop (the OSS _libhoop stub returns "missing protocol hoop
-# library" for every protocol) — the CI job checks it out at ./libhoop. The
-# transport suite skips only its protocol round-trip on the OSS stub.
+# Integration tests drive the real controller.Agent against upstream
+# containers via libhoop. Needs the enterprise libhoop (the OSS _libhoop stub
+# returns "missing protocol hoop library" for every protocol) — the CI job
+# checks it out at ./libhoop.
 test-integration: libhoop-map generate-wasm
-	env CGO_ENABLED=1 go test -tags integration -race -v -timeout 10m -count=1 ./agent/integration/... ./gateway/integration/transport/...
+	env CGO_ENABLED=1 go test -tags integration -race -v -timeout 10m -count=1 ./agent/integration/...
 
-# Agent↔gateway transport harness only (subset of test-integration). Runs
-# against the real gRPC transport; the PG round-trip needs the enterprise
-# libhoop proxy and skips on the OSS stub, so the rest still run locally.
+# Agent↔gateway transport harness. Runs against the real gateway gRPC
+# transport; the PG round-trip needs the enterprise libhoop proxy (skips on
+# the OSS stub), so the rest still run locally. Kept a separate target/CI job
+# from test-integration so its Postgres containers don't contend with the
+# heavy agent suite on a shared runner.
 test-transport: libhoop-map generate-wasm
 	env CGO_ENABLED=1 go test -tags integration -race -v -timeout 8m -count=1 ./gateway/integration/transport/...
 
@@ -107,7 +108,7 @@ test-transport: libhoop-map generate-wasm
 # go:embed, so the artifact already exists at build time. Skipping
 # generate-wasm keeps this target independent of the Rust toolchain. The path
 # is non-recursive on purpose: the transport suite (a subdir) needs the
-# enterprise libhoop and runs under test-integration instead.
+# enterprise libhoop and runs under test-transport instead.
 test-gateway: libhoop-map
 	env CGO_ENABLED=0 go test -tags integration -v -timeout 8m -count=1 ./gateway/integration/
 

--- a/gateway/api/middleware.go
+++ b/gateway/api/middleware.go
@@ -255,7 +255,26 @@ func (a *Api) AuditMiddleware() gin.HandlerFunc {
 		// Execute handler
 		c.Next()
 
-		// Log the audit entry after handler completes
+		// Snapshot everything the audit entry needs while still on the request
+		// goroutine. The audit write is dispatched asynchronously below, and
+		// gin.Context (plus the wrapped writer) must not be read from that
+		// goroutine: outer middlewares (otelgin, sentry) mutate the context
+		// during request teardown, which races a goroutine that outlives the
+		// handler. Reading here — before returning — keeps all context access
+		// single-threaded.
+		auditCtx := storagev2.ParseContext(c)
+		httpMethod := c.Request.Method
+		httpPath := c.Request.URL.Path
+		clientIP := c.ClientIP()
+		httpStatus := arw.Status()
+		var errorMessage string
+		if len(c.Errors) > 0 {
+			errorMessage = c.Errors.String()
+		} else if httpStatus >= 400 && arw.responseBody != nil && arw.responseBody.Len() > 0 {
+			errorMessage = extractErrorMessage(httpStatus, arw.responseBody)
+		}
+
+		// Log the audit entry after the handler completes, off the request path.
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -263,31 +282,16 @@ func (a *Api) AuditMiddleware() gin.HandlerFunc {
 				}
 			}()
 
-			ctx := storagev2.ParseContext(c)
-			if ctx == nil || ctx.OrgID == "" {
+			if auditCtx == nil || auditCtx.OrgID == "" {
 				return
 			}
 
-			// Get HTTP details
-			httpMethod := c.Request.Method
-			httpStatus := arw.Status()
-			httpPath := c.Request.URL.Path
-			clientIP := c.ClientIP()
-
-			// Derive resource type and action from path
+			// Derive resource type and action from the captured path/method.
 			resourceType, action := audit.DeriveResourceAndAction(httpPath, httpMethod)
-
-			// Collect error message if any
-			var errorMessage string
-			if len(c.Errors) > 0 {
-				errorMessage = c.Errors.String()
-			} else if httpStatus >= 400 && arw.responseBody != nil && arw.responseBody.Len() > 0 {
-				errorMessage = extractErrorMessage(httpStatus, arw.responseBody)
-			}
 
 			// Log to audit using the audit package function
 			audit.LogFromMiddleware(
-				ctx,
+				auditCtx,
 				httpMethod,
 				httpStatus,
 				httpPath,

--- a/gateway/integration/setup_test.go
+++ b/gateway/integration/setup_test.go
@@ -6,33 +6,21 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/gin-gonic/gin"
-
-	"github.com/hoophq/hoop/common/proto"
-	"github.com/hoophq/hoop/gateway/analytics"
-	"github.com/hoophq/hoop/gateway/api"
-	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
-	apiserverconfig "github.com/hoophq/hoop/gateway/api/serverconfig"
-	"github.com/hoophq/hoop/gateway/appconfig"
-	"github.com/hoophq/hoop/gateway/idp"
 	"github.com/hoophq/hoop/gateway/integration/testutil"
-	"github.com/hoophq/hoop/gateway/models"
-	modelsbootstrap "github.com/hoophq/hoop/gateway/models/bootstrap"
-	"github.com/hoophq/hoop/gateway/services"
 )
 
-// testServer is the shared gateway server under test. It is initialized once
-// in TestMain and used by every test in this package.
+// testServer is the shared gateway HTTP server under test. It is initialized
+// once in TestMain and used by every test in this package.
 var testServer *testutil.GatewayTestServer
 
 // TestMain boots a throwaway PostgreSQL container, runs the full migration
 // set, bootstraps the default organization the way gateway/main.go does
 // (minus plugins, proxies, and the gRPC server, none of which the smoke
 // tests exercise), then serves the gateway's complete gin route tree via an
-// in-process httptest server.
+// in-process httptest server. The shared boot lives in testutil.StartGateway
+// so this suite and the transport suite share one bootstrap implementation.
 func TestMain(m *testing.M) {
 	code, err := runMain(m)
 	if err != nil {
@@ -43,115 +31,12 @@ func TestMain(m *testing.M) {
 }
 
 func runMain(m *testing.M) (int, error) {
-	ctx := context.Background()
-
-	pg, err := testutil.StartPostgres(ctx)
+	gw, err := testutil.StartGateway(context.Background(), testutil.GatewayOptions{WithHTTP: true})
 	if err != nil {
 		return 0, err
 	}
-	defer func() {
-		if termErr := pg.Terminate(); termErr != nil {
-			fmt.Fprintf(os.Stderr, "gateway smoke teardown: failed terminating postgres container: %v\n", termErr)
-		}
-	}()
+	defer gw.Close()
 
-	migrationsPath, err := filepath.Abs(filepath.Join("..", "..", "rootfs", "app", "migrations"))
-	if err != nil {
-		return 0, fmt.Errorf("resolving migrations path: %w", err)
-	}
-
-	// appconfig.Load reads these env vars and stat-checks the migration path,
-	// so they must be set before Load. AUTH_METHOD=local makes the gateway
-	// issue/verify its own ed25519-signed JWTs without an external IDP.
-	for k, v := range map[string]string{
-		"POSTGRES_DB_URI":      pg.URI(),
-		"MIGRATION_PATH_FILES": migrationsPath,
-		"AUTH_METHOD":          "local",
-		"API_URL":              "http://127.0.0.1:8009",
-		"GRPC_URL":             "grpc://127.0.0.1:8010",
-		"GIN_MODE":             "release",
-	} {
-		if err := os.Setenv(k, v); err != nil {
-			return 0, fmt.Errorf("setenv %s: %w", k, err)
-		}
-	}
-
-	if err := appconfig.Load(); err != nil {
-		return 0, fmt.Errorf("appconfig.Load: %w", err)
-	}
-
-	if err := modelsbootstrap.MigrateDB(appconfig.Get().PgURI(), appconfig.Get().MigrationPathFiles()); err != nil {
-		return 0, fmt.Errorf("migrate db: %w", err)
-	}
-	if err := models.InitDatabaseConnection(); err != nil {
-		return 0, fmt.Errorf("init db connection: %w", err)
-	}
-	if err := modelsbootstrap.RunGolangMigrations(); err != nil {
-		return 0, fmt.Errorf("run golang migrations: %w", err)
-	}
-
-	// Warm the same caches gateway/main.go warms after migrations so the
-	// feature-flag and analytics-mode codepaths behave as they do in
-	// production rather than against cold caches.
-	services.WarmFeatureFlagCache()
-	analytics.WarmModeCache()
-
-	if err := bootstrapDefaultOrg(); err != nil {
-		return 0, fmt.Errorf("bootstrap default org: %w", err)
-	}
-
-	handler := buildTestHandler()
-	testServer = testutil.NewGatewayTestServer(handler)
-	defer testServer.Close()
-
+	testServer = gw.HTTP
 	return m.Run(), nil
-}
-
-// bootstrapDefaultOrg mirrors the single-tenant org bootstrap in
-// gateway/main.go (lines ~109-157), limited to what the API needs to accept
-// authenticated requests: the default org, its connection tags, the local
-// signing key (created lazily by the token verifier provider), and the global
-// user-role configuration consumed by the RBAC middleware.
-//
-// It intentionally omits the default runbook configuration, rulepack seeding,
-// and org agent-key provisioning: none of the smoke tests exercise those
-// features. If a future test does, add the corresponding bootstrap step here
-// (and mirror it from gateway/main.go) rather than relying on it being absent.
-func bootstrapDefaultOrg() error {
-	// Instantiating the token verifier provider generates and persists the
-	// shared ed25519 signing key for the local provider on first call.
-	if _, _, err := idp.NewTokenVerifierProvider(); err != nil {
-		return fmt.Errorf("init token verifier provider: %w", err)
-	}
-
-	org, _, err := models.CreateOrgGetOrganization(proto.DefaultOrgName, nil)
-	if err != nil {
-		return fmt.Errorf("create default org: %w", err)
-	}
-
-	if err := models.UpsertBatchConnectionTags(apiconnections.DefaultConnectionTags(org.ID)); err != nil {
-		return fmt.Errorf("seed default connection tags: %w", err)
-	}
-
-	// The RBAC middleware reads the global gateway user roles; without this
-	// the admin/read-only role checks have no role definitions to match.
-	if err := apiserverconfig.SetGlobalGatewayUserRoles(); err != nil {
-		return fmt.Errorf("set global gateway user roles: %w", err)
-	}
-
-	return nil
-}
-
-// buildTestHandler constructs the exact gin engine StartAPI serves, via the
-// shared api.BuildEngine constructor — same middleware chain (security, CORS,
-// Sentry), same /api route tree, and the same request validators. Tests
-// therefore exercise the production HTTP stack rather than a stripped-down
-// router. The ReleaseConnectionFn is a no-op because the review-approval
-// transport path is never exercised by the smoke tests.
-func buildTestHandler() *gin.Engine {
-	gin.SetMode(gin.ReleaseMode)
-	a := &api.Api{
-		ReleaseConnectionFn: func(_, _, _, _ string) {},
-	}
-	return a.BuildEngine()
 }

--- a/gateway/integration/testutil/gateway_boot.go
+++ b/gateway/integration/testutil/gateway_boot.go
@@ -1,0 +1,310 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc"
+
+	"github.com/hoophq/hoop/common/proto"
+	"github.com/hoophq/hoop/gateway/analytics"
+	"github.com/hoophq/hoop/gateway/api"
+	apiconnections "github.com/hoophq/hoop/gateway/api/connections"
+	apiserverconfig "github.com/hoophq/hoop/gateway/api/serverconfig"
+	"github.com/hoophq/hoop/gateway/appconfig"
+	"github.com/hoophq/hoop/gateway/idp"
+	"github.com/hoophq/hoop/gateway/models"
+	modelsbootstrap "github.com/hoophq/hoop/gateway/models/bootstrap"
+	"github.com/hoophq/hoop/gateway/services"
+	"github.com/hoophq/hoop/gateway/transport"
+	pluginsrbac "github.com/hoophq/hoop/gateway/transport/plugins/accesscontrol"
+	pluginsaudit "github.com/hoophq/hoop/gateway/transport/plugins/audit"
+	pluginsdlp "github.com/hoophq/hoop/gateway/transport/plugins/dlp"
+	pluginsreview "github.com/hoophq/hoop/gateway/transport/plugins/review"
+	pluginsslack "github.com/hoophq/hoop/gateway/transport/plugins/slack"
+	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
+	pluginswebhooks "github.com/hoophq/hoop/gateway/transport/plugins/webhooks"
+)
+
+// GatewayOptions selects which layers of the gateway a test suite boots. The
+// smoke suite only needs the HTTP API; the transport suite additionally needs
+// the plugin chain and the gRPC transport server. Keeping the layers opt-in
+// means each suite pays only for what it exercises and the two share one
+// bootstrap implementation.
+type GatewayOptions struct {
+	// WithHTTP starts the full gin route tree behind an httptest server,
+	// reachable via Gateway.HTTP.
+	WithHTTP bool
+	// WithPlugins registers the production transport plugin chain (review,
+	// audit, dlp, accesscontrol, webhooks, slack) in the same order as
+	// gateway/main.go and runs each plugin's OnStartup. Required for any
+	// client session that flows through PluginExecOnReceive.
+	WithPlugins bool
+	// WithGRPC starts the transport gRPC server on an ephemeral loopback
+	// port, reachable via Gateway.GRPCAddr.
+	WithGRPC bool
+}
+
+// Gateway is a fully booted, in-process gateway under test. It owns every
+// backing resource (PostgreSQL container, HTTP server, gRPC server) and tears
+// them all down on Close.
+type Gateway struct {
+	// Postgres is the throwaway state-store container.
+	Postgres *PostgresContainer
+	// HTTP is the in-process HTTP API server; nil unless WithHTTP was set.
+	HTTP *GatewayTestServer
+	// GRPCAddr is the "host:port" of the transport gRPC server; empty unless
+	// WithGRPC was set.
+	GRPCAddr string
+	// OrgID is the id of the bootstrapped default organization.
+	OrgID string
+
+	grpcServer   *grpc.Server
+	grpcListener net.Listener
+	auditPath    string
+}
+
+// StartGateway boots a gateway in-process the way gateway/main.go does, minus
+// the layers a test does not opt into. The boot order mirrors production:
+// load config, run migrations, warm caches, bootstrap the default org, then
+// (optionally) register plugins and start the HTTP and gRPC servers.
+//
+// PROCESS-EXCLUSIVE: the gateway is singleton-heavy — this function mutates
+// process globals (os.Setenv, the appconfig singleton, the global models.DB and
+// its warmed caches, plugintypes.AuditPath and plugintypes.RegisteredPlugins).
+// Call it exactly once per test binary, from TestMain, and never concurrently.
+// Two live gateways in one process would clobber each other's config, DB
+// handle, and plugin registry. This matches how gateway/main.go treats the same
+// globals in production (one gateway per process).
+//
+// The returned Gateway must be closed by the caller (typically via defer in
+// TestMain) to release the container and network listeners.
+func StartGateway(ctx context.Context, opts GatewayOptions) (gw *Gateway, err error) {
+	pg, err := StartPostgres(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// On any failure past this point, tear the container back down so a
+	// bootstrap error does not leak a running Postgres for the whole run.
+	defer func() {
+		if err != nil && pg != nil {
+			_ = pg.Terminate()
+		}
+	}()
+
+	migrationsPath, err := migrationsDir()
+	if err != nil {
+		return nil, err
+	}
+
+	// appconfig.Load reads these env vars and stat-checks the migration path,
+	// so they must be set before Load. AUTH_METHOD=local makes the gateway
+	// issue/verify its own ed25519-signed JWTs without an external IDP.
+	for k, v := range map[string]string{
+		"POSTGRES_DB_URI":      pg.URI(),
+		"MIGRATION_PATH_FILES": migrationsPath,
+		"AUTH_METHOD":          "local",
+		"API_URL":              "http://127.0.0.1:8009",
+		"GRPC_URL":             "grpc://127.0.0.1:8010",
+		"GIN_MODE":             "release",
+	} {
+		if serr := os.Setenv(k, v); serr != nil {
+			return nil, fmt.Errorf("setenv %s: %w", k, serr)
+		}
+	}
+
+	if err = appconfig.Load(); err != nil {
+		return nil, fmt.Errorf("appconfig.Load: %w", err)
+	}
+
+	if err = modelsbootstrap.MigrateDB(appconfig.Get().PgURI(), appconfig.Get().MigrationPathFiles()); err != nil {
+		return nil, fmt.Errorf("migrate db: %w", err)
+	}
+	if err = models.InitDatabaseConnection(); err != nil {
+		return nil, fmt.Errorf("init db connection: %w", err)
+	}
+	if err = modelsbootstrap.RunGolangMigrations(); err != nil {
+		return nil, fmt.Errorf("run golang migrations: %w", err)
+	}
+
+	// Warm the same caches gateway/main.go warms after migrations so the
+	// feature-flag and analytics-mode codepaths behave as they do in
+	// production rather than against cold caches.
+	services.WarmFeatureFlagCache()
+	analytics.WarmModeCache()
+
+	orgID, err := bootstrapDefaultOrg()
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap default org: %w", err)
+	}
+
+	gw = &Gateway{Postgres: pg, OrgID: orgID}
+
+	if opts.WithPlugins {
+		if err = gw.registerPlugins(); err != nil {
+			return nil, fmt.Errorf("register plugins: %w", err)
+		}
+	}
+
+	if opts.WithHTTP {
+		gw.HTTP = NewGatewayTestServer(buildEngine())
+	}
+
+	if opts.WithGRPC {
+		if err = gw.startGRPC(); err != nil {
+			return nil, fmt.Errorf("start grpc transport: %w", err)
+		}
+	}
+
+	return gw, nil
+}
+
+// Close tears down every resource the gateway owns. Safe to call once.
+func (g *Gateway) Close() {
+	if g == nil {
+		return
+	}
+	if g.grpcServer != nil {
+		// GracefulStop stops accepting and closes the listener; close it
+		// explicitly too so teardown is deterministic even if Serve never ran.
+		g.grpcServer.GracefulStop()
+	}
+	if g.grpcListener != nil {
+		_ = g.grpcListener.Close()
+	}
+	if g.HTTP != nil {
+		g.HTTP.Close()
+	}
+	if g.Postgres != nil {
+		if err := g.Postgres.Terminate(); err != nil {
+			fmt.Fprintf(os.Stderr, "gateway test teardown: terminate postgres: %v\n", err)
+		}
+	}
+	if g.auditPath != "" {
+		_ = os.RemoveAll(g.auditPath)
+	}
+}
+
+// registerPlugins mirrors the plugin registration in gateway/main.go. The
+// order is intentional and load-bearing (review runs before audit, etc.); do
+// not reorder. The audit plugin persists session WAL logs under a path it
+// stat-checks at startup, so we point it at a throwaway temp dir first.
+func (g *Gateway) registerPlugins() error {
+	auditPath, err := os.MkdirTemp("", "hoop-audit-*")
+	if err != nil {
+		return fmt.Errorf("create audit temp dir: %w", err)
+	}
+	g.auditPath = auditPath
+	// plugintypes.AuditPath is resolved from PLUGIN_AUDIT_PATH at package
+	// init, which has already run by the time TestMain executes. Assign the
+	// exported var directly so the audit plugin writes WAL logs into the
+	// throwaway dir instead of the production default (/opt/hoop/sessions).
+	plugintypes.AuditPath = auditPath
+
+	apiURL := appconfig.Get().ApiURL()
+	noopRelease := func(_, _, _, _ string) {}
+	plugintypes.RegisteredPlugins = []plugintypes.Plugin{
+		pluginsreview.New(apiURL),
+		pluginsaudit.New(),
+		pluginsdlp.New(),
+		pluginsrbac.New(),
+		pluginswebhooks.New(),
+		pluginsslack.New(noopRelease),
+	}
+	for _, p := range plugintypes.RegisteredPlugins {
+		if err := p.OnStartup(plugintypes.Context{}); err != nil {
+			return fmt.Errorf("plugin %s startup: %w", p.Name(), err)
+		}
+	}
+	return nil
+}
+
+// startGRPC binds an ephemeral loopback port and serves the transport gRPC
+// server built by the production wiring (transport.Server.NewGRPCServer), so
+// the harness exercises the exact interceptor chain and message-size limits
+// the gateway uses in production.
+func (g *Gateway) startGRPC() error {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	srv := &transport.Server{AppConfig: appconfig.Get()}
+	g.grpcServer = srv.NewGRPCServer()
+	g.grpcListener = lis
+	g.GRPCAddr = lis.Addr().String()
+	go func() {
+		// Serve returns ErrServerStopped after GracefulStop; that is the
+		// normal teardown path and not a test failure.
+		_ = g.grpcServer.Serve(lis)
+	}()
+	return nil
+}
+
+// bootstrapDefaultOrg mirrors the single-tenant org bootstrap in
+// gateway/main.go, limited to what the API and transport need to accept
+// authenticated requests: the default org, its connection tags, the local
+// signing key (created lazily by the token verifier provider), and the global
+// user-role configuration consumed by the RBAC middleware. It returns the
+// bootstrapped organization id.
+func bootstrapDefaultOrg() (string, error) {
+	// Instantiating the token verifier provider generates and persists the
+	// shared ed25519 signing key for the local provider on first call.
+	if _, _, err := idp.NewTokenVerifierProvider(); err != nil {
+		return "", fmt.Errorf("init token verifier provider: %w", err)
+	}
+
+	org, _, err := models.CreateOrgGetOrganization(proto.DefaultOrgName, nil)
+	if err != nil {
+		return "", fmt.Errorf("create default org: %w", err)
+	}
+
+	if err := models.UpsertBatchConnectionTags(apiconnections.DefaultConnectionTags(org.ID)); err != nil {
+		return "", fmt.Errorf("seed default connection tags: %w", err)
+	}
+
+	// The RBAC middleware reads the global gateway user roles; without this
+	// the admin/read-only role checks have no role definitions to match.
+	if err := apiserverconfig.SetGlobalGatewayUserRoles(); err != nil {
+		return "", fmt.Errorf("set global gateway user roles: %w", err)
+	}
+
+	return org.ID, nil
+}
+
+// buildEngine constructs the exact gin engine StartAPI serves, via the shared
+// api.BuildEngine constructor — same middleware chain (security, CORS,
+// Sentry), same /api route tree, and the same request validators. Tests
+// therefore exercise the production HTTP stack rather than a stripped-down
+// router. ReleaseConnectionFn is a no-op because the review-approval transport
+// path is not exercised through the HTTP server.
+func buildEngine() *gin.Engine {
+	gin.SetMode(gin.ReleaseMode)
+	a := &api.Api{
+		ReleaseConnectionFn: func(_, _, _, _ string) {},
+	}
+	return a.BuildEngine()
+}
+
+// migrationsDir resolves the absolute path to rootfs/app/migrations from this
+// source file's location, so it is independent of the test's working
+// directory (the smoke and transport suites live at different depths).
+func migrationsDir() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to resolve caller for migrations path")
+	}
+	// thisFile = <repo>/gateway/integration/testutil/gateway_boot.go
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+	path, err := filepath.Abs(filepath.Join(repoRoot, "rootfs", "app", "migrations"))
+	if err != nil {
+		return "", fmt.Errorf("resolving migrations path: %w", err)
+	}
+	return path, nil
+}

--- a/gateway/integration/transport/connect_test.go
+++ b/gateway/integration/transport/connect_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	commongrpc "github.com/hoophq/hoop/common/grpc"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// TestAgentConnectHandshake verifies a valid agent completes the Connect
+// handshake and receives GatewayConnectOK. This is the core agent-origin path
+// through the auth and sessionuuid interceptors.
+func TestAgentConnectHandshake(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			_, dsn := createAgent(t, uniqueName("agent"))
+
+			tr, err := c.DialAgent(context.Background(), dsn)
+			if err != nil {
+				t.Fatalf("DialAgent: %v", err)
+			}
+			defer tr.Close()
+
+			pkt, err := recvUntil(tr, 10*time.Second, pbagent.GatewayConnectOK)
+			if err != nil {
+				t.Fatalf("waiting for GatewayConnectOK: %v", err)
+			}
+			if pkt.Type != pbagent.GatewayConnectOK {
+				t.Fatalf("first packet = %q, want %q", pkt.Type, pbagent.GatewayConnectOK)
+			}
+		})
+	}
+}
+
+// TestAgentConnectRejectsInvalidDSN verifies the auth interceptor rejects an
+// agent whose secret does not resolve to a registered agent. The rejection
+// surfaces on the stream as an Unauthenticated status.
+func TestAgentConnectRejectsInvalidDSN(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			// A well-formed DSN for an agent that was never created.
+			badDSN := "grpc://ghost:wrong-secret@" + gw.GRPCAddr + "?mode=standard"
+
+			tr, err := c.DialAgent(context.Background(), badDSN)
+			if err != nil {
+				// Some wires may reject at dial; that is also acceptable.
+				if status.Code(err) != codes.Unauthenticated {
+					t.Fatalf("DialAgent error code = %v, want Unauthenticated", status.Code(err))
+				}
+				return
+			}
+			defer tr.Close()
+
+			_, err = recvUntil(tr, 10*time.Second, pbagent.GatewayConnectOK)
+			if err == nil {
+				t.Fatal("expected auth rejection, got GatewayConnectOK")
+			}
+			if status.Code(err) != codes.Unauthenticated {
+				t.Fatalf("recv error code = %v, want Unauthenticated (err=%v)", status.Code(err), err)
+			}
+		})
+	}
+}
+
+// TestDuplicateAgentRejected verifies the second concurrent Connect for the
+// same agent identity is refused (agent already connected) while the first
+// stays healthy.
+func TestDuplicateAgentRejected(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			agentID, dsn := createAgent(t, uniqueName("agent"))
+
+			first, err := c.DialAgent(context.Background(), dsn)
+			if err != nil {
+				t.Fatalf("DialAgent(first): %v", err)
+			}
+			defer first.Close()
+			if _, err := recvUntil(first, 10*time.Second, pbagent.GatewayConnectOK); err != nil {
+				t.Fatalf("first agent handshake: %v", err)
+			}
+
+			second, err := c.DialAgent(context.Background(), dsn)
+			if err != nil {
+				t.Fatalf("DialAgent(second): %v", err)
+			}
+			defer second.Close()
+
+			// The duplicate is refused at Save (FailedPrecondition, "agent
+			// already connected"); the stream errors instead of completing the
+			// handshake.
+			_, err = recvUntil(second, 10*time.Second, pbagent.GatewayConnectOK)
+			if err == nil {
+				t.Fatal("expected duplicate agent to be rejected, got GatewayConnectOK")
+			}
+			if code := status.Code(err); code != codes.FailedPrecondition && err != context.DeadlineExceeded {
+				t.Fatalf("duplicate rejection error code = %v, want FailedPrecondition (err=%v)", code, err)
+			}
+
+			// The first stream must remain healthy: a connection bound to this
+			// agent still reports online after the duplicate was refused.
+			connName := uniqueName("conn")
+			createPGConnection(t, connName, agentID)
+			waitConnectionStatus(t, connName, "online")
+		})
+	}
+}
+
+// TestConnectRejectsMissingOrigin verifies the transport refuses a Connect
+// stream that omits the origin metadata. This asserts the interceptor-chain
+// precondition every wire must enforce. It is gRPC-specific in mechanics (raw
+// metadata), so it targets the gRPC address directly rather than the seam.
+func TestConnectRejectsMissingOrigin(t *testing.T) {
+	_, dsn := createAgent(t, uniqueName("agent"))
+
+	conn, err := grpc.DialContext(context.Background(), gw.GRPCAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Authorization is present, but origin is deliberately omitted.
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer "+dsn)
+	stream, err := pb.NewTransportClient(conn).Connect(ctx)
+	if err != nil {
+		t.Fatalf("open connect stream: %v", err)
+	}
+	if err := stream.Send(&pb.Packet{Type: "test"}); err != nil {
+		// A send failure here is an acceptable manifestation of the rejection.
+		return
+	}
+	if _, err := stream.Recv(); err == nil {
+		t.Fatal("expected rejection for missing origin, got a packet")
+	} else if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("recv error code = %v, want InvalidArgument (err=%v)", status.Code(err), err)
+	}
+}
+
+// compile-time guard: the raw gRPC path above must use the same option keys
+// the seam uses, so drift is caught here.
+var _ = commongrpc.OptionConnectionName

--- a/gateway/integration/transport/connector_test.go
+++ b/gateway/integration/transport/connector_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"time"
+
+	commongrpc "github.com/hoophq/hoop/common/grpc"
+	pb "github.com/hoophq/hoop/common/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Connector is the transport-agnostic seam the scenarios are written against.
+// It exposes the four transport operations a client or agent performs against
+// the gateway — the unary PreConnect/HealthCheck RPCs and the two bidirectional
+// Connect stream variants (agent-origin and client-origin) — without leaking
+// the concrete wire type.
+//
+// gRPC is the only implementation today (grpcConnector). When the WebSocket
+// transport lands (DEP-40/41) it implements this same interface and is added
+// to transports(), so every scenario runs against both wires unchanged. This
+// is what makes the suite a behavioral-parity baseline rather than a
+// gRPC-specific test.
+//
+// The seam is defined over pb.ClientTransport — the same packet-stream
+// abstraction the agent controller already consumes — so it is "wire-agnostic
+// over the Packet protocol", not protocol-neutral. That is exactly the contract
+// the WebSocket transport must satisfy anyway (it has to implement
+// pb.ClientTransport to plug into the controller), so reusing it here is
+// deliberate, not a leak.
+type Connector interface {
+	// Name identifies the wire, used as the subtest name.
+	Name() string
+	// HealthCheck performs the unary HealthCheck RPC.
+	HealthCheck(ctx context.Context, req *pb.HealthCheckRequest) (*pb.HealthCheckResponse, error)
+	// PreConnect performs the unary PreConnect RPC authenticated as the agent
+	// identified by token (a DSN).
+	PreConnect(ctx context.Context, token string, req *pb.PreConnectRequest) (*pb.PreConnectResponse, error)
+	// DialAgent opens an agent-origin Connect stream authenticated with the
+	// given DSN token. The caller owns the returned transport and must Close it.
+	DialAgent(ctx context.Context, token string) (pb.ClientTransport, error)
+	// DialClient opens a client-origin Connect stream for the connection, verb
+	// and access token in cfg. The caller owns the returned transport.
+	DialClient(ctx context.Context, cfg ClientDialConfig) (pb.ClientTransport, error)
+}
+
+// ClientDialConfig carries the parameters a client sets when opening a
+// Connect stream: the user access token, the target connection name, and the
+// client verb (connect/exec/...).
+type ClientDialConfig struct {
+	Token          string
+	ConnectionName string
+	Verb           string
+}
+
+// grpcConnector implements Connector over the production gRPC dialers in
+// common/grpc, targeting the harness's ephemeral gateway address. It is the
+// reference wire the WebSocket transport is validated against.
+type grpcConnector struct {
+	addr string
+}
+
+func newGRPCConnector(addr string) *grpcConnector { return &grpcConnector{addr: addr} }
+
+func (c *grpcConnector) Name() string { return "grpc" }
+
+func (c *grpcConnector) HealthCheck(ctx context.Context, req *pb.HealthCheckRequest) (*pb.HealthCheckResponse, error) {
+	// HealthCheck is not wrapped by common/grpc (agents/clients never call it),
+	// so dial directly. Plaintext loopback matches the harness listener.
+	conn, err := grpc.DialContext(ctx, c.addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	return pb.NewTransportClient(conn).HealthCheck(ctx, req)
+}
+
+func (c *grpcConnector) PreConnect(_ context.Context, token string, req *pb.PreConnectRequest) (*pb.PreConnectResponse, error) {
+	return commongrpc.PreConnectRPC(c.clientConfig(token), req)
+}
+
+func (c *grpcConnector) DialAgent(_ context.Context, token string) (pb.ClientTransport, error) {
+	return commongrpc.Connect(c.clientConfig(token),
+		commongrpc.WithOption("origin", pb.ConnectionOriginAgent))
+}
+
+func (c *grpcConnector) DialClient(_ context.Context, cfg ClientDialConfig) (pb.ClientTransport, error) {
+	return commongrpc.Connect(c.clientConfig(cfg.Token),
+		commongrpc.WithOption(commongrpc.OptionConnectionName, cfg.ConnectionName),
+		commongrpc.WithOption("origin", pb.ConnectionOriginClient),
+		commongrpc.WithOption("verb", cfg.Verb))
+}
+
+// clientConfig builds the plaintext-loopback ClientConfig every gRPC dial in
+// this harness shares. The context on Dial* is unused here because
+// common/grpc manages its own dial timeout; it is retained on the interface
+// for transports (WebSocket) that honor it.
+func (c *grpcConnector) clientConfig(token string) commongrpc.ClientConfig {
+	return commongrpc.ClientConfig{
+		ServerAddress: c.addr,
+		Token:         token,
+		UserAgent:     "hoop-transport-itest",
+		Insecure:      true,
+	}
+}
+
+// transports returns every wire implementation the scenarios run against.
+// Today that is gRPC only; appending a WebSocket Connector here is the single
+// change that makes the whole suite validate the new transport for parity.
+func transports() []Connector {
+	return []Connector{newGRPCConnector(gw.GRPCAddr)}
+}
+
+// recvUntil reads packets from tr until one of the wanted types arrives, the
+// timeout expires, or the stream errors. It returns the matching packet. This
+// is the transport-agnostic primitive the scenarios use to assert on the
+// packet stream regardless of the underlying wire.
+//
+// Recv has no deadline, so a background goroutine performs the blocking reads.
+// On timeout the transport is closed to unblock that goroutine deterministically
+// (rather than leaking it): every caller treats a recvUntil timeout as fatal, so
+// closing the stream here is safe. The result channel is buffered so a late
+// delivery after the timeout never blocks the goroutine.
+func recvUntil(tr pb.ClientTransport, timeout time.Duration, wanted ...string) (*pb.Packet, error) {
+	want := make(map[string]struct{}, len(wanted))
+	for _, w := range wanted {
+		want[w] = struct{}{}
+	}
+	type result struct {
+		pkt *pb.Packet
+		err error
+	}
+	resc := make(chan result, 1)
+	go func() {
+		for {
+			pkt, err := tr.Recv()
+			if err != nil {
+				resc <- result{nil, err}
+				return
+			}
+			if _, ok := want[pkt.Type]; ok {
+				resc <- result{pkt, nil}
+				return
+			}
+		}
+	}()
+	select {
+	case r := <-resc:
+		return r.pkt, r.err
+	case <-time.After(timeout):
+		_, _ = tr.Close()
+		return nil, context.DeadlineExceeded
+	}
+}

--- a/gateway/integration/transport/doc.go
+++ b/gateway/integration/transport/doc.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+// Package transport holds the end-to-end integration test harness for the
+// agent↔gateway transport. It boots a real gateway in-process (PostgreSQL
+// container, migrations, plugin chain, and the production gRPC server on an
+// ephemeral port via testutil.StartGateway) and drives it with a real agent
+// controller and raw client streams over the wire.
+//
+// The scenarios are written against the transport-agnostic Connector seam
+// (see connector_test.go), not against gRPC types directly, so the same
+// scenario bodies can validate the upcoming WebSocket transport for
+// behavioral parity: a WebSocket Connector is added to transports() and every
+// test runs against both wires without being rewritten.
+//
+// Run with: make test-transport (or `go test -tags integration ./...`).
+package transport

--- a/gateway/integration/transport/guardrail_admission_test.go
+++ b/gateway/integration/transport/guardrail_admission_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestGuardedConnectionRefusedWithoutProvider is the guard for the guardrails
+// fix in getGuardRailsRulesForConnection: the fix makes a connection with ZERO
+// rules open normally (proven by TestPGProtocolRoundTrip), and this test proves
+// the other, security-critical half — a connection that DOES have real
+// guardrail rules is still fail-closed at session-open when no Presidio provider
+// is configured (#1573 / DEP-48).
+//
+// It binds an explicit guardrail rule to the connection (rather than relying on
+// the shared org's default security-pack, which another test may have cleared),
+// so it is order-independent. The refusal happens gateway-side before the agent
+// proxy runs, so this test needs no enterprise libhoop and runs on the OSS stub.
+func TestGuardedConnectionRefusedWithoutProvider(t *testing.T) {
+	c := transports()[0] // gateway-side admission; wire-agnostic, gRPC suffices
+
+	connName := uniqueName("guarded")
+	agentID, dsn := createAgent(t, uniqueName("agent"))
+	postPGConnection(t, connName, agentID)
+	createGuardrailForConnection(t, uniqueName("gr"), connectionID(t, connName))
+	startAgent(t, c, dsn)
+	waitConnectionOnline(t, connName)
+
+	cli, err := c.DialClient(context.Background(), ClientDialConfig{
+		Token:          adminToken(t),
+		ConnectionName: connName,
+		Verb:           pb.ClientVerbConnect,
+	})
+	if err != nil {
+		t.Fatalf("DialClient: %v", err)
+	}
+	defer cli.Close()
+
+	if err := cli.Send(&pb.Packet{
+		Type: pbagent.SessionOpen,
+		Spec: map[string][]byte{pb.SpecGatewaySessionID: []byte(uuid.NewString())},
+	}); err != nil {
+		t.Fatalf("send SessionOpen: %v", err)
+	}
+
+	// The guarded session must be refused at open time (DEP-48): the gateway
+	// terminates the Connect stream with FailedPrecondition before the agent
+	// ever opens the upstream. Receiving SessionOpenOK instead would mean the
+	// guardrails fix regressed and unguarded a guarded connection.
+	pkt, err := recvUntil(cli, 15*time.Second, pbclient.SessionOpenOK)
+	if err == nil {
+		t.Fatalf("guarded connection opened (got %s) without a Presidio provider; DEP-48 protection regressed", pkt.Type)
+	}
+	if code := status.Code(err); code != codes.FailedPrecondition {
+		t.Fatalf("refusal error code = %v, want FailedPrecondition (err=%v)", code, err)
+	}
+	if !strings.Contains(err.Error(), "Presidio") {
+		t.Fatalf("expected a Presidio/guardrail refusal, got: %v", err)
+	}
+}

--- a/gateway/integration/transport/healthcheck_test.go
+++ b/gateway/integration/transport/healthcheck_test.go
@@ -1,0 +1,31 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pb "github.com/hoophq/hoop/common/proto"
+)
+
+// TestHealthCheck verifies the unary HealthCheck RPC answers on every wire.
+// It is the simplest parity anchor: the WebSocket transport must return the
+// same "OK" status through the same interceptor stack.
+func TestHealthCheck(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			resp, err := c.HealthCheck(ctx, &pb.HealthCheckRequest{})
+			if err != nil {
+				t.Fatalf("HealthCheck: %v", err)
+			}
+			if resp.Status != "OK" {
+				t.Fatalf("HealthCheck: status = %q, want %q", resp.Status, "OK")
+			}
+		})
+	}
+}

--- a/gateway/integration/transport/pgwire_test.go
+++ b/gateway/integration/transport/pgwire_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+package transport
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+)
+
+// Minimal PostgreSQL v3 wire-protocol helpers, sufficient to drive one
+// authenticated query through the agent's transparent PG proxy. The proxy
+// terminates the client-side auth and authenticates upstream itself using the
+// connection's stored credentials, so the client here never performs SCRAM —
+// it sends an SSLRequest + StartupMessage and then simple queries.
+//
+// These are intentionally duplicated (not imported from agent/integration)
+// to keep this suite self-contained and free of the agent suite's container
+// dependencies; the wire format is stable and tiny.
+const (
+	pgProtocolVersion3 = 196608
+	pgProtocolSSL      = 80877103
+)
+
+func pgSSLRequest() []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint32(buf[0:4], 8)
+	binary.BigEndian.PutUint32(buf[4:8], pgProtocolSSL)
+	return buf
+}
+
+func pgStartupMessage(user, database string) []byte {
+	var params bytes.Buffer
+	params.WriteString("user")
+	params.WriteByte(0)
+	params.WriteString(user)
+	params.WriteByte(0)
+	params.WriteString("database")
+	params.WriteByte(0)
+	params.WriteString(database)
+	params.WriteByte(0)
+	params.WriteByte(0) // terminator
+
+	length := 4 + 4 + params.Len()
+	buf := make([]byte, length)
+	binary.BigEndian.PutUint32(buf[0:4], uint32(length))
+	binary.BigEndian.PutUint32(buf[4:8], pgProtocolVersion3)
+	copy(buf[8:], params.Bytes())
+	return buf
+}
+
+func pgSimpleQuery(sql string) []byte {
+	q := append([]byte(sql), 0)
+	total := 4 + len(q)
+	buf := make([]byte, 1+total)
+	buf[0] = 'Q'
+	binary.BigEndian.PutUint32(buf[1:5], uint32(total))
+	copy(buf[5:], q)
+	return buf
+}
+
+type pgMessage struct {
+	Type    byte
+	Payload []byte
+}
+
+// parsePGMessages splits a payload into tagged PG messages. A lone SSL
+// negotiation reply ('N'/'S', 1 byte) parses to zero messages because there
+// is no length prefix behind it, which is exactly what callers want: they
+// scan for 'Z'/'D' and ignore the negotiation byte.
+func parsePGMessages(data []byte) []pgMessage {
+	var msgs []pgMessage
+	r := bytes.NewReader(data)
+	for r.Len() > 0 {
+		typ, err := r.ReadByte()
+		if err != nil {
+			break
+		}
+		if r.Len() < 4 {
+			break
+		}
+		var lenBuf [4]byte
+		if _, err := r.Read(lenBuf[:]); err != nil {
+			break
+		}
+		frameLen := int(binary.BigEndian.Uint32(lenBuf[:])) - 4
+		if frameLen < 0 || r.Len() < frameLen {
+			break
+		}
+		frame := make([]byte, frameLen)
+		if _, err := r.Read(frame); err != nil {
+			break
+		}
+		msgs = append(msgs, pgMessage{Type: typ, Payload: frame})
+	}
+	return msgs
+}
+
+// dataRowValues decodes a DataRow ('D') message into its column values.
+func dataRowValues(m pgMessage) [][]byte {
+	if m.Type != 'D' {
+		return nil
+	}
+	r := bytes.NewReader(m.Payload)
+	var numCols int16
+	if err := binary.Read(r, binary.BigEndian, &numCols); err != nil {
+		return nil
+	}
+	vals := make([][]byte, 0, numCols)
+	for i := 0; i < int(numCols); i++ {
+		var colLen int32
+		if err := binary.Read(r, binary.BigEndian, &colLen); err != nil {
+			break
+		}
+		if colLen == -1 {
+			vals = append(vals, nil)
+			continue
+		}
+		val := make([]byte, colLen)
+		if _, err := r.Read(val); err != nil {
+			break
+		}
+		vals = append(vals, val)
+	}
+	return vals
+}
+
+// pgWritePacket wraps raw PG bytes in the agent-bound PGConnectionWrite packet,
+// carrying the session id and a client connection id the way a real client
+// proxy does.
+func pgWritePacket(sid, connID string, payload []byte) *pb.Packet {
+	return &pb.Packet{
+		Type:    pbagent.PGConnectionWrite,
+		Payload: payload,
+		Spec: map[string][]byte{
+			pb.SpecGatewaySessionID:   []byte(sid),
+			pb.SpecClientConnectionID: []byte(connID),
+		},
+	}
+}

--- a/gateway/integration/transport/preconnect_test.go
+++ b/gateway/integration/transport/preconnect_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pb "github.com/hoophq/hoop/common/proto"
+)
+
+// TestPreConnectBackoff verifies that an agent with no pending client requests
+// is told to back off. This is the steady-state answer the agent's reconnect
+// loop polls against.
+func TestPreConnectBackoff(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			_, dsn := createAgent(t, uniqueName("agent"))
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			resp, err := c.PreConnect(ctx, dsn, &pb.PreConnectRequest{})
+			if err != nil {
+				t.Fatalf("PreConnect: %v", err)
+			}
+			if resp.Status != pb.PreConnectStatusBackoffType {
+				t.Fatalf("PreConnect status = %q, want %q", resp.Status, pb.PreConnectStatusBackoffType)
+			}
+		})
+	}
+}
+
+// TestPreConnectConnectWhenClientWaiting verifies the coordination contract:
+// when a client is blocked waiting for an offline agent's connection, the
+// agent's next PreConnect returns CONNECT so it knows to open a Connect stream.
+// This exercises PreConnect together with the connection-request store that
+// links client dials to agent wake-ups.
+func TestPreConnectConnectWhenClientWaiting(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			connName := uniqueName("conn")
+			agentID, dsn := createAgent(t, uniqueName("agent"))
+			createPGConnection(t, connName, agentID)
+
+			// Dial as a client while the agent is offline; the gateway parks the
+			// request waiting for the agent, which is what flips PreConnect to
+			// CONNECT. Keep the stream open for the duration of the test.
+			clientCtx, cancelClient := context.WithCancel(context.Background())
+			defer cancelClient()
+			dialed := make(chan error, 1)
+			go func() {
+				cli, err := c.DialClient(context.Background(), ClientDialConfig{
+					Token:          adminToken(t),
+					ConnectionName: connName,
+					Verb:           pb.ClientVerbConnect,
+				})
+				dialed <- err
+				if err != nil {
+					return
+				}
+				defer cli.Close()
+				// Hold the stream open until the test finishes; drain packets so
+				// the parked request stays registered.
+				for {
+					if _, err := cli.Recv(); err != nil {
+						return
+					}
+					select {
+					case <-clientCtx.Done():
+						return
+					default:
+					}
+				}
+			}()
+
+			// Fail with a precise diagnostic if the client could not even dial,
+			// rather than burning the whole timeout and reporting "never CONNECT".
+			select {
+			case err := <-dialed:
+				if err != nil {
+					t.Fatalf("client dial: %v", err)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("client dial did not complete")
+			}
+
+			// The parked request registers shortly after the dial; poll
+			// PreConnect until it observes it.
+			deadline := time.Now().Add(12 * time.Second)
+			for time.Now().Before(deadline) {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				resp, err := c.PreConnect(ctx, dsn, &pb.PreConnectRequest{})
+				cancel()
+				if err != nil {
+					t.Fatalf("PreConnect: %v", err)
+				}
+				if resp.Status == pb.PreConnectStatusConnectType {
+					return
+				}
+				time.Sleep(200 * time.Millisecond)
+			}
+			t.Fatal("PreConnect never returned CONNECT while a client was waiting")
+		})
+	}
+}

--- a/gateway/integration/transport/reconnect_test.go
+++ b/gateway/integration/transport/reconnect_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+)
+
+// TestAgentReconnect verifies the transport's reconnect behavior end to end:
+// an agent connects (connection goes online), the stream drops (connection
+// goes offline), and a fresh Connect brings it back online. This is the state
+// machine the agent's exponential-backoff reconnect loop drives in production,
+// and it must behave identically on any wire.
+func TestAgentReconnect(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			connName := uniqueName("conn")
+			agentID, dsn := createAgent(t, uniqueName("agent"))
+			createPGConnection(t, connName, agentID)
+
+			// First connection.
+			first, err := c.DialAgent(context.Background(), dsn)
+			if err != nil {
+				t.Fatalf("DialAgent(first): %v", err)
+			}
+			if _, err := recvUntil(first, 10*time.Second, pbagent.GatewayConnectOK); err != nil {
+				t.Fatalf("first handshake: %v", err)
+			}
+			waitConnectionStatus(t, connName, "online")
+
+			// Drop the stream; the gateway must observe the disconnect and mark
+			// the connection offline.
+			first.Close()
+			waitConnectionStatus(t, connName, "offline")
+
+			// Reconnect with the same identity; the connection recovers.
+			second, err := c.DialAgent(context.Background(), dsn)
+			if err != nil {
+				t.Fatalf("DialAgent(second): %v", err)
+			}
+			defer second.Close()
+			if _, err := recvUntil(second, 10*time.Second, pbagent.GatewayConnectOK); err != nil {
+				t.Fatalf("second handshake: %v", err)
+			}
+			waitConnectionStatus(t, connName, "online")
+		})
+	}
+}

--- a/gateway/integration/transport/roundtrip_pg_test.go
+++ b/gateway/integration/transport/roundtrip_pg_test.go
@@ -1,0 +1,246 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/integration/testutil"
+)
+
+// TestPGProtocolRoundTrip is the end-to-end protocol round-trip: a real agent
+// controller connects over the transport, a client opens a session and runs
+// `SELECT 1` through the agent's transparent PostgreSQL proxy to a real
+// database, and the row comes back over the same wire. It exercises the full
+// interceptor chain (sessionuuid → auth → tracing → accessrequest), the plugin
+// chain (PluginExecOnReceive), bidirectional packet streaming, and one
+// protocol round-trip — the DEP-39 acceptance path.
+func TestPGProtocolRoundTrip(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			connName := uniqueName("pgconn")
+			agentID, dsn := createAgent(t, uniqueName("agent"))
+			createPGConnection(t, connName, agentID)
+			startAgent(t, c, dsn)
+			waitConnectionOnline(t, connName)
+
+			cli, err := c.DialClient(context.Background(), ClientDialConfig{
+				Token:          adminToken(t),
+				ConnectionName: connName,
+				Verb:           pb.ClientVerbConnect,
+			})
+			if err != nil {
+				t.Fatalf("DialClient: %v", err)
+			}
+
+			// pgReader owns cli's lifecycle (see its doc); do not also close cli.
+			r := newPGReader(cli)
+			defer r.close()
+
+			// Open the session. The gateway assigns the real SID (overwriting
+			// whatever we send) and enriches the packet with the connection's
+			// credentials before forwarding to the agent.
+			sid := uuid.NewString()
+			if err := cli.Send(&pb.Packet{
+				Type: pbagent.SessionOpen,
+				Spec: map[string][]byte{pb.SpecGatewaySessionID: []byte(sid)},
+			}); err != nil {
+				t.Fatalf("send SessionOpen: %v", err)
+			}
+			r.waitFor(t, pbclient.SessionOpenOK, 20*time.Second)
+
+			// PG handshake: SSLRequest + StartupMessage in one write. The agent's
+			// proxy authenticates upstream with the connection's stored creds and
+			// relays ReadyForQuery back.
+			const connID = "1"
+			handshake := append(pgSSLRequest(), pgStartupMessage(gw.Postgres.User, gw.Postgres.Database)...)
+			if err := cli.Send(pgWritePacket(sid, connID, handshake)); err != nil {
+				t.Fatalf("send PG handshake: %v", err)
+			}
+			r.readUntilReady(t, 20*time.Second)
+
+			// Run the query and read the result set.
+			if err := cli.Send(pgWritePacket(sid, connID, pgSimpleQuery("SELECT 1"))); err != nil {
+				t.Fatalf("send PG query: %v", err)
+			}
+			rows := r.readUntilReady(t, 20*time.Second)
+
+			if !containsValue(rows, "1") {
+				t.Fatalf("SELECT 1 round-trip: expected a row with value \"1\", got %v", rowsToStrings(rows))
+			}
+
+			// The whole session only works because the sessionuuid interceptor
+			// injected a SID that keyed the proxy stream and plugin context; the
+			// audit plugin then persisted a session under it. Assert that record
+			// exists as a direct check of both.
+			assertSessionRecorded(t)
+		})
+	}
+}
+
+// assertSessionRecorded verifies at least one session was persisted with a
+// valid UUID id — evidence the sessionuuid interceptor injected an id and the
+// audit plugin wrote the session row.
+func assertSessionRecorded(t *testing.T) {
+	t.Helper()
+	resp := gw.HTTP.Get(t, "/sessions", adminToken(t))
+	defer resp.Body.Close()
+	testutil.RequireStatus(t, resp, 200)
+
+	var list openapi.SessionList
+	testutil.DecodeJSON(t, resp, &list)
+	if list.Total < 1 || len(list.Items) == 0 {
+		t.Fatal("no sessions recorded; sessionuuid/audit did not persist the client session")
+	}
+	if _, err := uuid.Parse(list.Items[0].ID); err != nil {
+		t.Fatalf("recorded session id %q is not a valid UUID: %v", list.Items[0].ID, err)
+	}
+}
+
+// --- PG stream reader ----------------------------------------------------
+
+// pgReader owns a single background reader goroutine over a client transport,
+// feeding received packets to callers via a channel. It exists because the
+// round-trip reads the stream in several phases (SessionOpenOK, ReadyForQuery,
+// query result) and a single reader avoids racing multiple goroutines on one
+// stream. The reader owns the transport's lifecycle: close() both signals the
+// goroutine to stop and closes the transport, which unblocks the in-flight
+// Recv so the goroutine always exits (no leak). Callers therefore defer only
+// r.close(), not cli.Close().
+type pgReader struct {
+	cli       pb.ClientTransport
+	pkts      chan *pb.Packet
+	errc      chan error
+	stop      chan struct{}
+	closeOnce sync.Once
+}
+
+func newPGReader(cli pb.ClientTransport) *pgReader {
+	r := &pgReader{
+		cli:  cli,
+		pkts: make(chan *pb.Packet, 64),
+		errc: make(chan error, 1),
+		stop: make(chan struct{}),
+	}
+	go func() {
+		for {
+			pkt, err := r.cli.Recv()
+			if err != nil {
+				select {
+				case r.errc <- err:
+				case <-r.stop:
+				}
+				return
+			}
+			select {
+			case r.pkts <- pkt:
+			case <-r.stop:
+				return
+			}
+		}
+	}()
+	return r
+}
+
+func (r *pgReader) close() {
+	r.closeOnce.Do(func() {
+		close(r.stop)
+		_, _ = r.cli.Close()
+	})
+}
+
+// ossLibhoopMarker is the error the open-source _libhoop proxy stub returns
+// for every protocol. The real protocol proxy lives in the enterprise libhoop
+// (checked out in the integration-test CI job); when running against the stub
+// there is no way to complete a real PG exchange, so the round-trip skips
+// rather than fails — the same OSS/enterprise split the agent suite relies on.
+const ossLibhoopMarker = "missing protocol hoop library"
+
+// waitFor blocks until a packet of the given type arrives.
+func (r *pgReader) waitFor(t *testing.T, packetType string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case pkt := <-r.pkts:
+			if pkt.Type == packetType {
+				return
+			}
+			if pkt.Type == pbclient.SessionClose {
+				if strings.Contains(string(pkt.Payload), ossLibhoopMarker) {
+					t.Skip("PG round-trip requires the enterprise libhoop protocol proxy; skipping on the OSS stub")
+				}
+				t.Fatalf("unexpected SessionClose waiting for %s: %s", packetType, string(pkt.Payload))
+			}
+		case err := <-r.errc:
+			t.Fatalf("stream error waiting for %s: %v", packetType, err)
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s after %v", packetType, timeout)
+		}
+	}
+}
+
+// readUntilReady consumes PGConnectionWrite packets until ReadyForQuery ('Z'),
+// returning the first-column value of every DataRow seen along the way.
+func (r *pgReader) readUntilReady(t *testing.T, timeout time.Duration) [][]byte {
+	t.Helper()
+	var rows [][]byte
+	deadline := time.After(timeout)
+	for {
+		select {
+		case pkt := <-r.pkts:
+			if pkt.Type == pbclient.SessionClose {
+				if strings.Contains(string(pkt.Payload), ossLibhoopMarker) {
+					t.Skip("PG round-trip requires the enterprise libhoop protocol proxy; skipping on the OSS stub")
+				}
+				t.Fatalf("unexpected SessionClose during PG exchange: %s", string(pkt.Payload))
+			}
+			if pkt.Type != pbclient.PGConnectionWrite {
+				continue
+			}
+			for _, m := range parsePGMessages(pkt.Payload) {
+				switch m.Type {
+				case 'D':
+					if vals := dataRowValues(m); len(vals) > 0 {
+						rows = append(rows, vals[0])
+					}
+				case 'E':
+					t.Fatalf("postgres ErrorResponse during PG exchange: %q", string(m.Payload))
+				case 'Z':
+					return rows
+				}
+			}
+		case err := <-r.errc:
+			t.Fatalf("stream error during PG exchange: %v", err)
+		case <-deadline:
+			t.Fatalf("timed out during PG exchange after %v", timeout)
+		}
+	}
+}
+
+func containsValue(rows [][]byte, want string) bool {
+	for _, r := range rows {
+		if string(r) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func rowsToStrings(rows [][]byte) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = string(r)
+	}
+	return out
+}

--- a/gateway/integration/transport/setup_test.go
+++ b/gateway/integration/transport/setup_test.go
@@ -1,0 +1,255 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hoophq/hoop/agent/config"
+	"github.com/hoophq/hoop/agent/controller"
+	"github.com/hoophq/hoop/common/clientconfig"
+	"github.com/hoophq/hoop/common/dsnkeys"
+	pb "github.com/hoophq/hoop/common/proto"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/integration/testutil"
+	"github.com/hoophq/hoop/gateway/models"
+	"gorm.io/gorm"
+)
+
+// gw is the shared gateway under test, booted once in TestMain with the full
+// transport stack (plugins + gRPC) plus the HTTP API used for faithful,
+// API-driven bootstrap of users, agents and connections.
+var gw *testutil.Gateway
+
+// TestMain boots the gateway once for the whole package. The transport suite
+// needs three layers: the HTTP API (to register the admin user and create
+// connections the way an operator would), the plugin chain (client sessions
+// flow through PluginExecOnReceive), and the gRPC transport server (the system
+// under test).
+func TestMain(m *testing.M) {
+	code, err := runMain(m)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "transport harness setup failed: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(code)
+}
+
+func runMain(m *testing.M) (int, error) {
+	g, err := testutil.StartGateway(context.Background(), testutil.GatewayOptions{
+		WithHTTP:    true,
+		WithPlugins: true,
+		WithGRPC:    true,
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer g.Close()
+	gw = g
+	return m.Run(), nil
+}
+
+// clearOrgGuardrails removes the org's guardrail rules and their associations.
+//
+// The default rulepacks migration seeds per-org "Security Pack" guardrails that
+// auto-attach to database connections by attribute (e.g. the PostgreSQL
+// Security Pack), and connection creation re-materializes that association. Since
+// #1573 the gateway fail-closes any guarded session when no Presidio provider is
+// configured — and this suite runs no Presidio (guardrail enforcement is
+// agent-side middleware, orthogonal to transport parity). Callers invoke this
+// after creating a connection so the session under test exercises the wire, not
+// guardrail admission. Guardrail behavior is covered by the smoke suite and unit
+// tests, not here.
+func clearOrgGuardrails(t *testing.T) {
+	t.Helper()
+	err := models.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(`DELETE FROM private.guardrail_rules_connections
+			WHERE rule_id IN (SELECT id FROM private.guardrail_rules WHERE org_id = ?)`, gw.OrgID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`DELETE FROM private.guardrail_rules_attributes WHERE org_id = ?`, gw.OrgID).Error; err != nil {
+			return err
+		}
+		return tx.Exec(`DELETE FROM private.guardrail_rules WHERE org_id = ?`, gw.OrgID).Error
+	})
+	if err != nil {
+		t.Fatalf("clearOrgGuardrails: %v", err)
+	}
+}
+
+// --- shared identities ---------------------------------------------------
+
+var (
+	adminOnce sync.Once
+	adminTok  string
+)
+
+// adminToken registers the default org's first (admin) user on first call and
+// returns its JWT, reused across the suite. Registration can only happen once,
+// so it is guarded by a sync.Once.
+func adminToken(t *testing.T) string {
+	t.Helper()
+	adminOnce.Do(func() { adminTok = testutil.RegisterFirstUser(t, gw.HTTP) })
+	return adminTok
+}
+
+// --- bootstrap helpers ---------------------------------------------------
+
+// uniqueName returns a collision-free identifier for per-test resources.
+func uniqueName(prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, uuid.NewString()[:8])
+}
+
+// createAgent registers a standard-mode agent directly in the model layer and
+// returns its id plus a DSN token pointing at the harness gRPC address. The
+// DSN is what the agent presents to the auth interceptor.
+func createAgent(t *testing.T, name string) (agentID, dsn string) {
+	t.Helper()
+	secret := "itest-secret-" + name
+	keyHash := fmt.Sprintf("%x", sha256.Sum256([]byte(secret)))
+	if err := models.CreateAgent(gw.OrgID, name, pb.AgentModeStandardType, keyHash); err != nil {
+		t.Fatalf("createAgent: %v", err)
+	}
+	ag, err := models.GetAgentByNameOrID(gw.OrgID, name)
+	if err != nil {
+		t.Fatalf("createAgent: lookup %q: %v", name, err)
+	}
+	dsn, err = dsnkeys.NewString("grpc://"+gw.GRPCAddr, name, secret, pb.AgentModeStandardType)
+	if err != nil {
+		t.Fatalf("createAgent: build dsn: %v", err)
+	}
+	return ag.ID, dsn
+}
+
+// postPGConnection creates a postgres connection via the HTTP API (the faithful
+// operator path), pointed at the harness Postgres container so the agent proxies
+// real traffic to a real database. It performs no guardrail cleanup, so the
+// connection keeps the default security-pack guardrails the gateway attaches.
+func postPGConnection(t *testing.T, name, agentID string) {
+	t.Helper()
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	body := openapi.Connection{
+		Name:    name,
+		Type:    "database",
+		SubType: "postgres",
+		AgentId: agentID,
+		Command: []string{},
+		Secrets: map[string]any{
+			"envvar:HOST":    b64(gw.Postgres.Host),
+			"envvar:PORT":    b64(gw.Postgres.Port),
+			"envvar:USER":    b64(gw.Postgres.User),
+			"envvar:PASS":    b64(gw.Postgres.Password),
+			"envvar:DB":      b64(gw.Postgres.Database),
+			"envvar:SSLMODE": b64("disable"),
+		},
+		AccessModeRunbooks: "enabled",
+		AccessModeExec:     "enabled",
+		AccessModeConnect:  "enabled",
+		AccessSchema:       "disabled",
+	}
+	resp := gw.HTTP.Post(t, "/connections", adminToken(t), body)
+	defer resp.Body.Close()
+	testutil.RequireStatus(t, resp, 201)
+}
+
+// createPGConnection creates a postgres connection and strips the default
+// security-pack guardrails the gateway auto-attaches, so a session on it is not
+// fail-closed on a missing Presidio provider (see clearOrgGuardrails). Use this
+// for tests that need a session to actually open.
+func createPGConnection(t *testing.T, name, agentID string) {
+	t.Helper()
+	postPGConnection(t, name, agentID)
+	clearOrgGuardrails(t)
+}
+
+// connectionID looks up a connection's UUID via the API.
+func connectionID(t *testing.T, name string) string {
+	t.Helper()
+	resp := gw.HTTP.Get(t, "/connections/"+name, adminToken(t))
+	defer resp.Body.Close()
+	testutil.RequireStatus(t, resp, 200)
+	var conn openapi.Connection
+	testutil.DecodeJSON(t, resp, &conn)
+	if conn.ID == "" {
+		t.Fatalf("connectionID: %q has no id", name)
+	}
+	return conn.ID
+}
+
+// createGuardrailForConnection creates a guardrail rule bound to the given
+// connection via the API. Used to make a connection deterministically guarded
+// regardless of the shared org's default-rulepack state.
+func createGuardrailForConnection(t *testing.T, name, connectionID string) {
+	t.Helper()
+	body := openapi.GuardRailRuleRequest{
+		Name: name,
+		Input: map[string]any{
+			"rules": []map[string]any{
+				{"type": "deny_words_list", "words": []string{"SELECT"}, "pattern_regex": ""},
+			},
+		},
+		Output:        map[string]any{"rules": []map[string]any{}},
+		ConnectionIDs: []string{connectionID},
+	}
+	resp := gw.HTTP.Post(t, "/guardrails", adminToken(t), body)
+	defer resp.Body.Close()
+	testutil.RequireStatus(t, resp, 201)
+}
+
+// startAgent dials the gateway as the given agent and runs a real agent
+// controller against the stream, exactly as the production agent does. It
+// registers a t.Cleanup that tears the controller (and its stream) down.
+func startAgent(t *testing.T, c Connector, dsn string) {
+	t.Helper()
+	client, err := c.DialAgent(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("startAgent: dial: %v", err)
+	}
+	cfg := &config.Config{
+		Name:      "itest-agent",
+		Type:      clientconfig.ModeDsn,
+		AgentMode: pb.AgentModeStandardType,
+		Token:     dsn,
+		URL:       gw.GRPCAddr,
+	}
+	ctrl := controller.New(client, cfg, nil)
+	go func() { _ = ctrl.Run() }()
+	t.Cleanup(func() { ctrl.Close(nil) })
+}
+
+// waitConnectionStatus polls the connections API until the named connection
+// reaches the wanted status ("online"/"offline"). It gives the coordination
+// between agent connect/disconnect and the gateway's status bookkeeping a
+// deterministic gate.
+func waitConnectionStatus(t *testing.T, name, want string) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		resp := gw.HTTP.Get(t, "/connections/"+name, adminToken(t))
+		var conn openapi.Connection
+		testutil.DecodeJSON(t, resp, &conn)
+		resp.Body.Close()
+		last = conn.Status
+		if conn.Status == want {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("waitConnectionStatus: %q never became %q (last=%q)", name, want, last)
+}
+
+// waitConnectionOnline is the common case of waitConnectionStatus.
+func waitConnectionOnline(t *testing.T, name string) {
+	t.Helper()
+	waitConnectionStatus(t, name, "online")
+}

--- a/gateway/transport/server.go
+++ b/gateway/transport/server.go
@@ -46,6 +46,33 @@ type (
 
 const listenAddr = "0.0.0.0:8010"
 
+// NewGRPCServer builds the transport gRPC server with the full production
+// interceptor chain (sessionuuid → auth → tracing, plus the unary auth
+// validator) and registers the transport service on it. It is the single
+// wiring shared by the production entrypoint (StartRPCServer) and the
+// integration harness, which serves it on an ephemeral listener — so both
+// exercise the identical chain and message-size limits. It does not listen,
+// serve, or install signal handlers; the caller owns the listener lifecycle.
+func (s *Server) NewGRPCServer() *grpc.Server {
+	grpcInterceptors := grpc.ChainStreamInterceptor(
+		sessionuuidinterceptor.New(),
+		authinterceptor.New(),
+		tracinginterceptor.New(s.AppConfig.ApiURL()),
+	)
+	opts := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(commongrpc.MaxRecvMsgSize),
+		grpcInterceptors,
+		authinterceptor.WithUnaryValidator(),
+	}
+	if s.TLSConfig != nil {
+		opts = append(opts, grpc.Creds(credentials.NewTLS(s.TLSConfig)))
+	}
+	grpcServer := grpc.NewServer(opts...)
+	pb.RegisterTransportServer(grpcServer, s)
+	log.Debugf("server transport created, tls=%v", s.TLSConfig != nil)
+	return grpcServer
+}
+
 func (s *Server) StartRPCServer() {
 	log.Debugf("starting gateway at %v", listenAddr)
 	listener, err := net.Listen("tcp", listenAddr)
@@ -54,30 +81,8 @@ func (s *Server) StartRPCServer() {
 		log.Fatal(err)
 	}
 
-	grpcInterceptors := grpc.ChainStreamInterceptor(
-		sessionuuidinterceptor.New(),
-		authinterceptor.New(),
-		tracinginterceptor.New(s.AppConfig.ApiURL()),
-	)
-	var grpcServer *grpc.Server
-	if s.TLSConfig != nil {
-		grpcServer = grpc.NewServer(
-			grpc.MaxRecvMsgSize(commongrpc.MaxRecvMsgSize),
-			grpc.Creds(credentials.NewTLS(s.TLSConfig)),
-			grpcInterceptors,
-			authinterceptor.WithUnaryValidator(),
-		)
-	}
-	if grpcServer == nil {
-		grpcServer = grpc.NewServer(
-			grpc.MaxRecvMsgSize(commongrpc.MaxRecvMsgSize),
-			grpcInterceptors,
-			authinterceptor.WithUnaryValidator(),
-		)
-	}
-	pb.RegisterTransportServer(grpcServer, s)
+	grpcServer := s.NewGRPCServer()
 	handleGracefulShutdown()
-	log.Debugf("server transport created, tls=%v", s.TLSConfig != nil)
 	if err := grpcServer.Serve(listener); err != nil {
 		sentry.CaptureException(err)
 		log.Fatalf("failed to serve: %v", err)


### PR DESCRIPTION
## What

Establishes an end-to-end integration test harness for the agent↔gateway transport (DEP-39), the regression baseline for the upcoming WebSocket transport migration. Also lands two bug fixes the harness surfaced.

### Harness (`gateway/integration/transport`)
Scenarios are written against a **wire-agnostic `Connector` seam** (defined over the Packet protocol / `pb.ClientTransport`), so the WebSocket transport can be validated for byte-for-byte parity later by adding a single `Connector` implementation to `transports()` — no scenario rewrites.

Coverage: `HealthCheck`; `PreConnect` (backoff + client-wait coordination); the agent `Connect` handshake; auth rejections (invalid DSN, duplicate agent, missing origin); reconnect (online→offline→online); guarded-session admission (DEP-48); and a real **PostgreSQL protocol round-trip** through a real agent controller to a real database.

The suite boots a full gateway in-process via a new shared `testutil.StartGateway` (Postgres testcontainer, migrations, plugin chain, gRPC on an ephemeral port) and drives it with a real `controller.Agent` and raw client streams over the actual wire.

### Refactors
- Extracted `transport.Server.NewGRPCServer` from `StartRPCServer` so the identical interceptor chain serves on an ephemeral listener. Production `StartRPCServer` is unchanged (same bind, signal handler, `log.Fatal`).
- Moved the smoke suite onto `testutil.StartGateway`, removing duplicated bootstrap.

### Bug fix (surfaced by the harness)
- **Audit middleware race**: `AuditMiddleware` read `*gin.Context` from a goroutine after `c.Next()`, racing outer middlewares' teardown writes. Fixed by snapshotting all fields synchronously before dispatch. No audit fields change.

> Note: the harness also surfaced the DEP-48 guardrails "empty rules treated as configured" bug. That fix landed separately as #1580 (rebased into this branch's base), so it is no longer part of this PR's diff. This PR still guards it end-to-end via `TestGuardedConnectionRefusedWithoutProvider` (real rules still fail closed) and `TestPGProtocolRoundTrip` (zero rules open).

## Testing
- `go build ./...`, `go vet -tags integration ./integration/...` clean.
- Transport suite **10/10 under `-race`** with enterprise libhoop (round-trip + guarded-refusal included); the PG round-trip skips gracefully on the OSS `_libhoop` stub.
- Smoke suite and `gateway/transport` + `gateway/api` unit tests green.

## CI / Make
Runs under `make test-integration` (the CI job that provisions enterprise libhoop, `-race`). Adds a `test-transport` convenience target; `test-gateway` kept smoke-only (non-recursive).

Refs DEP-39, DEP-48

Automated by MisterMal
