### PR TITLE
fix: keep reviewed executions tracked past the 50s API timeout

### DIFF
--- a/gateway/api/mcpserver/tools_reviews.go
+++ b/gateway/api/mcpserver/tools_reviews.go
@@ -172,12 +172,11 @@ func reviewsExecuteHandler(ctx context.Context, _ *mcp.CallToolRequest, args rev
 	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancelFn()
 
-	reviewStatus := models.ReviewStatusExecuted
-	defer func() {
-		if err := models.UpdateReviewStatus(review.OrgID, review.ID, reviewStatus); err != nil {
-			log.With("sid", sid).Warnf("failed updating review to status=%v, err=%v", reviewStatus, err)
+	setReviewStatus := func(status models.ReviewStatusType) {
+		if err := models.UpdateReviewStatus(review.OrgID, review.ID, status); err != nil {
+			log.With("sid", sid).Warnf("failed updating review to status=%v, err=%v", status, err)
 		}
-	}()
+	}
 
 	select {
 	case resp := <-respCh:
@@ -185,9 +184,10 @@ func reviewsExecuteHandler(ctx context.Context, _ *mcp.CallToolRequest, args rev
 		// account (gcp_oauth) before this approved query can run. Keep the
 		// review APPROVED (not EXECUTED) so it can be retried after consent.
 		if oauthEnv, ok := federationConsentEnvelopeFromResponse(sc, resp); ok {
-			reviewStatus = models.ReviewStatusApproved
+			setReviewStatus(models.ReviewStatusApproved)
 			return jsonResult(oauthEnv)
 		}
+		setReviewStatus(models.ReviewStatusExecuted)
 		env := map[string]any{
 			"session_id":        resp.SessionID,
 			"output":            resp.Output,
@@ -204,7 +204,8 @@ func reviewsExecuteHandler(ctx context.Context, _ *mcp.CallToolRequest, args rev
 		return jsonResult(env)
 	case <-timeoutCtx.Done():
 		client.Close()
-		reviewStatus = models.ReviewStatusUnknown
+		// the review stays PROCESSING while the execution continues in the
+		// agent; it settles as EXECUTED when the session finishes
 		return jsonResult(map[string]any{
 			"session_id": session.ID,
 			"status":     "running",

--- a/gateway/api/session/run-exec.go
+++ b/gateway/api/session/run-exec.go
@@ -139,16 +139,13 @@ func RunReviewedExec(c *gin.Context) {
 		review.ID, review.ConnectionName, review.OwnerEmail, len(session.BlobInput))
 
 	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*50)
-	reviewStatus := models.ReviewStatusExecuted
-	defer func() {
-		cancelFn()
-		if err := models.UpdateReviewStatus(review.OrgID, review.ID, reviewStatus); err != nil {
-			log.Warnf("failed updating review to status=%v, err=%v", review.Status, err)
-		}
-	}()
+	defer cancelFn()
 	select {
 	case resp := <-respCh:
 		log.Infof("review exec response, %v", resp)
+		if err := models.UpdateReviewStatus(review.OrgID, review.ID, models.ReviewStatusExecuted); err != nil {
+			log.Warnf("failed updating review to status=%v, err=%v", models.ReviewStatusExecuted, err)
+		}
 		c.JSON(http.StatusOK, resp)
 	case <-timeoutCtx.Done():
 		log.Infof("review exec timeout (50s), it will return async")
@@ -156,9 +153,10 @@ func RunReviewedExec(c *gin.Context) {
 		// and the result will return async
 		client.Close()
 
-		// we do not know the status of this in the future.
-		// replaces the current "PROCESSING" status
-		reviewStatus = models.ReviewStatusUnknown
+		// the review stays PROCESSING while the execution continues in the
+		// agent; it settles as EXECUTED when the session finishes (audit
+		// plugin on session close, or the startup reconciliation after a
+		// gateway restart)
 		c.JSON(http.StatusAccepted, clientexec.NewTimeoutResponse(session.ID))
 	}
 }

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -214,12 +214,15 @@ func Run() {
 	streamclient.InitProxyMemoryCleanup()
 
 	// Settle reviews left in PROCESSING/UNKNOWN by executions whose session
-	// finished while the gateway was down.
-	if reconciled, err := models.ReconcileStaleReviews(models.DB); err != nil {
-		log.Warnf("failed reconciling stale reviews, reason=%v", err)
-	} else if reconciled > 0 {
-		log.Infof("reconciled %d stale review(s) to executed status", reconciled)
-	}
+	// finished while the gateway was down. Runs in background so a large
+	// backlog never delays gateway readiness.
+	go func() {
+		if reconciled, err := models.ReconcileStaleReviews(models.DB); err != nil {
+			log.Warnf("failed reconciling stale reviews, reason=%v", err)
+		} else if reconciled > 0 {
+			log.Infof("reconciled %d stale review(s) to executed status", reconciled)
+		}
+	}()
 
 	if grpc.ShouldDebugGrpc() {
 		log.SetGrpcLogger()

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -213,6 +213,14 @@ func Run() {
 	connectionstatus.InitConciliationProcess()
 	streamclient.InitProxyMemoryCleanup()
 
+	// Settle reviews left in PROCESSING/UNKNOWN by executions whose session
+	// finished while the gateway was down.
+	if reconciled, err := models.ReconcileStaleReviews(models.DB); err != nil {
+		log.Warnf("failed reconciling stale reviews, reason=%v", err)
+	} else if reconciled > 0 {
+		log.Infof("reconciled %d stale review(s) to executed status", reconciled)
+	}
+
 	if grpc.ShouldDebugGrpc() {
 		log.SetGrpcLogger()
 	}

--- a/gateway/models/reviews.go
+++ b/gateway/models/reviews.go
@@ -339,3 +339,40 @@ func UpdateReviewStatus(orgID, id string, status ReviewStatusType) error {
 	}
 	return nil
 }
+
+// SetReviewStatusExecutedIfFinished settles the one-time review of the given
+// session as EXECUTED once the session has finished. A review stays in
+// PROCESSING while the execution runs in the agent (legacy rows may hold
+// UNKNOWN); the session is the source of truth for the execution outcome, so
+// when it reaches the done status the review is considered consumed. It is a
+// no-op (false, nil) when the session has no review, the review is in any
+// other status or the session has not finished.
+func SetReviewStatusExecutedIfFinished(db *gorm.DB, orgID, sessionID string) (bool, error) {
+	res := db.Exec(`
+	UPDATE private.reviews AS r
+	SET status = ?
+	FROM private.sessions AS s
+	WHERE s.org_id = r.org_id AND s.id = r.session_id
+	AND r.org_id = ? AND r.session_id = ? AND r.type = ?
+	AND r.status IN (?, ?) AND s.status = 'done'`,
+		ReviewStatusExecuted, orgID, sessionID, ReviewTypeOneTime,
+		ReviewStatusProcessing, ReviewStatusUnknown)
+	return res.RowsAffected > 0, res.Error
+}
+
+// ReconcileStaleReviews settles as EXECUTED every one-time review left in
+// PROCESSING or UNKNOWN whose session already finished. These reviews are
+// normally settled when the session closes, but a gateway restart in between
+// leaves them stale; this runs once at startup. It returns the number of
+// reviews updated.
+func ReconcileStaleReviews(db *gorm.DB) (int64, error) {
+	res := db.Exec(`
+	UPDATE private.reviews AS r
+	SET status = ?
+	FROM private.sessions AS s
+	WHERE s.org_id = r.org_id AND s.id = r.session_id
+	AND r.type = ? AND r.status IN (?, ?) AND s.status = 'done'`,
+		ReviewStatusExecuted, ReviewTypeOneTime,
+		ReviewStatusProcessing, ReviewStatusUnknown)
+	return res.RowsAffected, res.Error
+}

--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -540,6 +540,18 @@ func UpdateSessionStatus(orgID, sessionID, status string) error {
 		UpdateColumn("status", status).Error
 }
 
+// SetSessionStatusOpenIfReady flips a session from ready to open when its
+// execution starts. Reviewed sessions are created ahead of the execution and
+// approved into the ready status; without this flip they would keep reporting
+// ready while the agent runs them. It is a no-op (false, nil) when the session
+// is in any other status.
+func SetSessionStatusOpenIfReady(db *gorm.DB, orgID, sessionID string) (bool, error) {
+	res := db.Table("private.sessions").
+		Where("org_id = ? AND id = ? AND status = ?", orgID, sessionID, "ready").
+		UpdateColumn("status", "open")
+	return res.RowsAffected > 0, res.Error
+}
+
 // SetSessionCredentialsExpireAt stores the credential expiry time in the session metadata.
 // The frontend reads metadata.credentials_expire_at to display validity and toggle the connect button.
 func SetSessionCredentialsExpireAt(orgID, sessionID string, expireAt time.Time) error {

--- a/gateway/transport/plugins/audit/audit.go
+++ b/gateway/transport/plugins/audit/audit.go
@@ -72,6 +72,16 @@ func (p *auditPlugin) OnConnect(pctx plugintypes.Context) error {
 
 	isMachine := pctx.IdentityType == identityTypeMachine
 
+	// client-api sessions are created by the HTTP layer before connecting, so
+	// the full upsert below is skipped for them. Reviewed sessions arrive here
+	// in the ready status set at approval time; flip them to open so the
+	// session reports the execution in flight (no-op for any other status).
+	if strings.HasPrefix(pctx.ClientOrigin, pb.ConnectionOriginClientAPI) {
+		if _, err := models.SetSessionStatusOpenIfReady(models.DB, pctx.OrgID, pctx.SID); err != nil {
+			log.With("sid", pctx.SID).Warnf("failed setting session status to open, reason=%v", err)
+		}
+	}
+
 	// persist session for public gRPC clients
 	if !strings.HasPrefix(pctx.ClientOrigin, pb.ConnectionOriginClientAPI) {
 		ctx := storagev2.NewContext(pctx.UserID, pctx.OrgID)
@@ -344,6 +354,15 @@ func (p *auditPlugin) closeSession(pctx plugintypes.Context, err error) {
 		if cerr := p.closeSessionWAL(pctx, err); cerr != nil {
 			log.With("sid", pctx.SID, "origin", pctx.ClientOrigin, "verb", pctx.ClientVerb).
 				Warnf("failed closing session, reason=%v", cerr)
+		}
+
+		// A one-time review stays PROCESSING while its execution runs in the
+		// agent; the finished session is what marks it consumed. The update
+		// only applies when the session was effectively marked done.
+		if updated, rerr := models.SetReviewStatusExecutedIfFinished(models.DB, pctx.OrgID, pctx.SID); rerr != nil {
+			log.With("sid", pctx.SID).Warnf("failed settling review status, reason=%v", rerr)
+		} else if updated {
+			log.With("sid", pctx.SID).Infof("review status settled as EXECUTED")
 		}
 		eventbroker.Default.Remove(pctx.SID)
 

--- a/webapp/src/webapp/audit/views/session_details.cljs
+++ b/webapp/src/webapp/audit/views/session_details.cljs
@@ -129,7 +129,6 @@
     session-stream-result (rf/subscribe [:audit->session-stream-result])
     connection-details (rf/subscribe [:connections->connection-details])
     clipboard-disabled? (rf/subscribe [:gateway->clipboard-disabled?])
-    executing-status (r/atom :ready)
     current-path (.-pathname (.-location js/window))
     is-dedicated-page? (cs/starts-with? current-path "/sessions/")
     ;; tracks the session id we have an SSE subscription open for, so we
@@ -161,6 +160,29 @@
                   (rf/dispatch [:connections->get-connection-details connection-name]))
               ready? (= (:status session) "ready")
               open? (= (:status session) "open")
+              exec-verb? (= (:verb session) "exec")
+              exec-status (:status @(rf/subscribe [:audit->execution-by-id (:id session)]))
+              ;; server-side signal that the reviewed exec is running: the
+              ;; review is PROCESSING while executing and UNKNOWN after the
+              ;; gateway stopped waiting (50s) with the agent still running.
+              ;; The session status itself stays "ready" during the execution,
+              ;; so only the review status tells the execution is in flight.
+              server-exec-running? (contains? #{"PROCESSING" "UNKNOWN"} review-status)
+              ;; reviewed exec still running in the agent: local state from
+              ;; the Execute click onwards, or the server signal when there is
+              ;; no local state (e.g. modal reopened after a page reload)
+              running-async? (and exec-verb?
+                                  has-review?
+                                  (not= (:status session) "done")
+                                  (or (contains? #{:executing :running :done} exec-status)
+                                      (and server-exec-running? (nil? exec-status))))
+              review-approved? (or (not has-review?) (= review-status "APPROVED"))
+              _ (when (and exec-verb?
+                           has-review?
+                           server-exec-running?
+                           (not= (:status session) "done")
+                           (nil? exec-status))
+                  (rf/dispatch [:audit->ensure-running-session-watch (:id session)]))
               ;; Interactive connect-verb sessions (postgres/ssh/tcp/http-proxy/…)
               ;; stream their audit events; exec/runbook keep their table views.
               connect? (= (:verb session) "connect")
@@ -335,6 +357,7 @@
             ;; response logs area
             (when-not (or credentials-expire-at
                           ready?
+                          running-async?
                           (and (some #(= "PENDING" (:status %))
                                      review-groups)
                                (= "PENDING" review-status)))
@@ -436,7 +459,9 @@
 
             ;; execution schedule information (time window)
             (when (and ready?
-                       (= (:verb session) "exec")
+                       exec-verb?
+                       review-approved?
+                       (not running-async?)
                        (get-in session [:review :time_window :configuration :start_time])
                        (get-in session [:review :time_window :configuration :end_time]))
               (let [start-time-utc (get-in session [:review :time_window :configuration :start_time])
@@ -455,29 +480,31 @@
                   "."]
                  (when is-session-owner?
                    [:> Flex {:justify "end" :gap "2"}
-                    [:> Button {:loading (when (= @executing-status :loading)
-                                           true)
-                                :disabled (not within-window?)
-                                :on-click (fn []
-                                            (reset! executing-status :loading)
-                                            (rf/dispatch [:audit->execute-session session]))}
+                    [:> Button {:disabled (not within-window?)
+                                :on-click #(rf/dispatch [:audit->execute-session session])}
                      "Execute"]])]))
 
             ;; Execute button (when no time window is configured)
             (when (and ready?
-                       (= (:verb session) "exec")
+                       exec-verb?
+                       review-approved?
+                       (not running-async?)
                        is-session-owner?
                        (not (get-in session [:review :time_window :configuration :start_time])))
               [:> Flex {:align "center" :justify "end" :gap "4"}
                [:> Text {:size "2" :class "text-gray-11"}
                 "This session is ready to be executed."]
 
-               [:> Button {:loading (when (= @executing-status :loading)
-                                      true)
-                           :on-click (fn []
-                                       (reset! executing-status :loading)
-                                       (rf/dispatch [:audit->execute-session session]))}
+               [:> Button {:on-click #(rf/dispatch [:audit->execute-session session])}
                 "Execute"]])
+
+            ;; reviewed exec running in the agent beyond the API wait window;
+            ;; polling renders the result here as soon as the session finishes
+            (when running-async?
+              [:> Flex {:align "center" :justify "end" :gap "2"}
+               [loaders/simple-loader {:size 4}]
+               [:> Text {:size "2" :class "text-gray-11"}
+                "Execution in progress. The result will appear here when it finishes."]])
 
             ;; Connect button for approved credential requests (verb = connect).
             (when (and (= (:verb session) "connect")

--- a/webapp/src/webapp/db.cljs
+++ b/webapp/src/webapp/db.cljs
@@ -12,6 +12,9 @@
    :audit->session-logs {:status :idle, :data nil}
    :audit->session-stream-result {:status :idle, :data nil}
    :audit->session-stream {}
+   ;; reviewed exec state per session id ({:status :executing|:running|:done}),
+   ;; kept outside the modal so it survives closing and reopening it
+   :audit->execution {}
    :audit->filtered-session-by-id {:status :idle, :data [] :errors [] :search-term "" :offset 0 :has-more? false :loading false}
    :audit-logs {:status :idle
                 :data []

--- a/webapp/src/webapp/events/audit.cljs
+++ b/webapp/src/webapp/events/audit.cljs
@@ -342,11 +342,15 @@
  (fn
    [{:keys [db]} [_ session]]
    (let [session-id (:id session)]
-     {:db (assoc-in db [:audit->execution session-id] {:status :executing})
-      :fx [[:dispatch [:fetch {:method "POST"
-                               :uri (str "/sessions/" session-id "/exec")
-                               :on-success #(rf/dispatch [:audit->execute-session-success session-id %])
-                               :on-failure #(rf/dispatch [:audit->execute-session-failure session-id %])}]]]})))
+     ;; no-op when an execution is already tracked for this session, so a
+     ;; double click never issues a duplicate POST
+     (if (contains? #{:executing :running} (get-in db [:audit->execution session-id :status]))
+       {}
+       {:db (assoc-in db [:audit->execution session-id] {:status :executing})
+        :fx [[:dispatch [:fetch {:method "POST"
+                                 :uri (str "/sessions/" session-id "/exec")
+                                 :on-success #(rf/dispatch [:audit->execute-session-success session-id %])
+                                 :on-failure #(rf/dispatch [:audit->execute-session-failure session-id %])}]]]}))))
 
 (rf/reg-event-fx
  :audit->execute-session-success
@@ -373,13 +377,19 @@
                                      :level :error
                                      :details error}]]]}))
 
+;; poll every 5s for the first ~5 minutes, then back off to 30s so an
+;; execution that never settles does not keep a tight polling loop forever
+(defn- watch-poll-interval-ms [attempts]
+  (if (< attempts 60) 5000 30000))
+
 (rf/reg-event-fx
  :audit->watch-running-session
  (fn
    [{:keys [db]} [_ session-id]]
    ;; the :running guard stops the loop when the execution state changes
    (if (= :running (get-in db [:audit->execution session-id :status]))
-     {:fx [[:dispatch [:fetch {:method "GET"
+     {:db (update-in db [:audit->execution session-id :attempts] (fnil inc 0))
+      :fx [[:dispatch [:fetch {:method "GET"
                                :uri (str "/sessions/" session-id)
                                :on-success #(rf/dispatch [:audit->watch-running-session-check session-id %])
                                ;; transient errors: keep polling
@@ -394,7 +404,9 @@
      {:db (assoc-in db [:audit->execution session-id] {:status :done})
       :fx [[:dispatch [:audit->get-sessions]]
            [:dispatch [:audit->get-session-by-id {:id session-id :verb "exec"}]]]}
-     {:fx [[:dispatch-later {:ms 5000 :dispatch [:audit->watch-running-session session-id]}]]})))
+     (let [attempts (get-in db [:audit->execution session-id :attempts] 0)]
+       {:fx [[:dispatch-later {:ms (watch-poll-interval-ms attempts)
+                               :dispatch [:audit->watch-running-session session-id]}]]}))))
 
 (rf/reg-event-fx
  :audit->ensure-running-session-watch

--- a/webapp/src/webapp/events/audit.cljs
+++ b/webapp/src/webapp/events/audit.cljs
@@ -341,24 +341,71 @@
  :audit->execute-session
  (fn
    [{:keys [db]} [_ session]]
-   (let [success (fn [res]
-                   (js/setTimeout
-                    (fn []
-                      (rf/dispatch [:audit->get-sessions])
-                      (rf/dispatch [:audit->get-session-by-id {:id (:session_id res) :verb "exec"}]))
-                    800))
-         failure (fn [error res]
-                   (let [session-id (:session_id res)]
-                     (if (and session-id (> (count session-id) 0))
-                       (success res)
-                       (rf/dispatch [:show-snackbar {:text "Failed to execute script"
-                                                     :level :error
-                                                     :details error}]))))]
-     {:fx [[:dispatch [:fetch (merge
-                               {:method "POST"
-                                :uri (str "/sessions/" (:id session) "/exec")
-                                :on-success success
-                                :on-failure failure})]]]})))
+   (let [session-id (:id session)]
+     {:db (assoc-in db [:audit->execution session-id] {:status :executing})
+      :fx [[:dispatch [:fetch {:method "POST"
+                               :uri (str "/sessions/" session-id "/exec")
+                               :on-success #(rf/dispatch [:audit->execute-session-success session-id %])
+                               :on-failure #(rf/dispatch [:audit->execute-session-failure session-id %])}]]]})))
+
+(rf/reg-event-fx
+ :audit->execute-session-success
+ (fn
+   [{:keys [db]} [_ session-id res]]
+   (if (= (:output_status res) "running")
+     ;; HTTP 202: the gateway stopped waiting after 50s but the execution
+     ;; keeps running in the agent; poll the session until it finishes
+     {:db (assoc-in db [:audit->execution session-id] {:status :running})
+      :fx [[:dispatch-later {:ms 5000 :dispatch [:audit->watch-running-session session-id]}]]}
+     {:db (assoc-in db [:audit->execution session-id] {:status :done})
+      :fx [[:dispatch-later {:ms 800 :dispatch [:audit->get-sessions]}]
+           [:dispatch-later {:ms 800 :dispatch [:audit->get-session-by-id {:id session-id :verb "exec"}]}]]})))
+
+(rf/reg-event-fx
+ :audit->execute-session-failure
+ (fn
+   [{:keys [db]} [_ session-id error]]
+   ;; refetch the session so the Execute gate re-evaluates against the
+   ;; server state (e.g. a 403 after the review left the APPROVED status)
+   {:db (update db :audit->execution dissoc session-id)
+    :fx [[:dispatch [:audit->get-session-by-id {:id session-id :verb "exec"}]]
+         [:dispatch [:show-snackbar {:text "Failed to execute script"
+                                     :level :error
+                                     :details error}]]]}))
+
+(rf/reg-event-fx
+ :audit->watch-running-session
+ (fn
+   [{:keys [db]} [_ session-id]]
+   ;; the :running guard stops the loop when the execution state changes
+   (if (= :running (get-in db [:audit->execution session-id :status]))
+     {:fx [[:dispatch [:fetch {:method "GET"
+                               :uri (str "/sessions/" session-id)
+                               :on-success #(rf/dispatch [:audit->watch-running-session-check session-id %])
+                               ;; transient errors: keep polling
+                               :on-failure #(rf/dispatch [:audit->watch-running-session-check session-id nil])}]]]}
+     {})))
+
+(rf/reg-event-fx
+ :audit->watch-running-session-check
+ (fn
+   [{:keys [db]} [_ session-id session]]
+   (if (= "done" (:status session))
+     {:db (assoc-in db [:audit->execution session-id] {:status :done})
+      :fx [[:dispatch [:audit->get-sessions]]
+           [:dispatch [:audit->get-session-by-id {:id session-id :verb "exec"}]]]}
+     {:fx [[:dispatch-later {:ms 5000 :dispatch [:audit->watch-running-session session-id]}]]})))
+
+(rf/reg-event-fx
+ :audit->ensure-running-session-watch
+ (fn
+   [{:keys [db]} [_ session-id]]
+   ;; resumes tracking a reviewed exec that is running server-side but has no
+   ;; local state (e.g. after a page reload); no-op when already tracked
+   (if (get-in db [:audit->execution session-id])
+     {}
+     {:db (assoc-in db [:audit->execution session-id] {:status :running})
+      :fx [[:dispatch [:audit->watch-running-session session-id]]]})))
 
 (rf/reg-event-fx
  :audit->re-run-session

--- a/webapp/src/webapp/subs.cljs
+++ b/webapp/src/webapp/subs.cljs
@@ -128,6 +128,11 @@
    (get-in db [:audit->session-stream session-id :state])))
 
 (re-frame/reg-sub
+ :audit->execution-by-id
+ (fn [db [_ session-id]]
+   (get-in db [:audit->execution session-id])))
+
+(re-frame/reg-sub
  :connections->test-connection
  (fn [db _]
    (:connections->test-connection db)))


### PR DESCRIPTION
## 📝 Description

When a reviewed execution takes longer than the gateway's 50s synchronous wait, the API returns `202` and the execution keeps running in the agent — but the review was flipped to a terminal `UNKNOWN` status (blocking any retry with a `403`) and the webapp lost track of the run: the Execute spinner never cleared, and reopening the session modal showed a clickable Execute button while the query was still running.

This PR is an improvement proposal based on those bugs: it makes the **session the source of truth for the execution outcome** and keeps the review status and the UI derived from it.

## 📣 User-facing impact

Reviewed executions that take longer than 50 seconds now show an "Execution in progress" indicator in the session modal — surviving modal close and page reload — and render the result when they finish, instead of a stuck spinner and a re-clickable Execute button.

## 🔗 Related Issue

Fixes EVL-84 EVL-91

- [EVL-84 — Execute button comes back after reopening the session modal](https://linear.app/hoophq/issue/EVL-84/botao-de-execute-volta-apos-reabrir-modal-da-sessao)
- [EVL-91 — Batch execution hangs forever on one target](https://linear.app/hoophq/issue/EVL-91/batch-execution-hangs-forever-on-one-target)

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

**Gateway**
- The 50s exec timeout no longer flips the review to `UNKNOWN` — it stays `PROCESSING` while the agent runs (`run-exec.go`, MCP `tools_reviews.go`).
- Reviews settle as `EXECUTED` when their session finishes (audit plugin on session close), plus a startup reconciliation for stale `PROCESSING`/`UNKNOWN` reviews whose session is already done.
- Reviewed sessions flip from `ready` to `open` when the execution starts, so the session status reflects the in-flight run.
- `UNKNOWN` is no longer produced anywhere; it is kept as a read-only legacy value (no API or DB enum change).

**Webapp**
- Execution state moved from modal-local state to app-db keyed by session id, so it survives closing/reopening the modal.
- `202` is detected by the response body (`output_status: "running"`): the modal shows "Execution in progress", polls `GET /sessions/:id` until `done` and renders the result. After a page reload, the `PROCESSING` review status resumes the tracking.
- The Execute button only renders for `APPROVED` reviews with no execution in flight — a consumed review can never be re-triggered from the UI.
- Fixed the failure-handler arity bug that swallowed every exec error into a generic snackbar.

## 🧪 Testing

Manual end-to-end on a reviewed connection with `sleep 90 && echo finished`:
1. Approve → Execute → "Execution in progress" appears immediately and persists across modal close/reopen and page reload.
2. At ~50s the gateway returns `202`; at ~90s polling detects `done` and the result renders; the review ends as `EXECUTED` in the DB and a retry via API returns `403` (one-shot semantics preserved).
3. Fast path (`sleep 5`) and failure path (agent down) behave correctly.
4. Startup sweep: a stale `PROCESSING`/`UNKNOWN` review with a done session is reconciled on gateway boot.

### Tests performed:
- [x] Unit tests pass (`go test` on `models`, `api/session`, `api/mcpserver`, `transport/plugins/audit`)
- [x] Manual testing completed (shadow-cljs compiles with 0 warnings)

## 📄 Additional Notes

The underlying design issue is that the review status doubles as an execution tracker (`PROCESSING`/`EXECUTED`/`UNKNOWN`) when its real job is the approval decision. The proper long-term fix is a refactor that keeps reviews to `PENDING → APPROVED/REJECTED/REVOKED`, derives "consumed" from the session, and moves the one-shot execution claim to the session itself. That touches the gRPC interceptor, review plugin, Slack/webhooks and the public API contract, so it is deliberately out of scope here — this PR is the minimal, backward-compatible step in that direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
