### PR TITLE
fix(gateway): do not require Presidio to enforce guardrails

### DIFF
--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -438,12 +438,13 @@ func (c Config) DlpProvider() string                   { return c.dlpProvider }
 func (c Config) DlpMode() string                       { return c.dlpMode }
 func (c Config) HasRedactCredentials() bool            { return c.hasRedactCredentials }
 
-// HasGuardrailProvider reports whether the server is configured with a DLP
-// provider capable of enforcing guardrails. Guardrails are evaluated exclusively
-// through MSPresidio, so this requires the mspresidio provider with both the
-// analyzer and anonymizer URLs configured. It is intentionally stricter than
-// HasRedactCredentials (which is also true for GCP), because GCP cannot enforce
-// guardrails.
+// HasGuardrailProvider reports whether the mspresidio provider is fully
+// configured (both analyzer and anonymizer URLs).
+//
+// NOTE: this is NOT used to gate guardrail enforcement. Guardrails are enforced
+// by the agent's built-in pattern-matching engine (see gateway/guardrails), not
+// by a DLP provider, so they do not require Presidio. Retained for informational
+// use; see the session-open admission logic in gateway/transport/client.go.
 func (c Config) HasGuardrailProvider() bool {
 	return c.dlpProvider == "mspresidio" && c.msPresidioAnalyzerURL != "" && c.msPresidioAnonymizerURL != ""
 }

--- a/gateway/integration/transport/guardrail_admission_test.go
+++ b/gateway/integration/transport/guardrail_admission_test.go
@@ -4,7 +4,6 @@ package transport
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,22 +12,20 @@ import (
 	pb "github.com/hoophq/hoop/common/proto"
 	pbagent "github.com/hoophq/hoop/common/proto/agent"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
-// TestGuardedConnectionRefusedWithoutProvider is the guard for the guardrails
-// fix in getGuardRailsRulesForConnection: the fix makes a connection with ZERO
-// rules open normally (proven by TestPGProtocolRoundTrip), and this test proves
-// the other, security-critical half — a connection that DOES have real
-// guardrail rules is still fail-closed at session-open when no Presidio provider
-// is configured (#1573 / DEP-48).
+// TestGuardedConnectionOpensWithoutProvider verifies the gateway admits a
+// session on a guarded connection even when no Presidio provider is configured.
+// Guardrails are enforced by the agent's built-in pattern-matching engine (see
+// gateway/guardrails), not by a DLP provider, so the earlier DEP-48 Presidio
+// gate was removed — it broke deployments that rely on that engine.
 //
-// It binds an explicit guardrail rule to the connection (rather than relying on
-// the shared org's default security-pack, which another test may have cleared),
-// so it is order-independent. The refusal happens gateway-side before the agent
-// proxy runs, so this test needs no enterprise libhoop and runs on the OSS stub.
-func TestGuardedConnectionRefusedWithoutProvider(t *testing.T) {
+// It binds an explicit guardrail rule to a supported (postgres) connection.
+// The admission decision is gateway-side; SessionOpenOK is sent by the agent
+// before any protocol proxy runs, so this needs no enterprise libhoop and runs
+// on the OSS stub. A FailedPrecondition here (the old behavior) would mean the
+// Presidio gate came back.
+func TestGuardedConnectionOpensWithoutProvider(t *testing.T) {
 	c := transports()[0] // gateway-side admission; wire-agnostic, gRPC suffices
 
 	connName := uniqueName("guarded")
@@ -55,18 +52,10 @@ func TestGuardedConnectionRefusedWithoutProvider(t *testing.T) {
 		t.Fatalf("send SessionOpen: %v", err)
 	}
 
-	// The guarded session must be refused at open time (DEP-48): the gateway
-	// terminates the Connect stream with FailedPrecondition before the agent
-	// ever opens the upstream. Receiving SessionOpenOK instead would mean the
-	// guardrails fix regressed and unguarded a guarded connection.
-	pkt, err := recvUntil(cli, 15*time.Second, pbclient.SessionOpenOK)
-	if err == nil {
-		t.Fatalf("guarded connection opened (got %s) without a Presidio provider; DEP-48 protection regressed", pkt.Type)
-	}
-	if code := status.Code(err); code != codes.FailedPrecondition {
-		t.Fatalf("refusal error code = %v, want FailedPrecondition (err=%v)", code, err)
-	}
-	if !strings.Contains(err.Error(), "Presidio") {
-		t.Fatalf("expected a Presidio/guardrail refusal, got: %v", err)
+	// The guarded session is admitted: the agent replies SessionOpenOK. If the
+	// Presidio gate were still present the gateway would instead terminate the
+	// stream with FailedPrecondition, which recvUntil surfaces as an error.
+	if _, err := recvUntil(cli, 15*time.Second, pbclient.SessionOpenOK); err != nil {
+		t.Fatalf("guarded connection was not admitted without a Presidio provider: %v", err)
 	}
 }

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -518,12 +518,16 @@ func (s *Server) processClientPacket(stream *streamclient.ProxyStream, pkt *pb.P
 				return err
 			}
 
-			// Fail closed: guardrails are enforced exclusively through Presidio and
-			// only for connection types whose agent proxy actually evaluates them.
-			// If a connection has guardrail rules but the server has no Presidio
-			// provider configured, OR the connection type cannot enforce guardrails,
-			// the request would run unguarded and blocked queries would pass through.
-			// Refuse the session at open time with a clear error instead (DEP-48).
+			// Fail closed for connection types whose agent proxy does not
+			// evaluate guardrails (mysql, mssql, mongodb): a guarded session of
+			// those types would run unguarded, so refuse it at session-open
+			// (DEP-48).
+			//
+			// Guardrails are enforced by the agent's built-in pattern-matching
+			// engine (deny-word / regex — see gateway/guardrails), NOT by a DLP
+			// provider, so Presidio is NOT required to enforce them. The earlier
+			// Presidio requirement here refused sessions on deployments that rely
+			// on that built-in engine and is intentionally not enforced.
 			//
 			// ClientVerbPlainExec is intentionally exempt (the enclosing branch):
 			// plain-exec is a gateway-internal verb gated by a per-process secret in
@@ -535,12 +539,6 @@ func (s *Server) processClientPacket(stream *streamclient.ProxyStream, pkt *pb.P
 			// for plain-exec sessions.
 			if len(guardRailRulesJsonData) > 0 {
 				logCtx := log.With("sid", pctx.SID, "connection", pctx.ConnectionName)
-				if !s.AppConfig.HasGuardrailProvider() {
-					logCtx.Warnf("refusing session: connection has guardrail rules but no Presidio provider is configured to enforce them")
-					return status.Errorf(codes.FailedPrecondition,
-						"this connection has guardrails configured, but the server has no Presidio (data masking) provider configured to enforce them; "+
-							"contact your administrator to configure Presidio")
-				}
 				if connType := pctx.ProtoConnectionType(); !connectionTypeSupportsGuardRails(connType) {
 					logCtx.Warnf("refusing session: connection type %q does not support guardrail enforcement", connType)
 					return status.Errorf(codes.FailedPrecondition,


### PR DESCRIPTION
Rolling back that check for now, since it doesnt work with Google DLP and Go Checks. 