### PR TITLE
(fix)[bug] Database explorer fails for schemas ending in -prod

### DIFF
--- a/gateway/api/connections/queries_schema.go
+++ b/gateway/api/connections/queries_schema.go
@@ -236,6 +236,10 @@ ORDER BY c.column_id;`, dbName, schemaName, tableName)
 }
 
 func getMySQLColumnsQuery(dbName, tableName, schemaName string) string {
+	// The database identifier must be backtick-quoted: names with hyphens or
+	// dots (allowed by validateDatabaseName) are invalid as bare identifiers.
+	// validateDatabaseName rejects backticks, so quoting here is injection-safe.
+	quotedDBName := "`" + dbName + "`"
 	return fmt.Sprintf(`
 USE %s;
 SELECT
@@ -250,7 +254,7 @@ SELECT
     c.IS_NULLABLE = 'NO' as not_null
 FROM INFORMATION_SCHEMA.COLUMNS c
 WHERE c.TABLE_SCHEMA = '%s' AND c.TABLE_NAME = '%s'
-ORDER BY c.ORDINAL_POSITION;`, dbName, schemaName, tableName)
+ORDER BY c.ORDINAL_POSITION;`, quotedDBName, schemaName, tableName)
 }
 
 func getOracleDBColumnsQuery(tableName, schemaName string) string {

--- a/gateway/api/connections/queries_schema_test.go
+++ b/gateway/api/connections/queries_schema_test.go
@@ -1,0 +1,49 @@
+package apiconnections
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMySQLColumnsQuery(t *testing.T) {
+	for _, tt := range []struct {
+		msg     string
+		dbName  string
+		wantUse string
+	}{
+		{
+			msg:     "it must quote database names with hyphens",
+			dbName:  "name-prod",
+			wantUse: "USE `name-prod`;",
+		},
+		{
+			msg:     "it must quote database names with dots",
+			dbName:  "name.prod",
+			wantUse: "USE `name.prod`;",
+		},
+		{
+			msg:     "it must quote plain database names",
+			dbName:  "name_prod",
+			wantUse: "USE `name_prod`;",
+		},
+	} {
+		t.Run(tt.msg, func(t *testing.T) {
+			query := getMySQLColumnsQuery(tt.dbName, "users", tt.dbName)
+			assert.Contains(t, query, tt.wantUse)
+			assert.Contains(t, query, "c.TABLE_SCHEMA = '"+tt.dbName+"'")
+			assert.Contains(t, query, "c.TABLE_NAME = 'users'")
+			// the identifier must never appear as a bare (unquoted) identifier
+			assert.NotContains(t, query, "USE "+tt.dbName+";")
+		})
+	}
+}
+
+func TestGetMySQLColumnsQueryFormatIsComplete(t *testing.T) {
+	// A mismatched fmt.Sprintf leaks error markers into the output instead of
+	// failing at compile time; guard against that class of regression.
+	query := getMySQLColumnsQuery("db-prod", "users", "db-prod")
+	assert.False(t, strings.Contains(query, "%!"), "query contains fmt error markers: %s", query)
+	assert.False(t, strings.Contains(query, "%s"), "query contains unexpanded verbs: %s", query)
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Fixes a MySQL syntax error in the database explorer when fetching table columns for databases whose names contain hyphens or dots (e.g. `name-prod`).

The columns query built by `getMySQLColumnsQuery` interpolated the database name into a `USE %s;` statement as a bare identifier. MySQL treats a hyphen in an unquoted identifier as the minus operator, so `USE name-prod;` fails with `ERROR 1064 (42000) ... near '-prod'` and the schema explorer cannot load columns. The name passes API validation because `validateDatabaseName` explicitly allows hyphens and dots.

The fix backtick-quotes the identifier (``USE `name-prod`;``), matching how the other drivers already handle this (`USE [%s]` for MSSQL, `\c %s` for psql). Quoting is injection-safe because `validateDatabaseName` rejects backticks.

## 📣 User-facing impact

Browsing table columns in the database explorer now works for MySQL databases with hyphens or dots in their name (e.g. `my-app-prod`).

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- `gateway/api/connections/queries_schema.go`: backtick-quote the database identifier in the `USE` statement of the MySQL columns query.
- `gateway/api/connections/queries_schema_test.go` (new): table-driven tests asserting the identifier is quoted for hyphenated, dotted, and underscore names, plus a guard against `fmt.Sprintf` verb/argument mismatches leaking `%!` markers into the generated SQL.

## 🧪 Testing

Reproduced against a MySQL connection with a hyphenated database name: `GET /api/connections/{name}/columns?database=name-prod&table=...` returned `ERROR 1064 (42000) ... near '-prod'` before the fix and the column list after it. Listing databases and tables was unaffected (those queries only use the name inside string literals).

### Test Configuration:
- **Browser(s)**: N/A (gateway API change)
- **OS**: macOS (gateway), MySQL connection via agent

### Tests performed:
- [x] Unit tests pass (`go test ./gateway/api/connections/`)
- [ ] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

The unquoted `USE` statement was introduced in #857 (first shipped in 1.36.14), so any org upgrading from an earlier version across that release hits this when browsing columns of a hyphenated MySQL database. Only `getMySQLColumnsQuery` was affected — the tables query references the name inside a quoted string literal, where hyphens are harmless.