### PR TITLE
Add HTTP in Hoop tunnel

### DIFF
--- a/tunnel/README.md
+++ b/tunnel/README.md
@@ -50,7 +50,7 @@ supported. Windows (Wintun) TUN setup is still tracked under Phase 2.
 | `netstack/`           | gVisor stack + TUN device wiring (Linux `/dev/net/tun`, macOS `utun`). |
 | `resolved/`           | Host DNS routing for `*.<tld>` (Linux systemd-resolved, macOS `/etc/resolver`). |
 | `service/`            | System-service install/uninstall (Linux systemd, macOS LaunchDaemon). |
-| `client/pipe.go`      | Per-flow gRPC pipe; sends SessionOpen + TCPConnectionWrite.   |
+| `client/pipe.go`      | Per-flow gRPC pipe; sends SessionOpen + TCP/HttpProxy ConnectionWrite. |
 | `client/connections.go` | Lists tunnelable connections via `GET /api/connections`.    |
 | `cmd/hsh-tunneld/`    | Daemon binary entry point.                                    |
 
@@ -153,11 +153,19 @@ per-flow session open / close events tagged with the connection name.
 
 ## Which connections are tunnelable?
 
-Only TCP-style protocols: **postgres, mysql, mssql, mongodb, oracledb,
-tcp**. SSH, HTTP-proxy, kubernetes, RDP, SSM, and command-line
+TCP-style protocols — **postgres, mysql, mssql, mongodb, oracledb,
+tcp** — plus **httpproxy**. SSH, kubernetes, RDP, SSM, and command-line
 connections need protocol-specific clients (or interactive shells) and
 are intentionally filtered out of the resolver. Use `hoop connect <name>`
 for those.
+
+httpproxy connections are served on port **80** only: the client speaks
+plain HTTP to the tunnel (`curl http://api-prod.hoop/path`) and the
+agent terminates TLS to the connection's `REMOTE_URL` upstream. Because
+the bytes cross the agent in cleartext, guardrails and DLP inspection
+apply exactly as they do for `hoop connect`. `https://<name>.hoop` can
+never work — the tunnel has no certificate for `*.hoop` — so port 443
+is rejected at the SYN.
 
 ## Addressing (dual-stack)
 

--- a/tunnel/client/connections.go
+++ b/tunnel/client/connections.go
@@ -46,10 +46,12 @@ type FetchConnectionsOptions struct {
 }
 
 // FetchConnections returns the list of connections available to the
