### PR TITLE
security(gateway): prevent SQL injection in schema introspection query builders

### DIFF
--- a/gateway/api/connections/database_explorer.go
+++ b/gateway/api/connections/database_explorer.go
@@ -213,7 +213,11 @@ func ListTables(c *gin.Context) {
 		}
 	}
 
-	script := getTablesQuery(currentConnectionType, dbName)
+	script, scriptErr := getTablesQuery(currentConnectionType, dbName)
+	if scriptErr != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": scriptErr.Error()})
+		return
+	}
 	if script == "" {
 		// Check for DynamoDB
 		if conn.Type == "custom" && conn.SubType.String == "dynamodb" {
@@ -381,12 +385,10 @@ func GetTableColumns(c *gin.Context) {
 		}
 	}
 
-	script := getColumnsQuery(currentConnectionType, dbName, tableName, schemaName)
-	if script == "" {
-		// Check for DynamoDB
-		if currentConnectionType == pb.ConnectionTypeDynamoDB {
-			script = fmt.Sprintf(`aws dynamodb describe-table --table-name %s --output json`, tableName)
-		}
+	script, scriptErr := getColumnsQuery(currentConnectionType, dbName, tableName, schemaName)
+	if scriptErr != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": scriptErr.Error()})
+		return
 	}
 
 	if script == "" {

--- a/gateway/api/connections/helpers.go
+++ b/gateway/api/connections/helpers.go
@@ -362,19 +362,11 @@ func parseDatabaseCommandOutput(output string) ([]string, error) {
 
 // validateDatabaseName returns an error if the database name contains invalid characters
 func validateDatabaseName(dbName string) error {
-	// Regular expression that allows only:
-	// - Letters (a-z, A-Z)
-	// - Numbers (0-9)
-	// - Underscores (_)
-	// - Hyphens (-)
-	// - Dots (.)
-	// With length between 1 and 128 characters
-	re := regexp.MustCompile(`^[a-zA-Z0-9_\-\.]{1,128}$`)
-
-	if !re.MatchString(dbName) {
+	// Allows only letters, numbers, underscores, hyphens, and dots with
+	// length between 1 and 128 characters (see validateSchemaIdentifier).
+	if err := validateSchemaIdentifier("database name", dbName); err != nil {
 		return fmt.Errorf("invalid database name. Only alphanumeric characters, underscore, hyphen and dot are allowed with length between 1 and 128 characters")
 	}
-
 	return nil
 }
 

--- a/gateway/api/connections/queries_schema.go
+++ b/gateway/api/connections/queries_schema.go
@@ -2,63 +2,117 @@ package apiconnections
 
 import (
 	"fmt"
+	"regexp"
 
 	pb "github.com/hoophq/hoop/common/proto"
 )
 
+// schemaIdentifierRe matches identifiers that are safe to interpolate into
+// generated schema scripts. It rejects quotes, backticks, whitespace, and
+// statement separators, so a matching value cannot break out of the quoting
+// context it is placed in (backtick/bracket-quoted identifiers or
+// single-quoted SQL literals).
+var schemaIdentifierRe = regexp.MustCompile(`^[a-zA-Z0-9_\-\.]{1,128}$`)
+
+// validateSchemaIdentifier returns an error when value cannot be safely
+// interpolated into a generated schema script.
+func validateSchemaIdentifier(kind, value string) error {
+	if !schemaIdentifierRe.MatchString(value) {
+		return fmt.Errorf("invalid %s: only alphanumeric characters, underscore, hyphen and dot are allowed, with length between 1 and 128 characters", kind)
+	}
+	return nil
+}
+
 // TablesQueryFor returns the backing query for listing tables on the given
-// connection type, or an empty string when the type is unsupported.
-// Exported for reuse by the MCP schema tools.
-func TablesQueryFor(connType pb.ConnectionType, dbName string) string {
+// connection type, or an empty string when the type is unsupported. It
+// returns an error when an identifier interpolated into the script fails
+// validation. Exported for reuse by the MCP schema tools.
+func TablesQueryFor(connType pb.ConnectionType, dbName string) (string, error) {
 	return getTablesQuery(connType, dbName)
 }
 
 // ColumnsQueryFor returns the backing query for listing columns of a specific
-// table on the given connection type, or an empty string when unsupported.
-// Exported for reuse by the MCP schema tools.
-func ColumnsQueryFor(connType pb.ConnectionType, dbName, tableName, schemaName string) string {
+// table on the given connection type, or an empty string when unsupported. It
+// returns an error when an identifier interpolated into the script fails
+// validation. Exported for reuse by the MCP schema tools.
+func ColumnsQueryFor(connType pb.ConnectionType, dbName, tableName, schemaName string) (string, error) {
 	return getColumnsQuery(connType, dbName, tableName, schemaName)
 }
 
-// getTablesQuery returns the query to list only the tables of a database
-func getTablesQuery(connType pb.ConnectionType, dbName string) string {
+// getTablesQuery returns the query to list only the tables of a database.
+// Every identifier interpolated into the script is validated first.
+func getTablesQuery(connType pb.ConnectionType, dbName string) (string, error) {
 	switch connType {
 	case pb.ConnectionTypeDynamoDB:
-		return getDynamoDBTablesQuery() // DynamoDB tables are listed as databases
+		return getDynamoDBTablesQuery(), nil // DynamoDB tables are listed as databases
 	case pb.ConnectionTypeCloudWatch:
-		return getCloudWatchTablesQuery()
-	case pb.ConnectionTypePostgres:
-		return getPostgresTablesQuery(dbName)
-	case pb.ConnectionTypeMSSQL:
-		return getMSSQLTablesQuery(dbName)
-	case pb.ConnectionTypeMySQL:
-		return getMySQLTablesQuery(dbName)
+		return getCloudWatchTablesQuery(), nil
 	case pb.ConnectionTypeOracleDB:
-		return getOracleDBTablesQuery()
-	case pb.ConnectionTypeMongoDB:
-		return getMongoDBTablesQuery(dbName)
+		return getOracleDBTablesQuery(), nil
+	case pb.ConnectionTypePostgres, pb.ConnectionTypeMSSQL, pb.ConnectionTypeMySQL, pb.ConnectionTypeMongoDB:
+		if err := validateSchemaIdentifier("database name", dbName); err != nil {
+			return "", err
+		}
+		switch connType {
+		case pb.ConnectionTypePostgres:
+			return getPostgresTablesQuery(dbName), nil
+		case pb.ConnectionTypeMSSQL:
+			return getMSSQLTablesQuery(dbName), nil
+		case pb.ConnectionTypeMySQL:
+			return getMySQLTablesQuery(dbName), nil
+		default:
+			return getMongoDBTablesQuery(dbName), nil
+		}
 	default:
-		return ""
+		return "", nil
 	}
 }
 
-// getColumnsQuery returns the query to get the columns of a specific table
-func getColumnsQuery(connType pb.ConnectionType, dbName, tableName, schemaName string) string {
+// getColumnsQuery returns the query to get the columns of a specific table.
+// Every identifier interpolated into the script is validated first.
+func getColumnsQuery(connType pb.ConnectionType, dbName, tableName, schemaName string) (string, error) {
 	switch connType {
 	case pb.ConnectionTypeDynamoDB:
-		return getDynamoDBColumnsQuery(tableName)
-	case pb.ConnectionTypePostgres:
-		return getPostgresColumnsQuery(dbName, tableName, schemaName)
-	case pb.ConnectionTypeMSSQL:
-		return getMSSQLColumnsQuery(dbName, tableName, schemaName)
-	case pb.ConnectionTypeMySQL:
-		return getMySQLColumnsQuery(dbName, tableName, schemaName)
+		if err := validateSchemaIdentifier("table name", tableName); err != nil {
+			return "", err
+		}
+		return getDynamoDBColumnsQuery(tableName), nil
+	case pb.ConnectionTypePostgres, pb.ConnectionTypeMSSQL, pb.ConnectionTypeMySQL:
+		if err := validateSchemaIdentifier("database name", dbName); err != nil {
+			return "", err
+		}
+		if err := validateSchemaIdentifier("table name", tableName); err != nil {
+			return "", err
+		}
+		if err := validateSchemaIdentifier("schema name", schemaName); err != nil {
+			return "", err
+		}
+		switch connType {
+		case pb.ConnectionTypePostgres:
+			return getPostgresColumnsQuery(dbName, tableName, schemaName), nil
+		case pb.ConnectionTypeMSSQL:
+			return getMSSQLColumnsQuery(dbName, tableName, schemaName), nil
+		default:
+			return getMySQLColumnsQuery(dbName, tableName, schemaName), nil
+		}
 	case pb.ConnectionTypeOracleDB:
-		return getOracleDBColumnsQuery(tableName, schemaName)
+		if err := validateSchemaIdentifier("table name", tableName); err != nil {
+			return "", err
+		}
+		if err := validateSchemaIdentifier("schema name", schemaName); err != nil {
+			return "", err
+		}
+		return getOracleDBColumnsQuery(tableName, schemaName), nil
 	case pb.ConnectionTypeMongoDB:
-		return getMongoDBColumnsQuery(dbName, tableName)
+		if err := validateSchemaIdentifier("database name", dbName); err != nil {
+			return "", err
+		}
+		if err := validateSchemaIdentifier("table name", tableName); err != nil {
+			return "", err
+		}
+		return getMongoDBColumnsQuery(dbName, tableName), nil
 	default:
-		return ""
+		return "", nil
 	}
 }
 
@@ -237,8 +291,9 @@ ORDER BY c.column_id;`, dbName, schemaName, tableName)
 
 func getMySQLColumnsQuery(dbName, tableName, schemaName string) string {
 	// The database identifier must be backtick-quoted: names with hyphens or
-	// dots (allowed by validateDatabaseName) are invalid as bare identifiers.
-	// validateDatabaseName rejects backticks, so quoting here is injection-safe.
+	// dots (allowed by validateSchemaIdentifier) are invalid as bare
+	// identifiers. getColumnsQuery validates every identifier before this
+	// builder runs, so no backtick or quote can reach the script.
 	quotedDBName := "`" + dbName + "`"
 	return fmt.Sprintf(`
 USE %s;

--- a/gateway/api/connections/queries_schema_test.go
+++ b/gateway/api/connections/queries_schema_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	pb "github.com/hoophq/hoop/common/proto"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,4 +47,80 @@ func TestGetMySQLColumnsQueryFormatIsComplete(t *testing.T) {
 	query := getMySQLColumnsQuery("db-prod", "users", "db-prod")
 	assert.False(t, strings.Contains(query, "%!"), "query contains fmt error markers: %s", query)
 	assert.False(t, strings.Contains(query, "%s"), "query contains unexpanded verbs: %s", query)
+}
+
+func TestGetTablesQueryRejectsUnsafeIdentifiers(t *testing.T) {
+	for _, connType := range []pb.ConnectionType{
+		pb.ConnectionTypePostgres,
+		pb.ConnectionTypeMSSQL,
+		pb.ConnectionTypeMySQL,
+		pb.ConnectionTypeMongoDB,
+	} {
+		for _, dbName := range []string{
+			"db`; DROP TABLE users; --",
+			"db'; DROP TABLE users; --",
+			"db name",
+			"",
+		} {
+			script, err := getTablesQuery(connType, dbName)
+			assert.Error(t, err, "connType=%s dbName=%q", connType, dbName)
+			assert.Empty(t, script, "connType=%s dbName=%q", connType, dbName)
+		}
+	}
+}
+
+func TestGetColumnsQueryRejectsUnsafeIdentifiers(t *testing.T) {
+	for _, connType := range []pb.ConnectionType{
+		pb.ConnectionTypePostgres,
+		pb.ConnectionTypeMSSQL,
+		pb.ConnectionTypeMySQL,
+		pb.ConnectionTypeMongoDB,
+		pb.ConnectionTypeOracleDB,
+		pb.ConnectionTypeDynamoDB,
+	} {
+		for _, tt := range []struct {
+			msg                           string
+			dbName, tableName, schemaName string
+		}{
+			{"backtick breakout in database", "db` USE mysql; --", "users", "db"},
+			{"quote breakout in table", "db", "users' OR '1'='1", "db"},
+			{"quote breakout in schema", "db", "users", "db' UNION SELECT authentication_string FROM mysql.user; --"},
+		} {
+			// Only assert on identifiers each type actually interpolates:
+			// DynamoDB uses only the table, OracleDB uses table+schema, and
+			// MongoDB uses database+table.
+			switch connType {
+			case pb.ConnectionTypeDynamoDB:
+				if tt.tableName == "users" {
+					continue
+				}
+			case pb.ConnectionTypeOracleDB:
+				if tt.tableName == "users" && tt.schemaName == "db" {
+					continue
+				}
+			case pb.ConnectionTypeMongoDB:
+				if tt.dbName == "db" && tt.tableName == "users" {
+					continue
+				}
+			}
+			script, err := getColumnsQuery(connType, tt.dbName, tt.tableName, tt.schemaName)
+			assert.Error(t, err, "connType=%s case=%s", connType, tt.msg)
+			assert.Empty(t, script, "connType=%s case=%s", connType, tt.msg)
+		}
+	}
+}
+
+func TestGetColumnsQueryAcceptsValidIdentifiers(t *testing.T) {
+	for _, connType := range []pb.ConnectionType{
+		pb.ConnectionTypePostgres,
+		pb.ConnectionTypeMSSQL,
+		pb.ConnectionTypeMySQL,
+		pb.ConnectionTypeMongoDB,
+		pb.ConnectionTypeOracleDB,
+		pb.ConnectionTypeDynamoDB,
+	} {
+		script, err := getColumnsQuery(connType, "db-prod", "users", "db-prod")
+		assert.NoError(t, err, "connType=%s", connType)
+		assert.NotEmpty(t, script, "connType=%s", connType)
+	}
 }

--- a/gateway/api/mcpserver/tools_schema.go
+++ b/gateway/api/mcpserver/tools_schema.go
@@ -95,7 +95,10 @@ func connectionTablesHandler(ctx context.Context, _ *mcp.CallToolRequest, args c
 	}
 
 	connType := pb.ToConnectionType(conn.Type, conn.SubType.String)
-	script := apiconnections.TablesQueryFor(connType, args.Database)
+	script, scriptErr := apiconnections.TablesQueryFor(connType, args.Database)
+	if scriptErr != nil {
+		return errResult(scriptErr.Error()), nil, nil
+	}
 	if script == "" {
 		return errResult(fmt.Sprintf("listing tables is not supported for connection type %q", connType)), nil, nil
 	}
@@ -137,7 +140,10 @@ func connectionColumnsHandler(ctx context.Context, _ *mcp.CallToolRequest, args 
 			schema = args.Database
 		}
 	}
-	script := apiconnections.ColumnsQueryFor(connType, args.Database, args.Table, schema)
+	script, scriptErr := apiconnections.ColumnsQueryFor(connType, args.Database, args.Table, schema)
+	if scriptErr != nil {
+		return errResult(scriptErr.Error()), nil, nil
+	}
 	if script == "" {
 		return errResult(fmt.Sprintf("listing columns is not supported for connection type %q", connType)), nil, nil
 	}


### PR DESCRIPTION
   - The **DynamoDB** columns path interpolated `tableName` into a shell command (`aws dynamodb describe-table --table-name %s`)   [0/6603]
 unvalidated.

   Since these scripts execute against the target database via `clientexec` with the connection's credentials, a crafted identifier
 allowed predicate manipulation or statement injection.

   Validation now lives inside the query builders themselves (`validateSchemaIdentifier`: alphanumeric, `_`, `-`, `.`, 1–128 chars —
 rejects backticks, quotes, whitespace, and separators), so every call path is covered regardless of caller behavior.
 `TablesQueryFor`/`ColumnsQueryFor` return `(string, error)`; callers surface the error as HTTP 422 or an MCP tool error.

   ## 📣 User-facing impact

   None — security hardening of internal schema introspection; no behavior change for valid database, table, or schema names.

   ## 🔗 Related Issue

   Fixes #

   ## 🚀 Type of Change

   - [x] 🐛 Bug fix (non-breaking change which fixes an issue)

   ## 📋 Changes Made

   - `gateway/api/connections/queries_schema.go`: added `validateSchemaIdentifier`; `getTablesQuery`/`getColumnsQuery` (and exported
 `TablesQueryFor`/`ColumnsQueryFor`) now validate every interpolated identifier and return `(string, error)`
   - `gateway/api/connections/helpers.go`: `validateDatabaseName` delegates to `validateSchemaIdentifier` (same regex, same error message)
 so the two cannot drift
   - `gateway/api/connections/database_explorer.go`: `ListTables`/`GetTableColumns` handle the builder error and return HTTP 422;
 `table`/`schema` are now validated on the columns endpoint
   - `gateway/api/mcpserver/tools_schema.go`: `connectionTablesHandler`/`connectionColumnsHandler` handle the builder error and return an
 MCP tool error result
   - `gateway/api/connections/queries_schema_test.go`: added injection-rejection tests (backtick/quote breakouts per connection type) and
 a valid-identifier acceptance test

   ## 🧪 Testing

   Ran `go test ./gateway/api/connections/ ./gateway/api/mcpserver/ -count=1` — all pass, including pre-existing
 `TestValidateDatabaseName` and MySQL quoting tests. Full `go build ./gateway/... ./common/...` clean; repo-wide grep confirms no other
 callers of the changed signatures.

   ### Test Configuration:
   - **Browser(s)**: N/A (backend only)
   - **OS**: macOS (darwin/arm64)

   ### Tests performed:
   - [x] Unit tests pass
   - [ ] Integration tests pass
   - [x] Manual testing completed

   ## 📸 Screenshots (if applicable)

   N/A

   ## ✅ Checklist

   - [x] My code follows the style guidelines of this project
   - [x] I have performed a self-review of my own code
   - [x] I have commented my code, particularly in hard-to-understand areas
   - [x] My changes generate no new warnings
   - [x] New and existing unit tests pass locally with my changes
   - [x] I have checked my code and corrected any misspellings

   ## 📄 Additional Notes

   - Reviewers: focus on `getColumnsQuery` — validation is per connection type, matching exactly the identifiers each builder interpolates
 (e.g. MongoDB ignores `schema`, OracleDB ignores `database`, DynamoDB uses only `table`).
   - The identifier charset is identical to the old `validateDatabaseName` regex, so no previously accepted name is rejected.
   - Label suggestion: `patch` (security fix, no API surface change).