### PR TITLE
build: bump agent-tools base image to noble-20260709-6890906

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Dockerfile.tools
-FROM hoophq/agent-tools:noble-20251013
+FROM hoophq/agent-tools:noble-20260709-6890906
 
 COPY rootfs /
 # SQL migrations are embedded in the gateway binary; the on-disk copy is

--- a/scripts/dev/Dockerfile
+++ b/scripts/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM hoophq/agent-tools:noble-20251013
+FROM hoophq/agent-tools:noble-20260709-6890906
 
 RUN mkdir -p /opt/hoop/sessions && \
   mkdir -p /opt/hoop/bin && \


### PR DESCRIPTION
Auto-generated by the agent-tools workflow after publishing `hoophq/agent-tools:noble-20260709-6890906` (license-gated: no AGPL/SSPL). Bumps the base image of `Dockerfile.dev` and `scripts/dev/Dockerfile` so hoopdev preview and dev images pick up the rebuilt base.