### PR TITLE
ci: PoC Trivy license scan on PR preview images

### DIFF
--- a/.github/workflows/pullrequest-release.yml
+++ b/.github/workflows/pullrequest-release.yml
@@ -727,3 +727,73 @@ jobs:
         run: |-
           gh pr comment ${{ github.event.pull_request.number }} -b "✅ Build Completed with Success, Version=${GIT_TAG}" || true
 
+
+  # PoC: scan the preview images for forbidden (AGPL-family) licenses and
+  # keep a single reconciled PR comment: created/updated when findings
+  # exist, updated to "resolved" when a later push fixes them. Non-blocking
+  # on purpose while we evaluate the tool; make the check step fail to turn
+  # it into a gate.
+  license-scan:
+    runs-on: ubuntu-latest
+    name: License Scan (Trivy)
+    # The preview images only exist for same-repo PRs (fork PRs cannot push
+    # to Docker Hub), and this guard also keeps the PAT away from any
+    # fork-triggered context.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    needs:
+      - docker-publish-hoopgateway-amd64
+      - docker-publish-hoopagent-amd64
+    steps:
+      - name: Scan preview images
+        run: |
+          mkdir -p /tmp/license-scan
+          for image in hoop hoopdev; do
+            ref="hoophq/${image}:${{ github.sha }}-amd64"
+            echo "scanning $ref"
+            docker run --rm \
+              -v /tmp/license-scan:/scan \
+              aquasec/trivy:0.72.0 image \
+              --scanners license \
+              --format json \
+              --quiet \
+              --output "/scan/${image}.json" \
+              "$ref"
+          done
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for forbidden licenses
+        id: check
+        run: |
+          python3 scripts/ci/check-forbidden-licenses.py \
+            --comment-out /tmp/license-scan/comment.json \
+            hoophq/hoop=/tmp/license-scan/hoop.json \
+            hoophq/hoopdev=/tmp/license-scan/hoopdev.json
+
+      - name: Reconcile PR comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |-
+          # Single sticky comment keyed by the marker: upsert on findings,
+          # update to "resolved" when a previous finding disappears, stay
+          # silent when the PR was never flagged.
+          marker='<!-- trivy-license-scan -->'
+          comment_id=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --paginate --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -1)
+
+          if [ "${{ steps.check.outputs.found }}" = "true" ]; then
+            if [ -n "$comment_id" ]; then
+              gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" \
+                --input /tmp/license-scan/comment.json
+            else
+              gh api -X POST "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+                --input /tmp/license-scan/comment.json
+            fi
+          elif [ -n "$comment_id" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" \
+              --input /tmp/license-scan/comment.json
+          fi

--- a/scripts/ci/check-forbidden-licenses.py
+++ b/scripts/ci/check-forbidden-licenses.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Check Trivy license-scan JSON reports for forbidden licenses.
+
+Reads one or more Trivy JSON reports (produced with `trivy image
+--scanners license --format json`) and looks for AGPL-family and SSPL
+licenses: the ones customer compliance scanners reject outright. Plain
+GPL is expected on an Ubuntu base (bash, coreutils, ...) and is
+deliberately not flagged.
+
+Outputs:
+- appends `found=true|false` to $GITHUB_OUTPUT (if set)
+- writes a GitHub comment payload (JSON, `{"body": ...}`) to the path
+  given by --comment-out: an alert with a findings table when forbidden
+  licenses are present, or a short "resolved" note when they are not.
+
+Usage:
+    check-forbidden-licenses.py --comment-out comment.json \
+        <image-name>=<trivy-report.json> [...]
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+FORBIDDEN = re.compile(r"\b(AGPL|SSPL)\b", re.IGNORECASE)
+MARKER = "<!-- trivy-license-scan -->"
+
+
+def md_cell(value: str) -> str:
+    """Neutralize markdown table metacharacters in untrusted metadata."""
+    return (value.replace("\\", "\\\\").replace("`", "\\`")
+            .replace("|", "\\|").replace("\n", " "))
+
+
+def scan_report(path: str) -> list[tuple[str, str]]:
+    with open(path) as fp:
+        report = json.load(fp)
+    return sorted({
+        (lic["PkgName"], lic["Name"])
+        for result in report.get("Results", [])
+        for lic in result.get("Licenses", [])
+        if FORBIDDEN.search(lic.get("Name", ""))
+    })
+
+
+def build_comment(findings: dict[str, list[tuple[str, str]]]) -> str:
+    if findings:
+        lines = [
+            MARKER,
+            "### :rotating_light: Forbidden licenses detected in preview images",
+            "",
+            "Trivy found AGPL/SSPL-licensed packages. These are rejected by",
+            "customer compliance scanners and must not ship in our images.",
+            "",
+            "| Image | Package | License |",
+            "|-------|---------|---------|",
+        ]
+        for image, hits in findings.items():
+            for pkg, lic in hits:
+                lines.append(
+                    f"| `{md_cell(image)}` | `{md_cell(pkg)}` | `{md_cell(lic)}` |")
+        lines += [
+            "",
+            "Most likely cause: a new apt package whose `Recommends` pulls",
+            "them in — install it with `--no-install-recommends` (see the",
+            "groff/ghostscript case in the Dockerfile.tools comments).",
+        ]
+    else:
+        lines = [
+            MARKER,
+            "### :white_check_mark: License scan resolved",
+            "",
+            "A previous push introduced AGPL/SSPL-licensed packages; the",
+            "latest preview images are clean.",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--comment-out", required=True,
+                        help="path to write the GitHub comment JSON payload")
+    parser.add_argument("reports", nargs="+", metavar="IMAGE=REPORT.json",
+                        help="image name and its Trivy JSON report path")
+    args = parser.parse_args()
+
+    findings: dict[str, list[tuple[str, str]]] = {}
+    for spec in args.reports:
+        image, sep, path = spec.partition("=")
+        if not sep or not image or not path:
+            parser.error(f"invalid report spec {spec!r}, expected IMAGE=PATH")
+        hits = scan_report(path)
+        if hits:
+            findings[image] = hits
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as out:
+            out.write(f"found={'true' if findings else 'false'}\n")
+
+    with open(args.comment_out, "w") as fp:
+        json.dump({"body": build_comment(findings)}, fp)
+
+    for image, hits in findings.items():
+        for pkg, lic in hits:
+            print(f"FORBIDDEN {image}: {pkg} ({lic})", file=sys.stderr)
+    print(f"forbidden licenses found: {'yes' if findings else 'no'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

A customer's compliance scanner recently flagged AGPL-licensed packages (ghostscript et al.) in our agent image (#1585). This PoC prevents a regression from shipping silently: every PR's preview images get license-scanned, and the PR gets flagged **before** release.

## What

New `license-scan` job in the Development Release workflow:

1. After the amd64 preview images are pushed, scans `hoophq/hoop:{sha}-amd64` and `hoophq/hoopdev:{sha}-amd64` with Trivy 0.72.0 (`--scanners license`), pulling straight from the registry.
2. `scripts/ci/check-forbidden-licenses.py` filters for **AGPL/SSPL only** — plain GPL is expected on an Ubuntu base (bash, coreutils...) and deliberately not flagged.
3. Sticky PR comment, reconciled: created/updated when findings appear, flipped to "resolved" when a later push fixes them, **never posted** on PRs that were never flagged.

Non-blocking for now (PoC) — making the check step fail on findings turns it into a gate later.

## Details

- Job gated to same-repo PRs (`head.repo.full_name == repository`): preview images don't exist for fork PRs, and it keeps the token away from fork-triggered contexts.
- Package/license names from image metadata are escaped before entering the comment markdown.
- Validated against real Trivy reports: the pre-#1585 `agent-tools` image produces exactly the ghostscript/AGPL table the customer's scanner saw; the fixed image produces `found=false`.
- This PR itself should demo the job (the check script lives outside the workflow's `paths-ignore`).

Automated by MisterMal