### PR TITLE
fix(gateway): bound RDP relay queue and recorder finalize memory

### DIFF
--- a/gateway/broker/protocol_rdp.go
+++ b/gateway/broker/protocol_rdp.go
@@ -70,8 +70,10 @@ func CreateRDPSession(
 		return nil, fmt.Errorf("agent not found: %s", connectionInfo.AgentName)
 	}
 
-	// 8192 is the maximum number of messages that can be queued without blocking
-	dataChannel := make(chan []byte, 8192)
+	// Slot count only decouples producer and consumer scheduling; the real
+	// bound on queued data is the byte budget (maxQueuedBytes) enforced by
+	// ForwardToTCP.
+	dataChannel := make(chan []byte, 1024)
 	credentialsReceived := make(chan bool, 1)
 
 	session := &Session{
@@ -86,6 +88,8 @@ func CreateRDPSession(
 		credentialsReceived: credentialsReceived,
 		ctx:                 ctx,
 		cancel:              timeoutCancelFn,
+		maxQueueBytes:       maxQueuedBytes,
+		spaceFreed:          make(chan struct{}, 1),
 	}
 
 	// Store session immediately so it can be found by WebSocket handler
@@ -135,14 +139,25 @@ func CreateRDPSession(
 		Payload:  []byte{}, // Empty payload since session ID is in header
 	}
 
+	// abort releases the session's context (unblocking any relay producer
+	// already racing data in) and deregisters it. It deliberately does NOT
+	// call session.Close(): that would close the AgentCommunicator, which is
+	// the agent's shared websocket — killing every other session on that
+	// agent over a single failed session setup. The client TCP connection is
+	// owned and closed by the caller on error.
+	abort := func() {
+		timeoutCancelFn()
+		BrokerInstance.sessions.Delete(sessionID)
+	}
+
 	framedData, err := EncodeWebSocketMessage(sessionID, msg)
 	if err != nil {
-		BrokerInstance.sessions.Delete(sessionID)
+		abort()
 		return nil, err
 	}
 
 	if err := session.SendToAgent(framedData); err != nil {
-		BrokerInstance.sessions.Delete(sessionID)
+		abort()
 		return nil, err
 	}
 
@@ -157,7 +172,7 @@ func CreateRDPSession(
 		return session, nil
 	case <-timeoutCtx.Done():
 		// Clean up session on timeout
-		BrokerInstance.sessions.Delete(sessionID)
+		abort()
 		return nil, fmt.Errorf("timeout waiting for %s started response", protocol)
 	}
 }

