### PR TITLE
[DEP-77] add the default valeu to the analyzer and some libhoop changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ deploy/docker-compose/hoopdata/sessions
 deploy/docker-compose/hoopdata/zitadel-admin-sa.json
 
 **/.claude/settings.local.json
+**/.claude/**
 **/.mcp.json
 # the root .mcp.json is versioned team config (Linear/Figma MCP servers)
 !/.mcp.json

--- a/webapp_v2/src/pages/Features/DataMasking/Create/index.jsx
+++ b/webapp_v2/src/pages/Features/DataMasking/Create/index.jsx
@@ -55,7 +55,10 @@ function DataMaskingFormFields({ rule, id, isEdit }) {
   const [form, setForm] = useState(() => ({
     name: rule?.name ?? '',
     description: rule?.description ?? '',
-    scoreThreshold: scoreToPercent(rule?.score_threshold),
+    // New blank rules start at 85%. Template/edited rules keep their own
+    // value — a stored NULL stays empty so saving doesn't silently add a
+    // threshold to a rule that masks every detection today.
+    scoreThreshold: rule ? scoreToPercent(rule.score_threshold) : 85,
     connectionIds: rule?.connection_ids ?? [],
     attributes: rule?.attributes ?? [],
   }))
@@ -201,7 +204,7 @@ function DataMaskingFormFields({ rule, id, isEdit }) {
                 const value = e.currentTarget.value
                 setField({ scoreThreshold: value === '' ? '' : Number(value) })
               }}
-              description="Minimum confidence level required to detect and mask sensitive data. Default 85% works well for most use cases."
+              description="Minimum confidence level (1-100) a detection needs to be masked. Defaults to 85% for new rules. Leave empty to mask every detection regardless of confidence. Custom entity types with a score below this value are never masked."
             />
           </Stack>
         </SectionRow>

--- a/webapp_v2/src/pages/Features/DataMasking/Create/index.jsx
+++ b/webapp_v2/src/pages/Features/DataMasking/Create/index.jsx
@@ -57,8 +57,10 @@ function DataMaskingFormFields({ rule, id, isEdit }) {
     description: rule?.description ?? '',
     // New blank rules start at 85%. Template/edited rules keep their own
     // value — a stored NULL stays empty so saving doesn't silently add a
-    // threshold to a rule that masks every detection today.
-    scoreThreshold: rule ? scoreToPercent(rule.score_threshold) : 85,
+    // threshold to a rule that masks every detection today. The `!isEdit`
+    // guard keeps the default out of edit flows even if a null rule ever
+    // slips past the page-level error gate.
+    scoreThreshold: !isEdit && !rule ? 85 : scoreToPercent(rule?.score_threshold),
     connectionIds: rule?.connection_ids ?? [],
     attributes: rule?.attributes ?? [],
   }))
