### PR TITLE
chore: team Claude Code setup (.claude package + MCP servers)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,61 @@
+# Team Claude Code setup
+
+This directory is versioned team infrastructure: every engineer's Claude Code
+behaves the same way in this repo. Change it via PR like any code.
+
+## What's here
+
+| File | What it standardizes |
+|---|---|
+| `settings.json` | Pre-approved permissions (build/test/lint/git/gh read), `CGO_ENABLED=1`, deny rules for secrets, hooks |
+| `hooks/gofmt.sh` | Auto-`gofmt` on every Go file Claude edits — deterministic, not a prose instruction |
+| `skills/fix-ticket/` | `/fix-ticket EVL-86` — the standard ticket→draft-PR flow |
+| `skills/test-plan/` | `/test-plan` — generates the mandatory "How to test" PR section |
+| `../.mcp.json` | Linear + Figma MCP servers for everyone (first run: approve + `/mcp` to authenticate) |
+
+## First-time setup (each engineer, once)
+
+1. Pull, open `claude` in the repo, accept the workspace trust prompt.
+2. Run `/mcp` and authenticate `linear` (and `figma` if you do frontend work).
+3. That's it — skills, permissions and hooks are active.
+
+## Parallel sessions with worktrees (the standard)
+
+One ticket = one worktree = one terminal tab. Never work on two tickets in
+the same checkout.
+
+```bash
+# new session on a ticket (creates .claude/worktrees/<name> on its own branch)
+claude --worktree evl-86
+
+# see all your running sessions (fleet view)
+claude agents
+```
+
+Or with plain git: `git worktree add .worktrees/evl-86 -b <branchName>` then
+run `claude` inside it.
+
+### hoop-specific worktree notes
+
+- **`make libhoop-map` is per-checkout**: the `libhoop` symlink is untracked,
+  so a fresh worktree doesn't have it. The `test-*` targets run it for you;
+  only run it manually if you need `go build` before any test.
+- **`webapp_v2` needs its own `npm install`** in each worktree (node_modules
+  is untracked).
+- **Only one dev stack at a time**: `make run-dev` binds :8009/:8010 —
+  parallel worktrees can build and unit-test freely, but only one can run the
+  full gateway+agent stack. Coordinate or use different ports.
+- Hygiene: worktree name = ticket ID; remove after merge
+  (`git worktree remove <path>`, `git worktree prune` weekly).
+
+Suggested daily loop: dispatch 3-4 tickets in the morning (one worktree +
+`/fix-ticket` each), then rotate — validate one session's output while the
+others run. You review and unblock; the agents wait, not you.
+
+## Conventions the skills enforce
+
+- Branch names come from Linear's `branchName` (auto-links the PR).
+- Commits start with the ticket ID.
+- Go: `make test-oss` green before PR. `webapp_v2`: `npm run lint` + build.
+- Every PR is born **draft** with a "How to test" section.
+- Linear ticket gets the PR link and moves to In Review.