--- a/gateway/broker/session.go
+++ b/gateway/broker/session.go
@@ -20,6 +20,22 @@ type Broker struct {
 
 var BrokerInstance = &Broker{}
 
+// maxQueuedBytes caps how many bytes the agent->client relay queue of a
+// single session may hold. When the client drains slower than the agent
+// produces (WAN browser vs. LAN agent), the producer blocks in ForwardToTCP
+// instead of queueing without bound — backpressure then propagates over the
+// agent websocket's TCP flow control into the protocol's own pacing. Before
+// this cap existed the queue was bounded only in message count (8192 slots),
+// which under RDP-sized frames meant multi-GB of heap and an OOM-killed
+// gateway (July 2026 tryrunops incident).
+//
+// Capacity planning note: this bounds the *queued* bytes. Total in-flight
+// data per session is up to maxQueuedBytes plus up to two messages held
+// outside the queue (one being written to the client, one unread remainder
+// in the conn wrapper) plus whatever the GC has not collected yet — budget
+// roughly 2x this constant per hot session.
+const maxQueuedBytes = 32 << 20 // 32 MiB
+
 type Session struct {
 	ID                 uuid.UUID
 	ClientCommunicator ConnectionCommunicator
@@ -35,6 +51,13 @@ type Session struct {
 	ctx                 context.Context
 	cancel              context.CancelFunc
 	mu                  sync.Mutex
+
+	// agent->client relay queue byte accounting (guarded by mu). spaceFreed
+	// is a capacity-1 wakeup signal: receivers nudge it after crediting
+	// budget back so a producer blocked in ForwardToTCP re-checks.
+	queuedBytes   int64
+	maxQueueBytes int64
+	spaceFreed    chan struct{}
 }
 
 func (s *Session) AcknowledgeCredentials() {
@@ -70,10 +93,11 @@ func (s *Session) Close() {
 		s.cancel()
 	}
 
-	// Close data channel safely
-	if s.dataChannel != nil {
-		close(s.dataChannel)
-	}
+	// The data channel is deliberately NOT closed: producers may be blocked
+	// in a send racing this close, and closing would turn that race into a
+	// send-on-closed-channel panic. Receivers observe termination through
+	// ctx.Done() instead; the channel itself is garbage collected with the
+	// session.
 
 	// Close consumer connection
 	if s.ClientCommunicator != nil {
@@ -89,24 +113,90 @@ func (s *Session) Close() {
 	BrokerInstance.sessions.Delete(s.ID)
 }
 
-// ForwardToTCP forward data from agent to tcp
+// ForwardToTCP relays data from the agent toward the client. The queue is
+// byte-budgeted: when the client is slower than the agent, this call blocks
+// once maxQueueBytes are in flight, propagating backpressure to the agent
+// websocket instead of growing the heap. A message larger than the whole
+// budget is still admitted once the queue is empty, so oversized frames
+// cannot deadlock the relay. Data is never silently dropped mid-stream — for
+// a byte-oriented protocol like RDP-in-TLS that would corrupt the stream;
+// the only discard case is session termination.
 func (s *Session) ForwardToTCP(data []byte) {
-	s.mu.Lock()
-	if s.closed || s.dataChannel == nil {
-		s.mu.Unlock()
-		return // Session is closed
+	if len(data) == 0 {
+		return
 	}
-	s.mu.Unlock()
+
+	// Acquire byte budget.
+	for {
+		s.mu.Lock()
+		if s.closed || s.dataChannel == nil {
+			s.mu.Unlock()
+			return // Session is closed
+		}
+		if s.queuedBytes == 0 || s.queuedBytes+int64(len(data)) <= s.maxQueueBytes {
+			s.queuedBytes += int64(len(data))
+			s.mu.Unlock()
+			break
+		}
+		s.mu.Unlock()
+
+		select {
+		case <-s.spaceFreed:
+			// budget may have been credited back; re-check
+		case <-s.ctx.Done():
+			return // Session is being closed
+		}
+	}
 
 	select {
-	// the data is created with a buffer size of 1024
-	// Up to 1024 messages can be queued without blocking
-	//If the buffer is full, new data is dropped rather than blocking
 	case s.dataChannel <- data:
-		// Successfully sent
+		// Successfully queued
 	case <-s.ctx.Done():
-		// Session is being closed, don't send
-		log.Infof("Session %s closed, dropping data", s.ID)
+		// Session closed while waiting for a channel slot; return the
+		// budget so a concurrent producer blocked above can observe it.
+		s.creditQueueBytes(int64(len(data)))
+	}
+}
+
+// creditQueueBytes returns budget to the queue and wakes one producer that
+// may be waiting for space.
+func (s *Session) creditQueueBytes(n int64) {
+	s.mu.Lock()
+	s.queuedBytes -= n
+	if s.queuedBytes < 0 {
+		// Accounting invariant broken — clamp so admission control keeps
+		// working, but log loudly: a silent underflow would quietly disable
+		// the byte budget.
+		log.Errorf("session %s relay queue accounting underflow (%d), clamping to 0", s.ID, s.queuedBytes)
+		s.queuedBytes = 0
+	}
+	s.mu.Unlock()
+	select {
+	case s.spaceFreed <- struct{}{}:
+	default:
+	}
+}
+
+// receiveData pops the next relay message, crediting its bytes back to the
+// producer budget. It returns io.EOF once the session is closed and ctx.Err()
+// when the caller-supplied context (read deadline) expires first.
+func (s *Session) receiveData(ctx context.Context) ([]byte, error) {
+	select {
+	case data := <-s.dataChannel:
+		s.creditQueueBytes(int64(len(data)))
+		return data, nil
+	case <-s.ctx.Done():
+		// Serve anything already queued before reporting EOF: the closing
+		// side may have raced messages into the channel.
+		select {
+		case data := <-s.dataChannel:
+			s.creditQueueBytes(int64(len(data)))
+			return data, nil
+		default:
+			return nil, io.EOF
+		}
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }
 
@@ -154,20 +244,18 @@ func (s *Session) ForwardToAgent(data []byte) error {
 
 // ForwardToClient this will forward data from agent to tcp
 func (s *Session) ForwardToClient() {
-	for data := range s.dataChannel {
+	for {
+		data, err := s.receiveData(context.Background())
+		if err != nil {
+			return // session closed
+		}
 
 		// Write directly to TCP connection
 		if err := s.ClientCommunicator.Send(data); err != nil {
 			log.Infof("TCP write error: %v", err)
-			break
+			return
 		}
 	}
-}
-
-// GetTCPDataChannel returns the channel that will be used to send data to the TCP connection
-// Warn: do not use this when calling ForwardToClient()
-func (s *Session) GetTCPDataChannel() chan []byte {
-	return s.dataChannel
 }
 
 // ToConn returns a net.Conn that can be used to read and write as a normal go connection
@@ -348,67 +436,56 @@ func RevokeByCredentialID(credentialID string) {
 
 var _ net.Conn = (*sessionConnWrapper)(nil)
 
-// sessionConnWrapper makes Session look like a normal net.Conn
+// sessionConnWrapper makes Session look like a normal net.Conn. The
+// unconsumed remainder of the last relay message is retained by reference in
+// `pending` and served on subsequent reads — never truncated. (A previous
+// version spilled the remainder into a fixed 16 KiB array, silently dropping
+// whatever exceeded it and corrupting the byte stream for large messages.)
+//
+// Field access is mutex-guarded so deadline updates racing a Read (e.g. from
+// a tls.Conn that assumes net.Conn thread-safety) stay memory-safe. Byte
+// ordering is only meaningful with a single reader goroutine, which is the
+// contract of a byte stream anyway.
 type sessionConnWrapper struct {
-	session   *Session
-	deadline  *time.Time
-	buffer    [16384]byte
-	bufferPos int // current position in buffer
-	bufferLen int // amount of valid data in a buffer
+	session  *Session
+	mu       sync.Mutex
+	deadline *time.Time
+	pending  []byte // unread tail of the last message popped from the queue
 }
 
 func (s *sessionConnWrapper) Read(b []byte) (n int, err error) {
+	// First, serve any buffered data and snapshot the deadline. The lock is
+	// NOT held while blocking on the queue below.
+	s.mu.Lock()
+	if len(s.pending) > 0 {
+		n := copy(b, s.pending)
+		s.pending = s.pending[n:]
+		s.mu.Unlock()
+		return n, nil
+	}
+	deadline := s.deadline
+	s.deadline = nil
+	s.mu.Unlock()
+
 	ctx := context.Background()
 	cancel := func() {}
-	if s.deadline != nil {
-		ctx, cancel = context.WithDeadline(ctx, *s.deadline)
+	if deadline != nil {
+		ctx, cancel = context.WithDeadline(ctx, *deadline)
+	}
+	defer cancel()
+
+	data, err := s.session.receiveData(ctx)
+	if err != nil {
+		return 0, err
 	}
 
-	defer func() {
-		cancel()
-		s.deadline = nil
-	}()
-
-	c := s.session.GetTCPDataChannel()
-
-	// First, serve any buffered data
-	if s.bufferLen > 0 {
-		n := copy(b, s.buffer[s.bufferPos:s.bufferPos+s.bufferLen])
-		s.bufferPos += n
-		s.bufferLen -= n
-		if s.bufferLen == 0 {
-			s.bufferPos = 0
-		}
-		return n, nil
+	n = copy(b, data)
+	if n < len(data) {
+		s.mu.Lock()
+		s.pending = data[n:]
+		s.mu.Unlock()
 	}
-
-	// Wait for data from a channel or context done
-	select {
-	case data := <-c:
-		if data == nil {
-			// Channel closed
-			return 0, io.EOF
-		}
-
-		// Copy as much as we can into the provided buffer
-		remaining := len(b)
-		if len(data) > remaining {
-			// Buffer the excess data in the internal buffer
-			n := copy(b, data[:remaining])
-
-			// Store the rest in the internal buffer
-			s.bufferLen = copy(s.buffer[:], data[remaining:])
-			s.bufferPos = 0
-			return n, nil
-		}
-
-		// Data fits entirely in the provided buffer
-		n := copy(b, data)
-		return n, nil
-
-	case <-ctx.Done():
-		return 0, ctx.Err()
-	}
+	return n, nil
 }
 
 func (s *sessionConnWrapper) Write(b []byte) (n int, err error) {
@@ -430,7 +507,9 @@ func (s *sessionConnWrapper) RemoteAddr() net.Addr {
 }
 
 func (s *sessionConnWrapper) SetDeadline(t time.Time) error {
+	s.mu.Lock()
 	s.deadline = &t
+	s.mu.Unlock()
 	return nil
 }
 

--- a/gateway/broker/session_bench_test.go
+++ b/gateway/broker/session_bench_test.go
@@ -1,0 +1,137 @@
+package broker
+
+import (
+	"context"
+	"net"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// heapSampler polls HeapAlloc in the background and records the peak value
+// observed. Used to measure how much memory the agent->client relay queue
+// holds when the producer outruns the consumer.
+type heapSampler struct {
+	stop chan struct{}
+	done chan struct{}
+	peak uint64
+}
+
+func startHeapSampler() *heapSampler {
+	s := &heapSampler{stop: make(chan struct{}), done: make(chan struct{})}
+	go func() {
+		defer close(s.done)
+		var m runtime.MemStats
+		ticker := time.NewTicker(500 * time.Microsecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.stop:
+				return
+			case <-ticker.C:
+				runtime.ReadMemStats(&m)
+				if m.HeapAlloc > s.peak {
+					s.peak = m.HeapAlloc
+				}
+			}
+		}
+	}()
+	return s
+}
+
+func (s *heapSampler) Stop() uint64 {
+	close(s.stop)
+	<-s.done
+	return s.peak
+}
+
+// benchClientConn is the consumer end of the relay: a fake RDP client that
+// drains at a fixed pace, emulating a WAN browser slower than the agent-side
+// producer (the exact condition observed in the gateway OOM incident).
+type benchClientConn struct {
+	perMsgDelay time.Duration
+	received    int64
+}
+
+func (c *benchClientConn) Send(data []byte) error {
+	time.Sleep(c.perMsgDelay)
+	c.received += int64(len(data))
+	return nil
+}
+func (c *benchClientConn) Read() (int, []byte, error) { return 0, nil, nil }
+func (c *benchClientConn) Close() error               { return nil }
+func (c *benchClientConn) WrapToConnection() net.Conn { return nil }
+
+// newBenchSession wires a Session the same way CreateRDPSession does, without
+// requiring a live agent websocket.
+func newBenchSession(client ConnectionCommunicator) (*Session, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ID:                  uuid.New(),
+		ClientCommunicator:  client,
+		Protocol:            ProtocolRDP,
+		dataChannel:         make(chan []byte, 1024),
+		credentialsReceived: make(chan bool, 1),
+		ctx:                 ctx,
+		cancel:              cancel,
+		maxQueueBytes:       maxQueuedBytes,
+		spaceFreed:          make(chan struct{}, 1),
+	}
+	BrokerInstance.sessions.Store(s.ID, s)
+	return s, cancel
+}
+
+// BenchmarkAgentToClientRelay reproduces the OOM scenario: the agent-side
+// websocket reader pushes frames through ForwardToTCP at memory speed while
+// the client drains slower. It reports the peak heap held by the queue
+// (peak_MB) alongside throughput.
+//
+// Workload per iteration: 2048 messages x 64 KiB = 128 MiB offered.
+// Consumer pace: 100us per message (~640 MB/s drain ceiling, but the producer
+// is faster still, so queue growth is bounded only by the relay's policy).
+func BenchmarkAgentToClientRelay(b *testing.B) {
+	const (
+		msgSize  = 64 * 1024
+		msgCount = 2048
+	)
+
+	var peakMax uint64
+	for b.Loop() {
+		client := &benchClientConn{perMsgDelay: 100 * time.Microsecond}
+		sess, cancel := newBenchSession(client)
+
+		runtime.GC()
+		var base runtime.MemStats
+		runtime.ReadMemStats(&base)
+		sampler := startHeapSampler()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sess.ForwardToClient()
+		}()
+
+		for range msgCount {
+			// fresh allocation per message, like websocket ReadMessage
+			data := make([]byte, msgSize)
+			sess.ForwardToTCP(data)
+		}
+		sess.Close()
+		wg.Wait()
+
+		peak := sampler.Stop()
+		if peak > base.HeapAlloc {
+			if delta := peak - base.HeapAlloc; delta > peakMax {
+				peakMax = delta
+			}
+		}
+		cancel()
+	}
+
+	b.SetBytes(int64(msgSize * msgCount))
+	b.ReportMetric(float64(peakMax)/(1<<20), "peak_MB")
+}

--- a/gateway/broker/session_queue_test.go
+++ b/gateway/broker/session_queue_test.go
@@ -1,0 +1,248 @@
+package broker
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// gatedClientConn releases consumed messages only when the test allows it.
+type gatedClientConn struct {
+	allow    chan struct{}
+	received atomic.Int64
+}
+
+func (c *gatedClientConn) Send(data []byte) error {
+	<-c.allow
+	c.received.Add(int64(len(data)))
+	return nil
+}
+func (c *gatedClientConn) Read() (int, []byte, error) { return 0, nil, nil }
+func (c *gatedClientConn) Close() error               { return nil }
+func (c *gatedClientConn) WrapToConnection() net.Conn { return nil }
+
+func newQueueTestSession(t *testing.T, client ConnectionCommunicator, budget int64) *Session {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ID:                  uuid.New(),
+		ClientCommunicator:  client,
+		Protocol:            ProtocolRDP,
+		dataChannel:         make(chan []byte, 1024),
+		credentialsReceived: make(chan bool, 1),
+		ctx:                 ctx,
+		cancel:              cancel,
+		maxQueueBytes:       budget,
+		spaceFreed:          make(chan struct{}, 1),
+	}
+	BrokerInstance.sessions.Store(s.ID, s)
+	t.Cleanup(s.Close)
+	return s
+}
+
+func (s *Session) queuedBytesNow() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.queuedBytes
+}
+
+// TestForwardToTCPByteBudgetBackpressure verifies that a producer pushing
+// against a stalled consumer blocks once the byte budget is reached instead
+// of queueing without bound, and that queued bytes never exceed the budget.
+func TestForwardToTCPByteBudgetBackpressure(t *testing.T) {
+	const budget = 64 * 1024
+	const msgSize = 16 * 1024
+
+	client := &gatedClientConn{allow: make(chan struct{})}
+	s := newQueueTestSession(t, client, budget)
+
+	go s.ForwardToClient()
+
+	var pushed atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 32 { // 512 KiB offered, 8x the budget
+			s.ForwardToTCP(make([]byte, msgSize))
+			pushed.Add(1)
+		}
+	}()
+
+	// With the consumer fully stalled the producer must stop at the budget.
+	// One message may additionally be parked inside the consumer's Send.
+	time.Sleep(200 * time.Millisecond)
+	if got := s.queuedBytesNow(); got > budget {
+		t.Fatalf("queued bytes exceeded budget: got=%d budget=%d", got, budget)
+	}
+	if p := pushed.Load(); p >= 32 {
+		t.Fatalf("producer was never backpressured: pushed all %d messages against a stalled consumer", p)
+	}
+
+	// Un-stall the consumer; everything must drain and the producer finish.
+	close(client.allow)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("producer did not finish after consumer drained")
+	}
+
+	// Wait for the consumer to drain the tail.
+	deadline := time.Now().Add(5 * time.Second)
+	for client.received.Load() != 32*msgSize {
+		if time.Now().After(deadline) {
+			t.Fatalf("consumer drained %d bytes, want %d", client.received.Load(), 32*msgSize)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestForwardToTCPUnblocksOnClose verifies a producer blocked on the byte
+// budget returns promptly when the session closes rather than leaking.
+func TestForwardToTCPUnblocksOnClose(t *testing.T) {
+	client := &gatedClientConn{allow: make(chan struct{})} // consumer never runs
+	s := newQueueTestSession(t, client, 1024)
+
+	s.ForwardToTCP(make([]byte, 1024)) // fills the budget exactly
+
+	blocked := make(chan struct{})
+	go func() {
+		defer close(blocked)
+		s.ForwardToTCP(make([]byte, 512)) // must block: budget full
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-blocked:
+		t.Fatal("producer was not blocked by a full budget")
+	default:
+	}
+
+	s.Close()
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("producer still blocked after session close")
+	}
+}
+
+// TestForwardToTCPOversizedMessage verifies a single message larger than the
+// whole budget is admitted when the queue is empty (no deadlock).
+func TestForwardToTCPOversizedMessage(t *testing.T) {
+	client := &gatedClientConn{allow: make(chan struct{})}
+	close(client.allow)
+	s := newQueueTestSession(t, client, 1024)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.ForwardToTCP(make([]byte, 64*1024)) // 64x the budget
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("oversized message deadlocked the relay")
+	}
+}
+
+// TestSessionConnWrapperNoDataLoss pushes messages far larger than the reader
+// chunk size and verifies every byte arrives, in order. The previous wrapper
+// spilled at most 16 KiB of remainder into a fixed array and silently dropped
+// the rest.
+func TestSessionConnWrapperNoDataLoss(t *testing.T) {
+	s := newQueueTestSession(t, &gatedClientConn{allow: make(chan struct{})}, maxQueuedBytes)
+	conn := s.ToConn()
+
+	// 100 KiB message: with 8 KiB reads the old code lost 100-8-16 = 76 KiB.
+	payload := make([]byte, 100*1024)
+	for i := range payload {
+		payload[i] = byte(i * 31)
+	}
+	go s.ForwardToTCP(bytes.Clone(payload))
+
+	got := make([]byte, 0, len(payload))
+	buf := make([]byte, 8*1024)
+	for len(got) < len(payload) {
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Fatalf("read failed after %d/%d bytes: %v", len(got), len(payload), err)
+		}
+		got = append(got, buf[:n]...)
+	}
+
+	if !bytes.Equal(got, payload) {
+		t.Fatal("relayed bytes differ from sent payload")
+	}
+}
+
+// TestSessionConnWrapperEOFAfterClose verifies reads return io.EOF once the
+// session closes and the queue is drained.
+func TestSessionConnWrapperEOFAfterClose(t *testing.T) {
+	s := newQueueTestSession(t, &gatedClientConn{allow: make(chan struct{})}, maxQueuedBytes)
+	conn := s.ToConn()
+
+	s.ForwardToTCP([]byte("tail"))
+	s.Close()
+
+	// The queued message is still served after close...
+	buf := make([]byte, 16)
+	n, err := conn.Read(buf)
+	if err != nil || string(buf[:n]) != "tail" {
+		t.Fatalf("expected queued tail before EOF, got n=%d err=%v", n, err)
+	}
+
+	// ...then EOF.
+	if _, err := conn.Read(buf); err != io.EOF {
+		t.Fatalf("expected io.EOF after drain, got %v", err)
+	}
+}
+
+// TestSessionConnWrapperDeadline verifies the read deadline still fires.
+func TestSessionConnWrapperDeadline(t *testing.T) {
+	s := newQueueTestSession(t, &gatedClientConn{allow: make(chan struct{})}, maxQueuedBytes)
+	conn := s.ToConn()
+
+	_ = conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	start := time.Now()
+	_, err := conn.Read(make([]byte, 16))
+	if err != context.DeadlineExceeded {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("deadline fired too late")
+	}
+}
+
+// TestForwardToTCPConcurrentClose hammers Close against in-flight producers;
+// under the previous implementation this raced into a send-on-closed-channel
+// panic.
+func TestForwardToTCPConcurrentClose(t *testing.T) {
+	for range 50 {
+		client := &gatedClientConn{allow: make(chan struct{})}
+		close(client.allow)
+		s := newQueueTestSession(t, client, maxQueuedBytes)
+		go s.ForwardToClient()
+
+		var wg sync.WaitGroup
+		for range 4 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 100 {
+					s.ForwardToTCP(make([]byte, 128))
+				}
+			}()
+		}
+		time.Sleep(time.Millisecond)
+		s.Close()
+		wg.Wait()
+	}
+}

--- a/gateway/rdp/recorder.go
+++ b/gateway/rdp/recorder.go
@@ -37,6 +37,15 @@ const finalizeChunkBytes = 8 << 20 // 8 MiB
 // (sessionwal.DefaultMaxRead).
 const maxRecordedBytes = 128 << 20 // 128 MiB
 
+// maxRecordedEventBytes caps a single encoded event line. Without it, one
+// huge bitmap update (an uncompressed full-screen paint on a large display
+// encodes at ~1.78x the pixel bytes) becomes the in-memory unit of finalize
+// streaming and defeats the finalizeChunkBytes bound. Oversized events are
+// skipped — losing one frame of replay — rather than truncated, since a
+// partial event line would not be valid JSON. Enforced at write time, and
+// again at read time as defense-in-depth for logs written by other versions.
+const maxRecordedEventBytes = finalizeChunkBytes
+
 // RDPSessionRecorder captures RDP traffic for session replay.
 // Bitmap events are streamed to a temp file to avoid holding everything in memory.
 type RDPSessionRecorder struct {
@@ -238,6 +247,15 @@ func (r *RDPSessionRecorder) parseAndStorePDU(data []byte) {
 			base64.StdEncoding.EncodeToString(eventJSON),
 		}
 		line, _ := json.Marshal(event)
+
+		// Skip single events too large to stream within the finalize memory
+		// bound; one lost frame beats an unbounded allocation at close.
+		if len(line)+1 > maxRecordedEventBytes {
+			log.With("sid", r.sessionID).Warnf(
+				"skipping oversized RDP bitmap event (%d bytes encoded, cap %d); one replay frame lost",
+				len(line), maxRecordedEventBytes)
+			continue
+		}
 
 		// Stop recording (not the session) once the replay log reaches the
 		// cap; an unbounded log would have to be streamed to the database at
@@ -476,12 +494,20 @@ func (r *RDPSessionRecorder) streamEvents(tmpPath string, sink func(chunk json.R
 		}
 	}
 
-	// Each line in the temp file is one complete JSON event.
+	// Each line in the temp file is one complete JSON event. Write-time
+	// enforcement of maxRecordedEventBytes makes oversized lines impossible
+	// in logs produced by this version; the guard below is defense-in-depth
+	// (older/foreign logs) so a single entry can never balloon the finalize
+	// memory unit past ~2x finalizeChunkBytes.
 	reader := bufio.NewReaderSize(f, 1<<20)
 	for {
 		line, readErr := reader.ReadBytes('\n')
 		line = bytes.TrimSuffix(line, []byte("\n"))
-		if len(line) > 0 {
+		if len(line) > maxRecordedEventBytes {
+			log.With("sid", r.sessionID).Warnf(
+				"skipping oversized recorded event (%d bytes, cap %d); one replay frame lost",
+				len(line), maxRecordedEventBytes)
+		} else if len(line) > 0 {
 			if err := appendEntry(line); err != nil {
 				return entryCount, entryBytes, err
 			}

--- a/gateway/rdp/recorder.go
+++ b/gateway/rdp/recorder.go
@@ -1,10 +1,13 @@
 package rdp
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -17,6 +20,22 @@ import (
 	"github.com/hoophq/hoop/gateway/rdp/analyzer"
 	"github.com/hoophq/hoop/gateway/rdp/parser"
 )
+
+// finalizeChunkBytes bounds how much of the recorded event log is held in
+// memory at a time while streaming the session blob to Postgres at close.
+// Each chunk is appended to the session's blob_stream via jsonb
+// concatenation, so peak finalize memory is ~one chunk instead of the whole
+// recording (which for long high-throughput sessions reached GBs and
+// OOM-killed the gateway).
+const finalizeChunkBytes = 8 << 20 // 8 MiB
+
+// maxRecordedBytes caps the on-disk event log per session. Once reached the
+// recorder stops capturing further bitmap events (the session itself is
+// unaffected); the replay is truncated rather than letting a marathon
+// screen-churn session grow an unbounded temp file that must later be
+// streamed to the database. Mirrors the audit WAL's flush cap philosophy
+// (sessionwal.DefaultMaxRead).
+const maxRecordedBytes = 128 << 20 // 128 MiB
 
 // RDPSessionRecorder captures RDP traffic for session replay.
 // Bitmap events are streamed to a temp file to avoid holding everything in memory.
@@ -47,6 +66,9 @@ type RDPSessionRecorder struct {
 	bitmapCount   int
 	bytesWritten  int64
 	lastTimestamp float64
+	// truncated is set once maxRecordedBytes is reached; further output is
+	// no longer parsed or recorded.
+	truncated bool
 }
 
 // rdpEvent stores a single RDP event: [timestamp_seconds, event_type, base64_data]
@@ -126,7 +148,7 @@ func (r *RDPSessionRecorder) RecordOutput(data []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.closed || len(data) == 0 || r.parser == nil {
+	if r.closed || r.truncated || len(data) == 0 || r.parser == nil {
 		return
 	}
 
@@ -217,6 +239,17 @@ func (r *RDPSessionRecorder) parseAndStorePDU(data []byte) {
 		}
 		line, _ := json.Marshal(event)
 
+		// Stop recording (not the session) once the replay log reaches the
+		// cap; an unbounded log would have to be streamed to the database at
+		// close, and marathon screen-churn sessions produced multi-GB logs.
+		if r.bytesWritten+int64(len(line))+1 > maxRecordedBytes {
+			r.truncated = true
+			log.With("sid", r.sessionID).Warnf(
+				"RDP recording reached %d MiB cap after %d events; replay will be truncated, session continues",
+				maxRecordedBytes>>20, r.eventCount)
+			return
+		}
+
 		// Write to temp file (one JSON line per event)
 		if _, err := r.tmpFile.Write(line); err != nil {
 			log.With("sid", r.sessionID).Errorf("failed to write bitmap to temp file: %v", err)
@@ -227,6 +260,7 @@ func (r *RDPSessionRecorder) parseAndStorePDU(data []byte) {
 			return
 		}
 
+		r.bytesWritten += int64(len(line)) + 1
 		r.eventCount++
 		r.bitmapCount++
 		r.lastTimestamp = timestamp
@@ -292,20 +326,39 @@ func (r *RDPSessionRecorder) Close(err error) {
 		return
 	}
 
-	// Close temp file for writing, then read it back
+	// Close temp file for writing, then stream it back. A failed close can
+	// mean unflushed event data — the finalize below still runs, but the
+	// replay may be truncated, so make that visible.
 	tmpPath := r.tmpFile.Name()
-	r.tmpFile.Close()
+	if closeErr := r.tmpFile.Close(); closeErr != nil {
+		log.With("sid", r.sessionID).Errorf("failed closing temp recording file, replay may be incomplete: %v", closeErr)
+	}
 	defer os.Remove(tmpPath)
 
-	// Build the final JSON array by reading back from the temp file
-	// Format: [ handshake_event, bitmap_event_1, bitmap_event_2, ... ]
-	eventsJSON, readErr := r.buildEventsJSON(tmpPath)
-	if readErr != nil {
-		log.With("sid", r.sessionID).Errorf("failed to build events JSON: %v", readErr)
-		return
+	// Stream the recorded events into the session's blob_stream in bounded
+	// chunks (finalizeChunkBytes each) instead of materializing the whole
+	// replay in memory. Final format in the database is identical to the
+	// previous single-blob write: [ handshake_event, bitmap_event_1, ... ]
+	var eventSize int64 = 2 // "[]"
+	streamOK := false
+	if blobErr := models.CreateEmptySessionStreamBlob(r.orgID, r.sessionID, nil); blobErr != nil {
+		log.With("sid", r.sessionID).Errorf("failed creating session stream blob: %v", blobErr)
+	} else {
+		entryCount, entryBytes, streamErr := r.streamEvents(tmpPath, func(chunk json.RawMessage) error {
+			return models.AppendSessionStream(r.orgID, r.sessionID, chunk)
+		})
+		if entryCount > 0 {
+			// size of "[e1,e2,...]": entries + separating commas + brackets
+			eventSize = entryBytes + int64(entryCount-1) + 2
+		}
+		if streamErr != nil {
+			// Partial replay is preserved; the session is still finalized
+			// below so it never gets stuck in the open state.
+			log.With("sid", r.sessionID).Errorf("failed streaming session events (%d entries persisted): %v", entryCount, streamErr)
+		} else {
+			streamOK = true
+		}
 	}
-
-	eventSize := int64(len(eventsJSON))
 
 	// Canvas dimensions
 	canvasWidth := r.maxWidth
@@ -330,23 +383,22 @@ func (r *RDPSessionRecorder) Close(err error) {
 		ID:         r.sessionID,
 		OrgID:      r.orgID,
 		Metrics:    map[string]any{"event_size": eventSize, "bitmap_count": r.bitmapCount, "canvas_width": canvasWidth, "canvas_height": canvasHeight},
-		BlobStream: json.RawMessage(eventsJSON),
 		Status:     string(openapi.SessionStatusDone),
 		ExitCode:   exitCode,
 		EndSession: &endTime,
 	}
 
-	if dbErr := models.UpdateSessionEventStream(sessDone); dbErr != nil {
+	if dbErr := models.MarkSessionDone(sessDone); dbErr != nil {
 		log.With("sid", r.sessionID).Errorf("failed to finalize RDP session: %v", dbErr)
 		return
 	}
 
 	// Enqueue async PII analysis if there are bitmap frames to analyze, the
-	// analysis pipeline is actually enabled on this gateway, AND the org has
-	// the experimental flag turned on. Otherwise the job would sit 'pending'
-	// forever (worker pool may be stopped by the supervisor) and the session
-	// would appear stuck.
-	if r.bitmapCount > 0 &&
+	// full replay stream was persisted, the analysis pipeline is actually
+	// enabled on this gateway, AND the org has the experimental flag turned
+	// on. Otherwise the job would sit 'pending' forever (worker pool may be
+	// stopped by the supervisor) and the session would appear stuck.
+	if streamOK && r.bitmapCount > 0 &&
 		analyzer.IsEnabled(appconfig.Get().MSPresidioAnalyzerURL()) &&
 		featureflag.IsEnabled(r.orgID, analyzer.FlagName) {
 		if enqueueErr := models.CreateRDPAnalysisJob(r.orgID, r.sessionID); enqueueErr != nil {
@@ -361,20 +413,57 @@ func (r *RDPSessionRecorder) Close(err error) {
 		r.eventCount, r.bitmapCount, eventSize)
 }
 
-// buildEventsJSON reads bitmap events from the temp file and builds the final JSON array
-func (r *RDPSessionRecorder) buildEventsJSON(tmpPath string) ([]byte, error) {
-	tmpData, err := os.ReadFile(tmpPath)
+// streamEvents reads the recorded events back from the temp file and hands
+// them to sink as JSON array chunks of at most ~finalizeChunkBytes each
+// (plus one entry of overshoot). Concatenating all chunk contents yields the
+// same event sequence the previous whole-file builder produced:
+// [handshake_event, bitmap_event_1, bitmap_event_2, ...]. Peak memory is one
+// chunk, independent of recording size.
+//
+// Returns the number of entries and their cumulative encoded size (entries
+// only, excluding array punctuation) that were successfully handed to the
+// sink. On error, entries already accepted by the sink remain persisted —
+// the caller decides how to proceed.
+func (r *RDPSessionRecorder) streamEvents(tmpPath string, sink func(chunk json.RawMessage) error) (entryCount int, entryBytes int64, err error) {
+	f, err := os.Open(tmpPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read temp file: %w", err)
+		return 0, 0, fmt.Errorf("failed to open temp file: %w", err)
+	}
+	defer f.Close()
+
+	chunk := bytes.NewBuffer(make([]byte, 0, finalizeChunkBytes+(1<<20)))
+	chunkEntries := 0
+
+	flush := func() error {
+		if chunkEntries == 0 {
+			return nil
+		}
+		chunk.WriteByte(']')
+		if err := sink(json.RawMessage(chunk.Bytes())); err != nil {
+			return err
+		}
+		entryCount += chunkEntries
+		entryBytes += int64(chunk.Len() - 2 - (chunkEntries - 1)) // strip brackets+commas
+		chunk.Reset()
+		chunkEntries = 0
+		return nil
 	}
 
-	// Build JSON array: [handshake, event1, event2, ...]
-	// Start with "["
-	var result []byte
-	result = append(result, '[')
+	appendEntry := func(entry []byte) error {
+		if chunkEntries == 0 {
+			chunk.WriteByte('[')
+		} else {
+			chunk.WriteByte(',')
+		}
+		chunk.Write(entry)
+		chunkEntries++
+		if chunk.Len() >= finalizeChunkBytes {
+			return flush()
+		}
+		return nil
+	}
 
-	// Add handshake event first if available
-	first := true
+	// Handshake event goes first so replay starts from the connection setup.
 	if len(r.handshakeData) > 0 {
 		handshakeEvent := [3]any{
 			0,
@@ -382,28 +471,30 @@ func (r *RDPSessionRecorder) buildEventsJSON(tmpPath string) ([]byte, error) {
 			base64.StdEncoding.EncodeToString(r.handshakeData),
 		}
 		hJSON, _ := json.Marshal(handshakeEvent)
-		result = append(result, hJSON...)
-		first = false
-	}
-
-	// Append each line from the temp file (each line is a JSON event)
-	start := 0
-	for i := 0; i < len(tmpData); i++ {
-		if tmpData[i] == '\n' {
-			line := tmpData[start:i]
-			if len(line) > 0 {
-				if !first {
-					result = append(result, ',')
-				}
-				result = append(result, line...)
-				first = false
-			}
-			start = i + 1
+		if err := appendEntry(hJSON); err != nil {
+			return entryCount, entryBytes, err
 		}
 	}
 
-	result = append(result, ']')
-	return result, nil
+	// Each line in the temp file is one complete JSON event.
+	reader := bufio.NewReaderSize(f, 1<<20)
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		line = bytes.TrimSuffix(line, []byte("\n"))
+		if len(line) > 0 {
+			if err := appendEntry(line); err != nil {
+				return entryCount, entryBytes, err
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return entryCount, entryBytes, fmt.Errorf("failed reading temp file: %w", readErr)
+		}
+	}
+
+	return entryCount, entryBytes, flush()
 }
 
 // GetSessionID returns the session ID

--- a/gateway/rdp/recorder_bench_test.go
+++ b/gateway/rdp/recorder_bench_test.go
@@ -1,0 +1,128 @@
+package rdp
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// writeSyntheticEventFile writes a jsonl temp file shaped exactly like the one
+// parseAndStorePDU produces: one `[timestamp, "b", base64(bitmapEventJSON)]`
+// line per bitmap event, totalling ~totalBytes.
+func writeSyntheticEventFile(tb testing.TB, totalBytes int) string {
+	tb.Helper()
+	tmpPath := filepath.Join(tb.TempDir(), "rdp-session-bench.jsonl")
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer f.Close()
+
+	// ~48 KiB of bitmap payload per event line, matching real band updates.
+	payload := make([]byte, 48*1024)
+	rnd := rand.New(rand.NewSource(1))
+	rnd.Read(payload)
+	b64 := base64.StdEncoding.EncodeToString(payload)
+
+	written := 0
+	ts := 0.0
+	for written < totalBytes {
+		line, err := json.Marshal([3]any{ts, "b", b64})
+		if err != nil {
+			tb.Fatal(err)
+		}
+		if _, err := f.Write(append(line, '\n')); err != nil {
+			tb.Fatal(err)
+		}
+		written += len(line) + 1
+		ts += 0.2
+	}
+	return tmpPath
+}
+
+// recorderHeapPeak samples HeapAlloc while fn runs and returns the peak delta
+// over the baseline taken right before fn.
+func recorderHeapPeak(fn func()) uint64 {
+	runtime.GC()
+	var base runtime.MemStats
+	runtime.ReadMemStats(&base)
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	var peak uint64
+	go func() {
+		defer close(done)
+		var m runtime.MemStats
+		ticker := time.NewTicker(500 * time.Microsecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				runtime.ReadMemStats(&m)
+				if m.HeapAlloc > peak {
+					peak = m.HeapAlloc
+				}
+			}
+		}
+	}()
+
+	fn()
+
+	close(stop)
+	<-done
+	if peak <= base.HeapAlloc {
+		return 0
+	}
+	return peak - base.HeapAlloc
+}
+
+// BenchmarkRecorderFinalize measures the memory profile of turning the
+// recorder's on-disk event log into the session blob at Close time. This is
+// the path that ran the gateway out of memory after long high-throughput RDP
+// sessions: the whole temp file is materialized (and re-copied) in heap.
+//
+// Workload: 64 MiB temp file (~1360 bitmap events of ~48 KiB payloads).
+func BenchmarkRecorderFinalize(b *testing.B) {
+	const fileBytes = 64 << 20
+
+	tmpPath := writeSyntheticEventFile(b, fileBytes)
+	r := &RDPSessionRecorder{
+		sessionID:     "bench-session",
+		handshakeData: []byte("bench-handshake-pdu"),
+		startTime:     time.Now().UTC(),
+	}
+
+	var peakMax uint64
+	var outBytes int64
+	b.ReportAllocs()
+	for b.Loop() {
+		peak := recorderHeapPeak(func() {
+			// sink mirrors the production path's cost model minus the DB:
+			// each chunk is fully materialized before being handed off.
+			_, entryBytes, err := r.streamEvents(tmpPath, func(chunk json.RawMessage) error {
+				return nil
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			outBytes = entryBytes
+		})
+		if peak > peakMax {
+			peakMax = peak
+		}
+	}
+
+	b.SetBytes(int64(fileBytes))
+	b.ReportMetric(float64(peakMax)/(1<<20), "peak_MB")
+	if outBytes == 0 {
+		b.Fatal(fmt.Errorf("no blob produced"))
+	}
+}

--- a/gateway/rdp/recorder_stream_test.go
+++ b/gateway/rdp/recorder_stream_test.go
@@ -1,0 +1,218 @@
+package rdp
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeEventLines writes a temp jsonl file with the given pre-encoded event
+// lines, mirroring the format parseAndStorePDU produces.
+func writeEventLines(t *testing.T, lines [][]byte) string {
+	t.Helper()
+	tmpPath := filepath.Join(t.TempDir(), "events.jsonl")
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	for _, line := range lines {
+		if _, err := f.Write(append(line, '\n')); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return tmpPath
+}
+
+func makeEventLine(t *testing.T, ts float64, payload []byte) []byte {
+	t.Helper()
+	line, err := json.Marshal([3]any{ts, "b", base64.StdEncoding.EncodeToString(payload)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return line
+}
+
+// legacyEventsJSON reproduces the output of the previous whole-file builder
+// so the streaming implementation can be checked for byte equivalence.
+func legacyEventsJSON(handshake []byte, lines [][]byte) []byte {
+	var result []byte
+	result = append(result, '[')
+	first := true
+	if len(handshake) > 0 {
+		hJSON, _ := json.Marshal([3]any{0, "h", base64.StdEncoding.EncodeToString(handshake)})
+		result = append(result, hJSON...)
+		first = false
+	}
+	for _, line := range lines {
+		if !first {
+			result = append(result, ',')
+		}
+		result = append(result, line...)
+		first = false
+	}
+	return append(result, ']')
+}
+
+// joinChunks concatenates streamed chunks back into one JSON array, the same
+// merge Postgres performs with jsonb `||` on the blob_stream column.
+func joinChunks(t *testing.T, chunks []json.RawMessage) []byte {
+	t.Helper()
+	var merged []any
+	for _, chunk := range chunks {
+		var entries []any
+		if err := json.Unmarshal(chunk, &entries); err != nil {
+			t.Fatalf("chunk is not a valid JSON array: %v", err)
+		}
+		merged = append(merged, entries...)
+	}
+	out, err := json.Marshal(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged == nil {
+		return []byte("[]")
+	}
+	return out
+}
+
+func TestStreamEventsMatchesLegacyFormat(t *testing.T) {
+	payload := make([]byte, 512)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	lines := [][]byte{
+		makeEventLine(t, 0.5, payload),
+		makeEventLine(t, 1.0, payload[:100]),
+		makeEventLine(t, 2.25, payload[100:300]),
+	}
+	handshake := []byte("handshake-pdu-bytes")
+
+	tmpPath := writeEventLines(t, lines)
+	r := &RDPSessionRecorder{sessionID: "sid-equiv", handshakeData: handshake, startTime: time.Now()}
+
+	var chunks []json.RawMessage
+	entryCount, entryBytes, err := r.streamEvents(tmpPath, func(chunk json.RawMessage) error {
+		chunks = append(chunks, bytes.Clone(chunk))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := len(lines) + 1; entryCount != want { // +1 handshake
+		t.Fatalf("entryCount=%d want %d", entryCount, want)
+	}
+
+	legacy := legacyEventsJSON(handshake, lines)
+	// Compare through a decode/encode cycle on both sides: Postgres jsonb
+	// normalizes representation, so semantic equality is the contract.
+	var legacyNorm []any
+	if err := json.Unmarshal(legacy, &legacyNorm); err != nil {
+		t.Fatal(err)
+	}
+	legacyJSON, _ := json.Marshal(legacyNorm)
+	if got := joinChunks(t, chunks); !bytes.Equal(got, legacyJSON) {
+		t.Fatalf("streamed content differs from legacy builder output\n got: %.200s\nwant: %.200s", got, legacyJSON)
+	}
+
+	// event_size arithmetic must match the legacy blob length:
+	// entries + separating commas + brackets.
+	if want := int64(len(legacy)); entryBytes+int64(entryCount-1)+2 != want {
+		t.Fatalf("event size arithmetic: got %d want %d", entryBytes+int64(entryCount-1)+2, want)
+	}
+}
+
+func TestStreamEventsChunking(t *testing.T) {
+	// Lines of ~1 MiB force multiple chunks with an 8 MiB budget.
+	payload := make([]byte, 768*1024)
+	var lines [][]byte
+	for i := range 20 { // ~20 MiB of encoded lines
+		lines = append(lines, makeEventLine(t, float64(i), payload))
+	}
+	tmpPath := writeEventLines(t, lines)
+	r := &RDPSessionRecorder{sessionID: "sid-chunks", startTime: time.Now()}
+
+	var chunks []json.RawMessage
+	total := 0
+	entryCount, _, err := r.streamEvents(tmpPath, func(chunk json.RawMessage) error {
+		if len(chunk) > finalizeChunkBytes+2*1024*1024 {
+			return fmt.Errorf("chunk exceeds budget plus one entry: %d", len(chunk))
+		}
+		var entries []any
+		if err := json.Unmarshal(chunk, &entries); err != nil {
+			return fmt.Errorf("invalid chunk JSON: %w", err)
+		}
+		total += len(entries)
+		chunks = append(chunks, nil) // count only
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entryCount != len(lines) || total != len(lines) {
+		t.Fatalf("entries: counted=%d sunk=%d want=%d", entryCount, total, len(lines))
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks for 20 MiB of events, got %d", len(chunks))
+	}
+}
+
+func TestStreamEventsEmpty(t *testing.T) {
+	tmpPath := writeEventLines(t, nil)
+	r := &RDPSessionRecorder{sessionID: "sid-empty", startTime: time.Now()}
+
+	calls := 0
+	entryCount, entryBytes, err := r.streamEvents(tmpPath, func(json.RawMessage) error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 || entryCount != 0 || entryBytes != 0 {
+		t.Fatalf("empty recording should stream nothing: calls=%d count=%d bytes=%d", calls, entryCount, entryBytes)
+	}
+}
+
+func TestStreamEventsSinkErrorStops(t *testing.T) {
+	payload := make([]byte, 768*1024)
+	var lines [][]byte
+	for i := range 20 {
+		lines = append(lines, makeEventLine(t, float64(i), payload))
+	}
+	tmpPath := writeEventLines(t, lines)
+	r := &RDPSessionRecorder{sessionID: "sid-err", startTime: time.Now()}
+
+	calls := 0
+	entryCount, _, err := r.streamEvents(tmpPath, func(json.RawMessage) error {
+		calls++
+		if calls == 2 {
+			return fmt.Errorf("db unavailable")
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected sink error to propagate")
+	}
+	if calls != 2 {
+		t.Fatalf("streaming continued after sink error: %d calls", calls)
+	}
+	// Only entries accepted by the sink are reported as persisted.
+	if entryCount == 0 || entryCount >= len(lines) {
+		t.Fatalf("entryCount=%d should reflect only the successfully sunk chunks", entryCount)
+	}
+}
+
+func TestRecordOutputStopsWhenTruncated(t *testing.T) {
+	r := &RDPSessionRecorder{sessionID: "sid-cap", startTime: time.Now(), truncated: true}
+	r.RecordOutput(make([]byte, 4096))
+	if len(r.outputBuffer) != 0 {
+		t.Fatal("RecordOutput must not accumulate once the recording cap is reached")
+	}
+}

--- a/gateway/rdp/recorder_stream_test.go
+++ b/gateway/rdp/recorder_stream_test.go
@@ -209,6 +209,31 @@ func TestStreamEventsSinkErrorStops(t *testing.T) {
 	}
 }
 
+func TestStreamEventsSkipsOversizedLines(t *testing.T) {
+	// One legitimate event, one oversized line (> maxRecordedEventBytes,
+	// as an old/foreign log could contain), one more legitimate event.
+	small := makeEventLine(t, 1.0, []byte("ok"))
+	big := makeEventLine(t, 2.0, make([]byte, maxRecordedEventBytes)) // >8 MiB after encoding
+	lines := [][]byte{small, big, makeEventLine(t, 3.0, []byte("ok2"))}
+
+	tmpPath := writeEventLines(t, lines)
+	r := &RDPSessionRecorder{sessionID: "sid-oversized", startTime: time.Now()}
+
+	entryCount, _, err := r.streamEvents(tmpPath, func(chunk json.RawMessage) error {
+		if len(chunk) > finalizeChunkBytes+maxRecordedEventBytes {
+			return fmt.Errorf("chunk exceeded the finalize memory unit: %d", len(chunk))
+		}
+		var entries []any
+		return json.Unmarshal(chunk, &entries)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entryCount != 2 {
+		t.Fatalf("entryCount=%d, want 2 (oversized entry skipped)", entryCount)
+	}
+}
+
 func TestRecordOutputStopsWhenTruncated(t *testing.T) {
 	r := &RDPSessionRecorder{sessionID: "sid-cap", startTime: time.Now(), truncated: true}
 	r.RecordOutput(make([]byte, 4096))


### PR DESCRIPTION
## Problem

The gateway OOM-crashed (crash-looped on a 512Mi pod) while relaying a high-throughput RDP session (~5.8 MB/s of redacted frames) to a client draining slower than the agent produced. Two unbounded memory paths were responsible:

1. **Broker relay queue** (`gateway/broker/session.go`): `dataChannel` was bounded at 8192 *messages* but not bytes — with RDP-sized frames that is multi-GB of heap.
2. **Recorder finalize** (`gateway/rdp/recorder.go`): `Close()` materialized the whole session recording in memory (measured 4.4x the temp file size at peak) before a single DB write.

## Fix

- `ForwardToTCP` enforces a 32 MiB per-session byte budget and blocks the producer when full — backpressure propagates over the agent websocket's TCP flow control. Data is never dropped mid-stream.
- Recorder finalize streams the recording to `blob_stream` in 8 MiB jsonb-append chunks (same pattern the audit WAL uses); recordings capped at 128 MiB at write time; the session is always marked done even if blob persistence partially fails (previously it could stay open forever).

Also fixed while in there:
- send-on-closed-channel panic race between `Close()` and in-flight producers (channel is no longer closed; receivers drain then get `io.EOF`)
- `sessionConnWrapper` silently dropped bytes beyond its fixed 16 KiB spill buffer for large messages (byte-stream corruption); replaced with an exact remainder slice + mutex-guarded state
- session-setup error paths leaked the session timeout context

## Benchmarks (before → after)

| Benchmark | Peak heap | Time | Allocs |
|---|---|---|---|
| `AgentToClientRelay` (128 MiB offered, slow client) | 126.9 MB → **64.5 MB** (live set capped at 32 MiB, was unbounded) | unchanged | — |
| `RecorderFinalize` (64 MiB recording) | 281.4 MB → **23.6 MB** | 46.6 ms → **12.1 ms** | 405 MB/op → **86 MB/op** |

Relay peak scales with offered load before the fix (a 1 GB burst = 1 GB heap) and stays flat after. Benchmarks are committed (`session_bench_test.go`, `recorder_bench_test.go`) and reproducible with `go test -bench`.

DB blob format is byte-compatible with the previous single-write path (equivalence-tested).

Automated by MisterMal