### PR TITLE
feat(httpproxy): per-user upstream Authorization passthrough (experimental.httpproxy_client_authorization)

### DIFF
--- a/agent/controller/agent.go
+++ b/agent/controller/agent.go
@@ -109,6 +109,12 @@ type (
 		connectionString   string
 		httpProxyRemoteURL string
 		httpProxyHeaders   map[string]string
+		// httpProxyAllowClientAuth opts an httpproxy connection into per-user
+		// upstream identity (ALLOW_CLIENT_AUTHORIZATION=true): a client-supplied
+		// X-Hoop-Upstream-Authorization header is promoted to the upstream
+		// Authorization header. Only honored when the
+		// experimental.httpproxy_client_authorization flag is enabled.
+		httpProxyAllowClientAuth bool
 		// gcpServiceAccountJSON carries the GCP service-account key configured
 		// on a claude-code connection that federates to Google Vertex AI. When
 		// present (and the experimental.claude_code_vertex flag is on) the agent
@@ -774,10 +780,11 @@ func parseConnectionEnvVars(envVars map[string]any, connType pb.ConnectionType) 
 		postgresSSLMode:   envVarS.Getenv("SSLMODE"),
 		options:           envVarS.Getenv("OPTIONS"),
 		// this option is only used by mongodb at the momento
-		connectionString:      envVarS.Getenv("CONNECTION_STRING"),
-		httpProxyRemoteURL:    envVarS.Getenv("REMOTE_URL"),
-		httpProxyHeaders:      httpProxyHeaders,
-		gcpServiceAccountJSON: envVarS.Getenv("GCP_SERVICE_ACCOUNT_JSON"),
+		connectionString:         envVarS.Getenv("CONNECTION_STRING"),
+		httpProxyRemoteURL:       envVarS.Getenv("REMOTE_URL"),
+		httpProxyHeaders:         httpProxyHeaders,
+		httpProxyAllowClientAuth: envVarS.Getenv("ALLOW_CLIENT_AUTHORIZATION") == "true",
+		gcpServiceAccountJSON:    envVarS.Getenv("GCP_SERVICE_ACCOUNT_JSON"),
 
 		kubernetesClusterURL:         envVarS.Getenv("KUBERNETES_CLUSTER_URL"),
 		kubernetesToken:              envVarS.Getenv("KUBERNETES_BEARER_TOKEN"),

--- a/agent/controller/httpproxy.go
+++ b/agent/controller/httpproxy.go
@@ -16,6 +16,13 @@ import (
 	pbclient "github.com/hoophq/hoop/common/proto/client"
 )
 
+// httpProxyClientAuthorizationFlag gates per-user upstream identity on
+// httpproxy connections. When on, a connection with
+// ALLOW_CLIENT_AUTHORIZATION=true lets the client supply the upstream
+// Authorization credential via the X-Hoop-Upstream-Authorization header.
+// When off, the agent leaves request headers untouched.
+const httpProxyClientAuthorizationFlag = "experimental.httpproxy_client_authorization"
+
 // httpProxyResponseChunkSize bounds the size of each gRPC packet emitted for an
 // HTTP proxy response. libhoop fully buffers a response and writes it to the
 // client stream in a single Write; without chunking, a large response (e.g. a
@@ -137,6 +144,14 @@ func (a *Agent) handleHttpProxyWrite(pkt *pb.Packet) {
 	connenv.httpProxyHeaders["mspresidio_analyzer_url"] = connParams.DlpPresidioAnalyzerURL
 	connenv.httpProxyHeaders["guard_rail_rules"] = guardRailRules
 	connenv.httpProxyHeaders["data_masking_entity_data"] = dataMaskingEntityTypesData
+
+	// Per-user upstream identity: the connection opted in via
+	// ALLOW_CLIENT_AUTHORIZATION=true, so libhoop promotes a client-supplied
+	// X-Hoop-Upstream-Authorization header to the upstream Authorization
+	// header (superseding any header_* configured on the connection).
+	if connenv.httpProxyAllowClientAuth && featureflagstate.IsEnabled(httpProxyClientAuthorizationFlag) {
+		connenv.httpProxyHeaders["allow_client_authorization"] = "true"
+	}
 
 	// add default values for kubernetes type
 	if connParams.ConnectionType == pb.ConnectionTypeKubernetes.String() {

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -103,6 +103,13 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentGateway},
 	},
+	"experimental.httpproxy_client_authorization": {
+		Name:        "experimental.httpproxy_client_authorization",
+		Description: "Allow httpproxy connections that set ALLOW_CLIENT_AUTHORIZATION=true to receive the upstream Authorization credential from the client: the agent promotes a client-supplied X-Hoop-Upstream-Authorization header to the upstream Authorization header, so each user can authenticate to the backend (e.g. an MCP server) with their own token instead of a shared connection credential. When off, the header is forwarded unchanged and never promoted. Note the client-supplied credential is recorded verbatim in session audit records; use time-bounded tokens.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentAgent},
+	},
 	"experimental.claude_code_vertex": {
 		Name:        "experimental.claude_code_vertex",
 		Description: "Allow claude-code connections to authenticate against Google Vertex AI: the connection stores a GCP service-account key and the agent mints a short-lived, auto-refreshing OAuth bearer that it injects as the upstream Authorization header while transparently proxying Claude Code traffic to Vertex. Claude Code runs in Vertex mode (CLAUDE_CODE_USE_VERTEX) pointed at the hoop proxy. When off, the Vertex provider is hidden in the connection form and the agent does not mint GCP tokens.",


### PR DESCRIPTION
> [!IMPORTANT]
> Label: `minor`

## 📝 Description

Adds opt-in per-user upstream identity for `httpproxy` connections. When a connection sets the env `ALLOW_CLIENT_AUTHORIZATION=true` and the `experimental.httpproxy_client_authorization` feature flag is enabled for the org, the agent promotes a client-supplied `X-Hoop-Upstream-Authorization` header to the upstream `Authorization` header, superseding any `HEADER_*` credential configured on the connection.

This lets each user authenticate to the proxied backend with their own token instead of a shared connection credential. Primary use case: fronting a remote MCP server (e.g. OpenMetadata at `https://<server>/mcp`) where every user supplies their own PAT, while hoop keeps audit, guardrails, and data masking on the traffic. The client sends two headers: `Authorization` carries the hoop proxy token (consumed and stripped by the gateway, as today), and `X-Hoop-Upstream-Authorization` carries the user's backend credential.

When the flag is off, or the connection did not opt in, behavior is byte-for-byte identical to today: the header is forwarded unchanged and never promoted.

Companion PR in `libhoop` implements the header promotion (`applyClientAuthorization`) for regular requests, SSE, and the WebSocket upgrade path — that PR must merge first.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

- Registered the `experimental.httpproxy_client_authorization` feature flag (default off, agent component) in `common/featureflag/featureflag.go`.
- `agent/controller/agent.go`: parse the `ALLOW_CLIENT_AUTHORIZATION` connection env into `connEnv`.
- `agent/controller/httpproxy.go`: when the connection opted in and the flag is on, pass `allow_client_authorization=true` to libhoop's HTTP proxy options.
- Note: the client-supplied credential appears verbatim in session audit records (documented in the flag description); users should generate time-bounded tokens.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a (agent/gateway change)
- **OS**: macOS (darwin), agent cross-compiled as usual

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

`go test ./agent/controller/... ./common/featureflag/ ./gateway/transport/plugins/audit/` all green; `go vet` clean. Header-promotion behavior is covered by table-driven tests in the libhoop companion PR (`TestApplyClientAuthorization`: promotion, superseding a connection-configured Authorization, no-op when disabled, passthrough header removal).

## 📸 Screenshots (if applicable)

n/a

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- Reviewers: the opt-in key cannot be spoofed via connection envs — the agent only copies `header_*`-prefixed envs into the proxy options, and `allow_client_authorization` is planted exclusively by the flag-gated branch in `handleHttpProxyWrite`.
- No helm/env.sample changes: `ALLOW_CLIENT_AUTHORIZATION` is a per-connection env, not a process env.
- Client config example (Claude Desktop / mcp-remote):
  `--header "Authorization:Bearer httpproxy<hoop-token>" --header "X-Hoop-Upstream-Authorization:Bearer <user-pat>"`