### PR TITLE
feat(auth): dark theme for auth-flow loading screens

### DIFF
--- a/webapp/src/webapp/auth/views/logout.cljs
+++ b/webapp/src/webapp/auth/views/logout.cljs
@@ -18,6 +18,5 @@
                                                              :login-hoop)))
      1500)
 
-    [loaders/page-loading-screen {:message "Logging out..."
-                                   :description "You will be redirected in a few seconds."
-                                   :dark true}]))
+    [loaders/auth-loading-screen {:message "Logging out..."
+                                  :description "You will be redirected in a few seconds."}]))

--- a/webapp/src/webapp/auth/views/logout.cljs
+++ b/webapp/src/webapp/auth/views/logout.cljs
@@ -19,4 +19,5 @@
      1500)
 
     [loaders/page-loading-screen {:message "Logging out..."
-                                   :description "You will be redirected in a few seconds."}]))
+                                   :description "You will be redirected in a few seconds."
+                                   :dark true}]))

--- a/webapp/src/webapp/components/loaders.cljs
+++ b/webapp/src/webapp/components/loaders.cljs
@@ -3,31 +3,28 @@
    [re-frame.core :as rf]
    [webapp.subs :as subs]))
 
-(defn- dots-loader [dark]
-  (let [dot-class (str "w-2 h-2 rounded-full animate-bounce "
-                       (if dark "bg-white" "bg-gray-12"))]
-    [:div {:class "flex gap-1.5"}
-     [:div {:class dot-class :style {:animation-delay "0ms"}}]
-     [:div {:class dot-class :style {:animation-delay "150ms"}}]
-     [:div {:class dot-class :style {:animation-delay "300ms"}}]]))
+(defn- dots-loader []
+  [:div {:class "flex gap-1.5"}
+   [:div {:class "w-2 h-2 rounded-full bg-gray-12 animate-bounce"
+          :style {:animation-delay "0ms"}}]
+   [:div {:class "w-2 h-2 rounded-full bg-gray-12 animate-bounce"
+          :style {:animation-delay "150ms"}}]
+   [:div {:class "w-2 h-2 rounded-full bg-gray-12 animate-bounce"
+          :style {:animation-delay "300ms"}}]])
 
-(defn- loader-content [{:keys [message description dark]}]
+(defn- loader-content [{:keys [message description]}]
   [:<>
-   [:img {:src (if dark
-                 "/images/hoop-branding/SVG/hoop-symbol_white.svg"
-                 "/images/hoop-branding/SVG/hoop-symbol_black.svg")
+   [:img {:src "/images/hoop-branding/SVG/hoop-symbol_black.svg"
           :height "40"
           :width "40"
           :alt "hoop"}]
-   [dots-loader dark]
+   [dots-loader]
    (when (or message description)
      [:div {:class "flex flex-col items-center gap-1 text-center"}
       (when message
-        [:p {:class (str "text-sm font-medium "
-                         (if dark "text-white" "text-gray-11"))} message])
+        [:p {:class "text-sm font-medium text-gray-11"} message])
       (when description
-        [:p {:class (str "text-xs opacity-70 "
-                         (if dark "text-white" "text-gray-11"))} description])])])
+        [:p {:class "text-xs text-gray-11 opacity-70"} description])])])
 
 (def spinner-lg
   [:div.w-12.h-12.rounded-full.border-8.border-t-gray-600.animate-spin])
@@ -55,9 +52,34 @@
                        " w-6 h-6"))}])
 
 (defn page-loading-screen
-  [{:keys [message description full-page dark]
+  [{:keys [message description full-page]
     :or {full-page true}}]
   [:div {:class (str (if full-page "min-h-screen" "h-full")
-                     " flex flex-col items-center justify-center gap-6"
-                     (when dark " bg-[#182449]"))}
-   [loader-content {:message message :description description :dark dark}]])
+                     " flex flex-col items-center justify-center gap-6")}
+   [loader-content {:message message :description description}]])
+
+(defn- dark-dots-loader []
+  [:div {:class "flex gap-1.5"}
+   [:div {:class "w-2 h-2 rounded-full bg-white animate-bounce"
+          :style {:animation-delay "0ms"}}]
+   [:div {:class "w-2 h-2 rounded-full bg-white animate-bounce"
+          :style {:animation-delay "150ms"}}]
+   [:div {:class "w-2 h-2 rounded-full bg-white animate-bounce"
+          :style {:animation-delay "300ms"}}]])
+
+(defn auth-loading-screen
+  "Full-page loading screen for auth-flow routes. Auth screens are always
+  dark -- there is no light variant -- so the dark styling is baked in."
+  [{:keys [message description]}]
+  [:div {:class "min-h-screen flex flex-col items-center justify-center gap-6 bg-[#182449]"}
+   [:img {:src "/images/hoop-branding/SVG/hoop-symbol_white.svg"
+          :height "40"
+          :width "40"
+          :alt "hoop"}]
+   [dark-dots-loader]
+   (when (or message description)
+     [:div {:class "flex flex-col items-center gap-1 text-center"}
+      (when message
+        [:p {:class "text-sm font-medium text-white"} message])
+      (when description
+        [:p {:class "text-xs opacity-70 text-white"} description])])])

