### PR TITLE
feat: silent token renewal for tunnel sessions (DEP-24)

### DIFF
--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -96,6 +96,13 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentAgent},
 	},
+	"experimental.tunnel_token_renewal": {
+		Name:        "experimental.tunnel_token_renewal",
+		Description: "Silently renew user access tokens before they expire so long-lived tunnel sessions (hsh-tunneld) never present an expired token: the HTTP auth middleware rotates tokens within a pre-expiry window via X-New-Access-Token (OIDC uses the stored refresh token; local auth re-mints a sliding-session JWT capped at 7 days from the original login). When off, tokens are only refreshed reactively after they expire, and local-auth tokens are never renewed.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentGateway},
+	},
 	"experimental.claude_code_vertex": {
 		Name:        "experimental.claude_code_vertex",
 		Description: "Allow claude-code connections to authenticate against Google Vertex AI: the connection stores a GCP service-account key and the agent mints a short-lived, auto-refreshing OAuth bearer that it injects as the upstream Authorization header while transparently proxying Claude Code traffic to Vertex. Claude Code runs in Vertex mode (CLAUDE_CODE_USE_VERTEX) pointed at the hoop proxy. When off, the Vertex provider is hidden in the connection form and the agent does not mint GCP tokens.",

--- a/common/keys/keys.go
+++ b/common/keys/keys.go
@@ -42,12 +42,32 @@ func GenerateSecureRandomKey(prefixKey string, size uint16) (secretKey, secretKe
 
 // NewJwtToken generates a new JWT token signed with HMAC using the provided secret key.
 func NewJwtToken(privKey ed25519.PrivateKey, subject, email string, tokenDuration time.Duration) (string, error) {
+	return NewJwtTokenWithAuthTime(privKey, subject, email, tokenDuration, time.Now().UTC())
+}
+
+// NewJwtTokenWithAuthTime generates a JWT like NewJwtToken but pins the
+// auth_time claim (RFC 9470 / OIDC core: time of the original end-user
+// authentication) to the provided value instead of now.
+//
+// Sliding-session renewal uses this to preserve the original login time
+// across re-mints so the absolute session cap can be enforced: each renewed
+// token carries a fresh iat/exp but the same auth_time as the first token
+// of the session.
+func NewJwtTokenWithAuthTime(privKey ed25519.PrivateKey, subject, email string, tokenDuration time.Duration, authTime time.Time) (string, error) {
 	now := time.Now().UTC()
+	// auth_time is the anchor of the absolute session cap: a future value
+	// would make the session age negative and the cap unenforceable, so
+	// refuse to mint such a token regardless of the caller.
+	if authTime.After(now.Add(time.Minute)) {
+		return "", fmt.Errorf("auth_time cannot be in the future")
+	}
 	var claims = struct {
-		Email string `json:"email"`
+		Email    string `json:"email"`
+		AuthTime int64  `json:"auth_time"`
 		jwt.RegisteredClaims
 	}{
-		Email: email,
+		Email:    email,
+		AuthTime: authTime.UTC().Unix(),
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   subject,
 			IssuedAt:  jwt.NewNumericDate(now),
@@ -57,6 +77,69 @@ func NewJwtToken(privKey ed25519.PrivateKey, subject, email string, tokenDuratio
 
 	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
 	return token.SignedString(privKey)
+}
+
+// SessionClaims is the subset of claims needed to renew a sliding-session
+// token: identity, original authentication time, and current expiry.
+type SessionClaims struct {
+	Subject  string
+	Email    string
+	AuthTime time.Time
+	ExpireAt time.Time
+}
+
+// VerifySessionClaims verifies the token signature and returns the claims
+// that drive sliding-session renewal. Tokens minted before auth_time was
+// introduced fall back to iat as the original authentication time, which is
+// correct for them: they were never renewed, so iat is the login time.
+func VerifySessionClaims(tokenString string, pubKey ed25519.PublicKey) (*SessionClaims, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodEd25519); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return pubKey, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse access token: %v", err)
+	}
+	if !token.Valid {
+		return nil, fmt.Errorf("access token is invalid")
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("failed type casting token.Claims (%T) to jwt.MapClaims", token.Claims)
+	}
+	subject, ok := claims["sub"].(string)
+	if !ok || subject == "" {
+		return nil, fmt.Errorf("'sub' not found or has an empty value")
+	}
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return nil, fmt.Errorf("'exp' not found or invalid")
+	}
+	out := &SessionClaims{Subject: subject, ExpireAt: exp.Time}
+	if email, ok := claims["email"].(string); ok {
+		out.Email = email
+	}
+	switch authTime := claims["auth_time"].(type) {
+	case float64:
+		out.AuthTime = time.Unix(int64(authTime), 0).UTC()
+	default:
+		// Pre-auth_time token: iat is the original login time.
+		iat, err := claims.GetIssuedAt()
+		if err != nil || iat == nil {
+			return nil, fmt.Errorf("neither 'auth_time' nor 'iat' present in token")
+		}
+		out.AuthTime = iat.Time
+	}
+	// Defense in depth mirroring the mint-side guard: a future auth_time
+	// would defeat the absolute session cap (negative session age), so
+	// treat it as an invalid session token even though the signature is
+	// good.
+	if out.AuthTime.After(time.Now().UTC().Add(time.Minute)) {
+		return nil, fmt.Errorf("'auth_time' is in the future")
+	}
+	return out, nil
 }
 
 // VerifyAccessToken verifies the access token and returns the subject if valid.

--- a/common/keys/session_test.go
+++ b/common/keys/session_test.go
@@ -1,0 +1,90 @@
+package keys
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewJwtTokenPreservesAuthTimeAcrossRenewal(t *testing.T) {
+	pub, priv, err := GenerateEd25519KeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+
+	// First token of the session: auth_time == iat (login moment).
+	login := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+	first, err := NewJwtTokenWithAuthTime(priv, "user-1", "u@x.io", time.Hour, login)
+	if err != nil {
+		t.Fatalf("mint first: %v", err)
+	}
+
+	claims, err := VerifySessionClaims(first, pub)
+	if err != nil {
+		t.Fatalf("verify first: %v", err)
+	}
+	if !claims.AuthTime.Equal(login) {
+		t.Fatalf("auth_time not preserved: got %v want %v", claims.AuthTime, login)
+	}
+	if claims.Subject != "user-1" || claims.Email != "u@x.io" {
+		t.Fatalf("identity claims corrupted: %+v", claims)
+	}
+
+	// Renewal: fresh expiry, same auth_time.
+	renewed, err := NewJwtTokenWithAuthTime(priv, claims.Subject, claims.Email, time.Hour, claims.AuthTime)
+	if err != nil {
+		t.Fatalf("mint renewed: %v", err)
+	}
+	renewedClaims, err := VerifySessionClaims(renewed, pub)
+	if err != nil {
+		t.Fatalf("verify renewed: %v", err)
+	}
+	if !renewedClaims.AuthTime.Equal(login) {
+		t.Fatalf("renewal must carry the original auth_time: got %v want %v", renewedClaims.AuthTime, login)
+	}
+	if !renewedClaims.ExpireAt.After(claims.AuthTime.Add(time.Hour)) {
+		t.Fatalf("renewal must extend expiry beyond the original")
+	}
+}
+
+func TestVerifySessionClaimsFallsBackToIatForLegacyTokens(t *testing.T) {
+	pub, priv, err := GenerateEd25519KeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	// NewJwtToken now embeds auth_time too, so simulate a legacy token by
+	// minting with the plain path and checking auth_time == iat semantics:
+	// for a never-renewed token they are the same instant either way.
+	tok, err := NewJwtToken(priv, "user-2", "", time.Hour)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	claims, err := VerifySessionClaims(tok, pub)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if time.Since(claims.AuthTime) > time.Minute {
+		t.Fatalf("fresh token must have auth_time ~now, got %v", claims.AuthTime)
+	}
+}
+
+func TestVerifySessionClaimsRejectsForgedToken(t *testing.T) {
+	pub, _, err := GenerateEd25519KeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	_, otherPriv, err := GenerateEd25519KeyPair()
+	if err != nil {
+		t.Fatalf("other keypair: %v", err)
+	}
+	forged, err := NewJwtToken(otherPriv, "attacker", "", time.Hour)
+	if err != nil {
+		t.Fatalf("mint forged: %v", err)
+	}
+	if _, err := VerifySessionClaims(forged, pub); err == nil {
+		t.Fatal("token signed by a different key must be rejected")
+	}
+	if _, err := VerifySessionClaims("not-a-jwt", pub); err == nil || !strings.Contains(err.Error(), "parse") {
+		t.Fatalf("garbage token must fail parsing, got %v", err)
+	}
+}

--- a/gateway/api/apiroutes/auth.go
+++ b/gateway/api/apiroutes/auth.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/hoophq/hoop/common/apiutils"
+	"github.com/hoophq/hoop/common/featureflag"
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/common/proto"
 	"github.com/hoophq/hoop/gateway/appconfig"
@@ -222,7 +225,99 @@ func (r *Router) AuthMiddleware(c *gin.Context) {
 
 	log.Debugf("access allowed: %v %v, roles=%v, email=%s, isadmin=%v, isauditor=%v",
 		c.Request.Method, c.Request.URL.Path, roles, ctx.UserEmail, ctx.IsAdmin(), ctx.IsAuditor())
+	r.maybeProactiveRotate(tokenVerifier, serverConfig, ctx, c)
 	r.setUserContext(ctx, c, serverConfig.GrpcURL, serverConfig.AuthMethod)
+}
+
+const (
+	// proactiveRotationWindow is how close to expiry a still-valid token must
+	// be before the middleware rotates it via X-New-Access-Token. Long-lived
+	// clients (hsh-tunneld) poll well within this window, so they always hold
+	// a token that is valid at gRPC stream-open time.
+	proactiveRotationWindow = 10 * time.Minute
+
+	// localAuthRenewalDuration is the lifetime of a re-minted local-auth
+	// token. It mirrors defaultTokenExpiration in gateway/api/login/local.
+	localAuthRenewalDuration = 12 * time.Hour
+
+	// localAuthMaxSessionAge is the absolute cap of a local-auth sliding
+	// session: renewal is refused once the original login (auth_time) is
+	// older than this, forcing a real re-authentication. Kept as a constant
+	// while the feature is experimental; per-org configuration is planned
+	// with the require_tunnel_for_data_plane org settings (DEP-16).
+	localAuthMaxSessionAge = 7 * 24 * time.Hour
+)
+
+// maybeProactiveRotate rotates a still-valid access token that is close to
+// expiry, emitting the replacement via the X-New-Access-Token header. It is
+// best-effort by design: any failure leaves the request untouched (the
+// presented token is still valid) and the client retries on its next call.
+//
+// Contract note: rotation happens after authn/authz succeed but BEFORE the
+// handler runs, so a client may receive a rotated token on a request whose
+// handler later fails (4xx/5xx). That is deliberate — the rotation is a
+// property of the (valid) session, not of the request outcome, and holding
+// it back on handler errors would leave long-lived clients stuck with an
+// almost-expired token exactly when they are erroring.
+//
+// Gated by the experimental.tunnel_token_renewal feature flag. Without it the
+// gateway keeps the pre-existing reactive behavior (refresh only after
+// expiry), which cannot keep gRPC tunnel streams working since the gRPC auth
+// interceptor has no refresh path.
+func (r *Router) maybeProactiveRotate(tokenVerifier idp.TokenVerifier, serverConfig idptypes.ServerConfig, ctx *models.Context, c *gin.Context) {
+	// The reactive path already rotated this request's token.
+	if c.Writer.Header().Get("X-New-Access-Token") != "" {
+		return
+	}
+	if !featureflag.IsEnabled(ctx.OrgID, "experimental.tunnel_token_renewal") {
+		return
+	}
+	accessToken, err := parseToken(c)
+	if err != nil {
+		return
+	}
+	expiresAt, ok := tokenExpiry(accessToken)
+	if !ok || time.Until(expiresAt) > proactiveRotationWindow {
+		return
+	}
+
+	var newAccessToken string
+	switch serverConfig.AuthMethod {
+	case idptypes.ProviderTypeLocal:
+		renewer, ok := tokenVerifier.(idp.SessionRenewer)
+		if !ok {
+			return
+		}
+		newAccessToken, err = renewer.RenewAccessToken(accessToken, localAuthRenewalDuration, localAuthMaxSessionAge)
+	case idptypes.ProviderTypeOIDC, idptypes.ProviderTypeIDP:
+		newAccessToken, err = idp.TryProactiveRefreshForVerifiedSubject(tokenVerifier, ctx.UserSubject)
+	default:
+		// SAML sessions cannot be renewed without a fresh assertion.
+		return
+	}
+	if err != nil {
+		log.With("subject", ctx.UserSubject).Debugf("proactive token rotation skipped: %v", err)
+		return
+	}
+	log.With("subject", ctx.UserSubject, "auth_method", serverConfig.AuthMethod).
+		Infof("access token rotated proactively (expiring in %v)", time.Until(expiresAt).Truncate(time.Second))
+	c.Header("X-New-Access-Token", newAccessToken)
+}
+
+// tokenExpiry extracts the exp claim from a JWT without re-verifying the
+// signature — callers must only use it on tokens that already passed
+// VerifyAccessToken. Returns false for opaque (non-JWT) tokens or tokens
+// without an exp claim; those are never proactively rotated.
+func tokenExpiry(tokenString string) (time.Time, bool) {
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(tokenString, claims); err != nil {
+		return time.Time{}, false
+	}
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return time.Time{}, false
+	}
+	return exp.Time, true
 }
 
 // setUserContext and call next middleware

