### PR TITLE
fix(gateway): raise httpproxy response wait to 5m and detect client disconnect

### DIFF
--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -654,6 +654,13 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 		log.Debugf("could not extend write deadline for response wait, sid=%s, conn=%s: %v", sess.sid, connectionID, err)
 	}
 
+	// Explicit timer instead of time.After so the 5-minute timer is released
+	// deterministically when another case wins instead of lingering in the
+	// runtime timer heap until GC. No drain after Stop: timer channels are
+	// unbuffered since Go 1.23.
+	waitTimer := time.NewTimer(responseWaitTimeout)
+	defer waitTimer.Stop()
+
 	select {
 	case <-sess.ctx.Done():
 		http.Error(w, "session expired", http.StatusUnauthorized)
@@ -666,7 +673,7 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 		log.Infof("client disconnected while waiting for response, sid=%s, conn=%s", sess.sid, connectionID)
 		sess.notifyAgentConnectionClose(connectionID)
 		return
-	case <-time.After(responseWaitTimeout):
+	case <-waitTimer.C:
 		sess.notifyAgentConnectionClose(connectionID)
 		http.Error(w, "request timeout", http.StatusGatewayTimeout)
 		return

--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -636,13 +636,37 @@ func (sess *httpProxySession) handleRequest(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Wait for response with shorter timeout
-	httpTimeout := 60 * time.Second
+	// Wait for the first response packet from the agent. Non-streaming LLM
+	// calls (e.g. Anthropic/Vertex rawPredict) only produce headers after the
+	// full completion is generated, which routinely exceeds a minute, so this
+	// must be generous. The agent's transport enforces a ResponseHeaderTimeout
+	// slightly above this value as the backstop for when the close
+	// notification below never reaches it. An upstream failure on the agent
+	// side unblocks this wait immediately: the agent sends TCPConnectionClose,
+	// which closes responseChan.
+	const responseWaitTimeout = 5 * time.Minute
+
+	// The wait can outlast the server's absolute WriteTimeout (armed when the
+	// request was read), which would fail every write below with an i/o
+	// timeout. Push the connection write deadline past the wait window; the
+	// buffered/SSE writers take over and roll it forward per chunk from there.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(responseWaitTimeout + 30*time.Second)); err != nil {
+		log.Debugf("could not extend write deadline for response wait, sid=%s, conn=%s: %v", sess.sid, connectionID, err)
+	}
+
 	select {
 	case <-sess.ctx.Done():
 		http.Error(w, "session expired", http.StatusUnauthorized)
 		return
-	case <-time.After(httpTimeout):
+	case <-r.Context().Done():
+		// The client went away while we were waiting (disconnect/abort), so
+		// nobody is left to receive the response. Tell the agent to abandon
+		// the upstream request; otherwise this wait would hold the handler
+		// goroutine and the upstream connection for the full timeout.
+		log.Infof("client disconnected while waiting for response, sid=%s, conn=%s", sess.sid, connectionID)
+		sess.notifyAgentConnectionClose(connectionID)
+		return
+	case <-time.After(responseWaitTimeout):
 		sess.notifyAgentConnectionClose(connectionID)
 		http.Error(w, "request timeout", http.StatusGatewayTimeout)
 		return


### PR DESCRIPTION
## 📝 Description

Using Claude (via Vertex AI) through the hoop http proxy fails with an endless `504 request timeout · Retrying (attempt N/10)` loop.

The gateway waits at most **60 seconds** for a response from the agent before giving up with a 504. Non-streaming LLM calls only return headers after the whole completion is generated, which often takes more than a minute — so the gateway kills requests that are still working.

This is one half of the fix. The other half (truncated SSE streams on the agent) is hoophq/libhoop#92.

## 🔗 Related Issue

Root-caused from production agent logs during support rotation (no linked issue).

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- Raised the response wait from 60s to 5 minutes (`responseWaitTimeout`). Failures on the agent side still unblock the wait immediately, so only requests that are genuinely still working wait longer.
- Extended the connection write deadline past the wait window — otherwise the server's absolute 90s `WriteTimeout` would make any response after ~90s fail to write.
- Added client-disconnect detection during the wait (`r.Context().Done()`): if the client gives up, the gateway now tells the agent to abandon the upstream request right away instead of holding it until the timeout.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A (backend only)
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass (`go test ./gateway/proxyproto/httpproxy/`)
- [ ] Integration tests pass
- [ ] Manual testing completed (end-to-end needs an agent rebuilt with hoophq/libhoop#92)

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- Merge order doesn't matter: this change works with old agents, it just doesn't fix streaming by itself. Full production fix = this PR + hoophq/libhoop#92 + agent image rebuild.
- Reviewer focus: the new `r.Context().Done()` case in the response-wait `select` — it fixes a pre-existing gap where a disconnected client left the handler and the upstream request hanging.
