### PR TITLE
fix(guardrails): Fix the guardrails for the web terminal

### DIFF
--- a/gateway/transport/agent_guardrails_test.go
+++ b/gateway/transport/agent_guardrails_test.go
@@ -9,6 +9,7 @@ import (
 	pgtypes "github.com/hoophq/hoop/common/pgtypes"
 	pb "github.com/hoophq/hoop/common/proto"
 	"github.com/hoophq/hoop/gateway/models"
+	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
 )
 
 func TestBuildLegacyGuardRailErrorMessage(t *testing.T) {
@@ -134,8 +135,8 @@ func TestConnectionTypeSupportsGuardRails(t *testing.T) {
 		}
 	}
 
-	// MySQL, MSSQL and MongoDB proxies do not evaluate guardrails yet, so a
-	// guarded session of these types must be refused (fail closed), not run
+	// MySQL, MSSQL and MongoDB native proxies do not evaluate guardrails, so
+	// native sessions of these types must be refused (fail closed), not run
 	// unguarded (DEP-48).
 	unsupported := []pb.ConnectionType{
 		pb.ConnectionTypeMySQL,
@@ -147,6 +148,53 @@ func TestConnectionTypeSupportsGuardRails(t *testing.T) {
 		if connectionTypeSupportsGuardRails(ct) {
 			t.Errorf("expected connection type %q to NOT support guardrails", ct)
 		}
+	}
+}
+
+func TestSessionSupportsGuardRails(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  plugintypes.Context
+		want bool
+	}{
+		{
+			name: "mssql web exec",
+			ctx: plugintypes.Context{
+				ConnectionType:    string(pb.ConnectionTypeMSSQL),
+				ConnectionSubType: "mssql",
+				ClientVerb:        pb.ClientVerbExec,
+				ClientOrigin:      pb.ConnectionOriginClientAPI,
+			},
+			want: true,
+		},
+		{
+			name: "mssql native session",
+			ctx: plugintypes.Context{
+				ConnectionType:    string(pb.ConnectionTypeMSSQL),
+				ConnectionSubType: "",
+				ClientVerb:        pb.ClientVerbExec,
+				ClientOrigin:      pb.ConnectionOriginClient,
+			},
+			want: false,
+		},
+		{
+			name: "mssql non-exec API session",
+			ctx: plugintypes.Context{
+				ConnectionType:    string(pb.ConnectionTypeMSSQL),
+				ConnectionSubType: "",
+				ClientVerb:        pb.ClientVerbPlainExec,
+				ClientOrigin:      pb.ConnectionOriginClientAPI,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sessionSupportsGuardRails(tt.ctx); got != tt.want {
+				t.Fatalf("sessionSupportsGuardRails() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -331,18 +331,9 @@ func encodeGuardRailRules(connGuardRailRules *models.ConnectionGuardRailRules) (
 	return guardRailRulesJsonData, nil
 }
 
-// connectionTypeSupportsGuardRails reports whether the agent-side proxy for the
-// given connection type actually evaluates guardrail rules. It is a session-open
-// admission policy: guarded sessions are only admitted for types with real
-// enforcement in libhoop. Guardrails are enforced for PostgreSQL, Oracle, HTTP
-// proxy, SSH and command-line (terminal console and exec, including the DB exec
-// drivers, which resolve to the command-line type). MySQL, MSSQL and MongoDB
-// native proxies do not yet evaluate guardrails, so a guarded session of those
-// types would run unguarded — we fail closed at session-open rather than
-// silently ignoring the configured rules (DEP-48).
-//
-// IMPORTANT: this list mirrors enforcement support in libhoop. When guardrail
-// evaluation is added to another protocol proxy there, add its type here.
+// connectionTypeSupportsGuardRails reports the connection types whose native
+// proxies evaluate guardrail rules. Database Web Exec is checked separately
+// because it uses the agent's terminal-exec path rather than the native proxy.
 func connectionTypeSupportsGuardRails(connType pb.ConnectionType) bool {
 	switch connType {
 	case pb.ConnectionTypePostgres,
@@ -354,6 +345,21 @@ func connectionTypeSupportsGuardRails(connType pb.ConnectionType) bool {
 	default:
 		return false
 	}
+}
+
+// sessionSupportsGuardRails reports whether this particular session has an
+// agent-side enforcement path. MSSQL is supported only for Web Exec: the
+// session API uses ClientAPI + exec and the agent's doExec path passes the
+// rules to the command/DB-exec redactor. Native MSSQL protocol sessions must
+// remain rejected because mssql.go does not inspect guardrails.
+func sessionSupportsGuardRails(pctx plugintypes.Context) bool {
+	if connectionTypeSupportsGuardRails(pctx.ProtoConnectionType()) {
+		return true
+	}
+
+	return pctx.ProtoConnectionType() == pb.ConnectionTypeMSSQL &&
+		pctx.ClientVerb == pb.ClientVerbExec &&
+		pctx.ClientOrigin == pb.ConnectionOriginClientAPI
 }
 
 func getAnalyzerMetricsRulesForConnection() (json.RawMessage, error) {
@@ -540,7 +546,7 @@ func (s *Server) processClientPacket(stream *streamclient.ProxyStream, pkt *pb.P
 			// for plain-exec sessions.
 			if len(guardRailRulesJsonData) > 0 {
 				logCtx := log.With("sid", pctx.SID, "connection", pctx.ConnectionName)
-				if connType := pctx.ProtoConnectionType(); !connectionTypeSupportsGuardRails(connType) {
+				if connType := pctx.ProtoConnectionType(); !sessionSupportsGuardRails(pctx) {
 					logCtx.Warnf("refusing session: connection type %q does not support guardrail enforcement", connType)
 					return status.Errorf(codes.FailedPrecondition,
 						"this connection has guardrails configured, but connection type %q does not support guardrail enforcement; "+


### PR DESCRIPTION
> [!IMPORTANT]
   > **Required PR label: `patch`**

   ## 📝 Description

   Allow guardrails on MSSQL Web Exec sessions while continuing to reject unsupported native MSSQL sessions.

   ## 🔗 Related Issue

   Fixes #1610 

   ## 🚀 Type of Change

   - [x] 🐛 Bug fix (non-breaking change which fixes an issue)

   ## 📋 Changes Made

   - Allow MSSQL guardrails for `client-api` Exec sessions.
   - Keep native and non-Exec MSSQL sessions fail-closed.
   - Added regression tests for supported and unsupported paths.

   ## 🧪 Testing

   ### Test Configuration:
   - **Browser(s)**: N/A
   - **OS**: macOS

   ### Tests performed:

   - [x] Unit tests pass
   - [ ] Integration tests pass
   - [ ] Manual testing completed

   ```bash
   go test ./gateway/transport
 ```

 📸 Screenshots (if applicable)

 Not applicable.

 ✅ Checklist

 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] My changes generate no new warnings
 - [x] New and existing unit tests pass locally with my changes
 - [x] I have checked my code and corrected any misspellings

 📄 Additional Notes

 Guardrails are supported for MSSQL Web Exec only. Native MSSQL protocol sessions remain unsupported and are rejected to prevent unguarded execution.