### PR TITLE
fix(cli): use GetUrlScheme for determining URL scheme in Claude configure

### DIFF
--- a/client/cmd/claude.go
+++ b/client/cmd/claude.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/hoophq/hoop/client/cmd/styles"
+	cmdutils "github.com/hoophq/hoop/client/cmd/utils"
 	clientconfig "github.com/hoophq/hoop/client/config"
 	"github.com/hoophq/hoop/common/httpclient"
 	"github.com/hoophq/hoop/common/version"
@@ -49,7 +50,7 @@ func runClaudeConfigure(connectionName string) {
 		printErrorAndExit("%s", err.Error())
 	}
 
-	scheme := "http"
+	scheme := cmdutils.GetUrlScheme(config.ApiURL)
 	baseURL := fmt.Sprintf("%s://%s:%s", scheme, creds.Hostname, creds.Port)
 	proxyToken := creds.ProxyToken
 

--- a/client/cmd/utils/utils.go
+++ b/client/cmd/utils/utils.go
@@ -3,6 +3,7 @@ package cmdutils
 import (
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,4 +77,12 @@ func ParseEnvPerType(envPairs []string) (envVar map[string]string, err error) {
 		return nil, fmt.Errorf("invalid env vars, expected env=var. found=%v", invalidEnvs)
 	}
 	return envVar, nil
+}
+
+func GetUrlScheme(urlAddress string) string {
+	parsed, err := url.Parse(urlAddress)
+	if err != nil || parsed.Scheme == "" {
+		return "http"
+	}
+	return parsed.Scheme
 }


### PR DESCRIPTION
   > [!IMPORTANT]                                                                                                                    
   > Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:                                             
   > - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.                              
   > - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).                               
                                                                                                                                     
   ## 📝 Description                                                                                                                 
                                                                                                                                     
   The `hoop claude configure` command previously hardcoded the URL scheme to `http` when building the base URL for the Claude proxy 
 settings. This meant that gateways served over HTTPS produced an invalid `http://` base URL. This PR derives the scheme dynamically 
 from the configured `ApiURL`, so the generated Claude settings correctly use `https` (or `http`) to match the gateway.              
                                                                                                                                     
   ## 🔗 Related Issue                                                                                                               
                                                                                                                                     
   <!-- Link to the issue this PR addresses (if applicable) -->                                                                      
                                                                                                                                     
   ## 🚀 Type of Change                                                                                                              
                                                                                                                                     
   - [x] 🐛 Bug fix (non-breaking change which fixes an issue)                                                                       
   - [ ] ✨ New feature (non-breaking change which adds functionality)                                                               
   - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)                         
   - [ ] 📚 Documentation update                                                                                                     
   - [ ] 🎨 Style/UI update                                                                                                          
   - [ ] ♻️ Code refactor                                                                                                            
   - [ ] ⚡ Performance improvement                                                                                                  
   - [ ] ✅ Test update                                                                                                              
   - [ ] 🔧 Build configuration change                                                                                               
   - [ ] 🧹 Chore                                                                                                                    
                                                                                                                                     
   ## 📋 Changes Made                                                                                                                
                                                                                                                                     
   - Added a `GetUrlScheme` helper in `client/cmd/utils/utils.go` that parses a URL and returns its scheme, falling back to `http`   
 when the URL is empty or unparsable.                                                                                                
   - Updated `runClaudeConfigure` in `client/cmd/claude.go` to derive the base URL scheme from `config.ApiURL` via `GetUrlScheme`    
 instead of the hardcoded `"http"` value.                                                                                            
                                                                                                                                     
   ## 🧪 Testing                                                                                                                     
                                                                                                                                     
   Manually configured Claude against a gateway served over HTTPS and verified the generated base URL uses the `https` scheme; also  
 verified the `http` fallback still works for plain HTTP gateways and for empty/unparsable URLs.                                     
                                                                                                                                     
   ### Test Configuration:                                                                                                           
   - **Browser(s)**: Brave                                                                                                           
   - **OS**: macOS                                                                                                                   
                                                                                                                                     
   ### Tests performed:                                                                                                              
   - [x] Unit tests pass                                                                                                             
   - [x] Integration tests pass                                                                                                      
   - [x] Manual testing completed                                                                                                    
                                                                                                                                     
   ## 📸 Screenshots (if applicable)                                                                                                 
                                                                                                                                     
   <!-- Add screenshots to help explain your changes -->                                                                             
                                                                                                                                     
   ## ✅ Checklist                                                                                                                   
                                                                                                                                     
   - [x] My code follows the style guidelines of this project                                                                        
   - [x] I have performed a self-review of my own code                                                                               
   - [x] I have commented my code, particularly in hard-to-understand areas                                                          
   - [x] My changes generate no new warnings                                                                                         
   - [x] New and existing unit tests pass locally with my changes                                                                    
   - [x] I have checked my code and corrected any misspellings                                                                       
                                                                                                                                     
   ## 📄 Additional Notes                                                                                                            
                                                                                                                                    
                                                                                                                                     
   ---       