### PR TITLE
fix: add MCP connection editor and OAuth flow integration

### DIFF
--- a/webapp_v2/src/pages/Roles/Configure/sections/credentials/McpRenderer.jsx
+++ b/webapp_v2/src/pages/Roles/Configure/sections/credentials/McpRenderer.jsx
@@ -1,0 +1,290 @@
+import { useEffect, useRef, useState } from 'react'
+import { Group, Paper, Stack, Text, Title } from '@mantine/core'
+import { Check, ShieldCheck } from 'lucide-react'
+import Button from '@/components/Button'
+import TextInput from '@/components/TextInput'
+import PasswordInput from '@/components/PasswordInput'
+import PredefinedFields from '@/pages/Roles/Configure/sections/credentials/shared/PredefinedFields'
+import HttpHeaders from '@/pages/Roles/Configure/sections/credentials/shared/HttpHeaders'
+import AllowInsecureSsl from '@/pages/Roles/Configure/sections/credentials/shared/AllowInsecureSsl'
+import AgentSelector from '@/pages/Roles/Configure/sections/credentials/shared/AgentSelector'
+import {
+  decodeSecretValue,
+  encodeSecretValue,
+} from '@/pages/Roles/Configure/utils/secretsCodec'
+import { useConfigureRoleStore } from '@/pages/Roles/Configure/store'
+import { connectionsService } from '@/services/connections'
+import { showSnackbar } from '@/utils/snackbar'
+
+// MCP httpproxy connection editor. Mirrors CLJS
+// webapp/.../resources/configure_role/mcp_edit.cljs: an MCP server URL,
+// an "Authorize with MCP" OAuth widget that freezes the obtained access
+// token into envvar:HEADER_AUTHORIZATION, plus the shared headers /
+// insecure-SSL / agent sections. The Authorization token is managed by
+// the widget, never shown as a plain header row (HEADERS_EXCLUDE).
+//
+// OAuth flow (gateway is the OAuth client — see
+// gateway/api/connections/connection_mcp_oauth.go):
+//   POST /mcp-oauth/authorize?redirect=<app-url> → { authorization_url, flow_id }
+//   popup drives the upstream login; the gateway callback redirects the
+//   popup back to <app-url>?mcp_oauth=success|error&flow_id=...
+//   GET /mcp-oauth/token/{flow_id} (single-use) → { authorization_header }
+// The header value is then staged like any other secret edit — nothing
+// persists until the user saves.
+const MCP_FIELDS = [
+  {
+    key: 'remote_url',
+    label: 'MCP Server URL',
+    required: true,
+    placeholder: 'e.g. https://mcp.linear.app',
+  },
+]
+
+const AUTH_HEADER_KEY = 'envvar:HEADER_AUTHORIZATION'
+const HEADERS_EXCLUDE = [AUTH_HEADER_KEY]
+
+const POPUP_TIMEOUT_MS = 5 * 60 * 1000
+const POPUP_POLL_MS = 500
+const POPUP_FEATURES = 'width=600,height=800,menubar=no,toolbar=no,location=yes'
+
+// Reads the same-origin callback return from the popup. Returns the
+// outcome ({ ok, flowId, reason }) once the popup navigated back to our
+// origin with ?mcp_oauth=..., or null while still on the provider's
+// (cross-origin) login page — reading .href throws there; expected.
+function readPopupOutcome(popup) {
+  let href
+  try {
+    href = popup.location.href
+  } catch {
+    return null
+  }
+  if (!href || !href.startsWith(window.location.origin)) return null
+  const params = new URLSearchParams(popup.location.search)
+  const outcome = params.get('mcp_oauth')
+  if (!outcome) return null
+  return {
+    ok: outcome === 'success',
+    flowId: params.get('flow_id'),
+    reason: params.get('reason'),
+  }
+}
+
+export default function McpRenderer({
+  connection,
+  availableSources,
+  forceNewState,
+  hideRoleInfo,
+}) {
+  const stagedSecrets = useConfigureRoleStore((s) => s.stagedSecrets)
+  const replaceSecret = useConfigureRoleStore((s) => s.replaceSecret)
+  const deleteSecret = useConfigureRoleStore((s) => s.deleteSecret)
+  const cancelSecretChange = useConfigureRoleStore((s) => s.cancelSecretChange)
+
+  // Auth-flow-only inputs — never persisted as connection env vars.
+  const [clientId, setClientId] = useState('')
+  const [clientSecret, setClientSecret] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [authError, setAuthError] = useState(null)
+  const pollTimer = useRef(null)
+
+  useEffect(() => () => clearInterval(pollTimer.current), [])
+
+  // Key presence is the existence signal (survives hide_role_info
+  // masking). A staged delete un-authorizes; a staged replace/new
+  // authorizes even before save.
+  const staged = stagedSecrets[AUTH_HEADER_KEY]
+  const persisted = Boolean(connection.secret && AUTH_HEADER_KEY in connection.secret)
+  const authorized = staged
+    ? staged.action !== 'delete' && Boolean(staged.value)
+    : persisted
+
+  const currentServerUrl = () => {
+    const stagedUrl = stagedSecrets['envvar:REMOTE_URL']
+    if (stagedUrl?.value) return decodeSecretValue(stagedUrl.value).trim()
+    return decodeSecretValue(connection.secret?.['envvar:REMOTE_URL']).trim()
+  }
+
+  const finishError = (message, details) => {
+    setBusy(false)
+    setAuthError(message)
+    showSnackbar({ level: 'error', text: 'MCP authorization failed', description: message, details })
+  }
+
+  const redeemToken = async (flowId) => {
+    if (!flowId) {
+      finishError('Missing flow id')
+      return
+    }
+    try {
+      const data = await connectionsService.mcpOAuthToken(flowId)
+      if (!data?.authorization_header) {
+        finishError('No token returned')
+        return
+      }
+      replaceSecret(AUTH_HEADER_KEY, encodeSecretValue(data.authorization_header))
+      setBusy(false)
+      setAuthError(null)
+      showSnackbar({ level: 'success', text: 'MCP connection authorized' })
+    } catch (err) {
+      finishError(err?.response?.data?.message || 'Failed to redeem token')
+    }
+  }
+
+  const watchPopup = (popup) => {
+    const started = Date.now()
+    pollTimer.current = setInterval(() => {
+      const stop = () => {
+        clearInterval(pollTimer.current)
+        pollTimer.current = null
+      }
+      if (popup.closed) {
+        stop()
+        setBusy(false)
+        return
+      }
+      if (Date.now() - started > POPUP_TIMEOUT_MS) {
+        stop()
+        popup.close()
+        finishError('Authorization timed out')
+        return
+      }
+      const outcome = readPopupOutcome(popup)
+      if (!outcome) return
+      stop()
+      popup.close()
+      if (outcome.ok) {
+        redeemToken(outcome.flowId)
+      } else {
+        const reason = outcome.reason
+          ? `: ${outcome.reason.replace(/_/g, ' ')}`
+          : ''
+        finishError(`Authorization denied${reason}`)
+      }
+    }, POPUP_POLL_MS)
+  }
+
+  const authorize = async () => {
+    const serverUrl = currentServerUrl()
+    if (!serverUrl) {
+      showSnackbar({
+        level: 'error',
+        text: 'Enter the MCP server URL before authorizing',
+      })
+      return
+    }
+    setBusy(true)
+    setAuthError(null)
+    // Strip query/hash so the popup lands on a clean app URL the gateway
+    // callback can redirect back to.
+    const redirect = window.location.origin + window.location.pathname
+    const payload = { server_url: serverUrl }
+    if (clientId.trim()) payload.client_id = clientId.trim()
+    if (clientSecret.trim()) payload.client_secret = clientSecret.trim()
+    try {
+      const data = await connectionsService.mcpOAuthAuthorize(payload, redirect)
+      if (!data?.authorization_url) {
+        finishError('Authorization URL was not returned')
+        return
+      }
+      const popup = window.open(data.authorization_url, 'hoop-mcp-oauth', POPUP_FEATURES)
+      if (!popup) {
+        finishError('Popup blocked. Allow popups for this site and retry.')
+        return
+      }
+      watchPopup(popup)
+    } catch (err) {
+      finishError(err?.response?.data?.message || 'Failed to start authorization')
+    }
+  }
+
+  const clearAuthorization = () => {
+    if (persisted) deleteSecret(AUTH_HEADER_KEY)
+    else cancelSecretChange(AUTH_HEADER_KEY)
+    setAuthError(null)
+  }
+
+  return (
+    <Stack gap="xl">
+      <Stack gap="md">
+        <Title order={4}>Basic info</Title>
+        <PredefinedFields
+          connection={connection}
+          fields={MCP_FIELDS}
+          availableSources={availableSources}
+          forceNewState={forceNewState}
+          hideRoleInfo={hideRoleInfo}
+        />
+      </Stack>
+
+      <Paper withBorder radius="md" p="md">
+        <Stack gap="md">
+          <Stack gap={4}>
+            <Title order={5}>MCP Authorization</Title>
+            <Text size="sm" c="dimmed">
+              {"Log in to the MCP server to obtain an access token. The token is stored in this connection's Authorization header."}
+            </Text>
+          </Stack>
+
+          <Stack gap="sm">
+            <TextInput
+              label="Client ID (optional)"
+              placeholder="Leave blank to register automatically"
+              value={clientId}
+              onChange={(e) => setClientId(e.currentTarget.value)}
+            />
+            <PasswordInput
+              label="Client Secret (optional)"
+              placeholder="Only if your client requires one"
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.currentTarget.value)}
+            />
+          </Stack>
+
+          {authorized ? (
+            <Group justify="space-between" align="center" gap="sm">
+              <Group gap={6} align="center">
+                <Check size={16} color="var(--mantine-color-green-8)" />
+                <Text size="sm" fw={500} c="green.8">
+                  {'Authorized — access token stored'}
+                </Text>
+              </Group>
+              <Group gap="sm">
+                <Button variant="light" disabled={busy} onClick={authorize}>
+                  Re-authorize
+                </Button>
+                <Button variant="subtle" color="red" onClick={clearAuthorization}>
+                  Clear
+                </Button>
+              </Group>
+            </Group>
+          ) : (
+            <Stack gap="xs">
+              <Button
+                w="fit-content"
+                leftSection={<ShieldCheck size={16} />}
+                loading={busy}
+                onClick={authorize}
+              >
+                {busy ? 'Authorizing…' : 'Authorize with MCP'}
+              </Button>
+              {authError && (
+                <Text size="sm" c="red">
+                  {authError}
+                </Text>
+              )}
+            </Stack>
+          )}
+        </Stack>
+      </Paper>
+
+      <HttpHeaders
+        connection={connection}
+        availableSources={availableSources}
+        excludeKeys={HEADERS_EXCLUDE}
+        hideRoleInfo={hideRoleInfo}
+      />
+      <AllowInsecureSsl connection={connection} />
+      <AgentSelector />
+    </Stack>
+  )
+}

