### PR TITLE
fix(docker): drop ghostscript/AGPL chain from agent images

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -22,7 +22,6 @@ RUN mkdir -p /app && \
     gnupg2 \
     net-tools \
     netcat-openbsd \
-    groff \
     jq \
     openssh-client \
     unzip \
@@ -38,6 +37,11 @@ RUN mkdir -p /app && \
     bzip2 \
     wget \
     redis-tools && \
+    # groff is only needed by `aws help` to render man pages to the terminal.
+    # Install it without Recommends: they pull ghostscript (AGPL), imagemagick,
+    # netpbm and psutils (GPL), which groff only uses for PostScript/PDF output
+    # that nothing in this image produces.
+    apt install -y --no-install-recommends groff && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 # https://github.com/nodejs/release-keys
@@ -139,7 +143,7 @@ RUN apt update -y && apt install -y \
     mongodb-org-tools=8.0.12 \
     default-mysql-client=1.1.0build1 \
     unixodbc-dev=2.3.12-1ubuntu0.24.04.1 \
-    postgresql-client-16=16.10-0ubuntu0.24.04.1 \
+    postgresql-client-16=16.14-0ubuntu0.24.04.1 \
     google-cloud-cli=$GCLOUD_VERSION \
     google-cloud-sdk-gke-gcloud-auth-plugin=$GCLOUD_GKE_AUTHN_PLUGIN_VERSION && \
     curl -fsSLO --compressed  https://github.com/microsoft/go-sqlcmd/releases/download/v1.8.2/sqlcmd-linux-$(dpkg --print-architecture).tar.bz2 && \

--- a/deploy/docker-compose/Dockerfile
+++ b/deploy/docker-compose/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update -y && \
     gnupg \
     gnupg2 \
     net-tools \
-    groff \
     jq \
     openssh-client \
     unzip \
@@ -24,6 +23,11 @@ RUN apt-get update -y && \
     less \
     gettext-base \
     lsb-release && \
+    # groff is only needed by `aws help` to render man pages to the terminal.
+    # Install it without Recommends: they pull ghostscript (AGPL), imagemagick,
+    # netpbm and psutils (GPL), which groff only uses for PostScript/PDF output
+    # that nothing in this image produces.
+    apt-get install -y --no-install-recommends groff && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 # kubectl / aws-cli / aws-session-manager


### PR DESCRIPTION
## Why

A customer license scan flagged ghostscript (**AGPL**) and its GPL dependency tree in our agent container image:

```
ghostscript, libgs10, libgs10-common, libgs-common, libgs10,
poppler-data, libwmflite-0.2-7, libjbig2dec0, fonts-urw-base35
```

None of it is used by hoop. Root cause (verified inside the published `hoophq/agent-tools` image): the **only** installed package depending on ghostscript is `groff`, which we install solely so `aws help` can render man pages. Ubuntu's `groff` *Recommends* ghostscript + imagemagick + netpbm + psutils, and apt installs Recommends by default. groff only uses them for PostScript/PDF output, which nothing in the image produces. The gateway image (`hoophq/hoop`) was checked and is clean.

## What

- Install `groff` with `--no-install-recommends` in `Dockerfile.tools` and `deploy/docker-compose/Dockerfile` — drops the entire AGPL/GPL chain while keeping `aws help` fully functional (groff's hard `Depends` are untouched).
- Bump `postgresql-client-16` pin `16.10 -> 16.14`: the old version was purged from the noble archive, so `Dockerfile.tools` no longer built from main at all.

## Verification

Full `docker build -f Dockerfile.tools` on this branch, then inside the image:
- `dpkg-query` shows **none** of the flagged packages
- `aws help` renders correctly through groff
- `psql` / `mongosh` / `mysql` / `sqlcmd` / `groff` all functional

## Follow-ups

- `hoophq/agent-tools` is built/published out-of-band — it needs a rebuild with a new tag and a `FROM` bump in `Dockerfile.dev` for this to reach `hoophq/hoopdev`.
- Reviewer suggestion (LOW): once agent-tools has a build pipeline, add an assertion that the flagged packages stay absent.

Automated by MisterMal