### PR TITLE
EVL-104: unify webapp_v2 snackbars on showSnackbar, remove @mantine/notifications

### DIFF
--- a/webapp_v2/CLAUDE.md
+++ b/webapp_v2/CLAUDE.md
@@ -128,7 +128,7 @@ When something in `pages/[Page]/components/` starts getting reused outside the p
 
 The legacy CLJS app shows toasts through `sonner` via a `:show-snackbar` re-frame event.
 While the migration is in progress, the React side uses the **same library** (`sonner`)
-through a thin wrapper at `src/utils/snackbar.js` so users see one consistent toast
+through a thin wrapper at `src/utils/snackbar.jsx` so users see one consistent toast
 style across CLJS and React routes.
 
 ```jsx
@@ -140,13 +140,14 @@ showSnackbar({ level: 'info',    text: 'Heads up.' })
 ```
 
 **Rules:**
-- Do NOT import `notifications` from `@mantine/notifications` in new code — it produces
-  a completely different visual from v1 and breaks parity.
+- Do NOT use `@mantine/notifications` — the dependency has been removed from the project
+  (it produced a completely different visual from v1 and broke parity). Do not re-add it.
 - The `<Toaster>` is mounted once at `src/App.jsx`. Do not add additional Toaster instances.
 - The wrapper accepts the same `{ level, text, description }` shape as the CLJS
   `:show-snackbar` event so the mental model stays identical on both sides.
-- Pre-existing pages still using Mantine `notifications.show()` should be migrated to
-  `showSnackbar` opportunistically whenever you touch them.
+- Do NOT show snackbars through the CLJS bridge (`clojureDispatch('show-snackbar', ...)`) —
+  the CLJS Toaster only exists while the CLJS tree is mounted, so toasts fired from
+  React-only routes would be silently lost. Always use `showSnackbar` from `@/utils/snackbar`.
 
 ## Authentication Flow
 

