### PR TITLE
ci: build and publish agent-tools on Dockerfile.tools changes (DEP-58)

### DIFF
--- a/.github/workflows/agent-tools-build.yml
+++ b/.github/workflows/agent-tools-build.yml
@@ -49,6 +49,20 @@ jobs:
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Fail fast on publish runs: bump-consumers needs the PAT at the very
+      # end of the pipeline, and discovering it is missing only after the
+      # image was already published leaves the registry and the consumers
+      # out of sync — the exact drift this workflow exists to prevent.
+      - name: Verify GH_TOKEN secret is present
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::secrets.GH_TOKEN (PAT) is required so the FROM-bump PR can be created after publishing. Add it in repo settings."
+            exit 1
+          fi
+
   build-amd64:
     runs-on: ubuntu-latest
     name: Build agent-tools (amd64)
@@ -197,6 +211,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           TAG: ${{ needs.meta.outputs.tag }}
+        # Idempotent by construction: TAG is deterministic per commit+day, so
+        # a rerun after a partial failure reuses the same branch (checkout -B
+        # + force push) and skips PR creation when one is already open.
         run: |
           set -euo pipefail
           branch="ci/agent-tools-bump-${TAG}"
@@ -210,9 +227,16 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
+          git checkout -B "$branch"
           git commit -am "build: bump agent-tools base image to ${TAG}"
-          git push -u origin "$branch"
+          # The branch is owned by this workflow and derived from TAG; force
+          # push makes reruns converge on the same content.
+          git push --force -u origin "$branch"
+
+          if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            echo "bump PR for ${TAG} already open; nothing to create"
+            exit 0
+          fi
 
           gh pr create \
             --title "build: bump agent-tools base image to ${TAG}" \

