### PR TITLE
fix: ensure migration for security_audit_log

### DIFF
--- a/gateway/migrations/000101_ensure_audit_log_http_fields.down.sql
+++ b/gateway/migrations/000101_ensure_audit_log_http_fields.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+SET search_path TO private;
+
+-- No-op: 000101 only re-applies (idempotently) the schema changes already
+-- owned by 000064_audit_log_http_fields. Dropping the columns/indexes here
+-- would revert 000064 as well, so this down migration intentionally does
+-- nothing. Roll back 000064 to remove the HTTP audit-log fields.
+
+COMMIT;

--- a/gateway/migrations/000101_ensure_audit_log_http_fields.up.sql
+++ b/gateway/migrations/000101_ensure_audit_log_http_fields.up.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+SET search_path TO private;
+
+-- Idempotent re-apply of 000064_audit_log_http_fields for environments
+-- where the original migration was recorded but not (fully) applied.
+
+-- Remove redundant columns (resource_id and resource_name will be in the payload)
+ALTER TABLE security_audit_log 
+  DROP COLUMN IF EXISTS resource_id,
+  DROP COLUMN IF EXISTS resource_name;
+
+-- Add HTTP request/response fields
+ALTER TABLE security_audit_log 
+  ADD COLUMN IF NOT EXISTS http_method VARCHAR(16) NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS http_status INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS http_path VARCHAR(512) NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS client_ip VARCHAR(45) NOT NULL DEFAULT '';
+
+-- Create indexes for common filter queries
+CREATE INDEX IF NOT EXISTS idx_security_audit_log_http_status ON security_audit_log(org_id, http_status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_security_audit_log_client_ip ON security_audit_log(org_id, client_ip, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_security_audit_log_http_path ON security_audit_log(org_id, http_path, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_security_audit_log_http_method ON security_audit_log(org_id, http_method, created_at DESC);
+
+COMMIT;


### PR DESCRIPTION
   > [!IMPORTANT]
   > Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
   >
   > - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
   > - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

   Adds an idempotent, guard-railed migration (`000101_ensure_audit_log_http_fields`) that re-applies the HTTP audit-log schema changes originally introduced by
 `000064_audit_log_http_fields`. In some environments migration `000064` was recorded as applied in `schema_migrations` but its DDL was never (fully) executed
 against `security_audit_log`, leaving the table without the expected HTTP columns/indexes. This new migration safely reconciles that drift using `IF EXISTS` /  
 `IF NOT EXISTS` guards so it is a no-op where the schema is already correct.

## 🔗 Related Issue

   <!-- Link to the issue this PR addresses (if applicable) -->

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `gateway/migrations/000101_ensure_audit_log_http_fields.up.sql` — idempotently drops the redundant `resource_id` / `resource_name` columns and
 (re)adds the HTTP fields (`http_method`, `http_status`, `http_path`, `client_ip`) plus their `org_id`-scoped composite indexes, all with `IF EXISTS` / `IF NOT  
 EXISTS` guards so it's safe on already-correct schemas.
- Added `gateway/migrations/000101_ensure_audit_log_http_fields.down.sql` — an intentional no-op (documented) so rolling back `000101` does not revert
 `000064`; the HTTP fields are still owned by `000064` and removed by rolling that migration back.
- Sequential migration numbering verified (`000101` follows `000100_mcp_oauth_flows`).

## 🧪 Testing

   Verified the migration applies cleanly against an environment where `000064` was recorded but not applied, and is a no-op against an environment where the
 schema already matches. Confirmed the down migration is a safe no-op and does not drop the HTTP columns owned by `000064`.

### Test Configuration

- **Browser(s)**: Brave
- **OS**: macOS

### Tests performed

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

   <!-- Not applicable — SQL migration only -->

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

   The `.up.sql` is fully idempotent (guarded with `IF EXISTS` / `IF NOT EXISTS`), so it is safe to run against clusters where `000064` did or did not actually  
 apply. The `.down.sql` is deliberately empty — reverting it would incorrectly undo `000064`'s schema. Suggested release label: **`patch`** (bug fix,
 non-breaking).