--- a/webapp_v2/COMPONENTS.md
+++ b/webapp_v2/COMPONENTS.md
@@ -628,10 +628,9 @@ showSnackbar({
 ```
 
 Error toasts auto-dismiss after 10 seconds (mirrors v1); other levels use sonner's
-default. Do NOT import `notifications` from `@mantine/notifications` in new code — it
-renders a completely different visual and breaks parity with v1. Pre-existing pages
-that still use it should be migrated opportunistically. See the "Snackbars / Toasts"
-section of `CLAUDE.md` for the full rule.
+default. Do NOT use `@mantine/notifications` — the dependency has been removed from
+the project (it rendered a completely different visual and broke parity with v1).
+See the "Snackbars / Toasts" section of `CLAUDE.md` for the full rule.
 
 ---
 

--- a/webapp_v2/CONTEXT_MIGRATION.md
+++ b/webapp_v2/CONTEXT_MIGRATION.md
@@ -131,7 +131,7 @@ Gateway backend (port 8009)
 | Sidebar | `shared_ui/sidebar/main.cljs` | ✅ Yes — `layout/Sidebar.jsx` |
 | Command Palette (cmd+k) | `shared_ui/cmdk/command_palette.cljs` | ✅ Yes — `features/CommandPalette/` |
 | Modal system | `components/modal.cljs` | ❌ Not yet |
-| Snackbar / Toast | `components/snackbar.cljs` | ❌ Not yet |
+| Snackbar / Toast | `components/toast.cljs` | ✅ Yes — `utils/snackbar.jsx` + `components/Snackbar/Toast.jsx` (sonner, top-right) |
 | Confirmation Dialog | `components/dialog.cljs` | ❌ Not yet |
 | Page loader | Re-frame `:page-loader-status` | ❌ Not yet |
 
@@ -235,8 +235,8 @@ Infinite scroll uses Mantine's built-in `useIntersection` (sentinel at list bott
 - Auth pages
 
 ### In Progress / Known Gaps 🔄
-- Modal/Snackbar/Dialog system not yet in React (CLJS still owns this)
-- No notification/toast system in React
+- Modal/Dialog system not yet in React (CLJS still owns this). Snackbar/Toast is done —
+  `showSnackbar` from `utils/snackbar.jsx` (sonner, top-right), see `CLAUDE.md`.
 
 ### Pages Prioritized for Migration (rough order)
 1. Dashboard

--- a/webapp_v2/package-lock.json
+++ b/webapp_v2/package-lock.json
@@ -11,7 +11,6 @@
         "@mantine/core": "^8.3.18",
         "@mantine/dates": "^8.3.18",
         "@mantine/hooks": "^8.3.18",
-        "@mantine/notifications": "^8.3.18",
         "@mantine/spotlight": "^8.3.18",
         "@segment/analytics-next": "^1.64.0",
         "axios": "^1.13.5",
@@ -1149,22 +1148,6 @@
         "react": "^18.x || ^19.x"
       }
     },
-    "node_modules/@mantine/notifications": {
-      "version": "8.3.18",
-      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-8.3.18.tgz",
-      "integrity": "sha512-IpQ0lmwbigTBbZCR6iSYWqIOKEx1tlcd7PcEJ5M5X1qeVSY/N3mmDQt1eJmObvcyDeL5cTJMbSA9UPqhRqo9jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mantine/store": "8.3.18",
-        "react-transition-group": "4.4.5"
-      },
-      "peerDependencies": {
-        "@mantine/core": "8.3.18",
-        "@mantine/hooks": "8.3.18",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
-      }
-    },
     "node_modules/@mantine/spotlight": {
       "version": "8.3.18",
       "resolved": "https://registry.npmjs.org/@mantine/spotlight/-/spotlight-8.3.18.tgz",
@@ -2151,6 +2134,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -2288,16 +2272,6 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/dset": {
       "version": "3.1.4",
@@ -3652,6 +3626,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3783,18 +3758,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -4148,15 +4111,6 @@
       "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
       "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==",
       "license": "MIT"
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -4555,17 +4509,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -4605,12 +4548,6 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/react-number-format": {
       "version": "5.4.4",
@@ -4754,22 +4691,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-pkg": {

--- a/webapp_v2/package.json
+++ b/webapp_v2/package.json
@@ -15,7 +15,6 @@
     "@mantine/core": "^8.3.18",
     "@mantine/dates": "^8.3.18",
     "@mantine/hooks": "^8.3.18",
-    "@mantine/notifications": "^8.3.18",
     "@mantine/spotlight": "^8.3.18",
     "@segment/analytics-next": "^1.64.0",
     "axios": "^1.13.5",

--- a/webapp_v2/src/features/CommandPalette/index.jsx
+++ b/webapp_v2/src/features/CommandPalette/index.jsx
@@ -9,7 +9,7 @@ import CommandPaletteRoot from './CommandPaletteRoot';
 import MainPage from './MainPage';
 import ResourceRolesPage from './ResourceRolesPage';
 import ConnectionActionsPage, { ACTION_TYPES } from './ConnectionActionsPage';
-import { notifications } from '@mantine/notifications'
+import { showSnackbar } from '@/utils/snackbar';
 import { clojureDispatch } from '@/utils/clojureDispatch';
 
 function ConnectedCommandPalette() {
@@ -74,7 +74,7 @@ function ConnectedCommandPalette() {
       case ACTION_TYPES.HOOP_CLI:
         const cmd = `hoop connect ${connection?.name}`;
         navigator.clipboard.writeText(cmd).then(() => {
-          notifications.show({ message: `Copied: ${cmd}`, color: 'green' });
+          showSnackbar({ level: 'success', text: `Copied: ${cmd}` });
         });
         break;
 

--- a/webapp_v2/src/features/CommandPalette/index.jsx
+++ b/webapp_v2/src/features/CommandPalette/index.jsx
@@ -5,12 +5,12 @@ import { spotlight } from '@mantine/spotlight';
 import { useCommandPaletteStore } from '@/stores/useCommandPaletteStore';
 import { useUserStore } from '@/stores/useUserStore';
 import { searchAll } from '@/services/search';
+import { showSnackbar } from '@/utils/snackbar';
+import { clojureDispatch } from '@/utils/clojureDispatch';
 import CommandPaletteRoot from './CommandPaletteRoot';
 import MainPage from './MainPage';
 import ResourceRolesPage from './ResourceRolesPage';
 import ConnectionActionsPage, { ACTION_TYPES } from './ConnectionActionsPage';
-import { showSnackbar } from '@/utils/snackbar';
-import { clojureDispatch } from '@/utils/clojureDispatch';
 
 function ConnectedCommandPalette() {
   const navigate = useNavigate();

--- a/webapp_v2/src/main.jsx
+++ b/webapp_v2/src/main.jsx
@@ -2,12 +2,10 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { MantineProvider } from '@mantine/core';
-import { Notifications } from '@mantine/notifications';
 import { theme, cssVariablesResolver } from '@/theme';
 import App from './App';
 
 import '@mantine/core/styles.layer.css';
-import '@mantine/notifications/styles.layer.css';
 import '@mantine/spotlight/styles.layer.css';
 import '@mantine/dates/styles.layer.css';
 import './layers.css';
@@ -22,7 +20,6 @@ window.__hoopReactShellPresent = true;
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <MantineProvider theme={theme} defaultColorScheme="light" cssVariablesResolver={cssVariablesResolver}>
-      <Notifications />
       <BrowserRouter>
         <App />
       </BrowserRouter>

--- a/webapp_v2/src/pages/Agents/index.jsx
+++ b/webapp_v2/src/pages/Agents/index.jsx
@@ -11,7 +11,6 @@ import {
   Flex,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
-import { notifications } from '@mantine/notifications'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Trash2, CircleDashed } from 'lucide-react'
@@ -22,6 +21,7 @@ import DocsBtnCallOut from '@/components/DocsBtnCallOut'
 import { docsUrl } from '@/utils/docsUrl'
 import PageLoader from '@/components/PageLoader'
 import { useMinDelay } from '@/hooks/useMinDelay'
+import { showSnackbar } from '@/utils/snackbar'
 
 function AgentStatusBadge({ status }) {
   const isOnline = status === 'CONNECTED'
@@ -120,9 +120,9 @@ function Agents() {
   const handleDeleteConfirm = async () => {
     try {
       await deleteAgent(selectedAgent.id)
-      notifications.show({ message: `Agent "${selectedAgent.name}" removed.`, color: 'green' })
+      showSnackbar({ level: 'success', text: `Agent "${selectedAgent.name}" removed.` })
     } catch {
-      notifications.show({ message: 'Failed to delete agent.', color: 'red' })
+      showSnackbar({ level: 'error', text: 'Failed to delete agent.' })
     } finally {
       close()
       setSelectedAgent(null)

--- a/webapp_v2/src/pages/EventRouting/Detail/index.jsx
+++ b/webapp_v2/src/pages/EventRouting/Detail/index.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { Box, Card, Group, Stack, Text, Title } from "@mantine/core"
 import { useDisclosure } from "@mantine/hooks"
-import { notifications } from "@mantine/notifications"
 import {
   ArrowLeft,
   ArrowRight,
@@ -22,6 +21,7 @@ import Code from "@/components/Code"
 import Modal from "@/components/Modal"
 import PageLoader from "@/components/PageLoader"
 import Tooltip from "@/components/Tooltip"
+import { showSnackbar } from "@/utils/snackbar"
 import { useEventRoutingStore } from "../store"
 import StatusBadge from "../components/StatusBadge"
 import DispatchBadge from "../components/DispatchBadge"
@@ -330,17 +330,17 @@ export default function EventRoutingDetail() {
   const handleTogglePause = async () => {
     try {
       await togglePause(sub.id)
-      notifications.show({
-        message:
+      showSnackbar({
+        level: "success",
+        text:
           sub.status === "active"
             ? "Subscription paused."
             : "Subscription resumed.",
-        color: "green",
       })
     } catch (e) {
-      notifications.show({
-        message: e?.response?.data?.message || "Failed.",
-        color: "red",
+      showSnackbar({
+        level: "error",
+        text: e?.response?.data?.message || "Failed.",
       })
     }
   }
@@ -349,12 +349,12 @@ export default function EventRoutingDetail() {
     setDeleting(true)
     try {
       await deleteSubscription(sub.id)
-      notifications.show({ message: `Deleted "${sub.name}".`, color: "green" })
+      showSnackbar({ level: "success", text: `Deleted "${sub.name}".` })
       navigate("/features/event-routing")
     } catch (e) {
-      notifications.show({
-        message: e?.response?.data?.message || "Failed to delete.",
-        color: "red",
+      showSnackbar({
+        level: "error",
+        text: e?.response?.data?.message || "Failed to delete.",
       })
       setDeleting(false)
     }

--- a/webapp_v2/src/pages/EventRouting/Form/index.jsx
+++ b/webapp_v2/src/pages/EventRouting/Form/index.jsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { Anchor, Box, Card, Grid, Group, Stack, Text, Title } from "@mantine/core"
 import { useInViewport } from "@mantine/hooks"
-import { notifications } from "@mantine/notifications"
 import { ArrowLeft, ArrowRight } from "lucide-react"
 import Button from "@/components/Button"
 import Code from "@/components/Code"
@@ -11,6 +10,7 @@ import Radio from "@/components/Radio"
 import Select from "@/components/Select"
 import TextInput from "@/components/TextInput"
 import Textarea from "@/components/Textarea"
+import { showSnackbar } from "@/utils/snackbar"
 import { useEventRoutingStore } from "../store"
 import EventDescription from "../components/EventDescription"
 
@@ -231,9 +231,9 @@ export default function EventRoutingForm() {
   const handleSave = async () => {
     if (!canSubmit) return
     if (!selectedRunbook) {
-      notifications.show({
-        message: "Pick a runbook before saving.",
-        color: "red",
+      showSnackbar({
+        level: "error",
+        text: "Pick a runbook before saving.",
       })
       return
     }
@@ -252,27 +252,27 @@ export default function EventRoutingForm() {
     try {
       if (isEdit) {
         await updateSubscription(id, payload)
-        notifications.show({
-          message: "Subscription updated.",
-          color: "green",
+        showSnackbar({
+          level: "success",
+          text: "Subscription updated.",
         })
         navigate(`/features/event-routing/${id}`)
       } else {
         await createSubscription(payload)
-        notifications.show({
-          message: "Subscription created.",
-          color: "green",
+        showSnackbar({
+          level: "success",
+          text: "Subscription created.",
         })
         navigate("/features/event-routing")
       }
     } catch (e) {
-      notifications.show({
-        message:
+      showSnackbar({
+        level: "error",
+        text:
           e?.response?.data?.message ||
           (isEdit
             ? "Failed to update subscription."
             : "Failed to create subscription."),
-        color: "red",
       })
     }
   }

--- a/webapp_v2/src/pages/EventRouting/components/ReplayDispatchModal.jsx
+++ b/webapp_v2/src/pages/EventRouting/components/ReplayDispatchModal.jsx
@@ -1,9 +1,9 @@
 import { Card, Group, Stack, Text } from '@mantine/core'
-import { notifications } from '@mantine/notifications'
 import { Send } from 'lucide-react'
 import Button from '@/components/Button'
 import Code from '@/components/Code'
 import Modal from '@/components/Modal'
+import { showSnackbar } from '@/utils/snackbar'
 import { useEventRoutingStore } from '../store'
 import DispatchBadge from './DispatchBadge'
 
@@ -17,9 +17,9 @@ export default function ReplayDispatchModal({ subId }) {
     if (!replayTarget || !subId) return
     try {
       await replayDispatch(subId, replayTarget.id)
-      notifications.show({ message: 'Dispatch replayed.', color: 'green' })
+      showSnackbar({ level: 'success', text: 'Dispatch replayed.' })
     } catch (e) {
-      notifications.show({ message: e?.response?.data?.message || 'Failed to replay.', color: 'red' })
+      showSnackbar({ level: 'error', text: e?.response?.data?.message || 'Failed to replay.' })
     } finally {
       setReplayTarget(null)
     }

--- a/webapp_v2/src/pages/Organization/Users/index.jsx
+++ b/webapp_v2/src/pages/Organization/Users/index.jsx
@@ -9,7 +9,6 @@ import {
   Title,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
-import { notifications } from '@mantine/notifications'
 import { useMinDelay } from '@/hooks/useMinDelay'
 import PageLoader from '@/components/PageLoader'
 import EmptyState from '@/layout/EmptyState'
@@ -24,6 +23,7 @@ import CopyButton from '@/components/CopyButton'
 import { usersService } from '@/services/users'
 import { authService } from '@/services/auth'
 import { docsUrl } from '@/utils/docsUrl'
+import { showSnackbar } from '@/utils/snackbar'
 
 const STATUS_OPTIONS = [
   { value: 'active', label: 'Active' },
@@ -87,11 +87,11 @@ function UserFormModal({ opened, onClose, formType, user, groups, isLocalAuth, o
   async function handleSubmit(e) {
     e.preventDefault()
     if (!name.trim()) {
-      notifications.show({ message: 'Name is required.', color: 'red' })
+      showSnackbar({ level: 'error', text: 'Name is required.' })
       return
     }
     if (formType === 'create' && !email.trim()) {
-      notifications.show({ message: 'Email is required.', color: 'red' })
+      showSnackbar({ level: 'error', text: 'Email is required.' })
       return
     }
     setSaving(true)
@@ -106,15 +106,15 @@ function UserFormModal({ opened, onClose, formType, user, groups, isLocalAuth, o
       }
       if (formType === 'create') {
         await usersService.create(payload)
-        notifications.show({ message: 'User created.', color: 'green' })
+        showSnackbar({ level: 'success', text: 'User created.' })
       } else {
         await usersService.update(user.id, payload)
-        notifications.show({ message: 'User updated.', color: 'green' })
+        showSnackbar({ level: 'success', text: 'User updated.' })
       }
       onSaved()
       onClose()
     } catch {
-      notifications.show({ message: `Failed to ${formType === 'create' ? 'create' : 'update'} user.`, color: 'red' })
+      showSnackbar({ level: 'error', text: `Failed to ${formType === 'create' ? 'create' : 'update'} user.` })
     } finally {
       setSaving(false)
     }

--- a/webapp_v2/src/pages/Roles/Configure/index.jsx
+++ b/webapp_v2/src/pages/Roles/Configure/index.jsx
@@ -5,8 +5,8 @@ import { useDisclosure } from '@mantine/hooks'
 import Modal from '@/components/Modal'
 import Button from '@/components/Button'
 import Tabs from '@/components/Tabs'
-import { useBridgeStore } from '@/stores/useBridgeStore'
 import PageLoader from '@/components/PageLoader'
+import { showSnackbar } from '@/utils/snackbar'
 import { useConfigureRoleStore } from '@/pages/Roles/Configure/store'
 import ConfigureHeader from '@/pages/Roles/Configure/ConfigureHeader'
 import FormFooter from '@/pages/Roles/Configure/FormFooter'
@@ -76,8 +76,6 @@ export default function ConfigureRolePage() {
     loadAuxiliaryData()
     return () => reset()
   }, [connectionName, loadConnection, loadAuxiliaryData, reset])
-
-  const showSnackbar = useBridgeStore((s) => s.showSnackbar)
 
   const handleSave = async () => {
     if (formRef.current && !formRef.current.checkValidity()) {

--- a/webapp_v2/src/pages/Rulepacks/Detail/RolesTab.jsx
+++ b/webapp_v2/src/pages/Rulepacks/Detail/RolesTab.jsx
@@ -7,13 +7,13 @@ import {
   Stack,
   Text,
 } from '@mantine/core'
-import { notifications } from '@mantine/notifications'
 import { ListVideo, Rotate3d, Search, Shapes } from 'lucide-react'
 import Button from '@/components/Button'
 import PageLoader from '@/components/PageLoader'
 import Table from '@/components/Table'
 import TextInput from '@/components/TextInput'
 import ValueFilter from '@/components/ValueFilter'
+import { showSnackbar } from '@/utils/snackbar'
 import { useRulepackStore } from '../store'
 
 function connectionTagValues(connection) {
@@ -103,16 +103,16 @@ export default function RolesTab() {
   const handleApply = async () => {
     const result = await applyConnections()
     if (result.ok) {
-      notifications.show({
-        color: 'green',
-        message: 'Rulepack applied successfully',
+      showSnackbar({
+        level: 'success',
+        text: 'Rulepack applied successfully',
       })
       return
     }
     const missing = result.missing
-    notifications.show({
-      color: 'red',
-      message:
+    showSnackbar({
+      level: 'error',
+      text:
         missing && missing.length > 0
           ? `Unknown connections: ${missing.join(', ')}`
           : 'Failed to apply rulepack',

--- a/webapp_v2/src/pages/Settings/Attributes/Form/index.jsx
+++ b/webapp_v2/src/pages/Settings/Attributes/Form/index.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Box, Button, Grid, Group, Stack, Text, Title } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
-import { notifications } from '@mantine/notifications'
 import { ArrowLeft } from 'lucide-react'
 import { useMinDelay } from '@/hooks/useMinDelay'
 import PageLoader from '@/components/PageLoader'
@@ -11,6 +10,7 @@ import TextInput from '@/components/TextInput'
 import MultiSelect from '@/components/MultiSelect'
 import { attributesService } from '@/services/attributes'
 import { connectionsService } from '@/services/connections'
+import { showSnackbar } from '@/utils/snackbar'
 
 function SectionRow({ title, description, children }) {
   return (
@@ -59,7 +59,7 @@ export default function AttributesForm() {
           setConnectionNames(attr.connection_names ?? [])
         }
       } catch {
-        notifications.show({ message: 'Failed to load data.', color: 'red' })
+        showSnackbar({ level: 'error', text: 'Failed to load data.' })
       } finally {
         setLoading(false)
       }
@@ -69,7 +69,7 @@ export default function AttributesForm() {
 
   async function handleSubmit() {
     if (!name.trim()) {
-      notifications.show({ message: 'Name is required.', color: 'red' })
+      showSnackbar({ level: 'error', text: 'Name is required.' })
       return
     }
     setSaving(true)
@@ -78,14 +78,14 @@ export default function AttributesForm() {
       if (description.trim()) body.description = description
       if (isEdit) {
         await attributesService.update(attrName, body)
-        notifications.show({ message: 'Attribute updated.', color: 'green' })
+        showSnackbar({ level: 'success', text: 'Attribute updated.' })
       } else {
         await attributesService.create(body)
-        notifications.show({ message: 'Attribute created.', color: 'green' })
+        showSnackbar({ level: 'success', text: 'Attribute created.' })
       }
       navigate('/settings/attributes')
     } catch {
-      notifications.show({ message: `Failed to ${isEdit ? 'update' : 'create'} attribute.`, color: 'red' })
+      showSnackbar({ level: 'error', text: `Failed to ${isEdit ? 'update' : 'create'} attribute.` })
     } finally {
       setSaving(false)
     }
@@ -95,10 +95,10 @@ export default function AttributesForm() {
     setSaving(true)
     try {
       await attributesService.remove(attrName)
-      notifications.show({ message: 'Attribute deleted.', color: 'green' })
+      showSnackbar({ level: 'success', text: 'Attribute deleted.' })
       navigate('/settings/attributes')
     } catch {
-      notifications.show({ message: 'Failed to delete attribute.', color: 'red' })
+      showSnackbar({ level: 'error', text: 'Failed to delete attribute.' })
     } finally {
       setSaving(false)
       closeDelete()

--- a/webapp_v2/src/pages/Settings/Experimental/index.jsx
+++ b/webapp_v2/src/pages/Settings/Experimental/index.jsx
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react'
 import { Group, Stack, Switch, Text, Title } from '@mantine/core'
-import { notifications } from '@mantine/notifications'
 import { useMinDelay } from '@/hooks/useMinDelay'
 import PageLoader from '@/components/PageLoader'
 import EmptyState from '@/layout/EmptyState'
 import Table from '@/components/Table'
 import Badge from '@/components/Badge'
 import { featureFlagsService } from '@/services/featureFlags'
+import { showSnackbar } from '@/utils/snackbar'
 
 const STABILITY_COLOR = {
   experimental: 'orange',
@@ -25,10 +25,9 @@ export default function SettingsExperimental() {
       .list()
       .then((res) => setFlags(res.data ?? []))
       .catch(() => {
-        notifications.show({
-          color: 'red',
-          title: 'Error',
-          message: 'Failed to load feature flags',
+        showSnackbar({
+          level: 'error',
+          text: 'Failed to load feature flags',
         })
       })
       .finally(() => setLoading(false))
@@ -51,10 +50,9 @@ export default function SettingsExperimental() {
       setFlags((prev) =>
         prev.map((f) => (f.name === flagName ? { ...f, enabled: previous } : f))
       )
-      notifications.show({
-        color: 'red',
-        title: 'Error',
-        message: `Failed to update flag "${flagName}"`,
+      showSnackbar({
+        level: 'error',
+        text: `Failed to update flag "${flagName}"`,
       })
     } finally {
       setPending((prev) => {

--- a/webapp_v2/src/pages/Settings/License/index.jsx
+++ b/webapp_v2/src/pages/Settings/License/index.jsx
@@ -10,7 +10,6 @@ import {
   TextInput,
   Title,
 } from '@mantine/core'
-import { notifications } from '@mantine/notifications'
 import { AlertCircle } from 'lucide-react'
 import { useMinDelay } from '@/hooks/useMinDelay'
 import { useUserStore } from '@/stores/useUserStore'
@@ -19,6 +18,7 @@ import Table from '@/components/Table'
 import licenseService from '@/services/license'
 import authService from '@/services/auth'
 import { docsUrl } from '@/utils/docsUrl'
+import { showSnackbar } from '@/utils/snackbar'
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
@@ -63,7 +63,7 @@ function SettingsLicense() {
       .getInfo()
       .then(setLicenseInfo)
       .catch(() =>
-        notifications.show({ color: 'red', title: 'Error', message: 'Failed to load license information' })
+        showSnackbar({ level: 'error', text: 'Failed to load license information' })
       )
       .finally(() => setLoading(false))
   }, [])
@@ -73,20 +73,20 @@ function SettingsLicense() {
     try {
       parsed = JSON.parse(licenseKey)
     } catch {
-      notifications.show({ color: 'red', title: 'Error', message: 'Error processing license: invalid JSON format' })
+      showSnackbar({ level: 'error', text: 'Error processing license: invalid JSON format' })
       return
     }
 
     setSaving(true)
     try {
       await licenseService.update(parsed)
-      notifications.show({ color: 'green', title: 'Saved', message: 'License updated successfully' })
+      showSnackbar({ level: 'success', text: 'License updated successfully' })
       const [updated, serverInfo] = await Promise.all([licenseService.getInfo(), authService.getServerInfo()])
       setLicenseInfo(updated)
       setServerInfo(serverInfo)
       setLicenseKey('')
     } catch {
-      notifications.show({ color: 'red', title: 'Error', message: 'Failed to update license' })
+      showSnackbar({ level: 'error', text: 'Failed to update license' })
     } finally {
       setSaving(false)
     }

--- a/webapp_v2/src/stores/useBridgeStore.js
+++ b/webapp_v2/src/stores/useBridgeStore.js
@@ -6,15 +6,10 @@ import { clojureDispatch } from '@/utils/clojureDispatch'
 // component" — wrap every dispatch in a store method so the
 // underlying mechanism can be swapped when the CLJS side is removed.
 //
-// snackbar: dispatched to CLJS so React pages share the same look
-// (top-right, 10s, dark) as the legacy snackbar component. Levels
-// match the CLJS handler at events/components/toast.cljs: 'success',
-// 'error', 'info'.
+// Snackbars are NOT bridged: the CLJS Toaster only exists while the
+// CLJS tree is mounted, so a dispatch from a React-only route would be
+// lost. Use `showSnackbar` from '@/utils/snackbar' instead.
 export const useBridgeStore = create(() => ({
-  showSnackbar: ({ level, text, details, description }) => {
-    clojureDispatch('show-snackbar', { level, text, details, description })
-  },
-
   // Refetch the current user in the CLJS app-db. Needed after React mutates
   // user-affecting state (e.g. applying a protection profile) so CLJS events
   // like :onboarding/check-user don't act on a stale cached user. No-op when


### PR DESCRIPTION
## 📝 Description

webapp_v2 had **two snackbar systems running at once**:

- The migrated one — `showSnackbar()` (`src/utils/snackbar.jsx`), backed by `sonner` with our custom `Snackbar/Toast` renderer (1:1 port of the CLJS toast). Mounted once as `<Toaster position="top-right" />` in `App.jsx`. Top-right, v1 visual parity.
- Mantine `@mantine/notifications` — provider mounted in `main.jsx` without a position prop (bottom-left default), completely different visual. Forbidden by `webapp_v2/CLAUDE.md`, but still used by 10 files / 33 call sites.

Depending on the page, users saw toasts in different corners with different designs. This PR unifies everything on `showSnackbar` and removes `@mantine/notifications` entirely so the second system cannot be reintroduced.

## 📣 User-facing impact

Notifications now appear consistently in the top-right corner with a single visual style across the whole platform, instead of varying in position and design depending on the page.

## 🔗 Related Issue

Closes [EVL-104](https://linear.app/hoophq/issue/EVL-104/webapp-v2-two-coexisting-snackbar-systems-mantine-notifications-vs)

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Migrated all 33 `notifications.show()` call sites (10 files) to `showSnackbar` (`color: green/red` → `level: success/error`; generic `Error`/`Saved` titles dropped — the level icon conveys them).
- `Roles/Configure` now uses the local `showSnackbar` instead of the CLJS bridge (`useBridgeStore.showSnackbar`). The bridge dispatched `:show-snackbar` to the CLJS bundle, but on React-only routes the CLJS Toaster is unmounted, so those toasts could be silently lost. The bridge method was removed so the fragile path can't be reused.
- Removed the `<Notifications />` provider, the `@mantine/notifications/styles.layer.css` import, and the `@mantine/notifications` dependency (package.json + lock).
- Updated `CLAUDE.md`, `COMPONENTS.md` and `CONTEXT_MIGRATION.md` (snackbar is migrated; new rule: never toast through the CLJS bridge).

## 🧪 Testing

`npm run lint` (no new issues — identical output to `main`) and `npm run build` pass in `webapp_v2/`.

### How to test

#### Setup

```bash
make run-dev-postgres        # skip if you already run your own PG
make run-dev                 # gateway on :8009
cd webapp_v2 && npm run dev  # Vite on :5173 (CLJS routes need npm run dev:full)
```

Login at `http://localhost:5173` as an **admin** user.

#### Steps

Every toast below must appear **top-right** as a white card with a colored level icon (the same style CLJS routes show) — never bottom-left/bottom-right in the old purple-accent Mantine style.

1. **Agents** — go to `/agents`, delete an agent, confirm.
   **Expected:** success toast `Agent "<name>" removed.`
2. **Organization → Users** (negative path) — click to create a user, leave Name empty, submit.
   **Expected:** error toast `Name is required.` (auto-dismisses after ~10 s).
3. **Settings → License** (negative path) — paste `not-json` into the license field and save.
   **Expected:** error toast `Error processing license: invalid JSON format`.
4. **Settings → Experimental** — toggle any flag with the gateway stopped (or block the request in DevTools).
   **Expected:** error toast `Failed to update flag "<name>"`; the switch rolls back.
5. **Command Palette** — `cmd+K` → pick a connection → *Hoop CLI* action.
   **Expected:** success toast `Copied: hoop connect <name>`; clipboard contains the command.
6. **Roles Configure (bridge fix)** — open `/roles/<name>/configure` **directly in a fresh tab** (do not visit any CLJS route first), change something and Save.
   **Expected:** success toast `Role <name> updated!` top-right. Before this PR the toast could be silently dropped because it was dispatched to the unmounted CLJS Toaster.
7. **Settings → Attributes** — create and then delete an attribute.
   **Expected:** success toasts `Attribute created.` / `Attribute deleted.`

EventRouting (subscription create/pause/replay) and Rulepacks (apply) were migrated with the same mechanical mapping; validate them if your env has those features enabled.

#### Regression check

1. A page that already used `showSnackbar` (e.g. **Settings → API Keys** → create) still shows its success toast unchanged, top-right.
2. A CLJS route (e.g. `/sessions`, requires `npm run dev:full`) still shows its own toasts identically — same corner, same design.
3. `grep -r "@mantine/notifications" webapp_v2/src` returns only the guidance comment in `utils/snackbar.jsx`; `npm ls @mantine/notifications` in `webapp_v2/` shows it is gone.

### Test Configuration:
- **Browser(s)**: Chrome (any Chromium-based)
- **OS**: macOS

### Tests performed:
- [ ] Unit tests pass (n/a — webapp_v2 has no unit test suite; lint + build are the gates)
- [ ] Integration tests pass (n/a)
- [ ] Manual testing completed (pending — draft; follow "How to test" above)

## 📸 Screenshots (if applicable)

N/A — the visible change is toast position/style unification; see "How to test".

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (n/a — no unit test suite in webapp_v2)
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- Toast messages were kept byte-for-byte identical to the old Mantine calls; only the transport/visual changed.
- Reviewers may want to focus on the level mapping (`green→success`, `red→error`) and on the `Roles/Configure` bridge removal (`useBridgeStore` keeps only `refreshLegacyUser`, still used by Onboarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
