### PR TITLE
feat: surface exec review reject details in the CLI + fix claude-code "Allow insecure SSL" toggle

### DIFF
--- a/gateway/api/mcpserver/tools_reviews.go
+++ b/gateway/api/mcpserver/tools_reviews.go
@@ -329,6 +329,7 @@ func makeReviewsUpdateHandler(releaseConnFn reviewapi.TransportReleaseConnection
 						rev.SessionID,
 						ptr.ToString(rev.OwnerSlackID),
 						rev.Status.Str(),
+						ptr.ToString(rev.RejectionReason),
 					)
 				} else {
 					log.Warnf("mcp: review update succeeded but transport release function is nil, sid=%v", rev.SessionID)

--- a/gateway/api/mcpserver/tools_reviews.go
+++ b/gateway/api/mcpserver/tools_reviews.go
@@ -330,6 +330,7 @@ func makeReviewsUpdateHandler(releaseConnFn reviewapi.TransportReleaseConnection
 						ptr.ToString(rev.OwnerSlackID),
 						rev.Status.Str(),
 						ptr.ToString(rev.RejectionReason),
+						rev.RejectedByEmail(),
 					)
 				} else {
 					log.Warnf("mcp: review update succeeded but transport release function is nil, sid=%v", rev.SessionID)

--- a/gateway/api/review/review.go
+++ b/gateway/api/review/review.go
@@ -33,7 +33,7 @@ var (
 	ErrUnknownStatus        = errors.New("unknown status")
 )
 
-type TransportReleaseConnectionFunc func(orgID, sid, reviewOwnerSlackID, reviewStatus, rejectReason string)
+type TransportReleaseConnectionFunc func(orgID, sid, reviewOwnerSlackID, reviewStatus, rejectReason, rejectedBy string)
 
 type handler struct {
 	TransportReleaseConnection TransportReleaseConnectionFunc
@@ -175,6 +175,7 @@ func (h *handler) ReviewByIdOrSid(c *gin.Context) {
 				ptr.ToString(rev.OwnerSlackID),
 				rev.Status.Str(),
 				ptr.ToString(rev.RejectionReason),
+				rev.RejectedByEmail(),
 			)
 		}
 		c.JSON(http.StatusOK, toOpenApiReview(rev))

--- a/gateway/api/review/review.go
+++ b/gateway/api/review/review.go
@@ -33,7 +33,7 @@ var (
 	ErrUnknownStatus        = errors.New("unknown status")
 )
 
-type TransportReleaseConnectionFunc func(orgID, sid, reviewOwnerSlackID, reviewStatus string)
+type TransportReleaseConnectionFunc func(orgID, sid, reviewOwnerSlackID, reviewStatus, rejectReason string)
 
 type handler struct {
 	TransportReleaseConnection TransportReleaseConnectionFunc
@@ -174,6 +174,7 @@ func (h *handler) ReviewByIdOrSid(c *gin.Context) {
 				rev.SessionID,
 				ptr.ToString(rev.OwnerSlackID),
 				rev.Status.Str(),
+				ptr.ToString(rev.RejectionReason),
 			)
 		}
 		c.JSON(http.StatusOK, toOpenApiReview(rev))

--- a/gateway/integration/testutil/gateway_boot.go
+++ b/gateway/integration/testutil/gateway_boot.go
@@ -272,7 +272,7 @@ func (g *Gateway) registerPlugins() error {
 	plugintypes.AuditPath = auditPath
 
 	apiURL := appconfig.Get().ApiURL()
-	noopRelease := func(_, _, _, _ string) {}
+	noopRelease := func(_, _, _, _, _, _ string) {}
 	plugintypes.RegisteredPlugins = []plugintypes.Plugin{
 		pluginsreview.New(apiURL),
 		pluginsaudit.New(),
@@ -350,7 +350,7 @@ func bootstrapDefaultOrg() (string, error) {
 func buildEngine() *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	a := &api.Api{
-		ReleaseConnectionFn: func(_, _, _, _ string) {},
+		ReleaseConnectionFn: func(_, _, _, _, _, _ string) {},
 	}
 	return a.BuildEngine()
 }

--- a/gateway/models/reviews.go
+++ b/gateway/models/reviews.go
@@ -78,6 +78,22 @@ type ReviewGroups struct {
 	ForcedReview bool             `json:"forced_review"`
 }
 
+// RejectedByEmail returns the email of the reviewer whose group rejected the
+// review, or "" when no rejecting group with an email is recorded. It mirrors
+// the web UI, which resolves "Rejected by" from the review group whose status
+// is REJECTED.
+func (r *Review) RejectedByEmail() string {
+	if r == nil {
+		return ""
+	}
+	for _, rg := range r.ReviewGroups {
+		if rg.Status == ReviewStatusRejected && rg.OwnerEmail != nil {
+			return *rg.OwnerEmail
+		}
+	}
+	return ""
+}
+
 type ReviewJit struct {
 	ID                string     `gorm:"column:id"`
 	OrgID             string     `gorm:"column:org_id"`

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -785,20 +785,28 @@ func (s *Server) ReleaseConnectionOnReview(orgID, sid, reviewOwnerSlackID, revie
 
 	proxyStream := streamclient.GetProxyStream(sid)
 	if proxyStream != nil {
-		var payload []byte
-		packetType := pbclient.SessionOpenApproveOK
 		if reviewStatus == string(openapi.ReviewStatusRejected) {
-			packetType = pbclient.SessionClose
 			deniedMsg := buildReviewDeniedMessage(rejectReason, rejectedBy)
-			payload = []byte(deniedMsg)
+			// Deliver the denial (reason + reviewer) to the client BEFORE tearing
+			// the stream down. Close cancels the stream context, so sending after
+			// it can race the client's Recv and drop the payload, leaving the CLI
+			// with a generic error instead of the reject details.
+			if err := proxyStream.Send(&pb.Packet{
+				Type:    pbclient.SessionClose,
+				Spec:    map[string][]byte{pb.SpecGatewaySessionID: []byte(sid)},
+				Payload: []byte(deniedMsg),
+			}); err != nil {
+				log.With("sid", sid).Warnf("failed sending session close to client on review rejection: %v", err)
+			}
 			proxyStream.Close(fmt.Errorf("%s", deniedMsg))
+		} else {
+			if err := proxyStream.Send(&pb.Packet{
+				Type: pbclient.SessionOpenApproveOK,
+				Spec: map[string][]byte{pb.SpecGatewaySessionID: []byte(sid)},
+			}); err != nil {
+				log.With("sid", sid).Warnf("failed sending approval to client: %v", err)
+			}
 		}
-		// TODO: return erroo to caller
-		_ = proxyStream.Send(&pb.Packet{
-			Type:    packetType,
-			Spec:    map[string][]byte{pb.SpecGatewaySessionID: []byte(sid)},
-			Payload: payload,
-		})
 	}
 	log.With("sid", sid, "has-stream", proxyStream != nil).Infof("review status change")
 }
@@ -809,13 +817,33 @@ func (s *Server) ReleaseConnectionOnReview(orgID, sid, reviewOwnerSlackID, revie
 // those are available. With neither, it degrades to the plain denial line.
 func buildReviewDeniedMessage(rejectReason, rejectedBy string) string {
 	msg := "Access to connection has been denied"
-	if rejectReason != "" {
-		msg += "\n  Reason: " + rejectReason
+	if reason := sanitizeTerminalText(rejectReason); reason != "" {
+		msg += "\n  Reason: " + reason
 	}
-	if rejectedBy != "" {
-		msg += "\n  Rejected by " + rejectedBy
+	if by := sanitizeTerminalText(rejectedBy); by != "" {
+		msg += "\n  Rejected by " + by
 	}
 	return msg
+}
+
+// sanitizeTerminalText neutralizes reviewer-provided text before it is embedded
+// into the CLI-facing denial message (and the stream close error). Control
+// characters (ANSI escapes, CR, LF, etc.) are replaced with spaces so a crafted
+// rejection reason cannot spoof or corrupt terminal output, and the length is
+// bounded to keep the payload small.
+func sanitizeTerminalText(s string) string {
+	const maxRunes = 500
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			r = ' '
+		}
+		out = append(out, r)
+		if len(out) >= maxRunes {
+			break
+		}
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func validateConnectionType(clientVerb string, pctx plugintypes.Context) error {

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -773,7 +773,7 @@ func handleSystemPacketRequests(pktType string) (handled bool) {
 	return
 }
 
-func (s *Server) ReleaseConnectionOnReview(orgID, sid, reviewOwnerSlackID, reviewStatus, rejectReason string) {
+func (s *Server) ReleaseConnectionOnReview(orgID, sid, reviewOwnerSlackID, reviewStatus, rejectReason, rejectedBy string) {
 	if reviewStatus == string(openapi.ReviewStatusApproved) {
 		pluginslack.SendApprovedMessage(
 			orgID,
@@ -789,10 +789,7 @@ func (s *Server) ReleaseConnectionOnReview(orgID, sid, reviewOwnerSlackID, revie
 		packetType := pbclient.SessionOpenApproveOK
 		if reviewStatus == string(openapi.ReviewStatusRejected) {
 			packetType = pbclient.SessionClose
-			deniedMsg := "access to connection has been denied"
-			if rejectReason != "" {
-				deniedMsg = fmt.Sprintf("access to connection has been denied: %s", rejectReason)
-			}
+			deniedMsg := buildReviewDeniedMessage(rejectReason, rejectedBy)
 			payload = []byte(deniedMsg)
 			proxyStream.Close(fmt.Errorf("%s", deniedMsg))
 		}
@@ -804,6 +801,21 @@ func (s *Server) ReleaseConnectionOnReview(orgID, sid, reviewOwnerSlackID, revie
 		})
 	}
 	log.With("sid", sid, "has-stream", proxyStream != nil).Infof("review status change")
+}
+
+// buildReviewDeniedMessage formats the message shown to the CLI when a review
+// is rejected. It mirrors the web UI's "Reject Details" panel: a denial line
+// followed by the reviewer's reason and who rejected the request, whenever
+// those are available. With neither, it degrades to the plain denial line.
+func buildReviewDeniedMessage(rejectReason, rejectedBy string) string {
+	msg := "Access to connection has been denied"
+	if rejectReason != "" {
+		msg += "\n  Reason: " + rejectReason
+	}
+	if rejectedBy != "" {
+		msg += "\n  Rejected by " + rejectedBy
+	}
+	return msg
 }
 
 func validateConnectionType(clientVerb string, pctx plugintypes.Context) error {

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -773,7 +773,7 @@ func handleSystemPacketRequests(pktType string) (handled bool) {
 	return
 }
 
-func (s *Server) ReleaseConnectionOnReview(orgID, sid, reviewOwnerSlackID, reviewStatus string) {
+func (s *Server) ReleaseConnectionOnReview(orgID, sid, reviewOwnerSlackID, reviewStatus, rejectReason string) {
 	if reviewStatus == string(openapi.ReviewStatusApproved) {
 		pluginslack.SendApprovedMessage(
 			orgID,
@@ -789,8 +789,12 @@ func (s *Server) ReleaseConnectionOnReview(orgID, sid, reviewOwnerSlackID, revie
 		packetType := pbclient.SessionOpenApproveOK
 		if reviewStatus == string(openapi.ReviewStatusRejected) {
 			packetType = pbclient.SessionClose
-			payload = []byte(`access to connection has been denied`)
-			proxyStream.Close(fmt.Errorf("access to connection has been denied"))
+			deniedMsg := "access to connection has been denied"
+			if rejectReason != "" {
+				deniedMsg = fmt.Sprintf("access to connection has been denied: %s", rejectReason)
+			}
+			payload = []byte(deniedMsg)
+			proxyStream.Close(fmt.Errorf("%s", deniedMsg))
 		}
 		// TODO: return erroo to caller
 		_ = proxyStream.Send(&pb.Packet{

--- a/gateway/transport/plugins/slack/events.go
+++ b/gateway/transport/plugins/slack/events.go
@@ -123,6 +123,7 @@ func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status mo
 				rev.SessionID,
 				ptr.ToString(rev.OwnerSlackID),
 				rev.Status.Str(),
+				ptr.ToString(rev.RejectionReason),
 			)
 		}
 		if rev.Status == models.ReviewStatusRejected {

--- a/gateway/transport/plugins/slack/events.go
+++ b/gateway/transport/plugins/slack/events.go
@@ -124,6 +124,7 @@ func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status mo
 				ptr.ToString(rev.OwnerSlackID),
 				rev.Status.Str(),
 				ptr.ToString(rev.RejectionReason),
+				rev.RejectedByEmail(),
 			)
 		}
 		if rev.Status == models.ReviewStatusRejected {

--- a/webapp/src/webapp/resources/setup/roles_step.cljs
+++ b/webapp/src/webapp/resources/setup/roles_step.cljs
@@ -243,116 +243,114 @@
     (if (map? v) (or (:value v) "") v)))
 
 (defn claude-code-role-form [role-index]
-  (let [credentials (rf/subscribe [:resource-setup/role-credentials role-index])
-        connection-method (rf/subscribe [:resource-setup/role-connection-method role-index])
-        vertex-flag? (rf/subscribe [:feature-flag/enabled? "experimental.claude_code_vertex"])]
-    (fn [role-index]
-      (let [creds @credentials
-            provider (let [p (claude-code-cred-display creds "provider")]
-                       (if (empty? p) "anthropic" p))
-            vertex? (= provider "vertex")
-            ;; Show the Vertex option when the feature is enabled, or when the
-            ;; role is already set to Vertex (so it never hides existing config).
-            show-vertex-option? (or @vertex-flag? vertex?)
-            api-url-value (claude-code-cred-display creds "remote_url")
-            api-key-value (claude-code-cred-display creds "HEADER_X_API_KEY")
-            region-value (claude-code-cred-display creds "GCP_REGION")
-            project-value (claude-code-cred-display creds "GCP_PROJECT_ID")
-            sa-json-value (claude-code-cred-display creds "GCP_SERVICE_ACCOUNT_JSON")
-            show-selector? (= @connection-method "secrets-manager")
-            update-cred (fn [k]
-                          (fn [e]
-                            (rf/dispatch [:resource-setup->update-role-credentials
-                                          role-index k (-> e .-target .-value)])))]
+  (let [creds @(rf/subscribe [:resource-setup/role-credentials role-index])
+        connection-method @(rf/subscribe [:resource-setup/role-connection-method role-index])
+        vertex-flag? @(rf/subscribe [:feature-flag/enabled? "experimental.claude_code_vertex"])
+        provider (let [p (claude-code-cred-display creds "provider")]
+                   (if (empty? p) "anthropic" p))
+        vertex? (= provider "vertex")
+        ;; Show the Vertex option when the feature is enabled, or when the
+        ;; role is already set to Vertex (so it never hides existing config).
+        show-vertex-option? (or vertex-flag? vertex?)
+        api-url-value (claude-code-cred-display creds "remote_url")
+        api-key-value (claude-code-cred-display creds "HEADER_X_API_KEY")
+        region-value (claude-code-cred-display creds "GCP_REGION")
+        project-value (claude-code-cred-display creds "GCP_PROJECT_ID")
+        sa-json-value (claude-code-cred-display creds "GCP_SERVICE_ACCOUNT_JSON")
+        show-selector? (= connection-method "secrets-manager")
+        update-cred (fn [k]
+                      (fn [e]
+                        (rf/dispatch [:resource-setup->update-role-credentials
+                                      role-index k (-> e .-target .-value)])))]
 
-        ;; Initialize default values. REMOTE_URL is only relevant for the
-        ;; Anthropic provider; Vertex derives it from the region at submit time.
-        (when (and (not vertex?) (empty? api-url-value))
-          (rf/dispatch [:resource-setup->update-role-credentials
-                        role-index
-                        "remote_url"
-                        "https://api.anthropic.com"]))
+    ;; Initialize default values. REMOTE_URL is only relevant for the
+    ;; Anthropic provider; Vertex derives it from the region at submit time.
+    (when (and (not vertex?) (empty? api-url-value))
+      (rf/dispatch [:resource-setup->update-role-credentials
+                    role-index
+                    "remote_url"
+                    "https://api.anthropic.com"]))
 
-        (when (nil? (get creds "insecure"))
-          (rf/dispatch [:resource-setup->update-role-credentials
-                        role-index
-                        "insecure"
-                        false]))
+    (when (nil? (get creds "insecure"))
+      (rf/dispatch [:resource-setup->update-role-credentials
+                    role-index
+                    "insecure"
+                    false]))
 
-        [:> Box {:class "space-y-radix-6"}
-         [:> Box {:class "space-y-radix-4"}
-          [:> Heading {:size "3"} "Basic info"]
+    [:> Box {:class "space-y-radix-6"}
+     [:> Box {:class "space-y-radix-4"}
+      [:> Heading {:size "3"} "Basic info"]
 
-          (when show-vertex-option?
-            [forms/select
-             {:label "Provider"
-              :options [{:text "Anthropic API" :value "anthropic"}
-                        {:text "Google Vertex AI" :value "vertex"}]
-              :selected provider
-              :on-change #(rf/dispatch [:resource-setup->update-role-credentials
-                                        role-index "provider" %])}])
+      (when show-vertex-option?
+        [forms/select
+         {:label "Provider"
+          :options [{:text "Anthropic API" :value "anthropic"}
+                    {:text "Google Vertex AI" :value "vertex"}]
+          :selected provider
+          :on-change #(rf/dispatch [:resource-setup->update-role-credentials
+                                    role-index "provider" %])}])
 
-          (if vertex?
-            [:<>
-             [:> Callout.Root {:size "1" :color "gray"}
-              [:> Callout.Text
-               "Claude Code runs in Vertex mode against hoop. hoop mints a short-lived "
-               "token from the service account below and proxies requests to Google Vertex AI."]]
+      (if vertex?
+        [:<>
+         [:> Callout.Root {:size "1" :color "gray"}
+          [:> Callout.Text
+           "Claude Code runs in Vertex mode against hoop. hoop mints a short-lived "
+           "token from the service account below and proxies requests to Google Vertex AI."]]
 
-             [forms/input {:label "GCP Region"
-                           :placeholder "us-east5"
-                           :value region-value
-                           :required true
-                           :type "text"
-                           :on-change (update-cred "GCP_REGION")}]
+         [forms/input {:label "GCP Region"
+                       :placeholder "us-east5"
+                       :value region-value
+                       :required true
+                       :type "text"
+                       :on-change (update-cred "GCP_REGION")}]
 
-             [forms/input {:label "GCP Project ID"
-                           :placeholder "my-gcp-project"
-                           :value project-value
-                           :required true
-                           :type "text"
-                           :on-change (update-cred "GCP_PROJECT_ID")}]
+         [forms/input {:label "GCP Project ID"
+                       :placeholder "my-gcp-project"
+                       :value project-value
+                       :required true
+                       :type "text"
+                       :on-change (update-cred "GCP_PROJECT_ID")}]
 
-             [forms/textarea {:label "Service Account JSON"
-                              :placeholder "{\n  \"type\": \"service_account\",\n  ...\n}"
-                              :value sa-json-value
-                              :required true
-                              :rows 8
-                              :on-change (update-cred "GCP_SERVICE_ACCOUNT_JSON")}]]
+         [forms/textarea {:label "Service Account JSON"
+                          :placeholder "{\n  \"type\": \"service_account\",\n  ...\n}"
+                          :value sa-json-value
+                          :required true
+                          :rows 8
+                          :on-change (update-cred "GCP_SERVICE_ACCOUNT_JSON")}]]
 
-            [:<>
-             [forms/input {:label "Anthropic API URL"
-                           :placeholder "https://api.anthropic.com"
-                           :value (if (empty? api-url-value) "https://api.anthropic.com" api-url-value)
-                           :required true
-                           :type "text"
-                           :on-change (update-cred "remote_url")
-                           :start-adornment (when show-selector?
-                                              [connection-method/source-selector role-index "remote_url"])}]
+        [:<>
+         [forms/input {:label "Anthropic API URL"
+                       :placeholder "https://api.anthropic.com"
+                       :value (if (empty? api-url-value) "https://api.anthropic.com" api-url-value)
+                       :required true
+                       :type "text"
+                       :on-change (update-cred "remote_url")
+                       :start-adornment (when show-selector?
+                                          [connection-method/source-selector role-index "remote_url"])}]
 
-             [forms/input {:label "Anthropic API Key"
-                           :placeholder "sk-ant-..."
-                           :value api-key-value
-                           :required true
-                           :type "password"
-                           :on-change (update-cred "HEADER_X_API_KEY")
-                           :start-adornment (when show-selector?
-                                              [connection-method/source-selector role-index "HEADER_X_API_KEY"])}]])]
+         [forms/input {:label "Anthropic API Key"
+                       :placeholder "sk-ant-..."
+                       :value api-key-value
+                       :required true
+                       :type "password"
+                       :on-change (update-cred "HEADER_X_API_KEY")
+                       :start-adornment (when show-selector?
+                                          [connection-method/source-selector role-index "HEADER_X_API_KEY"])}]])]
 
-         [configuration-inputs/http-headers-section role-index]
+     [configuration-inputs/http-headers-section role-index]
 
-         [:> Flex {:align "center" :gap "3"}
-          [:> Switch {:checked (get creds "insecure" false)
-                      :size "3"
-                      :onCheckedChange #(rf/dispatch [:resource-setup->update-role-credentials
-                                                      role-index
-                                                      "insecure"
-                                                      %])}]
-          [:> Box
-           [:> Heading {:as "h4" :size "3" :weight "medium" :class "text-[--gray-12]"}
-            "Allow insecure SSL"]
-           [:> Text {:as "p" :size "2" :class "text-[--gray-11]"}
-            "Skip SSL certificate verification for HTTPS connections."]]]]))))
+     [:> Flex {:align "center" :gap "3"}
+      [:> Switch {:checked (get creds "insecure" false)
+                  :size "3"
+                  :onCheckedChange #(rf/dispatch [:resource-setup->update-role-credentials
+                                                  role-index
+                                                  "insecure"
+                                                  %])}]
+      [:> Box
+       [:> Heading {:as "h4" :size "3" :weight "medium" :class "text-[--gray-12]"}
+        "Allow insecure SSL"]
+       [:> Text {:as "p" :size "2" :class "text-[--gray-11]"}
+        "Skip SSL certificate verification for HTTPS connections."]]]]))
 
 
 ;; MCP role form - HTTP proxy subtype whose endpoint is protected by OAuth


### PR DESCRIPTION
## 📝 Description

This branch bundles two related-but-distinct improvements around review/exec UX:

1. **Exec reject details in the CLI (EVL-7).** When an `exec` review is rejected, the CLI previously showed only a generic `access to connection has been denied`, forcing users to the web UI to learn why. The reject reason was already persisted (`Review.RejectionReason`) but was dropped on the client-notification path. The CLI now mirrors the web UI's **Reject Details** panel: an organized block with the reviewer's reason and **who rejected** the request.

2. **Fix the claude-code "Allow insecure SSL" toggle (bug).** In the Create Resource wizard, the `claude-code` role form was the only role form implemented as a reagent **Form-2** component; its working siblings are all **Form-1**. A controlled Radix `Switch` stops reflecting its state when its component stops re-rendering, so the toggle wouldn't flip. Converting to the Form-1 shape the working siblings use fixes it (and removes a latent stale `role-index` closure).

CLI output on rejection now looks like:

```
Access to connection has been denied
  Reason: <reviewer reason>
  Rejected by <reviewer-email>
```

## 🔗 Related Issue

- EVL-7 — Send exec reject reason back to the CLI
- EVL-1 — claude-code "Allow insecure SSL" toggle won't flip in the Create Resource wizard

Fixes EVL-1 EVL-7

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- **Gateway:** thread the review's `RejectionReason` and the rejecting reviewer's email through `ReleaseConnectionOnReview` into the `SessionClose` payload the CLI already prints; format it as an organized "Reject Details" block (`gateway/transport/client.go`).
- **Model:** add `Review.RejectedByEmail()` — resolves the email from the review group whose status is `REJECTED`, matching how the web UI resolves "Rejected by" (`gateway/models/reviews.go`).
- Extend `TransportReleaseConnectionFunc` with `rejectReason` and `rejectedBy`, and update all three callers: REST review handler, Slack action, and MCP review tool.
- **Webapp:** convert `claude-code-role-form` from a reagent Form-2 to the Form-1 shape used by the working sibling role forms so the "Allow insecure SSL" `Switch` reflects state changes; no change to the emitted secret (`INSECURE` is still sent as `envvar:INSECURE`) (`webapp/src/webapp/resources/setup/roles_step.cljs`).

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chromium (webapp / claude-code toggle)
- **OS**: Linux

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

`go build ./gateway/...` is clean and `go test` passes for the affected packages (`gateway/api/review`, `gateway/transport`, `gateway/models`, `gateway/api/mcpserver`, `gateway/transport/plugins/review`).

Manual verification still recommended by a reviewer:
- **Toggle:** `cd webapp_v2 && npm run dev:full` → Create Resource → `claude-code` → confirm the "Allow insecure SSL" switch flips/holds and the create payload carries `envvar:INSECURE = base64("true")`; re-check the MCP and generic HTTP-proxy toggles for regression.
- **Reject flow:** run `hoop exec <conn> -- <cmd>` on a review-gated connection, reject with a reason, and confirm the CLI shows the reason + "Rejected by <email>". Repeat rejecting via Slack and the MCP review tool.

## 📸 Screenshots

<img width="1165" height="144" alt="Screenshot 2026-07-13 at 12 45 56" src="https://github.com/user-attachments/assets/6e6f2cb4-82cc-4cdd-867e-de498898c4f8" />

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
