### PR TITLE
chore: add optional User-facing impact section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,14 @@
 
 <!-- Please provide a brief description of the changes in this PR -->
 
+## 📣 User-facing impact
+
+<!-- Optional. One or two sentences, in plain customer language, describing what users
+     gain from this PR — this feeds the public changelog at hoop.dev/docs/changelog.
+     Write "None" if this change is internal-only or gated behind a feature flag.
+     Leave the section untouched to let the changelog generator infer it from the
+     description. -->
+
 ## 🔗 Related Issue
 
 <!-- Link to the issue this PR addresses (if applicable) -->


### PR DESCRIPTION
## 📝 Description

Adds an **optional** "User-facing impact" section to the PR template. It feeds the automated changelog generator ([hoophq/changelog](https://github.com/hoophq/changelog)) that translates our GitHub releases into the public [Product updates page](https://hoop.dev/docs/changelog):

- When an author fills it, the generator prefers that wording over inferring from the Description.
- Writing `None` (or `internal-only`) excludes the change from the public changelog.
- Leaving the section untouched changes nothing — the generator falls back to Description/Changes Made.

No CI enforcement; zero added friction for PRs that skip it.

## 🔗 Related Issue

N/A — part of the changelog automation rollout.

## 🚀 Type of Change

- [x] 📚 Documentation update

## 📋 Changes Made

- Added the optional `## 📣 User-facing impact` section to `.github/PULL_REQUEST_TEMPLATE.md`, between Description and Related Issue, with an HTML comment explaining the contract.

## 🧪 Testing

### Tests performed:
- [x] Manual testing completed

Template-only change; verified the markdown renders correctly.

## 📄 Additional Notes

The section heading text (`User-facing impact`) is parsed by the generator (`internal/prtext` in hoophq/changelog) — if it is ever renamed, rename it there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)