### PR TITLE
fix(gateway): truncate RDP payloads in the audit WAL flush

### DIFF
--- a/gateway/transport/plugins/audit/wal.go
+++ b/gateway/transport/plugins/audit/wal.go
@@ -370,7 +370,7 @@ func (p *auditPlugin) encodeEventEntry(buf *strings.Builder, ev *eventlogv1.Even
 	if len(ev.Payload) == 0 {
 		return
 	}
-	stream := p.truncateTCPEventStream(ev.Payload, protoConnType)
+	stream := p.truncateOpaqueEventStream(ev.Payload, protoConnType)
 	if buf.Len() > 0 {
 		buf.WriteByte(',')
 	}
@@ -454,9 +454,20 @@ func accumulateAIAnalyzerVerdict(ev *eventlogv1.EventLog, metrics *SessionMetric
 	)
 }
 
-func (p *auditPlugin) truncateTCPEventStream(eventStream []byte, protoConnType pb.ConnectionType) []byte {
-	if len(eventStream) > 5000 && protoConnType == pb.ConnectionTypeTCP {
-		return eventStream[0:5000]
+// maxOpaqueEventStreamBytes caps how much of a single opaque byte-stream
+// event is persisted to the session blob_stream at flush time. Applies to
+// protocols whose payloads are unreadable binary in the audit replay (raw
+// TCP, RDP frames): storing them whole is pure cost — for RDP it meant
+// base64-encoding full bitmap frames into Postgres on every flush, up to the
+// 110 MiB per-session cap, with the corresponding gateway memory spike. RDP
+// session replay does not read this blob; it uses the dedicated RDP recorder
+// stream.
+const maxOpaqueEventStreamBytes = 5000
+
+func (p *auditPlugin) truncateOpaqueEventStream(eventStream []byte, protoConnType pb.ConnectionType) []byte {
+	isOpaque := protoConnType == pb.ConnectionTypeTCP || protoConnType == pb.ConnectionTypeRDP
+	if len(eventStream) > maxOpaqueEventStreamBytes && isOpaque {
+		return eventStream[0:maxOpaqueEventStreamBytes]
 	}
 	return eventStream
 }

--- a/gateway/transport/plugins/audit/wal_test.go
+++ b/gateway/transport/plugins/audit/wal_test.go
@@ -1,0 +1,95 @@
+package audit
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/hoophq/hoop/common/proto"
+	eventlogv1 "github.com/hoophq/hoop/gateway/session/eventlog/v1"
+)
+
+func TestTruncateOpaqueEventStream(t *testing.T) {
+	p := &auditPlugin{}
+	small := bytes.Repeat([]byte{0xAB}, 100)
+	big := bytes.Repeat([]byte{0xCD}, maxOpaqueEventStreamBytes*3)
+
+	tests := []struct {
+		name     string
+		payload  []byte
+		connType pb.ConnectionType
+		wantLen  int
+	}{
+		{"tcp small passes through", small, pb.ConnectionTypeTCP, len(small)},
+		{"tcp large truncated", big, pb.ConnectionTypeTCP, maxOpaqueEventStreamBytes},
+		{"rdp large truncated", big, pb.ConnectionTypeRDP, maxOpaqueEventStreamBytes},
+		{"rdp small passes through", small, pb.ConnectionTypeRDP, len(small)},
+		{"postgres large untouched", big, pb.ConnectionTypePostgres, len(big)},
+		{"ssh large untouched", big, pb.ConnectionTypeSSH, len(big)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.truncateOpaqueEventStream(tt.payload, tt.connType)
+			if len(got) != tt.wantLen {
+				t.Fatalf("len=%d want=%d", len(got), tt.wantLen)
+			}
+			// Truncation must be a prefix, never a rewrite.
+			if !bytes.Equal(got, tt.payload[:len(got)]) {
+				t.Fatal("truncated stream is not a prefix of the original payload")
+			}
+		})
+	}
+}
+
+// TestEncodeEventEntryTruncatesOpaqueProtocols exercises the full encode path
+// (not just the truncation helper): large opaque payloads must land in the
+// JSON triple as a base64 of the truncated prefix, while payloads of
+// non-opaque protocols are stored whole.
+func TestEncodeEventEntryTruncatesOpaqueProtocols(t *testing.T) {
+	p := &auditPlugin{}
+	startDate := time.Now().UTC()
+	payload := bytes.Repeat([]byte{0xEF}, maxOpaqueEventStreamBytes*2)
+
+	tests := []struct {
+		name     string
+		connType pb.ConnectionType
+		wantLen  int
+	}{
+		{"rdp truncated at encode", pb.ConnectionTypeRDP, maxOpaqueEventStreamBytes},
+		{"tcp truncated at encode", pb.ConnectionTypeTCP, maxOpaqueEventStreamBytes},
+		{"postgres stored whole", pb.ConnectionTypePostgres, len(payload)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := eventlogv1.New(startDate.Add(time.Second), eventlogv1.OutputType, payload, nil)
+			metrics := newSessionMetric()
+
+			var buf strings.Builder
+			p.encodeEventEntry(&buf, ev, &startDate, tt.connType, &metrics)
+
+			var triple [3]any
+			if err := json.Unmarshal([]byte(buf.String()), &triple); err != nil {
+				t.Fatalf("encoded entry is not a valid JSON triple: %v", err)
+			}
+			b64, ok := triple[2].(string)
+			if !ok {
+				t.Fatalf("third element is not a string: %T", triple[2])
+			}
+			decoded, err := base64.StdEncoding.DecodeString(b64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(decoded) != tt.wantLen {
+				t.Fatalf("persisted payload len=%d want=%d", len(decoded), tt.wantLen)
+			}
+			if !bytes.Equal(decoded, payload[:tt.wantLen]) {
+				t.Fatal("persisted payload is not a prefix of the original")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The audit plugin truncates opaque byte-stream payloads to 5000 bytes when flushing session events to `blob_stream` — but the guard only matched `ConnectionTypeTCP`. RDP sessions over the gRPC transport path (`ConnectionTypeRDP`) flushed **full frame payloads**: base64-encoded into Postgres every 50s, up to the 110 MiB per-session cap, with a matching transient memory spike on the gateway (`strings.Builder` encode + jsonb append).

All cost, zero value: no consumer reads RDP payloads from the audit blob. RDP replay uses the dedicated recorder stream (`/sessions/:id/rdp-frames`), verified across `gateway/api/session/` and the webapp session views.

Sibling of #1593 (same incident investigation, other RDP path).

## Fix

- `ConnectionTypeRDP` joins `ConnectionTypeTCP` in the truncation
- Helper renamed `truncateTCPEventStream` → `truncateOpaqueEventStream` — the stale TCP-specific name is exactly how the omission happened
- Cap extracted to a documented constant (`maxOpaqueEventStreamBytes`)
- Tests at both the helper level and the `encodeEventEntry` level (truncated prefix survives the base64/JSON encode; non-opaque protocols stored whole)

Automated by MisterMal