### PR TITLE
build: bump agent-tools base image to noble-20260724-0899b10

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@
 # AGENT_TOOLS_TAG selects the train: the pinned tag is the legacy (default)
 # train; the clean (AGPL/SSPL-free) train passes the same tag suffixed with
 # "-clean". Kept in sync by the agent-tools workflow's bump-consumers job.
-ARG AGENT_TOOLS_TAG=noble-20260709-6890906
+ARG AGENT_TOOLS_TAG=noble-20260724-0899b10
 FROM hoophq/agent-tools:${AGENT_TOOLS_TAG}
 
 COPY rootfs /

--- a/scripts/dev/Dockerfile
+++ b/scripts/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM hoophq/agent-tools:noble-20260709-6890906
+FROM hoophq/agent-tools:noble-20260724-0899b10
 
 RUN mkdir -p /opt/hoop/sessions && \
   mkdir -p /opt/hoop/bin && \


### PR DESCRIPTION
Auto-generated by the agent-tools workflow after publishing `hoophq/agent-tools:noble-20260724-0899b10` and `hoophq/agent-tools:noble-20260724-0899b10-clean` (license-gated: no AGPL/SSPL on the clean train). Bumps the base reference of `Dockerfile.dev` (ARG AGENT_TOOLS_TAG) and `scripts/dev/Dockerfile` so hoopdev preview and dev images pick up the rebuilt base. Automated by MisterMal