-// current user that are tunnelable (TCP-style protocols). Connections
-// that are not tunnelable (SSH, command-line, http-proxy, kubernetes,
-// RDP, SSM, etc.) are silently filtered out — they need a protocol-
-// specific client, not a transparent IP tunnel.
+// current user that are tunnelable (TCP-style protocols plus
+// httpproxy, which speaks plain HTTP to the tunnel while the agent
+// terminates TLS to the upstream). Connections that are not tunnelable
+// (SSH, command-line, kubernetes, RDP, SSM, etc.) are silently
+// filtered out — they need a protocol-specific client, not a
+// transparent IP tunnel.
 func FetchConnections(ctx context.Context, opts FetchConnectionsOptions) ([]Connection, error) {
 	if opts.APIBaseURL == "" {
 		return nil, errors.New("client.FetchConnections: APIBaseURL is required")
@@ -117,8 +119,8 @@ func FetchConnections(ctx context.Context, opts FetchConnectionsOptions) ([]Conn
 	return out, nil
 }
 
-// isTunnelableSubType mirrors pipe.go's isTunnelableType but works on
-// the raw openapi subtype field.
+// isTunnelableSubType mirrors pipe.go's profileFor but works on the
+// raw openapi subtype field.
 func isTunnelableSubType(subtype string) bool {
 	switch pb.ConnectionType(subtype) {
 	case pb.ConnectionTypePostgres,
@@ -126,7 +128,8 @@ func isTunnelableSubType(subtype string) bool {
 		pb.ConnectionTypeMSSQL,
 		pb.ConnectionTypeMongoDB,
 		pb.ConnectionTypeOracleDB,
-		pb.ConnectionTypeTCP:
+		pb.ConnectionTypeTCP,
+		pb.ConnectionTypeHttpProxy:
 		return true
 	}
 	return false

--- a/tunnel/client/pipe.go
+++ b/tunnel/client/pipe.go
@@ -17,12 +17,15 @@
 //	     plugin pipeline treats this stream as a plain `hoop connect`
 //	     session.
 //	  2. Sends pbagent.SessionOpen and waits for pbclient.SessionOpenOK.
-//	  3. Sends the initial pbagent.TCPConnectionWrite with
-//	     SpecTCPServerConnectKey to ask the agent to open its upstream
-//	     TCP socket.
-//	  4. Pumps bytes in both directions until either side closes:
-//	      local -> gateway via pbagent.TCPConnectionWrite packets
-//	      gateway -> local via pbclient.TCPConnectionWrite packets
+//	  3. For TCP-style connections, sends the initial
+//	     pbagent.TCPConnectionWrite with SpecTCPServerConnectKey to ask
+//	     the agent to open its upstream TCP socket. httpproxy
+//	     connections skip this step: the agent builds its HTTP proxy
+//	     lazily on the first data packet.
+//	  4. Pumps bytes in both directions until either side closes, using
+//	     the packet family for the connection type (see packetProfile):
+//	      local -> gateway via pbagent.{TCP,HttpProxy}ConnectionWrite
+//	      gateway -> local via pbclient.{TCP,HttpProxy}ConnectionWrite
 //	  5. On any termination, sends pbagent.TCPConnectionClose and tears
 //	     down the gRPC stream.
 //
@@ -67,6 +70,14 @@ type PipeOptions struct {
 	// gateway should route this stream to. Sent both as a gRPC metadata
 	// header and as the verb spec on SessionOpen.
 	ConnectionName string
+
+	// HttpProxyBaseURL is the URL clients use to reach this connection
+	// through the tunnel (e.g. "http://api-prod.hoop"). Only consumed
+	// when the session resolves to an httpproxy connection: libhoop
+	// rewrites absolute URLs / Location headers in upstream responses
+	// so redirects keep pointing at the proxy. Optional for TCP-style
+	// connections.
+	HttpProxyBaseURL string
 
 	// CorrelationID is an optional opaque ID the caller may set so logs
 	// on the gateway can be tied back to a single tunnel session.
@@ -159,18 +170,65 @@ func runPipe(ctx context.Context, transport pb.ClientTransport, local io.ReadWri
 		return err
 	}
 
-	// We only support TCP-style protocols on the tunnel. SSH, terminals,
-	// kubernetes/http proxies, etc. need protocol-specific clients and
-	// have no place in a transparent IP tunnel.
-	if !isTunnelableType(connType) {
-		return fmt.Errorf("connection %q has type %q which is not tunnelable; supported: postgres, mysql, mssql, mongodb, tcp",
+	// We only support connection types whose wire format is an opaque
+	// byte stream from the tunnel's point of view: TCP-style protocols
+	// and httpproxy (plain HTTP bytes; the agent parses and forwards
+	// them). SSH, terminals, kubernetes, etc. need protocol-specific
+	// clients and have no place in a transparent IP tunnel.
+	prof, ok := profileFor(connType)
+	if !ok {
+		return fmt.Errorf("connection %q has type %q which is not tunnelable; supported: postgres, mysql, mssql, mongodb, oracledb, tcp, httpproxy",
 			opts.ConnectionName, connType)
 	}
 
 	log.With("connection", opts.ConnectionName, "session", sessionID, "type", connType).
 		Debugf("tunnel pipe established")
 
-	return pumpBytes(ctx, transport, local, sessionID)
+	return pumpBytes(ctx, transport, local, sessionID, prof, opts)
+}
+
+// packetProfile captures how a connection type maps onto the gateway's
+// packet families. TCP-style protocols share one family; httpproxy has
+// its own (the agent routes it to the HTTP-parsing libhoop proxy
+// instead of a raw upstream socket).
+type packetProfile struct {
+	// agentWrite is the packet type for local -> gateway data.
+	agentWrite pb.PacketType
+	// clientWrite is the packet type for gateway -> local data.
+	clientWrite pb.PacketType
+	// sendTCPOpen indicates the agent needs an explicit "dial your
+	// upstream now" packet (SpecTCPServerConnectKey) before any data.
+	// The httpproxy handler has no such handshake: it lazily builds
+	// the proxy on the first data packet.
+	sendTCPOpen bool
+	// isHTTPProxy marks sessions whose spec must carry
+	// SpecHttpProxyBaseUrl on every write.
+	isHTTPProxy bool
+}
+
+// profileFor returns the packet profile for a hoop connection type, or
+// ok=false when the type is not tunnelable.
+func profileFor(connType string) (packetProfile, bool) {
+	switch pb.ConnectionType(connType) {
+	case pb.ConnectionTypePostgres,
+		pb.ConnectionTypeMySQL,
+		pb.ConnectionTypeMSSQL,
+		pb.ConnectionTypeMongoDB,
+		pb.ConnectionTypeOracleDB,
+		pb.ConnectionTypeTCP:
+		return packetProfile{
+			agentWrite:  pbagent.TCPConnectionWrite,
+			clientWrite: pbclient.TCPConnectionWrite,
+			sendTCPOpen: true,
+		}, true
+	case pb.ConnectionTypeHttpProxy:
+		return packetProfile{
+			agentWrite:  pbagent.HttpProxyConnectionWrite,
+			clientWrite: pbclient.HttpProxyConnectionWrite,
+			isHTTPProxy: true,
+		}, true
+	}
+	return packetProfile{}, false
 }
 
 // awaitSessionOpen reads packets from the transport until either a
@@ -240,25 +298,30 @@ func awaitSessionOpen(ctx context.Context, transport pb.ClientTransport, timeout
 
 // pumpBytes runs the bidirectional byte pump. It returns when either
 // direction terminates.
-func pumpBytes(ctx context.Context, transport pb.ClientTransport, local io.ReadWriteCloser, sessionID string) error {
+func pumpBytes(ctx context.Context, transport pb.ClientTransport, local io.ReadWriteCloser, sessionID string, prof packetProfile, opts PipeOptions) error {
 	spec := map[string][]byte{
 		pb.SpecGatewaySessionID:   []byte(sessionID),
 		pb.SpecClientConnectionID: []byte(connectionIDOnPipe),
 	}
-
-	// Tell the agent to open its upstream socket. The TCPServerConnectKey
-	// spec marks this as a no-op write so the agent does not forward an
-	// empty payload to the database.
-	openSpec := make(map[string][]byte, len(spec)+1)
-	for k, v := range spec {
-		openSpec[k] = v
+	if prof.isHTTPProxy && opts.HttpProxyBaseURL != "" {
+		spec[pb.SpecHttpProxyBaseUrl] = []byte(opts.HttpProxyBaseURL)
 	}
-	openSpec[pb.SpecTCPServerConnectKey] = nil
-	if err := transport.Send(&pb.Packet{
-		Type: pbagent.TCPConnectionWrite,
-		Spec: openSpec,
-	}); err != nil {
-		return fmt.Errorf("send TCPConnectionWrite open: %w", err)
+
+	if prof.sendTCPOpen {
+		// Tell the agent to open its upstream socket. The
+		// TCPServerConnectKey spec marks this as a no-op write so the
+		// agent does not forward an empty payload to the database.
+		openSpec := make(map[string][]byte, len(spec)+1)
+		for k, v := range spec {
+			openSpec[k] = v
+		}
+		openSpec[pb.SpecTCPServerConnectKey] = nil
+		if err := transport.Send(&pb.Packet{
+			Type: prof.agentWrite.String(),
+			Spec: openSpec,
+		}); err != nil {
+			return fmt.Errorf("send %s open: %w", prof.agentWrite, err)
+		}
 	}
 
 	transport.StartKeepAlive()
@@ -281,7 +344,7 @@ func pumpBytes(ctx context.Context, transport pb.ClientTransport, local io.ReadW
 	// local -> gateway
 	go func() {
 		defer wg.Done()
-		writer := pb.NewStreamWriter(transport, pbagent.TCPConnectionWrite, spec)
+		writer := pb.NewStreamWriter(transport, prof.agentWrite, spec)
 		_, err := io.Copy(writer, local)
 		// Tell the agent to close its upstream socket. We send this
 		// regardless of how io.Copy ended (EOF, error, or peer close
@@ -301,7 +364,7 @@ func pumpBytes(ctx context.Context, transport pb.ClientTransport, local io.ReadW
 	// gateway -> local
 	go func() {
 		defer wg.Done()
-		err := readFromGateway(pumpCtx, transport, local)
+		err := readFromGateway(pumpCtx, transport, local, prof.clientWrite)
 		if err != nil && !errors.Is(err, io.EOF) && !isClosedConnErr(err) {
 			finish(fmt.Errorf("gateway->local: %w", err))
 		}
@@ -317,7 +380,9 @@ func pumpBytes(ctx context.Context, transport pb.ClientTransport, local io.ReadW
 
 // readFromGateway loops on Recv() and writes packet payloads to local.
 // It returns when the stream ends or a non-recoverable packet arrives.
-func readFromGateway(ctx context.Context, transport pb.ClientTransport, local io.Writer) error {
+// dataType is the packet family carrying gateway -> local data for this
+// session (TCP or httpproxy writes).
+func readFromGateway(ctx context.Context, transport pb.ClientTransport, local io.Writer, dataType pb.PacketType) error {
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -330,7 +395,7 @@ func readFromGateway(ctx context.Context, transport pb.ClientTransport, local io
 			continue
 		}
 		switch pb.PacketType(pkt.Type) {
-		case pbclient.TCPConnectionWrite:
+		case dataType:
 			if len(pkt.Payload) == 0 {
 				continue
 			}
@@ -353,22 +418,6 @@ func readFromGateway(ctx context.Context, transport pb.ClientTransport, local io
 			// connections; we'd just drop them anyway).
 		}
 	}
-}
-
-// isTunnelableType reports whether a hoop connection type is suitable
-// for transparent IP-level tunneling. SSH/HTTP/Kubernetes connections
-// need protocol-aware clients and are excluded.
-func isTunnelableType(t string) bool {
-	switch pb.ConnectionType(t) {
-	case pb.ConnectionTypePostgres,
-		pb.ConnectionTypeMySQL,
-		pb.ConnectionTypeMSSQL,
-		pb.ConnectionTypeMongoDB,
-		pb.ConnectionTypeOracleDB,
-		pb.ConnectionTypeTCP:
-		return true
-	}
-	return false
 }
 
 // isClosedConnErr suppresses noise from the routine close races between

--- a/tunnel/client/pipe_test.go
+++ b/tunnel/client/pipe_test.go
@@ -286,6 +286,117 @@ func TestRunPipe_HappyPath_PostgresEcho(t *testing.T) {
 	}
 }
 
+func TestRunPipe_HappyPath_HttpProxyEcho(t *testing.T) {
+	ft := newFakeTransport()
+	const sessionID = "sess-http-1"
+	const wantClientBytes = "GET /v1/things HTTP/1.1\r\nHost: api-prod.hoop\r\n\r\n"
+	const wantServerBytes = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"
+	const wantBaseURL = "http://api-prod.hoop"
+
+	local := newFakeLocal([]byte(wantClientBytes))
+
+	// Drive the gateway's side of the protocol in a goroutine.
+	go func() {
+		pkts := waitForSent(t, ft, 1, 2*time.Second)
+		if pb.PacketType(pkts[0].Type) != pbagent.SessionOpen {
+			t.Errorf("first packet: want SessionOpen, got %s", pkts[0].Type)
+		}
+
+		ft.push(&pb.Packet{
+			Type: pbclient.SessionOpenOK,
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID: []byte(sessionID),
+				pb.SpecConnectionType:   []byte(pb.ConnectionTypeHttpProxy.String()),
+			},
+		})
+
+		// Wait for the request bytes. Unlike TCP-style sessions there
+		// is NO open-handshake packet: the first HttpProxyConnectionWrite
+		// already carries payload.
+		var payloadSeen bool
+		deadline := time.After(2 * time.Second)
+		for !payloadSeen {
+			for _, p := range ft.sentPackets() {
+				if pb.PacketType(p.Type) == pbagent.HttpProxyConnectionWrite &&
+					string(p.Payload) == wantClientBytes {
+					payloadSeen = true
+				}
+			}
+			if payloadSeen {
+				break
+			}
+			select {
+			case <-deadline:
+				t.Errorf("timeout waiting for http proxy payload; got %d packets", len(ft.sentPackets()))
+				return
+			case <-time.After(5 * time.Millisecond):
+			}
+		}
+
+		// Respond, then close the connection.
+		ft.push(&pb.Packet{
+			Type: pbclient.HttpProxyConnectionWrite,
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID:   []byte(sessionID),
+				pb.SpecClientConnectionID: []byte(connectionIDOnPipe),
+			},
+			Payload: []byte(wantServerBytes),
+		})
+		ft.push(&pb.Packet{
+			Type: pbclient.TCPConnectionClose,
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID:   []byte(sessionID),
+				pb.SpecClientConnectionID: []byte(connectionIDOnPipe),
+			},
+		})
+	}()
+
+	err := runPipe(context.Background(), ft, local, PipeOptions{
+		ConnectionName:     "api-prod",
+		HttpProxyBaseURL:   wantBaseURL,
+		SessionOpenTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("runPipe returned error: %v", err)
+	}
+
+	if got := string(local.writtenBytes()); got != wantServerBytes {
+		t.Errorf("local writes: want %q, got %q", wantServerBytes, got)
+	}
+
+	pkts := ft.sentPackets()
+	if pb.PacketType(pkts[0].Type) != pbagent.SessionOpen {
+		t.Errorf("packet[0]: want SessionOpen, got %s", pkts[0].Type)
+	}
+	var sawData, sawClose bool
+	for _, p := range pkts {
+		switch pb.PacketType(p.Type) {
+		case pbagent.HttpProxyConnectionWrite:
+			// The false-positive guard: no TCP open handshake may leak
+			// into the httpproxy packet family.
+			if _, ok := p.Spec[pb.SpecTCPServerConnectKey]; ok {
+				t.Errorf("httpproxy write carries SpecTCPServerConnectKey (TCP open handshake)")
+			}
+			if got := string(p.Spec[pb.SpecHttpProxyBaseUrl]); got != wantBaseURL {
+				t.Errorf("SpecHttpProxyBaseUrl: want %q, got %q", wantBaseURL, got)
+			}
+			if string(p.Payload) == wantClientBytes {
+				sawData = true
+			}
+		case pbagent.TCPConnectionWrite:
+			t.Errorf("httpproxy session sent a TCPConnectionWrite packet")
+		case pbagent.TCPConnectionClose:
+			sawClose = true
+		}
+	}
+	if !sawData {
+		t.Errorf("request bytes never sent as HttpProxyConnectionWrite")
+	}
+	if !sawClose {
+		t.Errorf("pipe did not send TCPConnectionClose to the gateway")
+	}
+}
+
 func TestRunPipe_RejectedConnectionType(t *testing.T) {
 	ft := newFakeTransport()
 	go func() {

--- a/tunnel/ipc/openapi.yaml
+++ b/tunnel/ipc/openapi.yaml
@@ -74,7 +74,7 @@ components:
           description: Hoop connection name (no domain suffix).
         subtype:
           type: string
-          enum: [postgres, mysql, mssql, mongodb, oracledb, tcp]
+          enum: [postgres, mysql, mssql, mongodb, oracledb, tcp, httpproxy]
         virtual_ip:
           type: string
           description: ULA IPv6 address inside the tunnel /48.

--- a/tunnel/portmap/portmap.go
+++ b/tunnel/portmap/portmap.go
@@ -46,6 +46,13 @@ func CanonicalPort(subType string) (uint16, bool) {
 		return 27017, true
 	case pb.ConnectionTypeOracleDB:
 		return 1521, true
+	case pb.ConnectionTypeHttpProxy:
+		// Clients speak plain HTTP to the tunnel (the agent terminates
+		// TLS to the real upstream), so port 80 is the only valid
+		// target. 443 is deliberately rejected: the tunnel has no
+		// certificate for *.hoop, so an https:// URL can never work
+		// and should fail fast at the SYN.
+		return 80, true
 	}
 	return 0, false
 }

--- a/tunnel/portmap/portmap_test.go
+++ b/tunnel/portmap/portmap_test.go
@@ -13,9 +13,10 @@ func TestCanonicalPort(t *testing.T) {
 		{"mssql", 1433, true},
 		{"mongodb", 27017, true},
 		{"oracledb", 1521, true},
-		{"tcp", 0, false},     // no canonical port for generic TCP
-		{"ssh", 0, false},     // not tunnelable
-		{"unknown", 0, false}, // unknown subtype
+		{"httpproxy", 80, true}, // plain HTTP into the tunnel; agent does TLS upstream
+		{"tcp", 0, false},       // no canonical port for generic TCP
+		{"ssh", 0, false},       // not tunnelable
+		{"unknown", 0, false},   // unknown subtype
 		{"", 0, false},
 	}
 	for _, tc := range cases {
@@ -44,6 +45,11 @@ func TestIsAcceptedPort(t *testing.T) {
 		{"mssql on 1433", "mssql", 1433, true},
 		{"mongodb on 27017", "mongodb", 27017, true},
 		{"oracledb on 1521", "oracledb", 1521, true},
+		{"httpproxy on 80", "httpproxy", 80, true},
+		// https://name.hoop can never work (no *.hoop certificate);
+		// reject at the SYN so clients fail fast.
+		{"httpproxy on 443 (wrong)", "httpproxy", 443, false},
+		{"httpproxy on 8080 (wrong)", "httpproxy", 8080, false},
 
 		// tcp accepts any non-zero port
 		{"tcp on 22", "tcp", 22, true},
@@ -54,7 +60,6 @@ func TestIsAcceptedPort(t *testing.T) {
 		// not-tunnelable subtypes always reject
 		{"ssh on 22", "ssh", 22, false},
 		{"kubernetes on 6443", "kubernetes", 6443, false},
-		{"httpproxy on 80", "httpproxy", 80, false},
 		{"rdp on 3389", "rdp", 3389, false},
 
 		// zero port always rejected (defensive)

--- a/tunnel/tunnelmgr/handlers.go
+++ b/tunnel/tunnelmgr/handlers.go
@@ -69,6 +69,7 @@ func (m *Manager) makeTCPHandler(
 ) netstack.Handler {
 	logger := m.opts.Logger
 	userAgent := m.opts.UserAgent
+	tld := m.opts.TLD
 	return func(conn *gonet.TCPConn, localAddr netip.Addr, localPort uint16) {
 		defer conn.Close()
 		name, ok := alloc.LookupAddr(localAddr)
@@ -88,6 +89,10 @@ func (m *Manager) makeTCPHandler(
 			GatewayConfig:  flowCfg,
 			ConnectionName: name,
 			UserAgent:      userAgent,
+			// Only consumed by httpproxy sessions: the URL clients use
+			// to reach this connection, so the agent's HTTP proxy can
+			// rewrite redirects/absolute URLs back at the tunnel.
+			HttpProxyBaseURL: "http://" + name + "." + tld,
 		})
 		if err != nil {
 			logger.Printf("tunnelmgr: pipe %s closed: %v", name, err)


### PR DESCRIPTION
> [!IMPORTANT]
> Label: `minor` — new non-breaking feature (httpproxy connections become tunnelable).

## 📝 Description

Adds support for `httpproxy` connections to the tunnel daemon (`hsh-tunneld`).
Until now the tunnel only carried TCP-style protocols (postgres, mysql, mssql,
mongodb, oracledb, tcp); httpproxy connections were filtered out and required
`hoop connect` with a per-user local port.

With this change, an httpproxy connection appears as a stable hostname inside
the tunnel (`http://<connection-name>.hoop`, port 80). Clients speak plain HTTP
to the tunnel; the agent's libhoop proxy parses the request and terminates TLS
to the connection's `REMOTE_URL` upstream, so guardrails and DLP inspection
apply exactly as they do on the `hoop connect` path. No gateway or agent
changes — the tunnel presents itself as an ordinary client stream.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- `tunnel/client/pipe.go`: introduced `packetProfile` (replaces `isTunnelableType`) so the per-flow pipe selects the packet family by connection type — `Agent/ClientHttpProxyConnectionWrite` for httpproxy, the TCP family for everything else. httpproxy sessions skip the `SpecTCPServerConnectKey` open handshake (the agent builds its HTTP proxy lazily on the first data packet) and stamp `SpecHttpProxyBaseUrl` on every write so libhoop rewrites redirects/absolute URLs back at the tunnel hostname.
- `tunnel/tunnelmgr/handlers.go`: passes `HttpProxyBaseURL: http://<name>.<tld>` to each pipe.
- `tunnel/portmap/portmap.go`: httpproxy gets canonical port **80**; 443 is rejected at the SYN (the tunnel has no `*.hoop` certificate, so `https://name.hoop` can never work and should fail fast).
- `tunnel/client/connections.go`: `isTunnelableSubType` now includes `httpproxy` so the daemon lists it and the resolver allocates an IP.
- Docs: `tunnel/README.md` tunnelable-connections section, `tunnel/ipc/openapi.yaml` subtype enum.

## 🧪 Testing

Unit tests cover the new behavior end-to-end at the pipe level with the fake
transport, including false-positive guards per repo convention:

- `TestRunPipe_HappyPath_HttpProxyEcho` (tunnel/client): asserts httpproxy
  sessions use the `HttpProxyConnectionWrite` packet family, carry
  `SpecHttpProxyBaseUrl`, send **no** TCP open-handshake packet and **no**
  `TCPConnectionWrite`, and still emit `TCPConnectionClose` on teardown.
- `TestCanonicalPort` / `TestIsAcceptedPort` (tunnel/portmap): httpproxy on 80
  accepted; 443 and 8080 rejected; all existing subtypes unchanged.

### Test Configuration:
- **Browser(s)**: n/a (Go daemon)
- **OS**: macOS (darwin), Linux via CI

### Tests performed:
- [x] Unit tests pass (`go build ./tunnel/...`, `go vet ./tunnel/...`, `go test ./tunnel/...`)
- [ ] Integration tests pass
- [ ] Manual testing completed

## 📸 Screenshots (if applicable)

n/a

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- Behavioral caveats reviewers should be aware of:
  - The client app still changes its base URL (e.g. `https://backend.internal`
    → `http://backend.hoop`). This is not `HTTPS_PROXY`-style transparency;
    the win over `hoop connect` is a stable hostname, no per-user local port,
    and no CLI session to keep open.
  - One TCP flow = one gRPC stream = one hoop session (same as the CLI path),
    so review/audit semantics carry over unchanged. With HTTP keep-alive that
    means many requests per session.
- The `tunnel/ipc` socket tests are untouched; they need unix-socket bind
  permissions to run locally.
- Manual verification steps: `make build-hsh-tunneld`, restart the daemon,
  `hsh tunnel refresh`, confirm the httpproxy connection shows in
  `hsh tunnel ls` on port 80, then `curl http://<name>.hoop/<path>`.