### PR TITLE
Add test for close connection on mongodb

### DIFF
--- a/agent/integration/mongodb_test.go
+++ b/agent/integration/mongodb_test.go
@@ -13,6 +13,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"github.com/hoophq/hoop/agent/integration/testutil"
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
 )
 
 const mongoTestTimeout = 30 * time.Second
@@ -241,6 +243,105 @@ func TestMongoDB_BadCredentials(t *testing.T) {
 	if err := client.PingWithTimeout(15 * time.Second); err == nil {
 		t.Fatal("expected ping to fail with bad upstream credentials, got nil")
 	}
+}
+
+// TestMongoDB_CloseKillsRunningOperation is the regression test for
+// operations surviving a client disconnect. Closing the proxy used to only
+// close the backend TCP socket, which MongoDB does not treat as a reason
+// to abort most in-flight operations (only cursor reads are aborted, and
+// only at interrupt checkpoints) — a heavy command kept running server-side
+// after the hoop client was gone. Close() must now kill the operations of
+// its backend connection through the killOp side channel.
+//
+// The long-running operation is the server `sleep` test command (hence
+// StartMongoDBWithTestCommands): unlike a slow find, it is deterministic
+// and is never self-aborted on disconnect, so the only way it disappears
+// from $currentOp is an explicit killOp.
+func TestMongoDB_CloseKillsRunningOperation(t *testing.T) {
+	mc := testutil.StartMongoDBWithTestCommands(t)
+	agent, tr := startAgent(t)
+	defer shutdownAgent(t, agent, tr)
+	sessionID := testutil.OpenMongoSession(t, tr, mc)
+	demux := testutil.StartRecvDemux(t, tr)
+	client := testutil.DialPipedMongo(t, tr, demux, mc, sessionID, "conn-kill")
+
+	if err := client.PingWithTimeout(mongoTestTimeout); err != nil {
+		t.Fatalf("mongodb ping through agent failed: %v", err)
+	}
+
+	// Sidecar admin client observing the server directly, bypassing the
+	// agent, to assert what is actually running server-side.
+	sidecarCtx, sidecarCancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+	defer sidecarCancel()
+	sidecar, err := mongo.Connect(sidecarCtx, options.Client().ApplyURI(mc.UpstreamConnString()))
+	if err != nil {
+		t.Fatalf("failed opening sidecar connection: %v", err)
+	}
+	defer sidecar.Disconnect(context.Background())
+
+	// Fire the long-running operation through the proxied connection. It
+	// returns with an error either when killOp aborts it (the fix) or when
+	// the bridge is torn down, so the goroutine always exits.
+	go func() {
+		_ = client.Client.Database("admin").RunCommand(context.Background(), bson.D{
+			{Key: "sleep", Value: 1},
+			{Key: "millis", Value: 120000},
+			{Key: "lock", Value: "none"},
+		}).Err()
+	}()
+
+	if !waitForMongoSleepOp(t, sidecar, true, 15*time.Second) {
+		t.Fatal("sleep operation never showed up in $currentOp; cannot exercise the kill path")
+	}
+
+	// Close the whole session at the agent — what a client disconnect
+	// triggers at the gateway. sessionCleanup closes every proxy of the
+	// session; the one owning the backend connection with the sleep
+	// operation must kill it.
+	tr.Inject(&pb.Packet{
+		Type: pbagent.SessionClose,
+		Spec: map[string][]byte{pb.SpecGatewaySessionID: []byte(sessionID)},
+	})
+
+	if !waitForMongoSleepOp(t, sidecar, false, 20*time.Second) {
+		t.Fatal("sleep operation still running on the server after session close: the killOp side channel did not terminate it")
+	}
+}
+
+// waitForMongoSleepOp polls $currentOp through the sidecar connection until
+// the presence of the sleep test command matches wantPresent, returning
+// false on timeout.
+func waitForMongoSleepOp(t *testing.T, sidecar *mongo.Client, wantPresent bool, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if mongoSleepOpRunning(t, sidecar) == wantPresent {
+			return true
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return false
+}
+
+// mongoSleepOpRunning reports whether a `sleep` command is currently
+// running on the server, checked via $currentOp over the sidecar (direct,
+// non-proxied) connection.
+func mongoSleepOpRunning(t *testing.T, sidecar *mongo.Client) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cursor, err := sidecar.Database("admin").Aggregate(ctx, mongo.Pipeline{
+		{{Key: "$currentOp", Value: bson.D{{Key: "allUsers", Value: true}}}},
+		{{Key: "$match", Value: bson.D{{Key: "command.sleep", Value: bson.D{{Key: "$exists", Value: true}}}}}},
+	})
+	if err != nil {
+		t.Fatalf("failed listing current operations: %v", err)
+	}
+	var ops []bson.M
+	if err := cursor.All(ctx, &ops); err != nil {
+		t.Fatalf("failed decoding current operations: %v", err)
+	}
+	return len(ops) > 0
 }
 
 // asMongoCommandError is errors.As specialized for mongo.CommandError.

