### PR TITLE
feat(agent): RESULT_METADATA connection env for MySQL driver exec

### DIFF
--- a/_libhoop/agent/dbexec/dbexec.go
+++ b/_libhoop/agent/dbexec/dbexec.go
@@ -29,3 +29,9 @@ const (
 	OptKeyInsecure    = "insecure"
 	OptKeyServiceName = "service_name"
 )
+
+// OptKeyResultMetadata carries the connection-level RESULT_METADATA setting
+// through the libhoop opts map. The agent sets it to "off" when the connection
+// disables the MySQL interactive-style result feedback lines; any other value
+// (including absent) leaves them on.
+const OptKeyResultMetadata = "result_metadata"

--- a/agent/controller/agent.go
+++ b/agent/controller/agent.go
@@ -124,6 +124,12 @@ type (
 		kubernetesInsecureSkipVerify bool
 
 		experimentalRedactRows string
+
+		// resultMetadata carries the connection's RESULT_METADATA setting for
+		// the driver-based SQL exec path. Normalized to "on"/"off" by
+		// parseConnectionEnvVars; only MySQL consumes it (the other engines'
+		// CLIs already print result metadata in batch mode).
+		resultMetadata string
 	}
 	ioMetricFlush struct {
 		client pb.ClientTransport
@@ -807,6 +813,19 @@ func parseConnectionEnvVars(envVars map[string]any, connType pb.ConnectionType) 
 		}
 		if env.host == "" || env.pass == "" || env.user == "" {
 			return nil, errors.New("missing required secrets for mysql connection [HOST, USER, PASS]")
+		}
+		// RESULT_METADATA toggles the interactive-style result feedback lines
+		// ("N rows in set", "Query OK, N rows affected") on the driver-based
+		// exec path. Defaults to on; "off" keeps the clean batch TSV output
+		// for scripting consumers.
+		switch strings.ToLower(envVarS.Getenv("RESULT_METADATA")) {
+		case "", "on", "true", "1":
+			env.resultMetadata = "on"
+		case "off", "false", "0":
+			env.resultMetadata = "off"
+		default:
+			return nil, fmt.Errorf("wrong option (%q) for RESULT_METADATA, accept only: %v",
+				envVarS.Getenv("RESULT_METADATA"), []string{"on", "off", "true", "false", "1", "0"})
 		}
 	case pb.ConnectionTypeMSSQL:
 		if env.port == "" {

--- a/agent/controller/agent_connenv_test.go
+++ b/agent/controller/agent_connenv_test.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	pb "github.com/hoophq/hoop/common/proto"
+)
+
+// mysqlEnvVars builds the envvar map shape term.NewEnvVarStore expects
+// (base64-encoded values under "envvar:" keys) for a MySQL connection.
+func mysqlEnvVars(extra map[string]string) map[string]any {
+	envs := map[string]any{
+		"envvar:HOST": base64.StdEncoding.EncodeToString([]byte("127.0.0.1")),
+		"envvar:USER": base64.StdEncoding.EncodeToString([]byte("root")),
+		"envvar:PASS": base64.StdEncoding.EncodeToString([]byte("secret")),
+	}
+	for k, v := range extra {
+		envs["envvar:"+k] = base64.StdEncoding.EncodeToString([]byte(v))
+	}
+	return envs
+}
+
+func TestParseConnectionEnvVarsMySQLResultMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		unset   bool
+		want    string
+		wantErr bool
+	}{
+		{name: "unset defaults to on", unset: true, want: "on"},
+		{name: "empty defaults to on", value: "", want: "on"},
+		{name: "on", value: "on", want: "on"},
+		{name: "true", value: "true", want: "on"},
+		{name: "1", value: "1", want: "on"},
+		{name: "off", value: "off", want: "off"},
+		{name: "false", value: "false", want: "off"},
+		{name: "0", value: "0", want: "off"},
+		{name: "mixed case normalizes", value: "OFF", want: "off"},
+		{name: "invalid value fails fast", value: "maybe", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extra := map[string]string{}
+			if !tt.unset {
+				extra["RESULT_METADATA"] = tt.value
+			}
+			env, err := parseConnectionEnvVars(mysqlEnvVars(extra), pb.ConnectionTypeMySQL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for RESULT_METADATA=%q, got nil", tt.value)
+				}
+				if !strings.Contains(err.Error(), "RESULT_METADATA") {
+					t.Errorf("error %q should mention RESULT_METADATA", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if env.resultMetadata != tt.want {
+				t.Errorf("resultMetadata = %q, want %q", env.resultMetadata, tt.want)
+			}
+		})
+	}
+}

--- a/agent/controller/terminal-exec.go
+++ b/agent/controller/terminal-exec.go
@@ -188,5 +188,8 @@ func (a *Agent) newDBExecProxy(driver string, connParams *pb.AgentConnectionPara
 	if connenv.insecure {
 		opts[dbexec.OptKeyInsecure] = "true"
 	}
+	if connenv.resultMetadata == "off" {
+		opts[dbexec.OptKeyResultMetadata] = "off"
+	}
 	return libhoop.NewAdHocDBExec(driver, payload, stdoutw, stderrw, opts)
 }


### PR DESCRIPTION
Implements [DEP-53](https://linear.app/hoophq/issue/DEP-53) (agent wiring; core in hoophq/libhoop#91): surfaces row-count / rows-affected feedback for MySQL on the driver-based exec path (`experimental.db_exec_driver`).

## What changed

- New optional MySQL connection env `RESULT_METADATA` controlling the interactive-style feedback lines (`N rows in set`, `Empty set`, `Query OK, N rows affected`) on driver exec:
  - unset / `on` / `true` / `1` → metadata on (default)
  - `off` / `false` / `0` → clean batch TSV output (previous behavior)
  - anything else → fail-fast connection error (mirrors SSLMODE validation)
- OSS `_libhoop` stub gains the `OptKeyResultMetadata` const so the OSS build compiles (driver path remains enterprise-only).

No migrations, no API changes; rides the existing `experimental.db_exec_driver` feature flag.

## Customer note

OneSpan (Intercom) can get metadata **today** on the default CLI path by customizing the connection command to `mysql -vv ...` — this PR makes it first-class on the driver path.

Automated by MisterMal