@@ -308,6 +310,13 @@ export default function DataMaskingForm() {
 
   if (isEdit && (activeStatus === 'loading' || activeStatus === 'idle')) {
     return <PageLoader h={400} />
+  }
+
+  // A failed fetch leaves `active` null; rendering the form would present a
+  // blank "edit" whose save overwrites the real rule with defaults (85%
+  // threshold, empty rows). Block it like the loading state.
+  if (isEdit && activeStatus === 'error') {
+    return <Text c="red">Failed to load data masking rule.</Text>
   }
 
   return (


### PR DESCRIPTION
   > [!IMPORTANT]
   > Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
   > - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
   > - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

   ## 📝 Description

   The Data Masking rule form claimed "Default 85%" for the analyzer confidence
   threshold, but no default existed anywhere in the stack: leaving the field
   empty omitted `score_threshold` from the payload entirely, so Presidio applied
   no filter (threshold 0, every detection masked). Typing 85 then made masking
   *stricter* than the supposed default — entities scored below 0.85 (e.g.
   template custom entities at 0.5/0.6) silently stopped masking, which users read as "data masking stopped working".

   This PR makes the UI match its own copy: new blank rules now initialize the
   threshold field to 85, so saving sends `score_threshold: 0.85`.

   Deliberately scoped to blank new rules only:
   - **Editing** an existing rule keeps its stored value; a stored `NULL` still
     renders empty — otherwise open-then-save would silently add a 0.85 filter to
     a rule that masks everything today.
   - **Template deep links** (`?template=`) keep their baked thresholds (0.5/0.6),
     since their custom entities are scored 0.5/0.6 and an 85 default would make
     them dead on arrival.                                                                                   - Clearing the field still means "no threshold, mask every detection"
    (`formToPayload` omits the key on empty, unchanged).

   The field description was rewritten to state the real semantics: default 85%
   for new rules, empty = mask everything, custom entity types scored below the
   threshold are never masked.

   ## 📣 User-facing impact

   New Live Data Masking rules now start with the advertised 85% confidence
   threshold pre-filled instead of silently applying no threshold, and the field
   help text now explains what the value does and what leaving it empty means.

   ## 🔗 Related Issue

   Fixes #

   ## 🚀 Type of Change

   - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
   - [ ] ✨ New feature (non-breaking change which adds functionality)
   - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
 expected)
   - [ ] ✨ New feature (non-breaking change which adds functionality)
   - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
   - [ ] 📚 Documentation update
   - [x] 🎨 Style/UI update
   - [ ] ♻️ Code refactor
   - [ ] ⚡ Performance improvement
   - [ ] ✅ Test update
   - [ ] 🔧 Build configuration change
   - [ ] 🧹 Chore

   ## 📋 Changes Made

   - `webapp_v2/src/pages/Features/DataMasking/Create/index.jsx`: form state
     initializes `scoreThreshold` to `85` for blank new rules; edit and
     template-seeded rules keep their own value (stored `NULL` stays empty).
   - Same file: replaced the misleading "Default 85% works well" description with
     accurate semantics (1-100 range, empty = mask every detection, custom entity
     scores below the threshold never mask).


   ### Changes

   **`redactor/mspresidio/client.go`**
   - `clampToValueSegments`: trims analyzer spans to value-segment boundaries
     before anonymization. Spans crossing a delimiter are split per segment; spans
     entirely inside a delimiter are dropped. Operates in rune space since Presidio
     offsets are code points. No-op for texts without the delimiter.
   - Startup log of the effective score setup (`scoreSetupString`): analyze
     threshold plus per-pattern scores for custom entities and guardrail rules.
   - Debug log of each analyzer request (threshold, entities, ad hoc recognizer
     count, payload size). Raw payload logging is opt-in via
     `PRESIDIO_DEBUG_PAYLOAD=true` since it contains unredacted customer data.

   **`redactor/types/codec.go`**
   - `extractValues` now decomposes string values that are themselves JSON
     objects/arrays (`parseNestedJSON`) into leaf values, so recognizers see
     isolated tokens. Scalars (`"true"`, `"42"`) keep their exact bytes.
   - `reconstructValues` mirrors this: redacted leaves are spliced back into the
     nested document and re-serialized, keeping the outer structure intact.
     Duplicate map/array leaf handling extracted into `reconstructLeaf`.
   - Exported `HttpJsonValueDelimiter` so the provider can clamp spans to value
     boundaries.


   ## 🧪 Testing

   ### How to test

   **Setup**
   ```sh
   make run-dev           # gateway + agent (needs mspresidio configured as DLP provider)
   cd webapp_v2 && npm run dev
 ```

 Steps
 1. Go to Features → Data Masking → New rule (no ?template= param).
 2. Check the "Analyzer confidence threshold" field.
 3. Save the rule with a name + one entity type, then re-open it.
 4. Create a rule from a template link:
 /features/data-masking/new?template=prod-mask-pii-developer-access.
 5. Edit a pre-existing rule that has no threshold (created before this change
 or via API without score_threshold), save it without touching the field.
 6. New rule again → clear the field → save.

 Expected
 1. Field shows 85 (a value, not just placeholder).
 2. Request body contains "score_threshold": 0.85 (network tab, POST /api/datamasking-rules).
 3. Edit form shows 85 (round-trips via scoreToPercent).
 4. Field shows 60 — template value preserved, not overridden to 85.
 5. Field stays empty; request body has no score_threshold key; the 