--- a/agent/integration/testutil/mongo_container.go
+++ b/agent/integration/testutil/mongo_container.go
@@ -39,6 +39,21 @@ const (
 // ping because mongod logs "waiting for connections" slightly before the
 // root user (created from the MONGO_INITDB env vars) is usable.
 func StartMongoDB(t T) *MongoContainer {
+	return startMongoDB(t)
+}
+
+// StartMongoDBWithTestCommands boots the same container as StartMongoDB
+// but with --setParameter enableTestCommands=1, unlocking server test
+// commands such as `sleep`, which tests use as a deterministic stand-in
+// for a long-running operation (unlike cursor reads, it is never aborted
+// by a client disconnect — only killOp stops it).
+func StartMongoDBWithTestCommands(t T) *MongoContainer {
+	return startMongoDB(t, "--setParameter", "enableTestCommands=1")
+}
+
+// startMongoDB boots the MongoDB container, passing any extra args to
+// mongod (the image entrypoint forwards container args to the daemon).
+func startMongoDB(t T, mongodArgs ...string) *MongoContainer {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
@@ -46,6 +61,7 @@ func StartMongoDB(t T) *MongoContainer {
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        "mongo:7",
 			ExposedPorts: []string{"27017/tcp"},
+			Cmd:          mongodArgs,
 			Env: map[string]string{
 				"MONGO_INITDB_ROOT_USERNAME": mongoRootUser,
 				"MONGO_INITDB_ROOT_PASSWORD": mongoRootPass,


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

MongoDB operations kept running on the server after the hoop client disconnected. Closing the proxy only closed the backend TCP socket, and MongoDB does not abort most in-flight operations on client disconnect (only cursor-producing reads, and only at interrupt checkpoints) — so a heavy command started through `hoop connect` would keep consuming server resources after the session was gone.

The fix lives in libhoop (hoophq/libhoop: `fix connection kill on mongodb`): the proxy now captures the server-assigned `connectionId` from the `hello` reply during authentication, and `Close()` kills any operation still running on that specific backend connection through a short-lived side channel (`$currentOp {allUsers: false}` filtered by `connectionId` + `killOp`). No extra privileges are required — the side channel authenticates with the same credentials as the proxied connection and only touches its own operations. This mirrors the MySQL `KILL CONNECTION` fix from #1582 / libhoop#87.

This PR adds the integration regression test covering that behavior end to end through the agent.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [x] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `TestMongoDB_CloseKillsRunningOperation` (`agent/integration/mongodb_test.go`): starts a 120s server-side `sleep` command through the bridged mongo driver, confirms it in `$currentOp` via a direct sidecar connection, injects a `SessionClose` packet at the agent, and asserts the operation disappears from the server. The `sleep` test command is used precisely because MongoDB never self-aborts it on disconnect — only `killOp` can stop it, so the test fails without the libhoop fix.
- Added `testutil.StartMongoDBWithTestCommands` (`agent/integration/testutil/mongo_container.go`): boots the same `mongo:7` container with `--setParameter enableTestCommands=1` to unlock the `sleep` command.
- Picks up the libhoop fix that adds the `killOp` side channel to the MongoDB proxy's `Close()`.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a
- **OS**: macOS (agent integration tests via testcontainers/Docker, `mongo:7`)

### Tests performed:
- [x] Unit tests pass (`go test ./libhoop/agent/mongodb/...`, `go vet` clean)
- [x] Integration tests pass (`go test -tags integration -run TestMongoDB ./agent/integration/` — full MongoDB suite green, new test passes in ~17s)
- [x] Manual testing completed (negative control: with the kill call disabled in libhoop, the sleep operation survives the session close and the new test fails — proving both the bug and the test's sensitivity)

## 📸 Screenshots (if applicable)

n/a — relevant agent log line on session close:

```
msg":"killed 1 operation(s) running on mongodb connection 6","sid":"...","conn":"conn-kill-2"
```

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- Reviewers: the interesting scoping property is in libhoop — the kill filters `$currentOp` by the exact backend `connectionId` of the closing proxy, so concurrent connections/sessions (including the driver's monitoring sockets, which never authenticate and keep id 0) can never k