### PR TITLE
feat: enhance guardrails-promotion component to handle DLP provider availability

### DIFF
--- a/webapp/src/webapp/features/promotion.cljs
+++ b/webapp/src/webapp/features/promotion.cljs
@@ -141,14 +141,14 @@
 (defn guardrails-promotion
   "Specific component for Guardrails.
 
-   When provider-available? is explicitly false, renders the 'DLP provider
-   required' variant: a documentation link and an explanation instead of the
-   create CTA. This mirrors how Live Data Masking presents its screen when a
-   Microsoft Presidio DLP provider is not configured — guardrails are enforced
-   through Presidio, so without it the feature cannot be set up (EVL-62)."
-  [{:keys [mode installed? provider-available?]}]
+   When dlp-available? is explicitly false, renders the 'DLP provider required'
+   variant: a documentation link and an explanation instead of the create CTA.
+   This mirrors how Live Data Masking presents its screen when no DLP provider
+   is configured — guardrails are enforced through a DLP provider (GCP or
+   Microsoft Presidio), so without one the feature cannot be set up (EVL-62)."
+  [{:keys [mode installed? dlp-available?]}]
   (let [empty-state? (= mode :empty-state)
-        dlp-missing? (false? provider-available?)]
+        dlp-missing? (false? dlp-available?)]
     [feature-promotion
      (merge
       {:feature-name "Guardrails"
@@ -165,8 +165,9 @@
                         :title "Context-Aware Access"
                         :description "Evaluate access requests based on user context, consider factors like time, location, and previous activity and create an adaptive security measurement based on risk assessment."}]}
       (if dlp-missing?
-        {:extra-information (str "Guardrails require a Microsoft Presidio DLP provider to be "
-                                "enforced. Configure Presidio to create and manage guardrails.")
+        {:extra-information (str "Guardrails require a DLP provider (Microsoft Presidio or "
+                                "Google Cloud DLP) to be enforced. Configure a DLP provider "
+                                "to create and manage guardrails.")
          :link-button-href [:features :guardrails]
          :link-button-text "Go to Guardrails documentation"}
         {:on-primary-click (if empty-state?

--- a/webapp/src/webapp/features/promotion.cljs
+++ b/webapp/src/webapp/features/promotion.cljs
@@ -139,28 +139,42 @@
                     "Request demo")}])
 
 (defn guardrails-promotion
-  "Specific component for Guardrails"
-  [{:keys [mode installed?]}]
-  [feature-promotion
-   {:feature-name "Guardrails"
-    :mode mode
-    :image "guardrails-promotion.png"
-    :description "Create custom rules to guide and protect usage within your resource roles."
-    :feature-items [{:icon [:> ListCheck {:size 20}]
-                     :title "Automated Policy Enforcement"
-                     :description "Real-time monitoring of access policies, automatic detection and prevention of risky operations with customizable rules based on your organization's security requirements."}
-                    {:icon [:> ShieldCheck {:size 20}]
-                     :title "Smart Command Filtering"
-                     :description "Block potentially dangerous commands before execution and prevent accidental data modifications or deletions."}
-                    {:icon [:> TextSearch {:size 20}]
-                     :title "Context-Aware Access"
-                     :description "Evaluate access requests based on user context, consider factors like time, location, and previous activity and create an adaptive security measurement based on risk assessment."}]
-    :on-primary-click (if (= mode :empty-state)
-                        #(rf/dispatch [:navigate :create-guardrail])
-                        request-demo)
-    :primary-text (if (= mode :empty-state)
-                    "Create new Guardrails"
-                    "Request demo")}])
+  "Specific component for Guardrails.
+
+   When provider-available? is explicitly false, renders the 'DLP provider
+   required' variant: a documentation link and an explanation instead of the
+   create CTA. This mirrors how Live Data Masking presents its screen when a
+   Microsoft Presidio DLP provider is not configured — guardrails are enforced
+   through Presidio, so without it the feature cannot be set up (EVL-62)."
+  [{:keys [mode installed? provider-available?]}]
+  (let [empty-state? (= mode :empty-state)
+        dlp-missing? (false? provider-available?)]
+    [feature-promotion
+     (merge
+      {:feature-name "Guardrails"
+       :mode mode
+       :image "guardrails-promotion.png"
+       :description "Create custom rules to guide and protect usage within your resource roles."
+       :feature-items [{:icon [:> ListCheck {:size 20}]
+                        :title "Automated Policy Enforcement"
+                        :description "Real-time monitoring of access policies, automatic detection and prevention of risky operations with customizable rules based on your organization's security requirements."}
+                       {:icon [:> ShieldCheck {:size 20}]
+                        :title "Smart Command Filtering"
+                        :description "Block potentially dangerous commands before execution and prevent accidental data modifications or deletions."}
+                       {:icon [:> TextSearch {:size 20}]
+                        :title "Context-Aware Access"
+                        :description "Evaluate access requests based on user context, consider factors like time, location, and previous activity and create an adaptive security measurement based on risk assessment."}]}
+      (if dlp-missing?
+        {:extra-information (str "Guardrails require a Microsoft Presidio DLP provider to be "
+                                "enforced. Configure Presidio to create and manage guardrails.")
+         :link-button-href [:features :guardrails]
+         :link-button-text "Go to Guardrails documentation"}
+        {:on-primary-click (if empty-state?
+                             #(rf/dispatch [:navigate :create-guardrail])
+                             request-demo)
+         :primary-text (if empty-state?
+                         "Create new Guardrails"
+                         "Request demo")}))]))
 
 (defn jira-templates-promotion
   "Specific component for Jira templates"

--- a/webapp/src/webapp/guardrails/main.cljs
+++ b/webapp/src/webapp/guardrails/main.cljs
@@ -16,7 +16,8 @@
         selected-connection (r/atom nil)
         selected-attribute (r/atom nil)
         connections (rf/subscribe [:connections])
-        user (rf/subscribe [:users->current-user])]
+        user (rf/subscribe [:users->current-user])
+        gateway-info (rf/subscribe [:gateway->info])]
     (rf/dispatch [:guardrails->get-all])
 
     (js/setTimeout #(reset! min-loading-done true) 1500)
@@ -27,6 +28,10 @@
             all-rules (:data @guardrails-rules-list)
             free-license? (-> @user :data :free-license?)
             limit-reached? (and free-license? (>= (count all-rules) 1))
+            redact-provider (-> @gateway-info :data :redact_provider)
+            has-redact-credentials? (-> @gateway-info :data :has_redact_credentials)
+            provider-available? (and (= redact-provider "mspresidio")
+                                     has-redact-credentials?)
             connections-data @connections
             connections-results (:results connections-data)
             by-connection (if (nil? @selected-connection)
@@ -44,6 +49,14 @@
         (cond
           loading?
           [loaders/page-loading-screen {:full-page false}]
+
+          ;; No DLP provider (Microsoft Presidio) configured: guardrails cannot
+          ;; be enforced, so present a provider-required screen instead of the
+          ;; setup UI, mirroring the Live Data Masking no-provider screen (EVL-62).
+          (not provider-available?)
+          [:> Box {:class "bg-gray-1 h-full"}
+           [promotion/guardrails-promotion {:mode :empty-state
+                                            :provider-available? false}]]
 
           (empty? all-rules)
           [:> Box {:class "bg-gray-1 h-full"}

--- a/webapp/src/webapp/guardrails/main.cljs
+++ b/webapp/src/webapp/guardrails/main.cljs
@@ -28,10 +28,9 @@
             all-rules (:data @guardrails-rules-list)
             free-license? (-> @user :data :free-license?)
             limit-reached? (and free-license? (>= (count all-rules) 1))
-            redact-provider (-> @gateway-info :data :redact_provider)
-            has-redact-credentials? (-> @gateway-info :data :has_redact_credentials)
-            provider-available? (and (= redact-provider "mspresidio")
-                                     has-redact-credentials?)
+            ;; A DLP provider (gcp or mspresidio) is required to enforce guardrails;
+            ;; has_redact_credentials is true only when one of those is configured.
+            dlp-available? (boolean (-> @gateway-info :data :has_redact_credentials))
             connections-data @connections
             connections-results (:results connections-data)
             by-connection (if (nil? @selected-connection)
@@ -50,13 +49,13 @@
           loading?
           [loaders/page-loading-screen {:full-page false}]
 
-          ;; No DLP provider (Microsoft Presidio) configured: guardrails cannot
-          ;; be enforced, so present a provider-required screen instead of the
-          ;; setup UI, mirroring the Live Data Masking no-provider screen (EVL-62).
-          (not provider-available?)
+          ;; No DLP provider (GCP or Microsoft Presidio) configured: guardrails
+          ;; cannot be enforced, so present a provider-required screen instead of
+          ;; the setup UI, mirroring the Live Data Masking no-provider screen (EVL-62).
+          (not dlp-available?)
           [:> Box {:class "bg-gray-1 h-full"}
            [promotion/guardrails-promotion {:mode :empty-state
-                                            :provider-available? false}]]
+                                            :dlp-available? false}]]
 
           (empty? all-rules)
           [:> Box {:class "bg-gray-1 h-full"}


### PR DESCRIPTION
   > [!IMPORTANT]
   > Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
   >
   > - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
   > - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

   Enhances the Guardrails feature so it correctly reflects its dependency on a Microsoft Presidio DLP provider. When no DLP
 provider is configured, Guardrails cannot be enforced (rules are applied through Presidio), so instead of showing the
 setup/empty-state UI, the page now presents a "DLP provider required" screen with a documentation link — mirroring how Live Data
 Masking behaves when Presidio is not configured.

## 🔗 Related Issue

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Extended `guardrails-promotion` in `webapp/src/webapp/features/promotion.cljs` to accept a `provider-available?` flag; when
 explicitly `false` it renders a DLP-provider-required variant (explanatory text + "Go to Guardrails documentation" link) instead of
 the create-guardrail CTA.
- Updated `webapp/src/webapp/guardrails/main.cljs` to subscribe to `:gateway->info`, derive `provider-available?` from
 `redact_provider == "mspresidio"` and `has_redact_credentials`, and short-circuit to the provider-required screen when no DLP
 provider is configured.

## 🧪 Testing

   Manually verified the Guardrails page in the webapp with and without a configured Microsoft Presidio DLP provider, confirming the
 provider-required screen shows when no provider is present and the normal setup/empty-state UI shows when Presidio is configured.

### Test Configuration

- **Browser(s)**: Brave
- **OS**: macOS

### Tests performed

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

   <!-- Add screenshots to help explain your changes -->

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

   This change is frontend-only (ClojureScript `webapp/`) and relies on the existing `/serverinfo` gateway fields `redact_provider`  
 and `has_redact_credentials`. 