--- a/webapp/src/webapp/components/loaders.cljs
+++ b/webapp/src/webapp/components/loaders.cljs
@@ -3,28 +3,31 @@
    [re-frame.core :as rf]
    [webapp.subs :as subs]))
 
-(defn- dots-loader []
-  [:div {:class "flex gap-1.5"}
-   [:div {:class "w-2 h-2 rounded-full bg-gray-12 animate-bounce"
-          :style {:animation-delay "0ms"}}]
-   [:div {:class "w-2 h-2 rounded-full bg-gray-12 animate-bounce"
-          :style {:animation-delay "150ms"}}]
-   [:div {:class "w-2 h-2 rounded-full bg-gray-12 animate-bounce"
-          :style {:animation-delay "300ms"}}]])
+(defn- dots-loader [dark]
+  (let [dot-class (str "w-2 h-2 rounded-full animate-bounce "
+                       (if dark "bg-white" "bg-gray-12"))]
+    [:div {:class "flex gap-1.5"}
+     [:div {:class dot-class :style {:animation-delay "0ms"}}]
+     [:div {:class dot-class :style {:animation-delay "150ms"}}]
+     [:div {:class dot-class :style {:animation-delay "300ms"}}]]))
 
-(defn- loader-content [{:keys [message description]}]
+(defn- loader-content [{:keys [message description dark]}]
   [:<>
-   [:img {:src "/images/hoop-branding/SVG/hoop-symbol_black.svg"
+   [:img {:src (if dark
+                 "/images/hoop-branding/SVG/hoop-symbol_white.svg"
+                 "/images/hoop-branding/SVG/hoop-symbol_black.svg")
           :height "40"
           :width "40"
           :alt "hoop"}]
-   [dots-loader]
+   [dots-loader dark]
    (when (or message description)
      [:div {:class "flex flex-col items-center gap-1 text-center"}
       (when message
-        [:p {:class "text-sm font-medium text-gray-11"} message])
+        [:p {:class (str "text-sm font-medium "
+                         (if dark "text-white" "text-gray-11"))} message])
       (when description
-        [:p {:class "text-xs text-gray-11 opacity-70"} description])])])
+        [:p {:class (str "text-xs opacity-70 "
+                         (if dark "text-white" "text-gray-11"))} description])])])
 
 (def spinner-lg
   [:div.w-12.h-12.rounded-full.border-8.border-t-gray-600.animate-spin])
@@ -52,8 +55,9 @@
                        " w-6 h-6"))}])
 
 (defn page-loading-screen
-  [{:keys [message description full-page]
+  [{:keys [message description full-page dark]
     :or {full-page true}}]
   [:div {:class (str (if full-page "min-h-screen" "h-full")
-                     " flex flex-col items-center justify-center gap-6")}
-   [loader-content {:message message :description description}]])
+                     " flex flex-col items-center justify-center gap-6"
+                     (when dark " bg-[#182449]"))}
+   [loader-content {:message message :description description :dark dark}]])

--- a/webapp_v2/COMPONENTS.md
+++ b/webapp_v2/COMPONENTS.md
@@ -24,6 +24,19 @@ import PageLoader from '@/components/PageLoader'
 ```
 Use with `useMinDelay` to prevent flash on fast requests.
 
+### `AuthPageLoader`
+Full-screen dark loading state for auth-flow routes (login redirect, OAuth callbacks, session verification). Auth screens are always dark — there is no light variant — so the dark styling is baked in. For loaders inside the (light) app shell, use `PageLoader`.
+```jsx
+import AuthPageLoader from '@/components/AuthPageLoader'
+
+<AuthPageLoader message="Verifying authentication..." />
+<AuthPageLoader
+  error
+  message="Authentication failed"
+  description="Redirecting to login..."
+/>
+```
+
 ### `EmptyState` (`src/layout/EmptyState/`)
 Empty list / zero-data state with icon, title, description, and optional CTA.
 ```jsx