--- a/webapp_v2/src/pages/Roles/Configure/sections/credentials/index.jsx
+++ b/webapp_v2/src/pages/Roles/Configure/sections/credentials/index.jsx
@@ -3,6 +3,7 @@ import CatalogRenderer from '@/pages/Roles/Configure/sections/credentials/Catalo
 import SshRenderer from '@/pages/Roles/Configure/sections/credentials/SshRenderer'
 import ClaudeCodeRenderer from '@/pages/Roles/Configure/sections/credentials/ClaudeCodeRenderer'
 import HttpProxyRenderer from '@/pages/Roles/Configure/sections/credentials/HttpProxyRenderer'
+import McpRenderer from '@/pages/Roles/Configure/sections/credentials/McpRenderer'
 import KubernetesTokenRenderer from '@/pages/Roles/Configure/sections/credentials/KubernetesTokenRenderer'
 import FreeFormCustomRenderer from '@/pages/Roles/Configure/sections/credentials/FreeFormCustomRenderer'
 
@@ -36,6 +37,12 @@ const RENDERER_RULES = [
     requiresCatalog: false,
     matches: (c) => c.type === 'httpproxy' && c.subtype === 'claude-code',
     render: (props) => <ClaudeCodeRenderer {...props} />,
+  },
+  {
+    name: 'httpproxy-mcp',
+    requiresCatalog: false,
+    matches: (c) => c.type === 'httpproxy' && c.subtype === 'mcp',
+    render: (props) => <McpRenderer {...props} />,
   },
   {
     name: 'httpproxy-generic',

--- a/webapp_v2/src/services/connections.js
+++ b/webapp_v2/src/services/connections.js
@@ -32,4 +32,15 @@ export const connectionsService = {
     api.delete(`/connections/${encodeURIComponent(name)}`),
   testConnection: (name) =>
     api.get(`/connections/${encodeURIComponent(name)}/test`).then((res) => res.data),
+
+  // MCP OAuth login flow (create/edit page "Authorize with MCP" widget).
+  // `redirect` is the app URL the gateway callback sends the popup back to,
+  // carrying ?mcp_oauth=success|error&flow_id=...
+  mcpOAuthAuthorize: (payload, redirect) =>
+    api
+      .post(`/mcp-oauth/authorize?redirect=${encodeURIComponent(redirect)}`, payload)
+      .then((res) => res.data),
+  // Single-use: the gateway consumes the flow on read.
+  mcpOAuthToken: (flowId) =>
+    api.get(`/mcp-oauth/token/${encodeURIComponent(flowId)}`).then((res) => res.data),
 }


### PR DESCRIPTION
  > [!IMPORTANT]
   > Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
   >
   > - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
   > - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

   Adds a dedicated editor for MCP (`httpproxy`/`mcp`) connections in the webapp v2 Roles Configure page,
 restoring the MCP editing experience from the legacy CLJS webapp (`configure_role/mcp_edit.cljs`).

## 🔗 Related Issue

   N/A

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added `webapp_v2/src/pages/Roles/Configure/sections/credentials/McpRenderer.jsx`: MCP connection editor
 with the "Authorize with MCP" OAuth widget — opens the provider login in a popup, polls for the same-origin
 callback (`?mcp_oauth=success|error&flow_id=...`), redeems the single-use token, and stages it as
 `envvar:HEADER_AUTHORIZATION` via the configure-role secrets store.
- Registered the `httpproxy-mcp` renderer rule in `sections/credentials/index.jsx` (matches `type ===
 'httpproxy' && subtype === 'mcp'`).
- Added `mcpOAuthAuthorize(payload, redirect)` and `mcpOAuthToken(flowId)` to
 `webapp_v2/src/services/connections.js` for the gateway MCP OAuth endpoints.

## 🧪 Testing

   Manually exercised the full flow on an MCP connection: authorize with automatic client registration and with  
 explicit client ID/secret, popup denied/closed/timeout paths, re-authorize, clear (staged vs. persisted token),
 and verified the Authorization header never appears in the generic headers list and only persists on save.

### Test Configuration

- **Browser(s)**: Brave
- **OS**: macOS

### Tests performed

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

   N/A

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- The gateway is the OAuth client (`gateway/api/connections/connection_mcp_oauth.go`); the webapp only starts
 the flow and redeems the token. The token endpoint is single-use — the gateway consumes the flow on read.
- Client ID/secret inputs are used only for the authorization request; they are never stored on the
 connection.