### PR TITLE
DEP-74 Connection type "mssql" and all proxies does not support guardrail enforcement;

### DIFF
--- a/_libhoop/guardrails.go
+++ b/_libhoop/guardrails.go
@@ -1,0 +1,18 @@
+package libhoop
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CheckGuardRailEnforcement returns an error when guardrail rules are
+// configured for a proxy that cannot enforce them. The OSS build has no
+// guardrail evaluation path at all, so any non-empty rule payload fails
+// closed (DEP-48).
+func CheckGuardRailEnforcement(guardRailRules, proxyName string) error {
+	if strings.TrimSpace(guardRailRules) == "" {
+		return nil
+	}
+	return fmt.Errorf("connection has guardrail rules configured, but the native %s proxy does not support guardrail enforcement; "+
+		"remove the guardrails from this connection or use exec instead", proxyName)
+}

--- a/_libhoop/guardrails.go
+++ b/_libhoop/guardrails.go
@@ -5,14 +5,26 @@ import (
 	"strings"
 )
 
-// CheckGuardRailEnforcement returns an error when guardrail rules are
-// configured for a proxy that cannot enforce them. The OSS build has no
-// guardrail evaluation path at all, so any non-empty rule payload fails
-// closed (DEP-48).
+// ErrGuardRailsUnsupported indicates guardrail rules are configured for a
+// proxy that has no guardrail evaluation path (DEP-48). Callers branch on it
+// with errors.As.
+type ErrGuardRailsUnsupported struct {
+	// ProxyName is the native proxy that cannot enforce the rules.
+	ProxyName string
+}
+
+func (e *ErrGuardRailsUnsupported) Error() string {
+	return fmt.Sprintf("connection has guardrail rules configured, but the native %s proxy does not support guardrail enforcement; "+
+		"remove the guardrails from this connection or use exec instead", e.ProxyName)
+}
+
+// CheckGuardRailEnforcement returns *ErrGuardRailsUnsupported when guardrail
+// rules are configured for a proxy that cannot enforce them. The OSS build
+// has no guardrail evaluation path at all, so any non-empty rule payload
+// fails closed (DEP-48).
 func CheckGuardRailEnforcement(guardRailRules, proxyName string) error {
 	if strings.TrimSpace(guardRailRules) == "" {
 		return nil
 	}
-	return fmt.Errorf("connection has guardrail rules configured, but the native %s proxy does not support guardrail enforcement; "+
-		"remove the guardrails from this connection or use exec instead", proxyName)
+	return &ErrGuardRailsUnsupported{ProxyName: proxyName}
 }

--- a/agent/controller/mongodb.go
+++ b/agent/controller/mongodb.go
@@ -51,6 +51,11 @@ func (a *Agent) processMongoDBProtocol(pkt *pb.Packet) {
 		dataMaskingEntityTypesData = string(connParams.DataMaskingEntityTypesData)
 	}
 
+	var guardRailRules string
+	if connParams.GuardRailRules != nil {
+		guardRailRules = string(connParams.GuardRailRules)
+	}
+
 	log.With("sid", sid, "conn", clientConnectionID, "legacy", connenv.connectionString == "").
 		Infof("starting mongodb connection at %v", connenv.Address())
 
