### PR TITLE
fix(rdp): render web client at native resolution on HiDPI displays

### DIFF
--- a/webapp/resources/public/rdpclient/index.js
+++ b/webapp/resources/public/rdpclient/index.js
@@ -51,8 +51,13 @@ async function initializeApp(rdpCredential) {
     // shadow canvas bound (maxCanvasDim in gateway/rdp/piigate.go and
     // MAX_CANVAS_DIM in agentrs/src/piigate/canvas.rs, both 4096). Beyond
     // that bound the guard skips redaction FAIL-OPEN, so oversized displays
-    // are scaled down proportionally instead (slightly soft, never
-    // unredacted). Keep the three values in lockstep.
+    // are scaled down proportionally instead. Keep the three values in
+    // lockstep.
+    //
+    // This clamp is best-effort: it bounds the size *requested* by this
+    // client, but the server may still negotiate a different desktop size.
+    // Authoritative enforcement at the gateway/agent boundary is tracked in
+    // DEP-70.
     const MAX_DESKTOP_DIM = 4096;
     const viewportWidth = Number.isFinite(window.innerWidth)
         ? Math.max(1, Math.floor(window.innerWidth)) : 1;

--- a/webapp/resources/public/rdpclient/index.js
+++ b/webapp/resources/public/rdpclient/index.js
@@ -40,12 +40,34 @@ async function initializeApp(rdpCredential) {
     rdpCanvas.style.top = '0px';
     rdpCanvas.style.left = '0px';
     document.body.style.margin = '0px';
-    document.body.overflow = 'hidden';
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
-    console.log(`Window Size: ${viewportWidth} x ${viewportHeight}`);
-    rdpCanvas.width = viewportWidth;
-    rdpCanvas.height = viewportHeight;
+    document.body.style.overflow = 'hidden';
+
+    // Size the canvas backing store in physical (device) pixels so the RDP
+    // desktop maps 1:1 to the screen. Using CSS pixels (window.innerWidth)
+    // on a HiDPI/Retina display forces the browser to upscale the canvas,
+    // blurring the whole session.
+    //
+    // SECURITY CONTRACT: MAX_DESKTOP_DIM must never exceed the PII guard's
+    // shadow canvas bound (maxCanvasDim in gateway/rdp/piigate.go and
+    // MAX_CANVAS_DIM in agentrs/src/piigate/canvas.rs, both 4096). Beyond
+    // that bound the guard skips redaction FAIL-OPEN, so oversized displays
+    // are scaled down proportionally instead (slightly soft, never
+    // unredacted). Keep the three values in lockstep.
+    const MAX_DESKTOP_DIM = 4096;
+    const viewportWidth = Number.isFinite(window.innerWidth)
+        ? Math.max(1, Math.floor(window.innerWidth)) : 1;
+    const viewportHeight = Number.isFinite(window.innerHeight)
+        ? Math.max(1, Math.floor(window.innerHeight)) : 1;
+    const dpr = (Number.isFinite(window.devicePixelRatio) && window.devicePixelRatio > 0)
+        ? window.devicePixelRatio : 1;
+    const scale = Math.min(
+        dpr,
+        MAX_DESKTOP_DIM / viewportWidth,
+        MAX_DESKTOP_DIM / viewportHeight,
+    );
+    console.log(`Window Size: ${viewportWidth} x ${viewportHeight}, DPR: ${dpr}, scale: ${scale}`);
+    rdpCanvas.width = Math.max(1, Math.min(MAX_DESKTOP_DIM, Math.round(viewportWidth * scale)));
+    rdpCanvas.height = Math.max(1, Math.min(MAX_DESKTOP_DIM, Math.round(viewportHeight * scale)));
 
     const RDP = new RemoteDesktopService(rdpCanvas, mod);
     window.RDP = RDP;

--- a/webapp/resources/public/rdpclient/rdp.js
+++ b/webapp/resources/public/rdpclient/rdp.js
@@ -110,7 +110,10 @@ export class RemoteDesktopService {
         // clamped below the device pixel ratio).
         const rect = this.canvas.getBoundingClientRect();
         const renderScale = rect.width > 0 ? this.canvas.width / rect.width : 1;
-        this.ctx.font = `${Math.round(20 * renderScale)}px Arial`;
+        // Clamp so degenerate layout states can't yield an invisible (0px)
+        // or absurdly large font.
+        const fontPx = Math.min(200, Math.max(10, Math.round(20 * renderScale)));
+        this.ctx.font = `${fontPx}px Arial`;
         this.ctx.textAlign = 'center';
         this.ctx.textBaseline = 'middle';
         this.ctx.fillText(text, this.canvas.width / 2, this.canvas.height / 2);

--- a/webapp/resources/public/rdpclient/rdp.js
+++ b/webapp/resources/public/rdpclient/rdp.js
@@ -104,7 +104,13 @@ export class RemoteDesktopService {
         this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
 
         this.ctx.fillStyle = 'white';
-        this.ctx.font = '20px Arial';
+        // The backing store is sized in physical pixels (see index.js), so
+        // scale the status text by the actual backing-store/CSS ratio to
+        // keep it readable on HiDPI displays (including when the store is
+        // clamped below the device pixel ratio).
+        const rect = this.canvas.getBoundingClientRect();
+        const renderScale = rect.width > 0 ? this.canvas.width / rect.width : 1;
+        this.ctx.font = `${Math.round(20 * renderScale)}px Arial`;
         this.ctx.textAlign = 'center';
         this.ctx.textBaseline = 'middle';
         this.ctx.fillText(text, this.canvas.width / 2, this.canvas.height / 2);


### PR DESCRIPTION
Fixes the blurry RDP web client on HiDPI/Retina displays, reported during the demo benchmark review.

## Root cause

The canvas backing store was sized in CSS pixels (`window.innerWidth`) while CSS-stretched to 100% of the window — on a DPR=2 display the browser upscales every frame 2x, blurring the session even without any resize. The IronRDP `desktopSize` follows `canvas.width/height`, so the server was also rendering at half the physical resolution.

## What changed

- Backing store now sized in physical pixels (`viewport x devicePixelRatio`) → pixel-perfect rendering; the RDP server renders at full native resolution.
- **Clamped to 4096px per dimension**: the PII guard's shadow canvas (`maxCanvasDim` / `MAX_CANVAS_DIM`) is fail-open beyond 4096, so oversized displays (5K @2x) scale down proportionally instead of silently bypassing redaction (partial mitigation for DEP-70).
- Inputs sanitized (non-finite/zero viewport or DPR) and final dims clamped to [1, 4096].
- Fixed no-op `document.body.overflow` assignment (missing `.style`).
- Connect/error status text scales by the actual backing-store ratio.

Mouse coordinates need no changes — `getMousePos` already scales by `canvas.width / rect.width`.

## Notes

- Remote UI renders sharp but ~2x smaller on HiDPI; proper DPI scaling requires advertising `desktopScaleFactor` at connect, which ironrdp-web doesn't expose yet — tracked in DEP-72 (upstream PR to IronRDP).
- PII-gated sessions now carry ~4x pixels through the OCR pipeline (relevant to DEP-55 capacity math). Shipping ungated per discussion.

Automated by MisterMal
