### PR TITLE
fix: update review URLs to sessions in exec and audit handlers

### DIFF
--- a/gateway/api/mcpserver/tools_exec.go
+++ b/gateway/api/mcpserver/tools_exec.go
@@ -208,7 +208,7 @@ func execHandler(ctx context.Context, _ *mcp.CallToolRequest, args execInput) (*
 		events.DeriveFromSessionStart(sc.OrgID, &newSession, conn)
 		return execResponseToEnvelope(&clientexec.Response{
 			HasReview:  true,
-			Output:     fmt.Sprintf("%s/reviews/%s", appconfig.Get().FullApiURL(), review.ID),
+			Output:     fmt.Sprintf("%s/sessions/%s", appconfig.Get().FullApiURL(), review.ID),
 			SessionID:  sessionID,
 			AIAnalysis: sessionapi.ToOpenApiSessionAIAnalysis(analyzeRes),
 		}, sessionID)

--- a/gateway/api/session/ai_decision.go
+++ b/gateway/api/session/ai_decision.go
@@ -115,7 +115,7 @@ func ApplyAIAnalysisDecision(
 
 		return AIDecisionReview, &clientexec.Response{
 			HasReview:  true,
-			Output:     fmt.Sprintf("%s/reviews/%s", appconfig.Get().FullApiURL(), review.ID),
+			Output:     fmt.Sprintf("%s/sessions/%s", appconfig.Get().FullApiURL(), review.ID),
 			SessionID:  session.ID,
 			AIAnalysis: ToOpenApiSessionAIAnalysis(analysis),
 		}, nil

--- a/gateway/transport/interceptors/accessrequest/accessrequest.go
+++ b/gateway/transport/interceptors/accessrequest/accessrequest.go
@@ -61,7 +61,7 @@ func getValidatedOneTimeReview(pctx plugintypes.Context) (bool, *plugintypes.Con
 			"status", otrev.Status).Info("one time review")
 
 		if !(otrev.Status == models.ReviewStatusApproved || otrev.Status == models.ReviewStatusProcessing) {
-			reviewURL := fmt.Sprintf("%s/reviews/%s", appconfig.Get().FullApiURL(), otrev.ID)
+			reviewURL := fmt.Sprintf("%s/sessions/%s", appconfig.Get().FullApiURL(), otrev.ID)
 			return false, &plugintypes.ConnectResponse{Context: nil, ClientPacket: &pb.Packet{
 				Type:    pbclient.SessionOpenWaitingApproval,
 				Payload: []byte(reviewURL),
@@ -170,13 +170,15 @@ func OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plugintypes.ConnectRe
 	}
 
 	// 2. check if there's an existing jit review for this connection, if yes validate and return it
-	resp, err = getValidatedJitReview(pctx)
-	if err != nil {
-		return nil, err
-	}
-	if resp != nil {
-		setSpecReview(pkt)
-		return resp, nil
+	if pctx.ClientVerb == pb.ClientVerbConnect {
+		resp, err = getValidatedJitReview(pctx)
+		if err != nil {
+			return nil, err
+		}
+		if resp != nil {
+			setSpecReview(pkt)
+			return resp, nil
+		}
 	}
 
 	// 3. if no existing review, create a new review
@@ -262,7 +264,7 @@ func OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plugintypes.ConnectRe
 
 	return &plugintypes.ConnectResponse{Context: nil, ClientPacket: &pb.Packet{
 		Type:    pbclient.SessionOpenWaitingApproval,
-		Payload: fmt.Appendf(nil, "%s/reviews/%s", appconfig.Get().FullApiURL(), newRev.ID),
+		Payload: fmt.Appendf(nil, "%s/sessions/%s", appconfig.Get().FullApiURL(), newRev.ID),
 		Spec:    map[string][]byte{pb.SpecGatewaySessionID: []byte(pctx.SID)},
 	}}, nil
 }

--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -238,7 +238,7 @@ func (p *auditPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 					pkt.Spec[pb.SpecHasReviewKey] = []byte("true")
 					return &plugintypes.ConnectResponse{Context: nil, ClientPacket: &pb.Packet{
 						Type:    pbclient.SessionOpenWaitingApproval,
-						Payload: fmt.Appendf(nil, "%s/reviews/%s", appconfig.Get().FullApiURL(), review.ID),
+						Payload: fmt.Appendf(nil, "%s/sessions/%s", appconfig.Get().FullApiURL(), review.ID),
 						Spec:    map[string][]byte{pb.SpecGatewaySessionID: []byte(pctx.SID)},
 					}}, nil
 				}

--- a/gateway/transport/plugins/review/review.go
+++ b/gateway/transport/plugins/review/review.go
@@ -58,7 +58,7 @@ func (p *reviewPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plu
 		log.With("id", otrev.ID, "sid", pctx.SID, "user", otrev.OwnerEmail, "org", pctx.OrgID,
 			"status", otrev.Status).Info("one time review")
 		if !(otrev.Status == models.ReviewStatusApproved || otrev.Status == models.ReviewStatusProcessing) {
-			reviewURL := fmt.Sprintf("%s/reviews/%s", p.apiURL, otrev.ID)
+			reviewURL := fmt.Sprintf("%s/sessions/%s", p.apiURL, otrev.ID)
 			p.setSpecReview(pkt)
 			return &plugintypes.ConnectResponse{Context: nil, ClientPacket: &pb.Packet{
 				Type:    pbclient.SessionOpenWaitingApproval,
@@ -200,7 +200,7 @@ func (p *reviewPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plu
 
 	return &plugintypes.ConnectResponse{Context: nil, ClientPacket: &pb.Packet{
 		Type:    pbclient.SessionOpenWaitingApproval,
-		Payload: fmt.Appendf(nil, "%s/reviews/%s", p.apiURL, newRev.ID),
+		Payload: fmt.Appendf(nil, "%s/sessions/%s", p.apiURL, newRev.ID),
 		Spec:    map[string][]byte{pb.SpecGatewaySessionID: []byte(pctx.SID)},
 	}}, nil
 }

--- a/gateway/transport/plugins/review/review.oss.go
+++ b/gateway/transport/plugins/review/review.oss.go
@@ -98,7 +98,7 @@ func (p *reviewPlugin) onReceiveOSS(pctx plugintypes.Context, pkt *pb.Packet) (*
 	}
 	return &plugintypes.ConnectResponse{Context: nil, ClientPacket: &pb.Packet{
 		Type:    pbclient.SessionOpenWaitingApproval,
-		Payload: fmt.Appendf(nil, "%s/reviews/%s", p.apiURL, newRev.ID),
+		Payload: fmt.Appendf(nil, "%s/sessions/%s", p.apiURL, newRev.ID),
 		Spec:    map[string][]byte{pb.SpecGatewaySessionID: []byte(pctx.SID)},
 	}}, nil
 


### PR DESCRIPTION
   > [!IMPORTANT]
   > Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
   >
   > - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
   > - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

   Fixes two review-flow issues in the gateway:

   1. **JIT review incorrectly reused for exec requests** — the access-request interceptor was validating and returning an existing  
 JIT review for *any* client verb. This meant a per-command (exec) request could match an existing JIT review (which grants broader  
 connect access) and bypass the correct per-command review flow. The JIT review lookup is now gated to only run for
 `ClientVerbConnect`; exec requests fall through and create the proper command review.

   2. **Wrong review URL returned to clients** — the "waiting for approval" responses and exec/AI-decision outputs pointed users at  
 `/reviews/{id}`, but reviews are now surfaced under the sessions view. All of these URLs were updated to `/sessions/{id}`.

## 🔗 Related Issue

   <!-- Link to the issue this PR addresses (if applicable) -->

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Gated the existing-JIT-review validation in `accessrequest.OnReceive` behind `pctx.ClientVerb == pb.ClientVerbConnect`, so exec
 requests no longer reuse a JIT review and correctly create a per-command review.
- Updated all "waiting for approval" / review URLs from `/reviews/{id}` to `/sessions/{id}` across the access-request
 interceptor, audit plugin, review plugin (enterprise + OSS), MCP exec tool, and AI-decision handler.

## 🧪 Testing

### Test Configuration

- **Browser(s)**: Brave
- **OS**: macOS

### Tests performed

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

   <!-- Add screenshots to help explain your changes -->

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

   The URL change assumes the frontend routes review details under `/sessions/{id}` rather than `/reviews/{id}` — worth confirming
 reviewers are aligned that the sessions view is now the canonical destination for these approval links.

   ---