@@ -70,6 +75,7 @@ func (a *Agent) processMongoDBProtocol(pkt *pb.Packet) {
 		"dlp_gcp_credentials":       connParams.DlpGcpRawCredentialsJSON,
 		"dlp_info_types":            strings.Join(connParams.DLPInfoTypes, ","),
 		"dlp_masking_character":     "#",
+		"guard_rail_rules":          guardRailRules,
 		// TODO: make it disable for now, it consumes too much resources only for collecting metrics
 		// on more intensive environments this is a problem, we can enable it later based on specific rules
 		// "analyzer_metrics_rules":    analyzerMetricsRules,

--- a/agent/controller/mssql.go
+++ b/agent/controller/mssql.go
@@ -46,13 +46,18 @@ func (a *Agent) processMSSQLProtocol(pkt *pb.Packet) {
 	}
 
 	log.Infof("session=%v - starting mssql connection at %v:%v", sessionID, connenv.host, connenv.port)
+	var guardRailRules string
+	if connParams.GuardRailRules != nil {
+		guardRailRules = string(connParams.GuardRailRules)
+	}
 	opts := map[string]string{
-		"sid":      sessionID,
-		"hostname": connenv.host,
-		"port":     connenv.port,
-		"username": connenv.user,
-		"password": connenv.pass,
-		"insecure": fmt.Sprintf("%v", connenv.insecure),
+		"sid":              sessionID,
+		"hostname":         connenv.host,
+		"port":             connenv.port,
+		"username":         connenv.user,
+		"password":         connenv.pass,
+		"insecure":         fmt.Sprintf("%v", connenv.insecure),
+		"guard_rail_rules": guardRailRules,
 	}
 	serverWriter, err := libhoop.NewDBCore(context.Background(), streamClient, opts).MSSQL()
 	if err != nil {

--- a/agent/controller/mysql.go
+++ b/agent/controller/mysql.go
@@ -51,6 +51,11 @@ func (a *Agent) processMySQLProtocol(pkt *pb.Packet) {
 		dataMaskingEntityTypesData = string(connParams.DataMaskingEntityTypesData)
 	}
 
+	var guardRailRules string
+	if connParams.GuardRailRules != nil {
+		guardRailRules = string(connParams.GuardRailRules)
+	}
+
 	// var analyzerMetricsRules string
 	// if connParams.AnalyzerMetricsRules != nil {
 	// 	analyzerMetricsRules = string(connParams.AnalyzerMetricsRules)
@@ -67,6 +72,7 @@ func (a *Agent) processMySQLProtocol(pkt *pb.Packet) {
 		"mspresidio_analyzer_url":   connParams.DlpPresidioAnalyzerURL,
 		"mspresidio_anonymizer_url": connParams.DlpPresidioAnonymizerURL,
 		"data_masking_entity_data":  dataMaskingEntityTypesData,
+		"guard_rail_rules":          guardRailRules,
 		// TODO: make it disable for now, it consumes too much resources only for collecting metrics
 		// on more intensive environments this is a problem, we can enable it later based on specific rules
 		// "analyzer_metrics_rules":    analyzerMetricsRules,

--- a/agent/controller/ssm.go
+++ b/agent/controller/ssm.go
@@ -65,12 +65,17 @@ func (a *Agent) processSSMProtocol(pkt *pb.Packet) {
 		return
 	}
 
+	var guardRailRules string
+	if connParams.GuardRailRules != nil {
+		guardRailRules = string(connParams.GuardRailRules)
+	}
 	opts := map[string]string{
 		"sid":                   sessionID,
 		"aws_access_key_id":     connenv.awsAccessKeyID,
 		"aws_secret_access_key": connenv.awsSecretAccessKey,
 		"aws_region":            connenv.awsRegion,
 		"aws_instance_id":       targetInstance,
+		"guard_rail_rules":      guardRailRules,
 	}
 	serverWriter, err := libhoop.NewDBCore(context.Background(), streamClient, opts).SSM()
 	if err != nil {

--- a/agent/controller/tcp.go
+++ b/agent/controller/tcp.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"io"
+	"libhoop"
 
 	"github.com/hoophq/hoop/common/log"
 	pb "github.com/hoophq/hoop/common/proto"
@@ -21,6 +22,14 @@ func (a *Agent) processTCPWriteServer(pkt *pb.Packet) {
 	if connParams == nil {
 		log.Printf("session=%s - connection params not found", sessionID)
 		a.sendClientSessionClose(sessionID, "connection params not found, contact the administrator")
+		return
+	}
+	// The raw TCP relay copies bytes verbatim and has no guardrail
+	// evaluation path; refuse guarded sessions instead of running them
+	// unguarded (DEP-48).
+	if err := libhoop.CheckGuardRailEnforcement(string(connParams.GuardRailRules), "tcp"); err != nil {
+		log.With("sid", sessionID).Warn(err)
+		a.sendClientSessionClose(sessionID, err.Error())
 		return
 	}
 	clientConnectionIDKey := fmt.Sprintf("%s:%s", sessionID, string(clientConnectionID))

--- a/agent/controller/tcp.go
+++ b/agent/controller/tcp.go
@@ -24,14 +24,6 @@ func (a *Agent) processTCPWriteServer(pkt *pb.Packet) {
 		a.sendClientSessionClose(sessionID, "connection params not found, contact the administrator")
 		return
 	}
-	// The raw TCP relay copies bytes verbatim and has no guardrail
-	// evaluation path; refuse guarded sessions instead of running them
-	// unguarded (DEP-48).
-	if err := libhoop.CheckGuardRailEnforcement(string(connParams.GuardRailRules), "tcp"); err != nil {
-		log.With("sid", sessionID).Warn(err)
-		a.sendClientSessionClose(sessionID, err.Error())
-		return
-	}
 	clientConnectionIDKey := fmt.Sprintf("%s:%s", sessionID, string(clientConnectionID))
 	if tcpServer, ok := a.connStore.Get(clientConnectionIDKey).(io.WriteCloser); ok {
 		if _, err := tcpServer.Write(pkt.Payload); err != nil {
@@ -46,6 +38,15 @@ func (a *Agent) processTCPWriteServer(pkt *pb.Packet) {
 	if err != nil {
 		log.Printf("session=%s - missing connection credentials in memory, err=%v", sessionID, err)
 		a.sendClientSessionClose(sessionID, "credentials are empty, contact the administrator")
+		return
+	}
+	// The raw TCP relay copies bytes verbatim and has no guardrail
+	// evaluation path; refuse guarded sessions instead of running them
+	// unguarded (DEP-48). Checked only when establishing the relay
+	// connection to keep the per-packet write path cheap.
+	if err := libhoop.CheckGuardRailEnforcement(string(connParams.GuardRailRules), "tcp"); err != nil {
+		log.With("sid", sessionID).Warn(err)
+		a.sendClientSessionClose(sessionID, err.Error())
 		return
 	}
 	tcpServer, err := newTCPConn(connenv)

--- a/gateway/transport/agent_guardrails_test.go
+++ b/gateway/transport/agent_guardrails_test.go
@@ -9,7 +9,6 @@ import (
 	pgtypes "github.com/hoophq/hoop/common/pgtypes"
 	pb "github.com/hoophq/hoop/common/proto"
 	"github.com/hoophq/hoop/gateway/models"
-	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
 )
 
 func TestBuildLegacyGuardRailErrorMessage(t *testing.T) {
@@ -116,83 +115,6 @@ func TestBuildLegacyGuardRailErrorMessage(t *testing.T) {
 			}
 			if msg != tt.expected {
 				t.Fatalf("unexpected rebuilt message\nexpected: %s\nactual:   %s", tt.expected, msg)
-			}
-		})
-	}
-}
-
-func TestConnectionTypeSupportsGuardRails(t *testing.T) {
-	supported := []pb.ConnectionType{
-		pb.ConnectionTypePostgres,
-		pb.ConnectionTypeOracleDB,
-		pb.ConnectionTypeHttpProxy,
-		pb.ConnectionTypeSSH,
-		pb.ConnectionTypeCommandLine,
-	}
-	for _, ct := range supported {
-		if !connectionTypeSupportsGuardRails(ct) {
-			t.Errorf("expected connection type %q to support guardrails", ct)
-		}
-	}
-
-	// MySQL, MSSQL and MongoDB native proxies do not evaluate guardrails, so
-	// native sessions of these types must be refused (fail closed), not run
-	// unguarded (DEP-48).
-	unsupported := []pb.ConnectionType{
-		pb.ConnectionTypeMySQL,
-		pb.ConnectionTypeMSSQL,
-		pb.ConnectionTypeMongoDB,
-		pb.ConnectionTypeTCP,
-	}
-	for _, ct := range unsupported {
-		if connectionTypeSupportsGuardRails(ct) {
-			t.Errorf("expected connection type %q to NOT support guardrails", ct)
-		}
-	}
-}
-
-func TestSessionSupportsGuardRails(t *testing.T) {
-	tests := []struct {
-		name string
-		ctx  plugintypes.Context
-		want bool
-	}{
-		{
-			name: "mssql web exec",
-			ctx: plugintypes.Context{
-				ConnectionType:    string(pb.ConnectionTypeMSSQL),
-				ConnectionSubType: "mssql",
-				ClientVerb:        pb.ClientVerbExec,
-				ClientOrigin:      pb.ConnectionOriginClientAPI,
-			},
-			want: true,
-		},
-		{
-			name: "mssql native session",
-			ctx: plugintypes.Context{
-				ConnectionType:    string(pb.ConnectionTypeMSSQL),
-				ConnectionSubType: "",
-				ClientVerb:        pb.ClientVerbExec,
-				ClientOrigin:      pb.ConnectionOriginClient,
-			},
-			want: false,
-		},
-		{
-			name: "mssql non-exec API session",
-			ctx: plugintypes.Context{
-				ConnectionType:    string(pb.ConnectionTypeMSSQL),
-				ConnectionSubType: "",
-				ClientVerb:        pb.ClientVerbPlainExec,
-				ClientOrigin:      pb.ConnectionOriginClientAPI,
-			},
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := sessionSupportsGuardRails(tt.ctx); got != tt.want {
-				t.Fatalf("sessionSupportsGuardRails() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -331,36 +331,13 @@ func encodeGuardRailRules(connGuardRailRules *models.ConnectionGuardRailRules) (
 	return guardRailRulesJsonData, nil
 }
 
-// connectionTypeSupportsGuardRails reports the connection types whose native
-// proxies evaluate guardrail rules. Database Web Exec is checked separately
-// because it uses the agent's terminal-exec path rather than the native proxy.
-func connectionTypeSupportsGuardRails(connType pb.ConnectionType) bool {
-	switch connType {
-	case pb.ConnectionTypePostgres,
-		pb.ConnectionTypeOracleDB,
-		pb.ConnectionTypeHttpProxy,
-		pb.ConnectionTypeSSH,
-		pb.ConnectionTypeCommandLine:
-		return true
-	default:
-		return false
-	}
-}
-
-// sessionSupportsGuardRails reports whether this particular session has an
-// agent-side enforcement path. MSSQL is supported only for Web Exec: the
-// session API uses ClientAPI + exec and the agent's doExec path passes the
-// rules to the command/DB-exec redactor. Native MSSQL protocol sessions must
-// remain rejected because mssql.go does not inspect guardrails.
-func sessionSupportsGuardRails(pctx plugintypes.Context) bool {
-	if connectionTypeSupportsGuardRails(pctx.ProtoConnectionType()) {
-		return true
-	}
-
-	return pctx.ProtoConnectionType() == pb.ConnectionTypeMSSQL &&
-		pctx.ClientVerb == pb.ClientVerbExec &&
-		pctx.ClientOrigin == pb.ConnectionOriginClientAPI
-}
+// Guardrail enforcement admission is NOT checked here. The authoritative
+// fail-closed check (DEP-48) lives in libhoop at proxy construction: native
+// proxies without a guardrail evaluation path (mysql, mssql, mongodb, ssm,
+// raw tcp) refuse guarded sessions at the agent, at the point of
+// enforcement. Gateways and agents are upgraded together, so a
+// gateway-side duplicate of that list would only drift (it did: DEP-48 →
+// #1611 → the mysql/mongodb web terminal regression).
 
 func getAnalyzerMetricsRulesForConnection() (json.RawMessage, error) {
 	rules := []redactor.DataMaskingEntityData{
@@ -525,16 +502,11 @@ func (s *Server) processClientPacket(stream *streamclient.ProxyStream, pkt *pb.P
 				return err
 			}
 
-			// Fail closed for connection types whose agent proxy does not
-			// evaluate guardrails (mysql, mssql, mongodb): a guarded session of
-			// those types would run unguarded, so refuse it at session-open
-			// (DEP-48).
-			//
-			// Guardrails are enforced by the agent's built-in pattern-matching
-			// engine (deny-word / regex — see gateway/guardrails), NOT by a DLP
-			// provider, so Presidio is NOT required to enforce them. The earlier
-			// Presidio requirement here refused sessions on deployments that rely
-			// on that built-in engine and is intentionally not enforced.
+			// Guardrail rules are shipped to the agent, which enforces them
+			// in-process (deny-word / RE2 via localguardrails; no DLP service
+			// required) and fails closed at proxy construction for protocol
+			// paths that cannot evaluate them — see libhoop's
+			// CheckGuardRailEnforcement (DEP-48).
 			//
 			// ClientVerbPlainExec is intentionally exempt (the enclosing branch):
 			// plain-exec is a gateway-internal verb gated by a per-process secret in
@@ -544,15 +516,6 @@ func (s *Server) processClientPacket(stream *streamclient.ProxyStream, pkt *pb.P
 			// input, so guardrail rules are not fetched nor enforced for it — the
 			// same long-standing behavior as DLP redaction, which is also disabled
 			// for plain-exec sessions.
-			if len(guardRailRulesJsonData) > 0 {
-				logCtx := log.With("sid", pctx.SID, "connection", pctx.ConnectionName)
-				if connType := pctx.ProtoConnectionType(); !sessionSupportsGuardRails(pctx) {
-					logCtx.Warnf("refusing session: connection type %q does not support guardrail enforcement", connType)
-					return status.Errorf(codes.FailedPrecondition,
-						"this connection has guardrails configured, but connection type %q does not support guardrail enforcement; "+
-							"remove the guardrails from this connection or use a supported connection type", connType)
-				}
-			}
 		}
 
 		// Resolve the AI session analyzer config for HTTP-family connections.

--- a/go.work.oss.sum
+++ b/go.work.oss.sum
@@ -1,0 +1,3 @@
+cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
+cloud.google.com/go/compute v1.64.0 h1:7MmuzeAxlG5MOG5PQD2NLtyYR6bWjkvGljRu7pByoRU=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
## 📝 Description

   Moves DEP-48 guardrail fail-closed enforcement from the gateway's session-open admission check to the agent, at the point of enforcement.

   The gateway refused guarded sessions based on a hardcoded connection-type list (`connectionTypeSupportsGuardRails`) — a duplicate of knowledge only the agent-side proxies have. It drifted twice:
 MSSQL Web Exec needed a special-case exemption (`sessionSupportsGuardRails`), and it caused the mysql/mongodb web terminal regression fixed in #1611. Each drift is either a false refusal of a working
 path or a guarded session silently running unguarded.

   Now the gateway always encodes and ships guardrail rules to the agent, and the agent is the single authority on whether it can enforce them: libhoop refuses construction of native proxies with no
 guardrail evaluation path (mysql, mssql, mongodb, ssm), and the raw TCP relay refuses guarded sessions directly.

   | Path | Guarded session |
   |---|---|
   | postgres, oracle, ssh, http, exec / web terminal | enforced (localguardrails in-process; Presidio not required) |
   | mysql, mssql, mongodb, ssm (native), raw tcp | refused at the agent, fail closed |
   | plain-exec (gateway-internal verb) | exempt, unchanged (same as DLP redaction) |
   Companion PR: hoophq/libhoop (constructor gate + `CheckGuardRailEnforcement`).

   ## 📣 User-facing impact

   Connections with guardrails configured no longer get wrongly refused on paths the agent can enforce (e.g. web terminal on MySQL/MongoDB). Native protocol sessions that cannot enforce guardrails are
 still refused with a clear error instead of running unprotected.

   ## 🔗 Related Issue

   Fixes DEP-48 (follow-up to #1611)
libhoop PR first https://github.com/hoophq/libhoop/pull/97
   ## 🚀 Type of Change

   - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
   - [ ] ✨ New feature (non-breaking change which adds functionality)
   - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
   - [ ] 📚 Documentation update
   - [ ] 🎨 Style/UI update
   - [ ] ♻️ Code refactor
   - [ ] ⚡ Performance improvement
   - [ ] ✅ Test update
   - [ ] 🔧 Build configuration change
   - [ ] 🧹 Chore

   ## 📋 Changes Made

   - **gateway**: deleted `connectionTypeSupportsGuardRails` / `sessionSupportsGuardRails` and the session-open refusal in `gateway/transport/client.go`; guardrail rules are always shipped to the agent
 (plain-exec remains exempt).
   - **agent**: mysql, mssql, mongodb and ssm controllers now pass `guard_rail_rules` into proxy opts so libhoop's fail-closed constructor gate sees them.
   - **agent**: the raw TCP relay (`agent/controller/tcp.go`) calls `libhoop.CheckGuardRailEnforcement` and refuses guarded sessions — it copies bytes verbatim with no evaluation path.
   - Removed gateway tests asserting the deleted admission list (fail-closed behavior is now covered in libhoop).

   ## 🧪 Testing

   ### Test Configuration:
   - **Browser(s)**: N/A
   - **OS**: macOS (arm64)

   ### Tests performed:
   - [x] Unit tests pass
   - [ ] Integration tests pass
   - [x] Manual testing completed

   Fail-closed coverage lives in the companion libhoop PR: `TestNativeProxiesFailClosedOnGuardRails` (per proxy: guarded construction refused, empty rule set admitted) and
 `TestMalformedGuardRailRulesFailClosed`. Locally: `go build ./agent/... ./gateway/...` clean, `gateway/transport` guardrail tests pass.

   ## 📸 Screenshots (if applicable)

   N/A

   ## ✅ Checklist

   - [x] My code follows the style guidelines of this project
   - [x] I have performed a self-review of my own code
   - [x] I have commented my code, particularly in hard-to-understand areas
   - [x] My changes generate no new warnings
   - [x] New and existing unit tests pass locally with my changes
   - [x] I have checked my code and corrected any misspellings

   ## 📄 Additional Notes

   **Deploy note — version skew**: gateway and agent must be upgraded together. An older agent paired with this gateway lacks the constructor gate and would run guarded mysql/mssql/mongodb native
 sessions unguarded; the removed gateway check was the only protection against that skew.

   Merge order: the libhoop companion PR must land first (this PR depends on `libhoop.CheckGuardRailEnforcement`).

   Suggested label: `patch`.