### PR TITLE
fix(gateway): Oracle tables listing times out on databases with many schemas

### DIFF
--- a/gateway/api/connections/queries_schema.go
+++ b/gateway/api/connections/queries_schema.go
@@ -126,6 +126,7 @@ ORDER BY t.TABLE_SCHEMA, t.TABLE_NAME;`, dbName)
 
 func getOracleDBTablesQuery() string {
 	return `
+SET ARRAYSIZE 1000;
 SELECT
     t.owner as schema_name,
     'table' as object_type,


### PR DESCRIPTION
## 📝 Description

Fixes a 30-second timeout when listing tables/schemas for Oracle connections with many schemas via the webapp database explorer.

The schema listing runs `getOracleDBTablesQuery()` through `sqlplus`. SQL*Plus's default `ARRAYSIZE` is 15, meaning it fetches only 15 rows per network round-trip. On databases with thousands of schemas/tables (e.g. ~10k rows from `all_tables`), that's ~670 sequential round-trips — with any meaningful network latency between the agent and the database (e.g. an RDS instance in another region), the transfer alone exceeds the gateway's 30s budget in `ListTables`, and the webapp shows `Request timed out (30s) while fetching tables`.

Setting `ARRAYSIZE 1000` reduces the fetch to a handful of round-trips, so the same listing completes in seconds. This is a client-side SQL*Plus setting scoped to the exec session: no server-side changes, no privileges required, and no effect on other connection types.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] ⚡ Performance improvement

## 📋 Changes Made

- Prepend `SET ARRAYSIZE 1000;` to the Oracle tables query in `getOracleDBTablesQuery()` (`gateway/api/connections/queries_schema.go`) so sqlplus fetches 1000 rows per round-trip instead of the default 15.

## 🧪 Testing

Reproduced against an Oracle 19c RDS instance seeded with 10,000 schemas (one table each):

- **Before**: `GET /api/connections/{name}/tables` consistently hit the 30s timeout (`timeout (30s) obtaining tables` in gateway logs); the agent kept streaming stdout after the proxy disconnected.
- **After**: the same request returns the full schema tree well within the timeout.
- Also verified against a local Oracle 19c container with a small number of schemas to confirm the output format is unchanged (`SET` commands produce no output in silent/CSV-markup mode, so `parseSQLTables` parsing is unaffected).

### Test Configuration:
- **Browser(s)**: Chrome (webapp database explorer)
- **OS**: macOS (agent) → Oracle 19c on AWS RDS (us-west-2) and local Docker container

### Tests performed:
- [x] Unit tests pass
- [x] Manual testing completed

## 📄 Additional Notes

- The root cause of slow listings is round-trip amplification, not query cost — `all_tables` itself returns quickly.
- Possible follow-ups (out of scope here): apply the same setting to `getOracleDBColumnsQuery()`; push the `?schema=` filter into the Oracle SQL instead of filtering in Go; replace the hardcoded internal-schema `NOT IN` list with `all_users.oracle_maintained = 'N'` (12c+), which would also hide internal accounts missing from the list, like `DBSFWUSER`.