--- a/.claude/hooks/gofmt.sh
+++ b/.claude/hooks/gofmt.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-format any Go file Claude edits or writes.
+# Deterministic — runs on every edit, unlike prose instructions in CLAUDE.md.
+file=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+case "$file" in
+  *.go) gofmt -w "$file" 2>/dev/null || true ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,52 @@
+{
+  "env": {
+    "CGO_ENABLED": "1"
+  },
+  "enableAllProjectMcpServers": true,
+  "permissions": {
+    "allow": [
+      "Bash(go build:*)",
+      "Bash(go test:*)",
+      "Bash(go vet:*)",
+      "Bash(go doc:*)",
+      "Bash(gofmt:*)",
+      "Bash(make test:*)",
+      "Bash(make test-oss:*)",
+      "Bash(make libhoop-map:*)",
+      "Bash(make generate-wasm:*)",
+      "Bash(npm run lint:*)",
+      "Bash(npm run build:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git branch:*)",
+      "Bash(git worktree:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh issue view:*)"
+    ],
+    "deny": [
+      "Read(.env*)",
+      "Read(**/.env*)",
+      "Read(**/*.pem)",
+      "Read(**/id_rsa*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gofmt.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/fix-ticket/SKILL.md
+++ b/.claude/skills/fix-ticket/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: fix-ticket
+description: Implement a Linear ticket end-to-end - fetch context, branch, code, tests, draft PR, update the ticket. Use when given a ticket ID like EVL-86 or DEP-123.
+---
+
+# Fix a Linear ticket
+
+Input: a Linear ticket ID. Follow every step — this encodes the team's
+standard flow.
+
+## 1. Context
+
+- Fetch the full ticket via the Linear MCP server (title, description,
+  comments, `branchName`, acceptance criteria). If Linear MCP is not
+  connected, ask the user to run `/mcp` to authenticate — do not guess the
+  ticket content.
+- Identify which module the change belongs to: `gateway/`, `agent/`,
+  `client/`, `common/`, `tunnel/`, or `webapp_v2/` (the legacy `webapp/` is
+  frozen — only touch it if the ticket says so explicitly).
+- For frontend tickets with a Figma link, pull the design context via the
+  Figma MCP before writing UI code.
+- If the ticket has no clear acceptance criteria and the change is not
+  obvious, post ONE clarifying comment on the ticket (or ask the user) before
+  writing code.
+
+## 2. Branch
+
+- Prefer a dedicated worktree per ticket (`claude --worktree <ticket-id>` —
+  see `.claude/README.md` for hoop-specific worktree notes).
+- Create the branch using Linear's `branchName` so Linear auto-links the PR.
+  Base it on up-to-date `main`.
+
+## 3. Implement
+
+- Smallest correct change that satisfies the ticket. Follow `CLAUDE.md`
+  (route registration/middleware order for gateway API, packet dispatch
+  patterns for agent, module conventions).
+- Commit messages start with the ticket ID: `EVL-86: <summary>`.
+
+## 4. Validate
+
+- Go changes: `make test-oss` (it runs `libhoop-map` + `generate-wasm`
+  itself). Fix failures caused by your change; never skip or weaken tests.
+- `webapp_v2/` changes: `npm run lint` and `npm run build` must pass.
+- New gateway endpoints/migrations: check `migration-check` /
+  `breaking-change-check` CI expectations before pushing.
+
+## 5. Draft PR
+
+Open with `gh pr create --draft`. Title: `<ID>: <summary>`. Body must contain:
+
+```
+## Ticket
+<Linear URL>
+
+## What & why
+<2-6 lines>
+
+## How to test
+<exact commands + steps + expected result — write it so a teammate
+ can validate the flow without asking anything>
+
+## Risks
+<what could break, or "low">
+```
+
+## 6. Close the loop
+
+- Comment the PR URL on the Linear ticket and move it to **In Review** via
+  the Linear MCP.
+- Report back: PR link, test results, and anything you flagged as risky.

--- a/.claude/skills/fix-ticket/SKILL.md
+++ b/.claude/skills/fix-ticket/SKILL.md
@@ -47,22 +47,30 @@ standard flow.
 
 ## 5. Draft PR
 
-Open with `gh pr create --draft`. Title: `<ID>: <summary>`. Body must contain:
+Open with `gh pr create --draft`. Title: `<ID>: <summary>`.
 
-```
-## Ticket
-<Linear URL>
+**Body: fill the repository template** — read `.github/PULL_REQUEST_TEMPLATE.md`
+and produce the body with its exact sections (`gh pr create --body` bypasses
+GitHub's auto-template, so you must fill it yourself). Map content like this:
 
-## What & why
-<2-6 lines>
+- **📝 Description** — what changed and why, plus the Linear ticket URL.
+- **📣 User-facing impact** — one plain-language sentence, or "None".
+- **🔗 Related Issue** — the Linear URL (leave `Fixes #` alone unless there is
+  a GitHub issue).
+- **🚀 Type of Change** — mark exactly the ones that apply.
+- **📋 Changes Made** — bullet list of the main changes.
+- **🧪 Testing** — exact commands + steps + expected results, written so a
+  teammate can validate the flow without asking anything. Fill Test
+  Configuration and check the boxes that are true (never check what you did
+  not run).
+- **✅ Checklist / 📄 Additional Notes** — check honestly; put risks and
+  review-focus points in Additional Notes.
 
-## How to test
-<exact commands + steps + expected result — write it so a teammate
- can validate the flow without asking anything>
-
-## Risks
-<what could break, or "low">
-```
+**Release label (merge is blocked without exactly one):** add it on create,
+e.g. `gh pr create --draft --label patch …`. Choose: `patch` = bug fix,
+`minor` = new feature/UI addition, `major` = breaking change,
+`skip-release` = docs/CI/refactor/chore. If unsure, say so in the PR and pick
+the more conservative option.
 
 ## 6. Close the loop
 

--- a/.claude/skills/test-plan/SKILL.md
+++ b/.claude/skills/test-plan/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: test-plan
+description: Generate the "How to test" section for the current branch's changes - exact commands, flows to exercise, expected results. Use before opening/updating a PR or when asked how to validate a change.
+---
+
+# Generate a test plan for the current changes
+
+Goal: a teammate (or a QA agent) must be able to validate this change without
+asking anything. This is the team's standard for every PR.
+
+## Steps
+
+1. Diff the branch against main: `git diff main...HEAD --stat` then read the
+   changed files' diffs.
+2. Identify what is observable from outside: which API response, CLI
+   behavior (`hoop connect` / `hoop exec` / proxy flow), gateway/agent
+   interaction, or `webapp_v2` screen changed.
+3. Write a `## How to test` section in markdown:
+   - **Setup**: exact commands — see `DEV.md` (`make run-dev`, Postgres via
+     `make run-dev-postgres`, agent, `webapp_v2`: `npm run dev`). Only what
+     this change needs.
+   - **Steps**: numbered, copy-pasteable commands or precise UI actions.
+   - **Expected**: the observable result per step — literal output where
+     possible (API status + body fields, CLI output, what the screen shows).
+   - **Regression check**: 1-2 quick checks that the closest existing
+     behavior still works.
+4. Cover the negative path too (permission denied, invalid input, guardrail
+   still blocking after a fix).
+5. If a step cannot be validated locally (needs enterprise libhoop, IDP,
+   cloud resources), say so explicitly and state what environment is needed —
+   never leave silent gaps.
+
+Output the section ready to paste into the PR body (or update the open PR
+with `gh pr edit --body-file` if asked).

--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,15 @@ deploy/docker-compose/hoopdata/zitadel-admin-sa.json
 
 **/.claude/settings.local.json
 **/.mcp.json
+# the root .mcp.json is versioned team config (Linear/Figma MCP servers)
+!/.mcp.json
 
 # rust build
 target/
 webapp/resources/public/data/connections-metadata.json
-.claude
+# .claude/ is versioned team config (settings, skills, hooks) — only
+# per-engineer state stays ignored
+.claude/worktrees/
+.worktrees/
 # WASM build output
 gateway/rdp/wasm/target/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,3 +303,17 @@ A `.env` in `webapp_v2/` is optional — `vite.config.js` defaults all dev
 proxy targets. Same goes for `webapp/.env`: only override `SENTRY_DSN`,
 `SEGMENT_WRITE_KEY` or `API_URL` if you need to (closure-defines in
 `shadow-cljs.edn` already supply usable defaults).
+
+## Team AI Workflow
+
+Shared Claude Code config lives in `.claude/` (see `.claude/README.md` for
+setup, hoop-specific worktree notes, and the daily flow). Conventions the
+tooling enforces:
+
+- One ticket = one worktree = one session (`claude --worktree <ticket-id>`)
+- `/fix-ticket <ID>` runs the standard ticket→draft-PR flow; `/test-plan`
+  generates the mandatory "How to test" PR section
+- Branch names come from Linear's `branchName`; commits start with the ticket ID
+- Go changes: `make test-oss` green before PR; `webapp_v2/`: `npm run lint`
+  and `npm run build`
+- Every PR is born draft


### PR DESCRIPTION
## 📝 Description

Adds the versioned team Claude Code setup, so every engineer's Claude behaves the same way in this repo — reviewed and evolved via PR like any code. This is the first brick of the AI-workflow standardization (parallel worktree sessions + shared skills/conventions).

What it standardizes:
- **`.claude/settings.json`** — pre-approved permissions (build/test/lint, local git, `gh` read-only), `CGO_ENABLED=1`, deny rules for secrets (`.env*`, keys), and a `PostToolUse` hook.
- **`.claude/hooks/gofmt.sh`** — deterministic auto-`gofmt` on every Go file Claude edits.
- **`.claude/skills/fix-ticket`** — the standard ticket→draft-PR flow: Linear context → branch from the ticket's `branchName` → implement → `make test-oss` / `npm run lint`+`build` → draft PR filling `.github/PULL_REQUEST_TEMPLATE.md` with exactly one release label → ticket moved to In Review.
- **`.claude/skills/test-plan`** — generates the "🧪 Testing" section so any teammate can validate a PR without asking anything.
- **`.mcp.json`** — Linear + Figma MCP servers for everyone (one-time `/mcp` OAuth per engineer).
- **`.claude/README.md`** — onboarding + the worktree flow (one ticket = one worktree = one session), with hoop-specific notes (`make libhoop-map` per checkout, `npm install` per worktree, single dev stack on :8009/:8010).
- **`CLAUDE.md`** — new "Team AI Workflow" section.
- **`.gitignore`** — `.claude` was fully ignored; now only per-engineer state is (`.claude/worktrees/`, `settings.local.json`), and the root `.mcp.json` is un-ignored.

## 📣 User-facing impact

None — internal engineering tooling only.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [x] 🔧 Build configuration change
- [x] 🧹 Chore

## 📋 Changes Made

- Add `.claude/` package: settings (permissions/hooks/env), gofmt hook, `fix-ticket` and `test-plan` skills, team README
- Add root `.mcp.json` with Linear and Figma MCP servers
- Add "Team AI Workflow" section to `CLAUDE.md`
- Adjust `.gitignore` to version `.claude/` selectively and un-ignore the root `.mcp.json`

## 🧪 Testing

Validated by running the flow end-to-end from worktrees based on this branch:

1. `git worktree add .worktrees/<ticket> -b <branch> claude-team-setup` + `claude` inside it
2. Skills load (`/fix-ticket`, `/test-plan` available), Linear MCP authenticates via `/mcp`
3. `/fix-ticket EVL-101` and `/fix-ticket EVL-102` ran **simultaneously in two worktrees**, each producing a draft PR from the Linear ticket
4. gofmt hook verified: Go file edited by Claude comes out formatted
5. Deny rules verified: reading `.env` is refused; `git status`/`make test-oss` run without prompts

### Test Configuration:
- **Browser(s)**: n/a
- **OS**: macOS

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

n/a

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (n/a — no application code touched)
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- **Review the permission grants in `.claude/settings.json` carefully** — that's the file that pre-approves what agents can run without prompting. `git push` and anything network-facing still prompt.
- After merge, the daily flow becomes `claude --worktree <ticket-id>` from anywhere in the repo + `/fix-ticket <ID>`.
- A second branch (`claude-linear-agent`, stacked on this one) holds the label-triggered Linear agent pipeline — separate PR later, don't merge together.
- First-time setup per engineer is 3 steps (see `.claude/README.md`): pull, trust prompt, `/mcp` auth.