--- a/webapp_v2/src/components/AuthPageLoader/index.jsx
+++ b/webapp_v2/src/components/AuthPageLoader/index.jsx
@@ -2,7 +2,10 @@ import { useEffect, useState } from 'react'
 import { Center, Stack, Loader, Text, Transition } from '@mantine/core'
 import { XCircle } from 'lucide-react'
 
-function PageLoader({ message, description, error, overlay, h }) {
+// Full-screen loading state for auth-flow routes (login redirect, OAuth
+// callbacks, session verification). Auth screens are always dark — there is
+// no light variant — so the dark styling is baked in rather than passed in.
+function AuthPageLoader({ message, description, error }) {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
@@ -10,22 +13,13 @@ function PageLoader({ message, description, error, overlay, h }) {
     return () => clearTimeout(timer)
   }, [])
 
-  const containerStyle = overlay
-    ? {
-        position: 'fixed',
-        inset: 0,
-        backgroundColor: 'var(--mantine-color-body)',
-        zIndex: 200,
-      }
-    : undefined
-
   return (
-    <Center style={containerStyle} h={overlay ? undefined : (h ?? '100vh')}>
+    <Center h="100vh" bg="var(--sidebar-bg)">
       <Transition mounted={visible} transition="fade" duration={300}>
         {(styles) => (
-          <Stack align="center" gap="xl" style={{ ...styles, maxWidth: 320 }}>
+          <Stack align="center" gap="xl" maw={320} style={styles}>
             <img
-              src="/images/hoop-branding/SVG/hoop-symbol_black.svg"
+              src="/images/hoop-branding/SVG/hoop-symbol_white.svg"
               height={40}
               width={40}
               alt="hoop"
@@ -34,18 +28,18 @@ function PageLoader({ message, description, error, overlay, h }) {
             {error ? (
               <XCircle size={32} color="var(--mantine-color-red-6)" strokeWidth={1.5} />
             ) : (
-              <Loader size="sm" type="dots" color="dark" />
+              <Loader size="sm" type="dots" color="gray.0" />
             )}
 
             {(message || description) && (
               <Stack align="center" gap={6}>
                 {message && (
-                  <Text size="sm" c="dimmed" ta="center" fw={500}>
+                  <Text size="sm" c="gray.0" ta="center" fw={500}>
                     {message}
                   </Text>
                 )}
                 {description && (
-                  <Text size="xs" c="dimmed" ta="center">
+                  <Text size="xs" c="gray.5" ta="center">
                     {description}
                   </Text>
                 )}
@@ -58,4 +52,4 @@ function PageLoader({ message, description, error, overlay, h }) {
   )
 }
 
-export default PageLoader
+export default AuthPageLoader

--- a/webapp_v2/src/components/PageLoader/index.jsx
+++ b/webapp_v2/src/components/PageLoader/index.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Center, Stack, Loader, Text, Transition } from '@mantine/core'
 import { XCircle } from 'lucide-react'
 
-function PageLoader({ message, description, error, overlay, h }) {
+function PageLoader({ message, description, error, overlay, h, dark }) {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
@@ -14,18 +14,24 @@ function PageLoader({ message, description, error, overlay, h }) {
     ? {
         position: 'fixed',
         inset: 0,
-        backgroundColor: 'var(--mantine-color-body)',
+        backgroundColor: dark ? 'var(--sidebar-bg)' : 'var(--mantine-color-body)',
         zIndex: 200,
       }
     : undefined
 
   return (
-    <Center style={containerStyle} h={overlay ? undefined : (h ?? '100vh')}>
+    <Center
+      style={containerStyle}
+      h={overlay ? undefined : (h ?? '100vh')}
+      bg={!overlay && dark ? 'var(--sidebar-bg)' : undefined}
+    >
       <Transition mounted={visible} transition="fade" duration={300}>
         {(styles) => (
           <Stack align="center" gap="xl" style={{ ...styles, maxWidth: 320 }}>
             <img
-              src="/images/hoop-branding/SVG/hoop-symbol_black.svg"
+              src={dark
+                ? '/images/hoop-branding/SVG/hoop-symbol_white.svg'
+                : '/images/hoop-branding/SVG/hoop-symbol_black.svg'}
               height={40}
               width={40}
               alt="hoop"
@@ -34,18 +40,18 @@ function PageLoader({ message, description, error, overlay, h }) {
             {error ? (
               <XCircle size={32} color="var(--mantine-color-red-6)" strokeWidth={1.5} />
             ) : (
-              <Loader size="sm" type="dots" color="dark" />
+              <Loader size="sm" type="dots" color={dark ? 'gray.0' : 'dark'} />
             )}
 
             {(message || description) && (
               <Stack align="center" gap={6}>
                 {message && (
-                  <Text size="sm" c="dimmed" ta="center" fw={500}>
+                  <Text size="sm" c={dark ? 'gray.0' : 'dimmed'} ta="center" fw={500}>
                     {message}
                   </Text>
                 )}
                 {description && (
-                  <Text size="xs" c="dimmed" ta="center">
+                  <Text size="xs" c={dark ? 'gray.5' : 'dimmed'} ta="center">
                     {description}
                   </Text>
                 )}

--- a/webapp_v2/src/components/ProtectedRoute.jsx
+++ b/webapp_v2/src/components/ProtectedRoute.jsx
@@ -5,7 +5,7 @@ import { useUserStore } from '@/stores/useUserStore'
 import { authService } from '@/services/auth'
 import { connectionsService } from '@/services/connections'
 import { featureFlagsService } from '@/services/featureFlags'
-import PageLoader from '@/components/PageLoader'
+import AuthPageLoader from '@/components/AuthPageLoader'
 
 function ProtectedRoute({ children, adminOnly = false }) {
   const location = useLocation()
@@ -106,7 +106,7 @@ function ProtectedRoute({ children, adminOnly = false }) {
   }
 
   if (initializing) {
-    return <PageLoader dark message="Verifying authentication..." />
+    return <AuthPageLoader message="Verifying authentication..." />
   }
 
   if (adminOnly && !isAdmin) {

--- a/webapp_v2/src/components/ProtectedRoute.jsx
+++ b/webapp_v2/src/components/ProtectedRoute.jsx
@@ -106,7 +106,7 @@ function ProtectedRoute({ children, adminOnly = false }) {
   }
 
   if (initializing) {
-    return <PageLoader message="Verifying authentication..." />
+    return <PageLoader dark message="Verifying authentication..." />
   }
 
   if (adminOnly && !isAdmin) {

--- a/webapp_v2/src/pages/Auth/Callback/index.jsx
+++ b/webapp_v2/src/pages/Auth/Callback/index.jsx
@@ -49,12 +49,14 @@ function AuthCallback() {
 
   return error ? (
     <PageLoader
+      dark
       error
       message="Authentication failed"
       description="Redirecting to login..."
     />
   ) : (
     <PageLoader
+      dark
       message="Verifying authentication..."
       description="Please wait while we complete your sign in"
     />

--- a/webapp_v2/src/pages/Auth/Callback/index.jsx
+++ b/webapp_v2/src/pages/Auth/Callback/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/stores/useAuthStore'
-import PageLoader from '@/components/PageLoader'
+import AuthPageLoader from '@/components/AuthPageLoader'
 
 function AuthCallback() {
   const navigate = useNavigate()
@@ -48,15 +48,13 @@ function AuthCallback() {
   }, [navigate, initializeToken, getAndClearRedirectUrl])
 
   return error ? (
-    <PageLoader
-      dark
+    <AuthPageLoader
       error
       message="Authentication failed"
       description="Redirecting to login..."
     />
   ) : (
-    <PageLoader
-      dark
+    <AuthPageLoader
       message="Verifying authentication..."
       description="Please wait while we complete your sign in"
     />

--- a/webapp_v2/src/pages/Auth/Login/index.jsx
+++ b/webapp_v2/src/pages/Auth/Login/index.jsx
@@ -15,7 +15,7 @@ import {
 } from '@mantine/core'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { authService } from '@/services/auth'
-import PageLoader from '@/components/PageLoader'
+import AuthPageLoader from '@/components/AuthPageLoader'
 
 const LOGIN_ERROR_MESSAGES = {
   slack_not_configured: 'You must configure your Slack with Hoop',
@@ -160,7 +160,7 @@ function Login() {
   }
 
   if (loadingAuthMethod || (authMethod !== 'local' && !error)) {
-    return <PageLoader dark message="Redirecting to login..." />
+    return <AuthPageLoader message="Redirecting to login..." />
   }
 
   if (authMethod !== 'local' && error) {

--- a/webapp_v2/src/pages/Auth/Login/index.jsx
+++ b/webapp_v2/src/pages/Auth/Login/index.jsx
@@ -160,7 +160,7 @@ function Login() {
   }
 
   if (loadingAuthMethod || (authMethod !== 'local' && !error)) {
-    return <PageLoader message="Redirecting to login..." />
+    return <PageLoader dark message="Redirecting to login..." />
   }
 
   if (authMethod !== 'local' && error) {

--- a/webapp_v2/src/pages/Auth/SignupCallback/index.jsx
+++ b/webapp_v2/src/pages/Auth/SignupCallback/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/stores/useAuthStore'
-import PageLoader from '@/components/PageLoader'
+import AuthPageLoader from '@/components/AuthPageLoader'
 
 function SignupCallback() {
   const navigate = useNavigate()
@@ -41,15 +41,13 @@ function SignupCallback() {
   }, [navigate, initializeToken])
 
   return error ? (
-    <PageLoader
-      dark
+    <AuthPageLoader
       error
       message="Authentication failed"
       description="Redirecting to login..."
     />
   ) : (
-    <PageLoader
-      dark
+    <AuthPageLoader
       message="Setting up your account..."
       description="Please wait while we complete your sign up"
     />

--- a/webapp_v2/src/pages/Auth/SignupCallback/index.jsx
+++ b/webapp_v2/src/pages/Auth/SignupCallback/index.jsx
@@ -42,12 +42,14 @@ function SignupCallback() {
 
   return error ? (
     <PageLoader
+      dark
       error
       message="Authentication failed"
       description="Redirecting to login..."
     />
   ) : (
     <PageLoader
+      dark
       message="Setting up your account..."
       description="Please wait while we complete your sign up"
     />


### PR DESCRIPTION
## Summary
Adds a `dark` variant to the shared `PageLoader` (React) and its CLJS counterpart, then opts only the **auth-flow** call sites into it. Non-auth loaders (settings pages, users list, event routing, CLJS bridge, etc.) stay on the current light theme.

## Motivation
Feedback-driven: customers recently flagged the abrupt white flash during the OAuth handoff as jarring against the rest of the (dark) product theme. This is purely a color alignment — copy and structure are untouched. Deeper redesign of the auth loading experience can happen in a follow-up.

## Preview

<!-- Paste the 000_verifying.png preview here -->

## Scope

**React (`webapp_v2`)**
- `components/PageLoader/index.jsx` — new `dark` prop; swaps bg to `--sidebar-bg` (`#182449`), logo to white variant, text/dots to `gray.0`/`gray.5` (theme tokens, no hardcoded values)
- `pages/Auth/Callback/index.jsx` — pass `dark` on both success + error `PageLoader` instances
- `pages/Auth/SignupCallback/index.jsx` — same
- `pages/Auth/Login/index.jsx` — pass `dark` on the "Redirecting to login..." state
- `components/ProtectedRoute.jsx` — pass `dark` on the "Verifying authentication..." flash

**CLJS (`webapp`)**
- `components/loaders.cljs` — parallel `:dark true` option on `page-loading-screen` (uses `bg-[#182449]` and the white logo)
- `auth/views/logout.cljs` — the only auth-flow route still owned by CLJS; passes `:dark true`

## Not changed
- `login`, `signup`, `auth/callback`, `signup/callback` — React-owned per `Router.jsx`; CLJS versions are dead code (shadowed) and left alone
- Auth0 hosted screens — outside this repo
- Non-auth PageLoader/CLJS-loader call sites — stay light

## Test plan
- [ ] `/auth/callback` shows dark loader on success → smooth transition into the dark app shell
- [ ] `/auth/callback?error=xxx` shows the red `XCircle` error state on dark bg
- [ ] `/signup/callback` shows dark loader with "Setting up your account..."
- [ ] `/login` (non-local auth) shows dark "Redirecting to login..." during the OAuth handoff
- [ ] Any protected route on a fresh session briefly shows dark "Verifying authentication..." from `ProtectedRoute`
- [ ] `/logout` shows dark "Logging out..." (CLJS)
- [ ] Non-auth pages (settings, users list, EventRouting) still show the light loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)