--- a/gateway/idp/core.go
+++ b/gateway/idp/core.go
@@ -67,6 +67,18 @@ type ExpiredTokenSubjectVerifier interface {
 	VerifyExpiredTokenSubject(tokenStr string) (string, error)
 }
 
+// SessionRenewer is an optional interface for providers that mint their own
+// tokens (local auth) and can renew a still-valid token as a sliding session:
+// the renewed token gets a fresh expiry but preserves the original auth_time,
+// and renewal is refused once the session is older than maxSessionAge.
+type SessionRenewer interface {
+	// RenewAccessToken verifies currentToken (which must still be valid),
+	// and returns a re-minted token with the same subject/email/auth_time
+	// and a fresh tokenDuration expiry. It fails if the original
+	// authentication happened more than maxSessionAge ago.
+	RenewAccessToken(currentToken string, tokenDuration, maxSessionAge time.Duration) (string, error)
+}
+
 var (
 	singletonStore         = memory.New()
 	singletonStoreKey      = "1"
@@ -119,6 +131,15 @@ func (v userInfoTokenVerifier) VerifyExpiredTokenSubject(tokenStr string) (strin
 	return "", fmt.Errorf("expired token subject verification not supported by this provider")
 }
 
+// RenewAccessToken delegates to the underlying provider if it supports
+// sliding-session renewal (local auth).
+func (v userInfoTokenVerifier) RenewAccessToken(currentToken string, tokenDuration, maxSessionAge time.Duration) (string, error) {
+	if sr, ok := v.UserInfoTokenVerifier.(SessionRenewer); ok {
+		return sr.RenewAccessToken(currentToken, tokenDuration, maxSessionAge)
+	}
+	return "", fmt.Errorf("session renewal not supported by this provider")
+}
+
 // TryRefreshExpiredToken validates the signature of an expired JWT, extracts
 // the subject, looks up the stored refresh token, and exchanges it for a new
 // access token. On success it persists the new tokens, syncs user groups from
@@ -133,12 +154,37 @@ func TryRefreshExpiredToken(tokenVerifier TokenVerifier, expiredToken string) (s
 	if err != nil {
 		return "", "", fmt.Errorf("failed to verify expired token: %w", err)
 	}
-
-	type refreshResult struct {
-		subject        string
-		newAccessToken string
+	newAccessToken, err := refreshForSubject(tokenVerifier, subject, "reactive")
+	if err != nil {
+		return "", "", err
 	}
+	return subject, newAccessToken, nil
+}
 
+// TryProactiveRefreshForVerifiedSubject exchanges the stored refresh token
+// for a new access token for a subject whose current token is still valid
+// (pre-expiry rotation).
+//
+// SECURITY: the subject MUST come from a token that already passed
+// signature verification in the caller — this function performs a refresh
+// exchange keyed solely by subject and does not re-verify anything. Do not
+// call it with a subject from any other source (headers, request bodies,
+// unverified claims): that would be a confused-deputy refresh.
+//
+// Long-lived clients (hsh-tunneld) rely on this to always hold a token that
+// is valid at gRPC stream-open time: the HTTP middleware rotates the token
+// before it expires, so there is no window where new tunnel flows race the
+// expiry moment.
+func TryProactiveRefreshForVerifiedSubject(tokenVerifier TokenVerifier, subject string) (string, error) {
+	return refreshForSubject(tokenVerifier, subject, "proactive")
+}
+
+// refreshForSubject performs the actual refresh-token exchange for a subject.
+// Concurrent calls for the same subject (reactive or proactive) are
+// deduplicated via singleflight — the subject key is shared on purpose so a
+// proactive rotation and a reactive refresh racing each other produce a
+// single IDP round-trip.
+func refreshForSubject(tokenVerifier TokenVerifier, subject, mode string) (string, error) {
 	result, err, _ := refreshGroup.Do(subject, func() (any, error) {
 		userToken, err := models.GetUserToken(models.DB, subject)
 		if err != nil || userToken == nil {
@@ -168,15 +214,13 @@ func TryRefreshExpiredToken(tokenVerifier TokenVerifier, expiredToken string) (s
 
 		syncUserGroupsFromUserInfo(tokenVerifier, subject, newToken.AccessToken)
 
-		log.With("subject", subject).Infof("access token refreshed successfully")
-		return &refreshResult{subject: subject, newAccessToken: newToken.AccessToken}, nil
+		log.With("subject", subject, "mode", mode).Infof("access token refreshed successfully")
+		return newToken.AccessToken, nil
 	})
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
-
-	r := result.(*refreshResult)
-	return r.subject, r.newAccessToken, nil
+	return result.(string), nil
 }
 
 // syncUserGroupsFromUserInfo fetches fresh group claims from the IDP userinfo

--- a/gateway/idp/local/local.go
+++ b/gateway/idp/local/local.go
@@ -43,3 +43,28 @@ func (p *Provider) VerifyAccessToken(accessToken string) (string, error) {
 	}
 	return keys.VerifyAccessToken(accessToken, pubKey)
 }
+
+// RenewAccessToken implements idp.SessionRenewer: it re-mints a still-valid
+// token as a sliding session. The renewed token carries a fresh expiry but
+// preserves the original auth_time claim, and renewal is refused once the
+// original authentication is older than maxSessionAge — a stolen token can
+// therefore only be kept alive up to the absolute cap, never indefinitely.
+func (p *Provider) RenewAccessToken(currentToken string, tokenDuration, maxSessionAge time.Duration) (string, error) {
+	if len(p.tokenSigningKey) == 0 {
+		return "", fmt.Errorf("signing key is not set")
+	}
+	pubKey, ok := p.tokenSigningKey.Public().(ed25519.PublicKey)
+	if !ok {
+		return "", fmt.Errorf("internal error, failed to cast private key to ed25519.PublicKey")
+	}
+	claims, err := keys.VerifySessionClaims(currentToken, pubKey)
+	if err != nil {
+		return "", fmt.Errorf("cannot renew: %w", err)
+	}
+	sessionAge := time.Since(claims.AuthTime)
+	if sessionAge > maxSessionAge {
+		return "", fmt.Errorf("session exceeded the maximum age (%s > %s), re-authentication required",
+			sessionAge.Truncate(time.Minute), maxSessionAge)
+	}
+	return keys.NewJwtTokenWithAuthTime(p.tokenSigningKey, claims.Subject, claims.Email, tokenDuration, claims.AuthTime)
+}

--- a/gateway/idp/local/local_test.go
+++ b/gateway/idp/local/local_test.go
@@ -1,0 +1,115 @@
+package localprovider
+
+import (
+	"crypto/ed25519"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/common/keys"
+)
+
+func newTestProvider(t *testing.T) *Provider {
+	t.Helper()
+	_, priv, err := keys.GenerateEd25519KeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	p, err := New(Options{SharedSigningKey: priv})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p
+}
+
+func TestRenewAccessTokenSlidingSession(t *testing.T) {
+	p := newTestProvider(t)
+
+	original, err := p.NewAccessToken("subj-1", "u@x.io", time.Hour)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	renewed, err := p.RenewAccessToken(original, 12*time.Hour, 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("renew: %v", err)
+	}
+	if renewed == original {
+		t.Fatal("renewal must mint a new token")
+	}
+
+	// Renewed token must verify and keep the identity.
+	subject, err := p.VerifyAccessToken(renewed)
+	if err != nil {
+		t.Fatalf("verify renewed: %v", err)
+	}
+	if subject != "subj-1" {
+		t.Fatalf("subject changed across renewal: %q", subject)
+	}
+}
+
+func TestRenewAccessTokenRefusesBeyondMaxSessionAge(t *testing.T) {
+	p := newTestProvider(t)
+
+	// Simulate a session that originally authenticated 8 days ago by
+	// minting with a pinned auth_time (still-valid expiry).
+	authTime := time.Now().UTC().Add(-8 * 24 * time.Hour)
+	old, err := keys.NewJwtTokenWithAuthTime(p.tokenSigningKey, "subj-2", "", time.Hour, authTime)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	_, err = p.RenewAccessToken(old, 12*time.Hour, 7*24*time.Hour)
+	if err == nil {
+		t.Fatal("renewal past the absolute cap must be refused")
+	}
+	if !strings.Contains(err.Error(), "maximum age") {
+		t.Fatalf("expected the max-age error, got: %v", err)
+	}
+}
+
+func TestRenewAccessTokenPreservesAuthTime(t *testing.T) {
+	p := newTestProvider(t)
+	pubKey, ok := p.tokenSigningKey.Public().(ed25519.PublicKey)
+	if !ok {
+		t.Fatal("failed to derive public key")
+	}
+
+	authTime := time.Now().UTC().Add(-3 * 24 * time.Hour).Truncate(time.Second)
+	tok, err := keys.NewJwtTokenWithAuthTime(p.tokenSigningKey, "subj-3", "a@b.c", time.Hour, authTime)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	// Renew twice; auth_time must survive both hops so the absolute cap
+	// keeps counting from the original login, not the last renewal.
+	for i := 0; i < 2; i++ {
+		tok, err = p.RenewAccessToken(tok, 12*time.Hour, 7*24*time.Hour)
+		if err != nil {
+			t.Fatalf("renew #%d: %v", i+1, err)
+		}
+	}
+	claims, err := keys.VerifySessionClaims(tok, pubKey)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !claims.AuthTime.Equal(authTime) {
+		t.Fatalf("auth_time drifted across renewals: got %v want %v", claims.AuthTime, authTime)
+	}
+	if claims.Email != "a@b.c" {
+		t.Fatalf("email lost across renewals: %q", claims.Email)
+	}
+}
+
+func TestRenewAccessTokenRejectsForeignToken(t *testing.T) {
+	p := newTestProvider(t)
+	other := newTestProvider(t)
+
+	foreign, err := other.NewAccessToken("subj-4", "", time.Hour)
+	if err != nil {
+		t.Fatalf("mint foreign: %v", err)
+	}
+	if _, err := p.RenewAccessToken(foreign, 12*time.Hour, 7*24*time.Hour); err == nil {
+		t.Fatal("a token signed by another key must not be renewable")
+	}
+}

--- a/tunnel/client/connections.go
+++ b/tunnel/client/connections.go
@@ -38,6 +38,11 @@ type FetchConnectionsOptions struct {
 	// HTTPClient lets callers inject a client with custom TLS / proxies.
 	// Defaults to a 15-second-timeout client.
 	HTTPClient *http.Client
+
+	// OnNewToken, when set, is invoked with the rotated access token if
+	// the gateway's response carries an X-New-Access-Token header. See
+	// token.go for the rotation contract.
+	OnNewToken func(newToken string)
 }
 
 // FetchConnections returns the list of connections available to the
@@ -79,10 +84,14 @@ func FetchConnections(ctx context.Context, opts FetchConnectionsOptions) ([]Conn
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("GET %s: %w", base.String(), ErrUnauthorized)
+	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("GET %s returned %s: %s", base.String(), resp.Status, strings.TrimSpace(string(body)))
 	}
+	harvestRotatedToken(resp, opts.OnNewToken)
 
 	// The non-paginated endpoint returns a flat array of openapi.Connection.
 	// We decode only the two fields we need so this code is robust to

--- a/tunnel/client/serverinfo.go
+++ b/tunnel/client/serverinfo.go
@@ -39,6 +39,11 @@ type FetchServerInfoOptions struct {
 	// HTTPClient lets callers inject a client with custom TLS / proxies.
 	// Defaults to a 15-second-timeout client.
 	HTTPClient *http.Client
+
+	// OnNewToken, when set, is invoked with the rotated access token if
+	// the gateway's response carries an X-New-Access-Token header. See
+	// token.go for the rotation contract.
+	OnNewToken func(newToken string)
 }
 
 // FetchServerInfo calls GET /api/serverinfo and returns the gateway
@@ -77,7 +82,9 @@ func FetchServerInfo(ctx context.Context, opts FetchServerInfoOptions) (*ServerI
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		// ok, fall through
+		harvestRotatedToken(resp, opts.OnNewToken)
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("GET %s: %w", base.String(), ErrUnauthorized)
 	case http.StatusNotFound:
 		return nil, fmt.Errorf("GET %s: gateway does not expose the serverinfo route", base.String())
 	default:

--- a/tunnel/client/token.go
+++ b/tunnel/client/token.go
@@ -1,0 +1,39 @@
+// token.go — shared token plumbing for the REST helpers.
+//
+// The gateway's HTTP auth middleware rotates access tokens via the
+// X-New-Access-Token response header (reactively after expiry, and —
+// behind the experimental.tunnel_token_renewal flag — proactively within
+// a pre-expiry window). Every REST helper in this package harvests that
+// header so the daemon can persist the fresh token and keep long-lived
+// tunnel sessions alive without the user ever reopening a browser
+// (DEP-24).
+package client
+
+import (
+	"errors"
+	"net/http"
+)
+
+// ErrUnauthorized is returned (wrapped) when the gateway rejects the
+// bearer token with 401. It means the server-side refresh also failed —
+// the session is dead and only a fresh login can recover it. Callers
+// use errors.Is to distinguish this terminal state from transient
+// fetch failures.
+var ErrUnauthorized = errors.New("gateway rejected the access token (401 unauthorized)")
+
+// newAccessTokenHeader is the rotation header emitted by the gateway's
+// auth middleware and consumed by every hoop client (webapp, hsh CLI,
+// and this daemon).
+const newAccessTokenHeader = "X-New-Access-Token"
+
+// harvestRotatedToken invokes onNewToken when the response carries a
+// rotated access token. No-op when the header is absent or no callback
+// was provided.
+func harvestRotatedToken(resp *http.Response, onNewToken func(string)) {
+	if onNewToken == nil {
+		return
+	}
+	if newToken := resp.Header.Get(newAccessTokenHeader); newToken != "" {
+		onNewToken(newToken)
+	}
+}

--- a/tunnel/client/token_test.go
+++ b/tunnel/client/token_test.go
@@ -1,0 +1,113 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newRotationGateway is a fake gateway whose /api/serverinfo and
+// /api/connections endpoints honour the X-New-Access-Token rotation
+// contract: when rotateTo is non-empty the header is attached to
+// successful responses, and requests carrying deadToken get a 401.
+func newRotationGateway(t *testing.T, rotateTo, deadToken string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	handler := func(body string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") == "Bearer "+deadToken {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			if rotateTo != "" {
+				w.Header().Set("X-New-Access-Token", rotateTo)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}
+	}
+	mux.HandleFunc("/api/serverinfo", handler(`{"grpc_url":"grpc://127.0.0.1:8010"}`))
+	mux.HandleFunc("/api/connections", handler(`[{"name":"pg-prod","subtype":"postgres"}]`))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestFetchServerInfoHarvestsRotatedToken(t *testing.T) {
+	srv := newRotationGateway(t, "fresh-token", "")
+
+	var got string
+	si, err := FetchServerInfo(context.Background(), FetchServerInfoOptions{
+		APIBaseURL: srv.URL,
+		Token:      "old-token",
+		OnNewToken: func(tok string) { got = tok },
+	})
+	if err != nil {
+		t.Fatalf("FetchServerInfo: %v", err)
+	}
+	if si.GrpcURL == "" {
+		t.Fatal("missing grpc_url")
+	}
+	if got != "fresh-token" {
+		t.Fatalf("OnNewToken not invoked with the rotated token: got %q", got)
+	}
+}
+
+func TestFetchConnectionsHarvestsRotatedToken(t *testing.T) {
+	srv := newRotationGateway(t, "fresh-token", "")
+
+	var got string
+	conns, err := FetchConnections(context.Background(), FetchConnectionsOptions{
+		APIBaseURL: srv.URL,
+		Token:      "old-token",
+		OnNewToken: func(tok string) { got = tok },
+	})
+	if err != nil {
+		t.Fatalf("FetchConnections: %v", err)
+	}
+	if len(conns) != 1 || conns[0].Name != "pg-prod" {
+		t.Fatalf("unexpected connections: %+v", conns)
+	}
+	if got != "fresh-token" {
+		t.Fatalf("OnNewToken not invoked with the rotated token: got %q", got)
+	}
+}
+
+func TestNoRotationHeaderMeansNoCallback(t *testing.T) {
+	srv := newRotationGateway(t, "", "")
+
+	called := false
+	_, err := FetchServerInfo(context.Background(), FetchServerInfoOptions{
+		APIBaseURL: srv.URL,
+		Token:      "old-token",
+		OnNewToken: func(string) { called = true },
+	})
+	if err != nil {
+		t.Fatalf("FetchServerInfo: %v", err)
+	}
+	if called {
+		t.Fatal("OnNewToken must not fire without the rotation header")
+	}
+}
+
+func TestUnauthorizedIsTypedOnBothEndpoints(t *testing.T) {
+	srv := newRotationGateway(t, "", "dead-token")
+
+	_, err := FetchServerInfo(context.Background(), FetchServerInfoOptions{
+		APIBaseURL: srv.URL,
+		Token:      "dead-token",
+	})
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("FetchServerInfo 401 must wrap ErrUnauthorized, got: %v", err)
+	}
+
+	_, err = FetchConnections(context.Background(), FetchConnectionsOptions{
+		APIBaseURL: srv.URL,
+		Token:      "dead-token",
+	})
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("FetchConnections 401 must wrap ErrUnauthorized, got: %v", err)
+	}
+}

--- a/tunnel/cmd/hsh-tunneld/main.go
+++ b/tunnel/cmd/hsh-tunneld/main.go
@@ -229,6 +229,11 @@ func run(logger *log.Logger, opts runOptions) error {
 	// Build the lifecycle owner. The Manager handles every operation
 	// that touches the netstack / gateway / route table; main.go only
 	// triggers it via the daemonService.
+	// Shared token state (DEP-24): the manager reads the current token
+	// per flow and reports gateway-driven rotations; the service (built
+	// below) persists rotations and swaps the token on login/logout.
+	tokens := newTokenState()
+
 	mgr, err := tunnelmgr.New(tunnelmgr.Options{
 		Logger:        logger,
 		SessionSeed:   opts.sessionSeed,
@@ -237,6 +242,7 @@ func run(logger *log.Logger, opts runOptions) error {
 		TLSSkipVerify: os.Getenv("HOOP_TLS_SKIP_VERIFY") == "true",
 		TLSServerName: os.Getenv("HOOP_TLSSERVERNAME"),
 		UserAgent:     userAgent(),
+		TokenSource:   tokens,
 	})
 	if err != nil {
 		return fmt.Errorf("init tunnelmgr: %w", err)
@@ -258,6 +264,7 @@ func run(logger *log.Logger, opts runOptions) error {
 		OnTunnelDown: func() {
 			logger.Printf("tunnel torn down — netstack and routes released")
 		},
+		Tokens: tokens,
 	})
 	if err != nil {
 		return fmt.Errorf("init service: %w", err)
@@ -289,6 +296,12 @@ func run(logger *log.Logger, opts runOptions) error {
 	// tunnel is down, so it covers both "tunnel already up at startup"
 	// and "tunnel comes up later via login" without extra wiring.
 	svc.StartAutoRefresh(ctx, opts.refreshInterval, logger.Printf)
+
+	// Start the silent token-renewal scheduler (DEP-24). Like the
+	// auto-refresh loop it runs for the whole daemon lifetime and
+	// no-ops while logged out, so it covers login-before-startup and
+	// login-after-startup identically.
+	svc.StartTokenRenewal(ctx, logger.Printf)
 
 	// Block on signal. TearDown on shutdown is best-effort: the
 	// per-tunnel ctx is parented to ctx, so closing it cancels the
@@ -330,18 +343,18 @@ func mergeConfigWithEnv(file daemonconfig.Config) daemonconfig.Config {
 // Branches on snap.ResolvedConfigured:
 //
 //   - true:  tunnelmgr already wired the TUN device into
-//            systemd-resolved at bring-up. The banner reports that
-//            *.<tld> names resolve natively now and skips the
-//            manual-hint block entirely. Users can run `psql -h
-//            foo.hoop` immediately.
+//     systemd-resolved at bring-up. The banner reports that
+//     *.<tld> names resolve natively now and skips the
+//     manual-hint block entirely. Users can run `psql -h
+//     foo.hoop` immediately.
 //
 //   - false: either the host doesn't run systemd-resolved (the
-//            common Alpine/FreeBSD/whatever case) or resolvectl
-//            failed. The banner prints the historical manual-hint
-//            block so the operator can wire DNS through whatever
-//            resolver they do use. tunnelmgr already logged the
-//            specific failure to the journal; we don't repeat it
-//            here.
+//     common Alpine/FreeBSD/whatever case) or resolvectl
+//     failed. The banner prints the historical manual-hint
+//     block so the operator can wire DNS through whatever
+//     resolver they do use. tunnelmgr already logged the
+//     specific failure to the journal; we don't repeat it
+//     here.
 func printTunnelUpBanner(logger *log.Logger, snap tunnelmgr.Snapshot, tld string) {
 	logger.Printf("tunnel is up.")
 	logger.Printf("  host addr: %s (%s)", snap.HostAddr, snap.DeviceName)
@@ -473,5 +486,3 @@ func startIPCServer(ctx context.Context, logger *log.Logger, opts runOptions, sv
 		}
 	}
 }
-
-

--- a/tunnel/cmd/hsh-tunneld/service.go
+++ b/tunnel/cmd/hsh-tunneld/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hoophq/hoop/common/version"
 
+	"github.com/hoophq/hoop/tunnel/client"
 	"github.com/hoophq/hoop/tunnel/daemonconfig"
 	"github.com/hoophq/hoop/tunnel/ipc"
 	"github.com/hoophq/hoop/tunnel/loginflow"
@@ -52,6 +53,12 @@ type daemonService struct {
 	// Config persistence.
 	configPath string
 
+	// tokens is the shared in-memory owner of the current gateway
+	// bearer token (see tokenrenewal.go). The service keeps it in
+	// lock-step with cfg.Token: login/logout/auth-expiry call SetLocal,
+	// gateway-driven rotations arrive through the rotation hook.
+	tokens *tokenState
+
 	mu        sync.RWMutex
 	lastError string
 	loggedIn  bool
@@ -89,6 +96,10 @@ type daemonServiceOptions struct {
 	// OnTunnelDown fires after Manager.TearDown completes — used
 	// today only for the logout path.
 	OnTunnelDown func()
+
+	// Tokens is the shared token state also wired into the tunnel
+	// manager's TokenProvider / OnTokenRotated options. Required.
+	Tokens *tokenState
 }
 
 func newDaemonService(opts daemonServiceOptions) (*daemonService, error) {
@@ -98,15 +109,24 @@ func newDaemonService(opts daemonServiceOptions) (*daemonService, error) {
 	if opts.ParentContext == nil {
 		return nil, errors.New("daemonService: ParentContext is required")
 	}
+	if opts.Tokens == nil {
+		return nil, errors.New("daemonService: Tokens is required")
+	}
 	s := &daemonService{
 		mgr:          opts.Manager,
 		parentCtx:    opts.ParentContext,
 		configPath:   opts.ConfigPath,
+		tokens:       opts.Tokens,
 		cfg:          opts.InitialConfig,
 		loggedIn:     opts.InitialConfig.LoggedIn(),
 		onTunnelUp:   opts.OnTunnelUp,
 		onTunnelDown: opts.OnTunnelDown,
 	}
+	// Seed the shared token state from the persisted config and route
+	// gateway-driven rotations back through this service so they reach
+	// the config file.
+	s.tokens.SetLocal(opts.InitialConfig.Token)
+	s.tokens.SetRotationHook(s.persistRotatedToken)
 	if opts.InitialConfig.APIURL != "" {
 		flow, err := loginflow.New(loginflow.Options{
 			APIURL:    opts.InitialConfig.APIURL,
@@ -127,6 +147,66 @@ func (s *daemonService) SetLastError(msg string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastError = msg
+}
+
+// persistRotatedToken is the tokenState rotation hook: it writes a
+// token the gateway rotated via X-New-Access-Token to the daemon's
+// config file. The in-memory rotation already happened (tokenState is
+// updated before the hook fires), so a disk failure degrades to
+// "renewal survives until the daemon restarts" — recorded in lastError
+// but never fatal to the live tunnel.
+func (s *daemonService) persistRotatedToken(newToken string) {
+	s.mu.Lock()
+	next := s.cfg
+	next.Token = newToken
+	s.mu.Unlock()
+
+	if s.configPath != "" {
+		if err := daemonconfig.Save(s.configPath, next, daemonconfig.SaveOptions{}); err != nil {
+			s.SetLastError("persist rotated token: " + err.Error())
+			return
+		}
+	}
+
+	s.mu.Lock()
+	s.cfg = next
+	s.mu.Unlock()
+}
+
+// authExpired is the clean-failure path of DEP-24: the gateway rejected
+// the token with 401 and could not renew it server-side, so the session
+// is unrecoverable. Tear the tunnel down, drop the dead credential from
+// config and memory, and leave an explicit reason in lastError so
+// `hsh tunnel status` tells the user exactly what to do instead of the
+// tunnel silently half-working with a dead token.
+func (s *daemonService) authExpired(reason string) {
+	s.mu.Lock()
+	next := s.cfg
+	next.Token = ""
+	s.mu.Unlock()
+
+	if s.configPath != "" {
+		if err := daemonconfig.Save(s.configPath, next, daemonconfig.SaveOptions{}); err != nil {
+			// Keep going: the in-memory state still transitions to
+			// logged-out; the stale on-disk token will fail bring-up at
+			// next restart and land in this same path again.
+			reason += " (also failed to clear the stored token: " + err.Error() + ")"
+		}
+	}
+
+	s.mu.Lock()
+	s.cfg = next
+	s.loggedIn = false
+	s.mu.Unlock()
+	s.tokens.SetLocal("")
+
+	if err := s.mgr.TearDown(); err != nil {
+		reason += " (tear down: " + err.Error() + ")"
+	}
+	if s.onTunnelDown != nil {
+		s.onTunnelDown()
+	}
+	s.SetLastError(reason)
 }
 
 // BringUpFromConfig is invoked by main.go at startup when the config
@@ -180,6 +260,7 @@ func (s *daemonService) persistTokenFromLogin(token string) error {
 	s.cfg = next
 	s.loggedIn = true
 	s.mu.Unlock()
+	s.tokens.SetLocal(token)
 
 	// Hot-reload: try to bring the tunnel up with the new token.
 	// If the tunnel was already up (rare — login flow refuses
@@ -327,6 +408,7 @@ func (s *daemonService) Logout(context.Context) error {
 	s.cfg = next
 	s.loggedIn = false
 	s.mu.Unlock()
+	s.tokens.SetLocal("")
 
 	// Hot tear-down: drop the live tunnel so the connection list
 	// vanishes immediately and any in-flight gRPC pipes terminate.
@@ -488,6 +570,13 @@ func (s *daemonService) RefreshConnections(ctx context.Context) (ipc.RefreshConn
 		return ipc.RefreshConnectionsResponse{Running: false, Count: 0}, nil
 	}
 	if err := s.mgr.Refresh(ctx); err != nil {
+		if errors.Is(err, client.ErrUnauthorized) {
+			// Session is dead (server-side refresh also failed): clean
+			// teardown with an explicit reason instead of retrying a
+			// dead credential every tick (DEP-24).
+			s.authExpired("session expired and could not be renewed; run 'hsh tunnel login' to re-authenticate")
+			return ipc.RefreshConnectionsResponse{}, fmt.Errorf("refresh connections: %w", err)
+		}
 		s.SetLastError("refresh connections: " + err.Error())
 		return ipc.RefreshConnectionsResponse{}, fmt.Errorf("refresh connections: %w", err)
 	}
@@ -536,4 +625,3 @@ func (s *daemonService) StartAutoRefresh(ctx context.Context, interval time.Dura
 		}
 	}()
 }
-

--- a/tunnel/cmd/hsh-tunneld/service_test.go
+++ b/tunnel/cmd/hsh-tunneld/service_test.go
@@ -32,6 +32,7 @@ func newTestService(t *testing.T, initialCfg daemonconfig.Config) *daemonService
 		ParentContext: context.Background(),
 		ConfigPath:    "", // in-memory: do not persist
 		InitialConfig: initialCfg,
+		Tokens:        newTokenState(),
 	})
 	if err != nil {
 		t.Fatalf("newDaemonService: %v", err)

--- a/tunnel/cmd/hsh-tunneld/tokenrenewal.go
+++ b/tunnel/cmd/hsh-tunneld/tokenrenewal.go
@@ -1,0 +1,313 @@
+// tokenrenewal.go — daemon-side half of DEP-24 silent token renewal.
+//
+// The gateway rotates access tokens through the X-New-Access-Token
+// response header (see tunnel/client/token.go). This file owns the
+// daemon's side of that contract:
+//
+//   - tokenState is the single in-memory owner of the current bearer
+//     token, shared between the tunnel manager (snapshots it per flow,
+//     reports rotations harvested during its own REST calls) and the
+//     daemon service (persists rotations, swaps it on login/logout).
+//     Rotations are epoch-guarded so a slow response from a dead
+//     session can never resurrect its token after logout/auth-expiry.
+//   - StartTokenRenewal is a background scheduler that wakes shortly
+//     before the current token expires and performs a cheap
+//     authenticated call so the gateway's pre-expiry rotation window
+//     can hand the daemon a fresh token — no browser, no webapp.
+//   - When the gateway answers 401 the session is beyond saving (the
+//     server-side refresh token itself is expired or revoked): the
+//     daemon tears the tunnel down with an explicit reason instead of
+//     limping along with a dead credential.
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hoophq/hoop/tunnel/client"
+)
+
+// renewalLead is how long before expiry the scheduler performs the
+// renewal call. It must stay comfortably inside the gateway's
+// proactive rotation window (10 minutes) so a single wake-up is
+// normally enough.
+const renewalLead = 5 * time.Minute
+
+// renewalFlagName is the gateway feature flag that enables pre-expiry
+// rotation. The scheduler reads it from /api/serverinfo responses to
+// avoid probing a gateway that will never rotate proactively.
+const renewalFlagName = "experimental.tunnel_token_renewal"
+
+// tokenState is the daemon's single source of truth for the current
+// gateway bearer token. Constructed in main before the tunnel manager
+// and the daemon service, so both can reference it without a
+// construction cycle. Implements tunnelmgr.TokenSource. Safe for
+// concurrent use.
+//
+// The epoch counts token-generation swaps (SetLocal calls). Rotations
+// carry the epoch of the snapshot their request was built from and are
+// rejected on mismatch: without this, an in-flight request from a
+// session that ended (logout, auth-expiry, re-login as someone else)
+// could install its rotated token over the new state.
+type tokenState struct {
+	mu       sync.RWMutex
+	token    string
+	epoch    uint64
+	onRotate func(newToken string)
+}
+
+func newTokenState() *tokenState { return &tokenState{} }
+
+// Current returns the token new REST calls and gRPC flows must use.
+func (t *tokenState) Current() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.token
+}
+
+// Snapshot implements tunnelmgr.TokenSource.
+func (t *tokenState) Snapshot() (string, uint64) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.token, t.epoch
+}
+
+// SetLocal replaces the token and starts a new epoch, invalidating any
+// rotation still in flight from the previous generation. It never
+// fires the rotation hook — it is for state the service persisted
+// itself: the initial config load, a completed login, a logout, or an
+// auth-expired teardown.
+func (t *tokenState) SetLocal(token string) {
+	t.mu.Lock()
+	t.token = token
+	t.epoch++
+	t.mu.Unlock()
+}
+
+// SetRotationHook registers the callback fired by accepted rotations.
+// Called once by the daemon service during construction.
+func (t *tokenState) SetRotationHook(hook func(newToken string)) {
+	t.mu.Lock()
+	t.onRotate = hook
+	t.mu.Unlock()
+}
+
+// Rotate implements tunnelmgr.TokenSource: it installs a token the
+// gateway rotated via X-New-Access-Token for a request built at the
+// given epoch, firing the persistence hook. Rejected when the epoch no
+// longer matches (the session that made the request is gone) and
+// no-oped on empty or unchanged tokens so repeated harvests of the
+// same rotation don't rewrite the config file.
+//
+// Accepted rotations deliberately do NOT bump the epoch: a rotation is
+// a continuation of the same login session, and concurrent requests
+// from that session must still be able to deliver their (equal or
+// newer) rotations.
+func (t *tokenState) Rotate(newToken string, epoch uint64) {
+	if newToken == "" {
+		return
+	}
+	t.mu.Lock()
+	if epoch != t.epoch || newToken == t.token {
+		t.mu.Unlock()
+		return
+	}
+	t.token = newToken
+	hook := t.onRotate
+	t.mu.Unlock()
+	if hook != nil {
+		hook(newToken)
+	}
+}
+
+// renewalFlagCache remembers whether the gateway reported the renewal
+// feature flag as disabled — scoped to a token epoch. A logout/login
+// can land on a different gateway/org where the flag state differs, so
+// the cache resets to the optimistic default (enabled) whenever the
+// epoch changes and re-learns from the next serverinfo response.
+type renewalFlagCache struct {
+	disabled bool
+	epoch    uint64
+}
+
+// disabledFor returns the cached flag state for the given epoch,
+// resetting to the optimistic default when the epoch changed since the
+// last observation.
+func (c *renewalFlagCache) disabledFor(epoch uint64) bool {
+	if epoch != c.epoch {
+		c.disabled = false
+		c.epoch = epoch
+	}
+	return c.disabled
+}
+
+// observe records the flag state reported by a serverinfo response for
+// the given epoch. Returns true when the effective state flipped (for
+// logging). Observations from a stale epoch are ignored.
+func (c *renewalFlagCache) observe(enabled bool, epoch uint64) (flipped bool) {
+	if epoch != c.epoch {
+		return false
+	}
+	newDisabled := !enabled
+	flipped = c.disabled != newDisabled
+	c.disabled = newDisabled
+	return flipped
+}
+
+// jwtExpiry extracts the exp claim from a JWT without verifying the
+// signature — the daemon is the party that RECEIVED this token from
+// the gateway; it only needs the timestamp for scheduling. Returns
+// false for opaque tokens or tokens without exp; those cannot be
+// scheduled and rely on passive harvesting alone.
+func jwtExpiry(token string) (time.Time, bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return time.Time{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, false
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(claims.Exp, 0), true
+}
+
+// StartTokenRenewal launches the background token-renewal scheduler.
+// It runs for the whole daemon lifetime (exits when ctx is cancelled)
+// and is a cheap no-op while the daemon is logged out.
+//
+// Each iteration sleeps until renewalLead before the current token's
+// expiry, then performs a GET /api/serverinfo carrying the token: if
+// the gateway's rotation window is active the response header hands
+// back a fresh token, which is persisted via the tokenState rotation
+// hook. Inside the window the cadence is one attempt per minute (with
+// jitter so daemon fleets don't synchronize).
+//
+// The serverinfo response also reports the gateway's feature flags:
+// when experimental.tunnel_token_renewal is reported disabled the
+// scheduler stops pre-expiry probing and schedules a single probe just
+// after expiry instead — on OIDC gateways that probe harvests the
+// (ungated) reactive refresh; on local-auth it yields the 401 that
+// triggers the clean teardown.
+//
+// A 401 means the token expired AND the gateway could not refresh it
+// server-side (refresh token revoked/expired, or local-auth without
+// renewal): the daemon performs a clean teardown with an explicit
+// reason so `hsh tunnel status` tells the user to log in again.
+func (s *daemonService) StartTokenRenewal(ctx context.Context, logf func(string, ...any)) {
+	go func() {
+		logf("token-renewal scheduler started (lead=%v)", renewalLead)
+		// flags caches the renewal flag state the gateway reported,
+		// scoped to the token epoch so a re-login (possibly against a
+		// different gateway/org) re-learns instead of inheriting the
+		// previous session's state.
+		var flags renewalFlagCache
+		for {
+			_, currentEpoch := s.tokens.Snapshot()
+			delay := s.nextRenewalDelay(flags.disabledFor(currentEpoch))
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(delay):
+			}
+
+			token, epoch := s.tokens.Snapshot()
+			if token == "" {
+				continue // logged out — idle poll
+			}
+
+			s.mu.RLock()
+			apiURL := s.cfg.APIURL
+			s.mu.RUnlock()
+			if apiURL == "" {
+				continue
+			}
+
+			rotated := false
+			si, err := client.FetchServerInfo(ctx, client.FetchServerInfoOptions{
+				APIBaseURL: apiURL,
+				Token:      token,
+				OnNewToken: func(newToken string) {
+					rotated = true
+					s.tokens.Rotate(newToken, epoch)
+				},
+			})
+			switch {
+			case errors.Is(err, client.ErrUnauthorized):
+				logf("token renewal: session is no longer renewable — tearing the tunnel down")
+				s.authExpired("session expired and could not be renewed; run 'hsh tunnel login' to re-authenticate")
+			case err != nil:
+				// Transient (gateway restart, network blip). The next
+				// iteration recomputes the delay from the same token and
+				// retries; the reactive refresh path keeps REST working
+				// even slightly past expiry on OIDC gateways.
+				logf("token renewal: probe failed (will retry): %v", err)
+			default:
+				if enabled, reported := si.FeatureFlags[renewalFlagName]; reported {
+					if flags.observe(enabled, epoch) {
+						logf("token renewal: gateway reports %s=%v", renewalFlagName, enabled)
+					}
+				}
+				if rotated {
+					if exp, ok := jwtExpiry(s.tokens.Current()); ok {
+						logf("token renewed silently — next expiry %s", exp.UTC().Format(time.RFC3339))
+					} else {
+						logf("token renewed silently")
+					}
+				}
+			}
+		}
+	}()
+}
+
+// nextRenewalDelay computes how long the scheduler sleeps before the
+// next renewal attempt, based on the current token:
+//
+//   - logged out            → 30s idle poll (cheap, no I/O)
+//   - opaque token (no exp) → hourly; passive harvesting still works
+//   - renewal flag off      → just past expiry (reactive-refresh
+//     harvest on OIDC, clean 401 on local auth)
+//   - exp known             → until renewalLead before expiry, floored
+//     at ~1 minute (jittered) so attempts inside
+//     the window pace at 1/min without fleet
+//     synchronization.
+//
+// A token rotated by other paths (connection-list refresh harvest)
+// while the scheduler sleeps simply makes the next wake-up a cheap
+// no-op probe; the iteration after that re-derives the schedule from
+// the new token's expiry.
+func (s *daemonService) nextRenewalDelay(renewalDisabled bool) time.Duration {
+	token := s.tokens.Current()
+	if token == "" {
+		return 30 * time.Second
+	}
+	exp, ok := jwtExpiry(token)
+	if !ok {
+		return time.Hour
+	}
+	minCadence := time.Minute + time.Duration(rand.Int63n(int64(30*time.Second)))
+	if renewalDisabled {
+		// No pre-expiry window to hit: one probe shortly after expiry.
+		d := time.Until(exp) + 30*time.Second
+		if d < minCadence {
+			return minCadence
+		}
+		return d
+	}
+	d := time.Until(exp) - renewalLead
+	if d < minCadence {
+		return minCadence
+	}
+	return d
+}

--- a/tunnel/cmd/hsh-tunneld/tokenrenewal_test.go
+++ b/tunnel/cmd/hsh-tunneld/tokenrenewal_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// mintUnsignedJWT builds a structurally valid JWT with the given exp.
+// The daemon never verifies signatures (it received the token from the
+// gateway), so a fake signature is fine for scheduling tests.
+func mintUnsignedJWT(t *testing.T, exp time.Time) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"EdDSA","typ":"JWT"}`))
+	payload, err := json.Marshal(map[string]any{"sub": "u", "exp": exp.Unix()})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return fmt.Sprintf("%s.%s.%s", header, base64.RawURLEncoding.EncodeToString(payload), "sig")
+}
+
+func TestTokenStateRotationSemantics(t *testing.T) {
+	ts := newTokenState()
+
+	var hookCalls []string
+	ts.SetRotationHook(func(tok string) { hookCalls = append(hookCalls, tok) })
+
+	// SetLocal never fires the hook (state the service persisted itself).
+	ts.SetLocal("initial")
+	if len(hookCalls) != 0 {
+		t.Fatal("SetLocal must not fire the rotation hook")
+	}
+	token, epoch := ts.Snapshot()
+	if token != "initial" {
+		t.Fatalf("Snapshot token: %q", token)
+	}
+
+	// A gateway rotation at the current epoch fires the hook exactly once.
+	ts.Rotate("rotated-1", epoch)
+	if ts.Current() != "rotated-1" || len(hookCalls) != 1 || hookCalls[0] != "rotated-1" {
+		t.Fatalf("rotation not applied: current=%q hooks=%v", ts.Current(), hookCalls)
+	}
+
+	// Re-harvesting the same token (multiple REST calls in the rotation
+	// window) must not rewrite the config again. Rotations do not bump
+	// the epoch, so the original epoch is still valid.
+	ts.Rotate("rotated-1", epoch)
+	if len(hookCalls) != 1 {
+		t.Fatalf("duplicate rotation must be a no-op, hooks=%v", hookCalls)
+	}
+
+	// Empty rotations are ignored.
+	ts.Rotate("", epoch)
+	if ts.Current() != "rotated-1" {
+		t.Fatal("empty rotation must not clear the token")
+	}
+
+	// A follow-up rotation from the same session (same epoch) is accepted.
+	ts.Rotate("rotated-2", epoch)
+	if ts.Current() != "rotated-2" || len(hookCalls) != 2 {
+		t.Fatalf("same-epoch follow-up rotation must apply: current=%q hooks=%v", ts.Current(), hookCalls)
+	}
+}
+
+func TestTokenStateRejectsStaleRotationAfterLogout(t *testing.T) {
+	ts := newTokenState()
+	var hookCalls []string
+	ts.SetRotationHook(func(tok string) { hookCalls = append(hookCalls, tok) })
+
+	ts.SetLocal("session-A")
+	_, epochA := ts.Snapshot()
+
+	// Logout while a request from session A is still in flight.
+	ts.SetLocal("")
+
+	// The late response must NOT resurrect the dead session.
+	ts.Rotate("rotated-from-A", epochA)
+	if ts.Current() != "" || len(hookCalls) != 0 {
+		t.Fatalf("stale rotation resurrected a dead session: current=%q hooks=%v", ts.Current(), hookCalls)
+	}
+
+	// Re-login as a different session; the stale rotation must not
+	// clobber the new session's token either.
+	ts.SetLocal("session-B")
+	ts.Rotate("rotated-from-A", epochA)
+	if ts.Current() != "session-B" || len(hookCalls) != 0 {
+		t.Fatalf("stale rotation clobbered a new session: current=%q hooks=%v", ts.Current(), hookCalls)
+	}
+
+	// While a rotation at the CURRENT epoch is accepted normally.
+	_, epochB := ts.Snapshot()
+	ts.Rotate("rotated-from-B", epochB)
+	if ts.Current() != "rotated-from-B" || len(hookCalls) != 1 {
+		t.Fatalf("current-epoch rotation rejected: current=%q hooks=%v", ts.Current(), hookCalls)
+	}
+}
+
+func TestJwtExpiry(t *testing.T) {
+	exp := time.Now().Add(45 * time.Minute).Truncate(time.Second)
+	got, ok := jwtExpiry(mintUnsignedJWT(t, exp))
+	if !ok {
+		t.Fatal("expected exp to parse")
+	}
+	if !got.Equal(exp) {
+		t.Fatalf("exp mismatch: got %v want %v", got, exp)
+	}
+
+	if _, ok := jwtExpiry("opaque-token"); ok {
+		t.Fatal("opaque token must not yield an expiry")
+	}
+	if _, ok := jwtExpiry("a.!!!.c"); ok {
+		t.Fatal("invalid base64 payload must not yield an expiry")
+	}
+}
+
+func TestNextRenewalDelay(t *testing.T) {
+	newSvc := func(token string) *daemonService {
+		ts := newTokenState()
+		ts.SetLocal(token)
+		return &daemonService{tokens: ts}
+	}
+
+	// isMinuteCadence matches the jittered in-window pacing (1m..1m30s).
+	isMinuteCadence := func(d time.Duration) bool {
+		return d >= time.Minute && d <= time.Minute+30*time.Second
+	}
+
+	// Logged out → short idle poll.
+	if d := newSvc("").nextRenewalDelay(false); d != 30*time.Second {
+		t.Fatalf("logged-out delay: %v", d)
+	}
+
+	// Opaque token → hourly.
+	if d := newSvc("opaque").nextRenewalDelay(false); d != time.Hour {
+		t.Fatalf("opaque delay: %v", d)
+	}
+
+	// Far-future expiry → sleep until renewalLead before it.
+	far := mintUnsignedJWT(t, time.Now().Add(2*time.Hour))
+	if d := newSvc(far).nextRenewalDelay(false); d < 2*time.Hour-renewalLead-time.Minute || d > 2*time.Hour-renewalLead {
+		t.Fatalf("far-future delay out of range: %v", d)
+	}
+
+	// Inside the window (or already expired) → jittered 1-minute cadence.
+	near := mintUnsignedJWT(t, time.Now().Add(2*time.Minute))
+	if d := newSvc(near).nextRenewalDelay(false); !isMinuteCadence(d) {
+		t.Fatalf("in-window delay: %v", d)
+	}
+	expired := mintUnsignedJWT(t, time.Now().Add(-time.Hour))
+	if d := newSvc(expired).nextRenewalDelay(false); !isMinuteCadence(d) {
+		t.Fatalf("expired delay: %v", d)
+	}
+
+	// Renewal disabled on the gateway → skip the pre-expiry window and
+	// wake shortly after expiry instead.
+	if d := newSvc(far).nextRenewalDelay(true); d < 2*time.Hour || d > 2*time.Hour+time.Minute {
+		t.Fatalf("flag-off delay must land just past expiry: %v", d)
+	}
+	if d := newSvc(expired).nextRenewalDelay(true); !isMinuteCadence(d) {
+		t.Fatalf("flag-off expired delay: %v", d)
+	}
+}
+
+func TestRenewalFlagCacheResetsOnEpochChange(t *testing.T) {
+	var c renewalFlagCache
+
+	// Optimistic default at epoch 1.
+	if c.disabledFor(1) {
+		t.Fatal("cache must start optimistic (renewal enabled)")
+	}
+
+	// Gateway for session at epoch 1 reports the flag off.
+	if flipped := c.observe(false, 1); !flipped {
+		t.Fatal("enabled→disabled must report a flip")
+	}
+	if !c.disabledFor(1) {
+		t.Fatal("flag-off observation must stick within the same epoch")
+	}
+	if c.observe(false, 1) {
+		t.Fatal("repeated identical observation must not report a flip")
+	}
+
+	// Logout + re-login (epoch bump): the new session must NOT inherit
+	// the previous session's flag-off state.
+	if c.disabledFor(2) {
+		t.Fatal("epoch change must reset the cache to optimistic")
+	}
+
+	// A late observation from the dead epoch must be ignored.
+	if c.observe(false, 1) {
+		t.Fatal("stale-epoch observation must be ignored")
+	}
+	if c.disabledFor(2) {
+		t.Fatal("stale-epoch observation must not poison the new session")
+	}
+}

--- a/tunnel/tunnelmgr/gateway.go
+++ b/tunnel/tunnelmgr/gateway.go
@@ -21,7 +21,7 @@ import (
 // pinned via cfg.GrpcURL. TLSSkipVerify / TLSServerName come from
 // the manager opts so the same envs the legacy code honoured
 // continue to work.
-func (m *Manager) buildGatewayConfig(ctx context.Context, cfg daemonconfig.Config) (grpc.ClientConfig, string, error) {
+func (m *Manager) buildGatewayConfig(ctx context.Context, cfg daemonconfig.Config, tokens TokenSource) (grpc.ClientConfig, string, error) {
 	if cfg.APIURL == "" || cfg.Token == "" {
 		return grpc.ClientConfig{}, "", errors.New("api_url and token are required")
 	}
@@ -29,9 +29,11 @@ func (m *Manager) buildGatewayConfig(ctx context.Context, cfg daemonconfig.Confi
 
 	grpcURL := cfg.GrpcURL
 	if grpcURL == "" {
+		token, epoch := tokens.Snapshot()
 		si, err := client.FetchServerInfo(ctx, client.FetchServerInfoOptions{
 			APIBaseURL: apiBase,
-			Token:      cfg.Token,
+			Token:      token,
+			OnNewToken: func(newToken string) { tokens.Rotate(newToken, epoch) },
 		})
 		if err != nil {
 			return grpc.ClientConfig{}, "", fmt.Errorf("fetch serverinfo: %w", err)
@@ -43,10 +45,14 @@ func (m *Manager) buildGatewayConfig(ctx context.Context, cfg daemonconfig.Confi
 	if err != nil {
 		return grpc.ClientConfig{}, "", fmt.Errorf("parse gRPC URL %q: %w", grpcURL, err)
 	}
+	currentToken, _ := tokens.Snapshot()
 	return grpc.ClientConfig{
 		ServerAddress: srvAddr,
-		Token:         cfg.Token,
-		Insecure:      isInsecureScheme(grpcURL),
+		// Token here is the bring-up snapshot; per-flow dials overwrite
+		// it with a fresh snapshot so rotations apply to new streams
+		// (see makeTCPHandler).
+		Token:    currentToken,
+		Insecure: isInsecureScheme(grpcURL),
 		// Honour the same env-var escape hatches the daemon honoured
 		// pre-refactor. Wiring them through Options would be cleaner
 		// but for dev/integration runs the env is what people set.

--- a/tunnel/tunnelmgr/handlers.go
+++ b/tunnel/tunnelmgr/handlers.go
@@ -65,6 +65,7 @@ func (m *Manager) makeTCPHandler(
 	alloc *addressing.Allocator,
 	registry *connRegistry,
 	gatewayCfg grpc.ClientConfig,
+	tokens TokenSource,
 ) netstack.Handler {
 	logger := m.opts.Logger
 	userAgent := m.opts.UserAgent
@@ -78,8 +79,13 @@ func (m *Manager) makeTCPHandler(
 		}
 		subType, _ := registry.subTypeOf(name)
 		logger.Printf("tunnelmgr: accept %s:%d -> %s (%s)", localAddr, localPort, name, subType)
+		// Re-snapshot the token per flow: gatewayCfg is a value copy, so
+		// a token rotated mid-session (DEP-24) is picked up by every new
+		// stream while in-flight pipes keep their original credentials.
+		flowCfg := gatewayCfg
+		flowCfg.Token, _ = tokens.Snapshot()
 		err := client.DialAndPipe(context.Background(), conn, client.PipeOptions{
-			GatewayConfig:  gatewayCfg,
+			GatewayConfig:  flowCfg,
 			ConnectionName: name,
 			UserAgent:      userAgent,
 		})

--- a/tunnel/tunnelmgr/manager.go
+++ b/tunnel/tunnelmgr/manager.go
@@ -52,9 +52,12 @@ import (
 // State enumerates the manager lifecycle.
 //
 // Idle  → no netstack, no routes, no goroutines. The daemon is "logged
-//         out" or simply hasn't been asked to bring the tunnel up yet.
+//
+//	out" or simply hasn't been asked to bring the tunnel up yet.
+//
 // Up    → netstack is serving TCP + DNS, routes are configured, the
-//         gateway gRPC is dialable from the TUN side.
+//
+//	gateway gRPC is dialable from the TUN side.
 //
 // We intentionally do NOT expose the transient BringingUp / TearingDown
 // values — callers should observe steady states only. Internally we
@@ -164,38 +167,73 @@ type Options struct {
 	// back to the manual hint on unsupported hosts). Tests inject a
 	// fake to assert call shape without spawning resolvectl.
 	ResolvedConfigurer resolved.Configurer
+
+	// TokenSource, when set, supplies the current gateway bearer token
+	// and receives tokens the gateway rotates via X-New-Access-Token.
+	// The manager snapshots it at every use site (per-flow gRPC dials,
+	// connection-list refreshes) instead of pinning the token captured
+	// at bring-up, so a token rotated mid-session (DEP-24 silent
+	// renewal) takes effect on the next dial without re-bringing the
+	// tunnel up. Optional: when nil, the bring-up config's Token is
+	// used for the whole session (pre-renewal behaviour).
+	TokenSource TokenSource
 }
+
+// TokenSource is the manager's view of the daemon's token state. The
+// epoch makes rotation race-safe: a rotation harvested from an
+// in-flight response is only accepted if the token state has not been
+// swapped (login/logout/auth-expiry) since the request was built —
+// otherwise a slow response from a dead session could resurrect its
+// token after an explicit logout.
+type TokenSource interface {
+	// Snapshot returns the token to attach to a request right now and
+	// the epoch identifying this token generation.
+	Snapshot() (token string, epoch uint64)
+
+	// Rotate installs a token the gateway rotated during a request
+	// built at the given epoch. Implementations must reject the
+	// rotation when the epoch no longer matches.
+	Rotate(newToken string, epoch uint64)
+}
+
+// staticTokenSource pins a single token for the whole tunnel session —
+// the pre-DEP-24 behaviour, used when Options.TokenSource is nil
+// (tests, embedded usage).
+type staticTokenSource struct{ token string }
+
+func (s staticTokenSource) Snapshot() (string, uint64) { return s.token, 0 }
+func (s staticTokenSource) Rotate(string, uint64)      {}
 
 // Manager is the lifecycle owner. Construct with New; drive with
 // BringUp / TearDown; read with Snapshot. Safe for concurrent use.
 type Manager struct {
 	opts Options
 
-	mu       sync.RWMutex
-	state    State
-	since    time.Time
-	current  *liveTunnel // non-nil iff state == StateUp
+	mu      sync.RWMutex
+	state   State
+	since   time.Time
+	current *liveTunnel // non-nil iff state == StateUp
 }
 
 // liveTunnel groups every resource that participates in a single
 // "up" session. Held under Manager.mu while transitioning; readable
 // without the lock once published to Manager.current.
 type liveTunnel struct {
-	ctx      context.Context
-	cancel   context.CancelFunc
-	alloc    *addressing.Allocator
-	registry *connRegistry
-	stack    *netstack.Stack
+	ctx        context.Context
+	cancel     context.CancelFunc
+	alloc      *addressing.Allocator
+	registry   *connRegistry
+	stack      *netstack.Stack
 	deviceName string
 	prefix     string
 	hostAddr   netip.Addr
 	gateway    netip.Addr
 	apiBase    string
-	// token is the gateway bearer token captured at bring-up, reused by
-	// Refresh to re-fetch the connection list without going through the
-	// daemon config again. It lives only in memory for the tunnel's
-	// lifetime (the daemon's config file is the durable copy).
-	token string
+	// tokens supplies the gateway bearer token for every use site and
+	// receives epoch-guarded rotations harvested during this tunnel's
+	// own REST calls (DEP-24). Never nil: BringUp falls back to a
+	// static source pinning the bring-up token.
+	tokens TokenSource
 
 	// routeCfg is the exact addressing handed to netstack.ConfigureRoutes
 	// at bring-up. Stored verbatim so teardown reverses precisely what was
@@ -425,7 +463,15 @@ func (m *Manager) buildTunnel(parentCtx context.Context, cfg daemonconfig.Config
 		return nil, err
 	}
 
-	gatewayCfg, apiBase, err := m.buildGatewayConfig(ctx, cfg)
+	// Resolve the token plumbing once: with a TokenSource the token is
+	// re-snapshotted at every use site so mid-session rotations (DEP-24)
+	// apply to new flows; without one, the bring-up token is pinned.
+	source := m.opts.TokenSource
+	if source == nil {
+		source = staticTokenSource{token: cfg.Token}
+	}
+
+	gatewayCfg, apiBase, err := m.buildGatewayConfig(ctx, cfg, source)
 	if err != nil {
 		return cleanup(err)
 	}
@@ -437,7 +483,7 @@ func (m *Manager) buildTunnel(parentCtx context.Context, cfg daemonconfig.Config
 		alloc.Prefix(), alloc.Gateway())
 
 	registry := newConnRegistry()
-	added, err := loadConnections(ctx, alloc, registry, apiBase, gatewayCfg.Token, m.opts.Logger)
+	added, err := loadConnections(ctx, alloc, registry, apiBase, source, m.opts.Logger)
 	if err != nil {
 		return cleanup(err)
 	}
@@ -453,7 +499,7 @@ func (m *Manager) buildTunnel(parentCtx context.Context, cfg daemonconfig.Config
 		GatewayV4:  alloc.GatewayV4(),
 		DeviceName: m.opts.DeviceName,
 		TCPAccept:  m.makeAcceptFunc(alloc, registry),
-		TCPHandler: m.makeTCPHandler(alloc, registry, gatewayCfg),
+		TCPHandler: m.makeTCPHandler(alloc, registry, gatewayCfg, source),
 		DNSHandler: rsvr.HandleUDP,
 	})
 	if err != nil {
@@ -514,7 +560,7 @@ func (m *Manager) buildTunnel(parentCtx context.Context, cfg daemonconfig.Config
 		hostAddr:       alloc.HostAddr(),
 		gateway:        alloc.Gateway(),
 		apiBase:        apiBase,
-		token:          gatewayCfg.Token,
+		tokens:         source,
 		routeCfg:       routeCfg,
 		resolvedActive: resolvedActive,
 		resolved:       m.opts.ResolvedConfigurer,
@@ -536,12 +582,15 @@ func loadConnections(
 	ctx context.Context,
 	alloc *addressing.Allocator,
 	registry *connRegistry,
-	apiBase, token string,
+	apiBase string,
+	tokens TokenSource,
 	logger Logger,
 ) (activeCount int, err error) {
+	token, epoch := tokens.Snapshot()
 	conns, err := client.FetchConnections(ctx, client.FetchConnectionsOptions{
 		APIBaseURL: apiBase,
 		Token:      token,
+		OnNewToken: func(newToken string) { tokens.Rotate(newToken, epoch) },
 	})
 	if err != nil {
 		return 0, fmt.Errorf("fetch connections: %w", err)
@@ -577,7 +626,7 @@ func (m *Manager) Refresh(ctx context.Context) error {
 	if t == nil {
 		return nil
 	}
-	_, err := loadConnections(ctx, t.alloc, t.registry, t.apiBase, t.token, m.opts.Logger)
+	_, err := loadConnections(ctx, t.alloc, t.registry, t.apiBase, t.tokens, m.opts.Logger)
 	return err
 }
 


### PR DESCRIPTION
Fixes DEP-24

## Problem

A tunnel session dies with its access token. The gateway's `X-New-Access-Token` rotation was **reactive-only** (fires after expiry, HTTP middleware only) and `hsh-tunneld` **discarded the header**, treating its token as a static credential. Net effect: users had to reopen the webapp to renew their session, and even that didn't help the tunnel — the gRPC auth interceptor has no refresh path, so new flows die at stream-open once the daemon's token copy lapses.

## Change

**Gateway** (gated by new flag `experimental.tunnel_token_renewal`, default off):
- Auth middleware rotates **still-valid** tokens within a 10-min pre-expiry window (after authn/authz), so long-lived clients always hold a token that is valid at gRPC stream-open time
- OIDC: exchanges the server-side stored refresh token (shares the singleflight refresh core with the reactive path; `TryProactiveRefreshForVerifiedSubject` documents the trust contract)
- Local auth: sliding-session re-mint with a signature-verified `auth_time` claim preserved across renewals and a **7-day absolute cap** — stolen tokens can't be kept alive indefinitely; future `auth_time` rejected at mint and verify
- Renewals logged with subject + auth method (audit requirement)

**Daemon** (`tunnel/`, works with or without the flag):
- Harvests `X-New-Access-Token` from every REST response; persists to the daemon config
- `tunnelmgr.TokenSource`: per-flow dials snapshot the current token; rotations are **epoch-guarded** so a slow response from an ended session (logout/auth-expiry/re-login) can never resurrect its token
- Renewal scheduler wakes 5 min before `exp` and probes `/api/serverinfo`; when the gateway reports the flag off it degrades to one probe just past expiry (harvests the ungated reactive OIDC refresh); jittered cadence, epoch-scoped flag cache
- **Clean failure**: 401 (server-side refresh also dead) → tunnel teardown, credential cleared, explicit re-login instruction in `hsh tunnel status` — replaces today's silent half-dead limping

## Tests

- `common/keys`: auth_time preservation, legacy iat fallback, forged-token rejection
- `gateway/idp/local`: sliding renewal, absolute cap, auth_time preservation across hops, foreign-key rejection
- `tunnel/client`: rotation harvesting, no-header no-callback, typed 401 on both endpoints
- `tunnel/cmd/hsh-tunneld`: tokenState epoch semantics incl. the logout/late-rotation race and re-login-as-other-user clobber, jwtExpiry, scheduler delays (all modes), flag-cache epoch reset

## Follow-ups

- Middleware behavior-matrix test (flag off / near-expiry local / beyond-cap / OIDC / SAML) belongs in the integration harness — needs DB-backed flag store
- Compressed-time E2E for the 24h acceptance criterion (short-lived local tokens + the standalone harness)
- 7-day local-auth cap is a constant while experimental; per-org configuration lands with the DEP-16 org settings

Two review passes: initial HIGH (token-resurrection race) fixed via epoch guarding; follow-up MEDIUM (flag cache crossing session boundaries) fixed via epoch-scoped cache. Reviewer signed off on the design after fixes.

Automated by MisterMal