--- a/.github/workflows/agent-tools-build.yml
+++ b/.github/workflows/agent-tools-build.yml
@@ -1,0 +1,220 @@
+# Builds and publishes hoophq/agent-tools from Dockerfile.tools whenever the
+# recipe changes, gated by the forbidden-license scan (DEP-58).
+#
+# Why this exists: Dockerfile.tools was fixed to stop pulling AGPL packages
+# (ghostscript chain via groff Recommends), but the published image was never
+# rebuilt — the recipe and the registry drifted for weeks while every
+# hoophq/hoopdev preview build kept inheriting AGPL packages from the stale
+# base. This workflow makes that drift impossible:
+#
+#   - pull_request touching Dockerfile.tools: build (amd64) + license scan,
+#     no push — a recipe reintroducing AGPL/SSPL fails CI here, at the source.
+#   - push to main touching Dockerfile.tools (or manual dispatch): build both
+#     arches natively, license-gate, push hoophq/agent-tools:noble-<date>-<sha>
+#     per-arch tags + multi-arch manifest, then open a PR bumping the FROM
+#     lines in Dockerfile.dev and scripts/dev/Dockerfile.
+name: agent-tools
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile.tools
+      - .github/workflows/agent-tools-build.yml
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.tools
+      - .github/workflows/agent-tools-build.yml
+  workflow_dispatch: {}
+
+concurrency:
+  group: agent-tools-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  meta:
+    runs-on: ubuntu-latest
+    name: Compute image tag
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      publish: ${{ steps.tag.outputs.publish }}
+    steps:
+      - id: tag
+        run: |
+          short_sha=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          echo "tag=noble-$(date -u +%Y%m%d)-${short_sha}" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-amd64:
+    runs-on: ubuntu-latest
+    name: Build agent-tools (amd64)
+    needs: [meta]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build image
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.tools
+          context: '.'
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          load: true
+          push: false
+          tags: hoophq/agent-tools:${{ needs.meta.outputs.tag }}-amd64
+
+      # License gate BEFORE anything is pushed: agent-tools is the base of
+      # hoophq/hoopdev, so a forbidden license here propagates to everything.
+      - name: Scan licenses (Trivy)
+        run: |
+          mkdir -p /tmp/license-scan
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v /tmp/license-scan:/scan \
+            aquasec/trivy:0.72.0 image \
+            --scanners license \
+            --format json \
+            --quiet \
+            --output /scan/agent-tools.json \
+            "hoophq/agent-tools:${{ needs.meta.outputs.tag }}-amd64"
+      - name: Gate on forbidden licenses
+        id: check
+        run: |
+          python3 scripts/ci/check-forbidden-licenses.py \
+            --comment-out /tmp/license-scan/comment.json \
+            hoophq/agent-tools=/tmp/license-scan/agent-tools.json
+      - name: Fail on forbidden licenses
+        if: steps.check.outputs.found == 'true'
+        run: |
+          echo "::error::forbidden licenses detected in agent-tools; refusing to publish (see scan output above)"
+          exit 1
+
+      - name: Login to Docker Hub
+        if: needs.meta.outputs.publish == 'true'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push
+        if: needs.meta.outputs.publish == 'true'
+        run: docker push hoophq/agent-tools:${{ needs.meta.outputs.tag }}-amd64
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    name: Build agent-tools (arm64)
+    needs: [meta]
+    if: needs.meta.outputs.publish == 'true'
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build image
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.tools
+          context: '.'
+          platforms: linux/arm64
+          provenance: false
+          sbom: false
+          load: true
+          push: false
+          tags: hoophq/agent-tools:${{ needs.meta.outputs.tag }}-arm64
+
+      # Same gate as amd64: package sets can differ per-arch, so scan both.
+      - name: Scan licenses (Trivy)
+        run: |
+          mkdir -p /tmp/license-scan
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v /tmp/license-scan:/scan \
+            aquasec/trivy:0.72.0 image \
+            --scanners license \
+            --format json \
+            --quiet \
+            --output /scan/agent-tools.json \
+            "hoophq/agent-tools:${{ needs.meta.outputs.tag }}-arm64"
+      - name: Gate on forbidden licenses
+        id: check
+        run: |
+          python3 scripts/ci/check-forbidden-licenses.py \
+            --comment-out /tmp/license-scan/comment.json \
+            hoophq/agent-tools=/tmp/license-scan/agent-tools.json
+      - name: Fail on forbidden licenses
+        if: steps.check.outputs.found == 'true'
+        run: |
+          echo "::error::forbidden licenses detected in agent-tools (arm64); refusing to publish"
+          exit 1
+
+      - name: Push
+        run: docker push hoophq/agent-tools:${{ needs.meta.outputs.tag }}-arm64
+
+  manifest:
+    runs-on: ubuntu-latest
+    name: Push multi-arch manifest
+    needs: [meta, build-amd64, build-arm64]
+    if: needs.meta.outputs.publish == 'true'
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Create manifest and push
+        run: |
+          docker manifest create hoophq/agent-tools:${{ needs.meta.outputs.tag }} \
+            hoophq/agent-tools:${{ needs.meta.outputs.tag }}-amd64 \
+            hoophq/agent-tools:${{ needs.meta.outputs.tag }}-arm64
+          docker manifest push hoophq/agent-tools:${{ needs.meta.outputs.tag }}
+
+  bump-consumers:
+    runs-on: ubuntu-latest
+    name: Open FROM-bump PR
+    needs: [meta, manifest]
+    if: needs.meta.outputs.publish == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Bump FROM lines and open PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          TAG: ${{ needs.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          branch="ci/agent-tools-bump-${TAG}"
+          sed -i "s|^FROM hoophq/agent-tools:.*|FROM hoophq/agent-tools:${TAG}|" \
+            Dockerfile.dev scripts/dev/Dockerfile
+
+          if git diff --quiet; then
+            echo "consumers already reference ${TAG}; nothing to bump"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git commit -am "build: bump agent-tools base image to ${TAG}"
+          git push -u origin "$branch"
+
+          gh pr create \
+            --title "build: bump agent-tools base image to ${TAG}" \
+            --label patch \
+            --body "Auto-generated by the agent-tools workflow after publishing \`hoophq/agent-tools:${TAG}\` (license-gated: no AGPL/SSPL). Bumps the base image of \`Dockerfile.dev\` and \`scripts/dev/Dockerfile\` so hoopdev preview and dev images pick up the rebuilt base."


### PR DESCRIPTION
## Problem (DEP-58)

`Dockerfile.tools` was fixed in #1585 to stop pulling the AGPL chain (ghostscript & friends via groff Recommends), but the published `hoophq/agent-tools:noble-20251013` was **never rebuilt** — nothing in CI builds it. The recipe and the registry drifted, and every `hoophq/hoopdev` preview build kept inheriting the 17 AGPL packages the Trivy scan flags on PRs (e.g. #1593).

## Fix: make the drift impossible

New `agent-tools` workflow:

| Trigger | Behavior |
|---|---|
| PR touching `Dockerfile.tools` | build amd64 + **Trivy license gate** — reintroducing AGPL/SSPL fails CI at the source, no push |
| push to `main` touching `Dockerfile.tools` / manual dispatch | build amd64+arm64 on native runners (house pattern: per-arch tags + `docker manifest`), license-gate **both arches before pushing**, publish `hoophq/agent-tools:noble-<date>-<shortsha>`, then **auto-open a PR** bumping the `FROM` lines in `Dockerfile.dev` + `scripts/dev/Dockerfile` |

Reuses `scripts/ci/check-forbidden-licenses.py` (#1586) and the existing `DOCKER_LOGIN`/`DOCKER_PASSWORD` + `GH_TOKEN` secrets. actionlint clean (same action pins as existing workflows).

## Rollout to close DEP-58

1. Merge this
2. Run the workflow via **workflow_dispatch** (the fixed `Dockerfile.tools` is already on main, so no path trigger fires)
3. Merge the auto-generated FROM-bump PR
4. Next PR preview → Trivy license comment comes back clean → close DEP-58

Automated by MisterMal

## Linear

Closes DEP-58
