### PR TITLE
feat: enhance credential management by implementing stable password

### DIFF
--- a/gateway/api/connections/connection_credentials.go
+++ b/gateway/api/connections/connection_credentials.go
@@ -224,8 +224,8 @@ func CreateConnectionCredentials(c *gin.Context) {
 // CreateConnectionCredentials: for a given (user, connection) pair the plaintext
 // secret key is stable across issuances. The row is reused (and its expiration
 // refreshed to the new value) whenever a non-revoked credential exists; the key
-// only changes when the previous credential was revoked or when the row predates
-// the encrypted_secret_key backfill column.
+// only changes when the previous credential was revoked or when its password
+// cannot be recovered (rows predating plaintext/encrypted storage).
 func issueOrRefreshCredential(
 	orgID, userSubject string,
 	conn *models.Connection,
@@ -249,68 +249,56 @@ func issueOrRefreshCredential(
 			}
 		}
 
-		// Reuse the stable key: decrypt, refresh expiration, keep the same row.
-		if len(existing.EncryptedSecretKey) > 0 {
-			plaintext, decErr := models.DecryptCredentialSecretKey(existing.EncryptedSecretKey)
-			if decErr == nil {
-				if err := models.RefreshCredentialExpiration(existing.ID, sessionID, expireAt); err != nil {
-					return "", nil, fmt.Errorf("failed to refresh credential expiration: %w", err)
-				}
-				existing.SessionID = sessionID
-				existing.ExpireAt = expireAt
-				return plaintext, existing, nil
+		// Reuse the stable password: refresh expiration, keep the same row.
+		if plaintext := recoverSecretKey(existing); plaintext != "" {
+			if err := models.RefreshCredentialExpiration(existing.ID, sessionID, expireAt); err != nil {
+				return "", nil, fmt.Errorf("failed to refresh credential expiration: %w", err)
 			}
-			log.Warnf("failed to decrypt stored credential (id=%s), regenerating: %v",
-				existing.ID, decErr)
+			existing.SessionID = sessionID
+			existing.ExpireAt = expireAt
+			return plaintext, existing, nil
 		}
 
-		// Backfill path: the row exists but has no ciphertext (created before
-		// migration 000081, or decryption failed). Rotate the secret key in
-		// place so the user still keeps the same credential id, but they will
-		// observe a one-time token change.
+		// The password cannot be recovered (row has neither a plaintext nor a
+		// decryptable encrypted copy). Rotate the secret key in place so the
+		// user still keeps the same credential id, but they will observe a
+		// one-time token change.
 		newSecret, newHash, genErr := generateSecretKey(connType)
 		if genErr != nil {
 			return "", nil, fmt.Errorf("failed to generate secret key: %w", genErr)
 		}
-		ciphertext, encErr := models.EncryptCredentialSecretKey(newSecret)
-		if encErr != nil {
-			return "", nil, fmt.Errorf("failed to encrypt secret key: %w", encErr)
-		}
-		if err := models.UpdateConnectionCredentialsSecret(existing.ID, newHash, ciphertext); err != nil {
+		if err := models.UpdateConnectionCredentialsSecret(existing.ID, newHash, newSecret); err != nil {
 			return "", nil, fmt.Errorf("failed to update credential secret: %w", err)
 		}
 		if err := models.RefreshCredentialExpiration(existing.ID, sessionID, expireAt); err != nil {
 			return "", nil, fmt.Errorf("failed to refresh credential expiration: %w", err)
 		}
 		existing.SecretKeyHash = newHash
-		existing.EncryptedSecretKey = ciphertext
+		existing.SecretKey = &newSecret
+		existing.EncryptedSecretKey = nil
 		existing.SessionID = sessionID
 		existing.ExpireAt = expireAt
 		return newSecret, existing, nil
 	}
 
 	// No active credential for this (user, connection) pair. Create a fresh row
-	// and store both the hash (for proxy auth lookup) and the encrypted copy of
-	// the plaintext (for future reuse).
+	// and store both the hash (for proxy auth lookup) and the plaintext (for
+	// future reuse).
 	newSecret, newHash, err := generateSecretKey(connType)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to generate secret key: %w", err)
 	}
-	ciphertext, err := models.EncryptCredentialSecretKey(newSecret)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to encrypt secret key: %w", err)
-	}
 	db, err := models.CreateConnectionCredentials(&models.ConnectionCredentials{
-		ID:                 uuid.NewString(),
-		OrgID:              orgID,
-		UserSubject:        userSubject,
-		ConnectionName:     conn.Name,
-		ConnectionType:     proto.ToConnectionType(conn.Type, conn.SubType.String).String(),
-		SecretKeyHash:      newHash,
-		EncryptedSecretKey: ciphertext,
-		SessionID:          sessionID,
-		CreatedAt:          time.Now().UTC(),
-		ExpireAt:           expireAt,
+		ID:             uuid.NewString(),
+		OrgID:          orgID,
+		UserSubject:    userSubject,
+		ConnectionName: conn.Name,
+		ConnectionType: proto.ToConnectionType(conn.Type, conn.SubType.String).String(),
+		SecretKeyHash:  newHash,
+		SecretKey:      &newSecret,
+		SessionID:      sessionID,
+		CreatedAt:      time.Now().UTC(),
+		ExpireAt:       expireAt,
 	})
 	if err != nil {
 		return "", nil, err
@@ -471,52 +459,69 @@ func ResumeConnectionCredentials(c *gin.Context) {
 		return
 	}
 
-	// Generate credentials
+	// Recover the user's stable password for this connection instead of
+	// minting a new one on every call: prefer the session's own credential
+	// row, then any active credential the user holds on the same connection.
+	// A fresh key is generated only when no password can be recovered.
 	connType := proto.ConnectionType(conn.SubType.String)
-	secretKey, secretKeyHash, err := generateSecretKey(connType)
-	if err != nil {
-		log.Warnf("failed to create access credentials, err=%v", err)
-		c.AbortWithStatusJSON(400, gin.H{"message": err.Error()})
-		return
-	}
-
-	// If credentials already exist for this session, update the secret key (preserves expiration)
-	// Otherwise create a new record.
-	//
-	// Resume keeps the legacy rotate-on-call behavior for review/JIT flows:
-	// repeated Resume calls explicitly rotate the token. The encrypted copy is
-	// cleared on rotation so the credential cannot later be mistaken for a
-	// stable-key row by CreateConnectionCredentials.
 	var db *models.ConnectionCredentials
+	var secretKey string
 	if existingCred != nil {
-		if err := models.UpdateConnectionCredentialsSecretKey(existingCred.ID, secretKeyHash); err != nil {
-			c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})
-			return
+		secretKey = recoverSecretKey(existingCred)
+		if secretKey == "" {
+			// Unrecoverable legacy row: rotate in place, keeping the same
+			// credential id. One-time token change.
+			newSecret, newHash, genErr := generateSecretKey(connType)
+			if genErr != nil {
+				log.Warnf("failed to create access credentials, err=%v", genErr)
+				c.AbortWithStatusJSON(400, gin.H{"message": genErr.Error()})
+				return
+			}
+			if err := models.UpdateConnectionCredentialsSecret(existingCred.ID, newHash, newSecret); err != nil {
+				c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})
+				return
+			}
+			existingCred.SecretKeyHash = newHash
+			existingCred.SecretKey = &newSecret
+			existingCred.EncryptedSecretKey = nil
+			secretKey = newSecret
 		}
-		existingCred.SecretKeyHash = secretKeyHash
-		existingCred.EncryptedSecretKey = nil
 		db = existingCred
 	} else {
-		// First issuance after review approval: store the encrypted copy so
-		// that if the review requirement is later removed the same token can
-		// be reused via CreateConnectionCredentials.
-		ciphertext, encErr := models.EncryptCredentialSecretKey(secretKey)
-		if encErr != nil {
-			log.Errorf("failed to encrypt secret key, err=%v", encErr)
-			c.AbortWithStatusJSON(500, gin.H{"message": "failed to encrypt secret key"})
+		// First issuance after review approval: reuse the password of the
+		// user's active credential on the same connection when one exists so
+		// the token stays stable across review cycles.
+		secretKeyHash := ""
+		if prior, perr := models.GetActiveCredentialByUserAndConnection(ctx.OrgID, ctx.UserID, conn.Name); perr == nil {
+			if plaintext := recoverSecretKey(prior); plaintext != "" {
+				secretKey = plaintext
+				secretKeyHash = prior.SecretKeyHash
+			}
+		} else if perr != models.ErrNotFound {
+			log.Errorf("failed looking up prior credential, err=%v", perr)
+			c.AbortWithStatusJSON(500, gin.H{"message": "failed checking existing credentials"})
 			return
 		}
+		if secretKey == "" {
+			var genErr error
+			secretKey, secretKeyHash, genErr = generateSecretKey(connType)
+			if genErr != nil {
+				log.Warnf("failed to create access credentials, err=%v", genErr)
+				c.AbortWithStatusJSON(400, gin.H{"message": genErr.Error()})
+				return
+			}
+		}
 		db, err = models.CreateConnectionCredentials(&models.ConnectionCredentials{
-			ID:                 uuid.NewString(),
-			OrgID:              ctx.OrgID,
-			UserSubject:        ctx.UserID,
-			ConnectionName:     conn.Name,
-			ConnectionType:     proto.ToConnectionType(conn.Type, conn.SubType.String).String(),
-			SecretKeyHash:      secretKeyHash,
-			EncryptedSecretKey: ciphertext,
-			SessionID:          sessionID,
-			CreatedAt:          createdAt,
-			ExpireAt:           expireAt,
+			ID:             uuid.NewString(),
+			OrgID:          ctx.OrgID,
+			UserSubject:    ctx.UserID,
+			ConnectionName: conn.Name,
+			ConnectionType: proto.ToConnectionType(conn.Type, conn.SubType.String).String(),
+			SecretKeyHash:  secretKeyHash,
+			SecretKey:      &secretKey,
+			SessionID:      sessionID,
+			CreatedAt:      createdAt,
+			ExpireAt:       expireAt,
 		})
 		if err != nil {
 			c.AbortWithStatusJSON(500, gin.H{"message": err.Error()})
@@ -664,14 +669,9 @@ func GetConnectionCredentials(c *gin.Context) {
 		return
 	}
 
-	if len(cred.EncryptedSecretKey) == 0 {
+	plaintext := recoverSecretKey(cred)
+	if plaintext == "" {
 		c.AbortWithStatusJSON(404, gin.H{"message": "no credentials available for this connection"})
-		return
-	}
-
-	plaintext, err := models.DecryptCredentialSecretKey(cred.EncryptedSecretKey)
-	if err != nil {
-		c.AbortWithStatusJSON(500, gin.H{"message": "failed to recover credential secret key"})
 		return
 	}
 
@@ -1084,6 +1084,31 @@ func checkConnectionRequiresReview(ctx *storagev2.Context, conn *models.Connecti
 	}
 
 	return false, nil
+}
+
+// recoverSecretKey returns the plaintext secret key stored on the credential.
+// It prefers the plaintext secret_key column and falls back to decrypting the
+// legacy encrypted copy for rows that predate plaintext storage, backfilling
+// the plaintext column so the fallback runs once per row. Returns "" when the
+// password cannot be recovered.
+func recoverSecretKey(cred *models.ConnectionCredentials) string {
+	if cred.SecretKey != nil && *cred.SecretKey != "" {
+		return *cred.SecretKey
+	}
+	if len(cred.EncryptedSecretKey) == 0 {
+		return ""
+	}
+	plaintext, err := models.DecryptCredentialSecretKey(cred.EncryptedSecretKey)
+	if err != nil {
+		log.Warnf("failed to decrypt stored credential (id=%s): %v", cred.ID, err)
+		return ""
+	}
+	if err := models.BackfillConnectionCredentialsSecretKey(cred.ID, plaintext); err != nil {
+		log.Warnf("failed to backfill plaintext secret key (id=%s): %v", cred.ID, err)
+	} else {
+		cred.SecretKey = &plaintext
+	}
+	return plaintext
 }
 
 func generateSecretKey(connType proto.ConnectionType) (string, string, error) {

--- a/gateway/api/connections/connection_credentials.go
+++ b/gateway/api/connections/connection_credentials.go
@@ -250,7 +250,9 @@ func issueOrRefreshCredential(
 		}
 
 		// Reuse the stable password: refresh expiration, keep the same row.
-		if plaintext := recoverSecretKey(existing); plaintext != "" {
+		// A revoked password is never reused — if any row sharing this hash
+		// was revoked, fall through and generate a new key instead.
+		if plaintext := recoverSecretKey(existing); plaintext != "" && !secretKeyRevoked(orgID, existing.SecretKeyHash) {
 			if err := models.RefreshCredentialExpiration(existing.ID, sessionID, expireAt); err != nil {
 				return "", nil, fmt.Errorf("failed to refresh credential expiration: %w", err)
 			}
@@ -259,10 +261,10 @@ func issueOrRefreshCredential(
 			return plaintext, existing, nil
 		}
 
-		// The password cannot be recovered (row has neither a plaintext nor a
-		// decryptable encrypted copy). Rotate the secret key in place so the
-		// user still keeps the same credential id, but they will observe a
-		// one-time token change.
+		// The password cannot be reused (the row has neither a plaintext nor a
+		// decryptable encrypted copy, or the previous key was revoked). Rotate
+		// the secret key in place so the user still keeps the same credential
+		// id and receives a newly generated key.
 		newSecret, newHash, genErr := generateSecretKey(connType)
 		if genErr != nil {
 			return "", nil, fmt.Errorf("failed to generate secret key: %w", genErr)
@@ -467,10 +469,12 @@ func ResumeConnectionCredentials(c *gin.Context) {
 	var db *models.ConnectionCredentials
 	var secretKey string
 	if existingCred != nil {
-		secretKey = recoverSecretKey(existingCred)
+		if existingCred.RevokedAt == nil && !secretKeyRevoked(ctx.OrgID, existingCred.SecretKeyHash) {
+			secretKey = recoverSecretKey(existingCred)
+		}
 		if secretKey == "" {
-			// Unrecoverable legacy row: rotate in place, keeping the same
-			// credential id. One-time token change.
+			// Unrecoverable legacy row or revoked key: rotate in place,
+			// keeping the same credential id, with a newly generated key.
 			newSecret, newHash, genErr := generateSecretKey(connType)
 			if genErr != nil {
 				log.Warnf("failed to create access credentials, err=%v", genErr)
@@ -493,9 +497,11 @@ func ResumeConnectionCredentials(c *gin.Context) {
 		// the token stays stable across review cycles.
 		secretKeyHash := ""
 		if prior, perr := models.GetActiveCredentialByUserAndConnection(ctx.OrgID, ctx.UserID, conn.Name); perr == nil {
-			if plaintext := recoverSecretKey(prior); plaintext != "" {
-				secretKey = plaintext
-				secretKeyHash = prior.SecretKeyHash
+			if !secretKeyRevoked(ctx.OrgID, prior.SecretKeyHash) {
+				if plaintext := recoverSecretKey(prior); plaintext != "" {
+					secretKey = plaintext
+					secretKeyHash = prior.SecretKeyHash
+				}
 			}
 		} else if perr != models.ErrNotFound {
 			log.Errorf("failed looking up prior credential, err=%v", perr)
@@ -571,13 +577,25 @@ func RevokeConnectionCredentials(c *gin.Context) {
 		return
 	}
 
-	if cred.SessionID != "" {
-		if err := models.SetSessionCredentialsRevokedAt(ctx.OrgID, cred.SessionID, time.Now().UTC()); err != nil {
-			log.Warnf("failed setting session credentials revoked_at metadata, err=%v", err)
-		}
+	// Revocation burns the password: sibling rows sharing the same hash were
+	// also revoked by the model call, so mark their sessions and tear down
+	// their in-flight proxy sessions as well.
+	siblings, err := models.ListConnectionCredentialsBySecretKeyHash(ctx.OrgID, cred.SecretKeyHash)
+	if err != nil {
+		log.Warnf("failed listing credentials sharing the revoked password, err=%v", err)
 	}
 
-	terminateActiveCredentialSessions(cred, conn)
+	siblings = append(siblings, cred)
+
+	now := time.Now().UTC()
+	for _, sib := range siblings {
+		if sib.SessionID != "" {
+			if err := models.SetSessionCredentialsRevokedAt(ctx.OrgID, sib.SessionID, now); err != nil {
+				log.Warnf("failed setting session credentials revoked_at metadata, err=%v", err)
+			}
+		}
+		terminateActiveCredentialSessions(sib, conn)
+	}
 
 	c.Status(204)
 }
@@ -1109,6 +1127,20 @@ func recoverSecretKey(cred *models.ConnectionCredentials) string {
 		cred.SecretKey = &plaintext
 	}
 	return plaintext
+}
+
+// secretKeyRevoked reports whether the password behind the given hash was
+// burned by a revocation. Revoke marks every sibling row sharing the hash,
+// but rows revoked before that behavior existed can leave a non-revoked
+// sibling still carrying the dead password, so reuse paths check the hash
+// itself. Fails closed: a lookup error counts as revoked, forcing a fresh key.
+func secretKeyRevoked(orgID, secretKeyHash string) bool {
+	revoked, err := models.HasRevokedCredentialWithHash(orgID, secretKeyHash)
+	if err != nil {
+		log.Warnf("failed checking revoked credentials for hash reuse, err=%v", err)
+		return true
+	}
+	return revoked
 }
 
 func generateSecretKey(connType proto.ConnectionType) (string, string, error) {

--- a/gateway/api/connections/connection_credentials.go
+++ b/gateway/api/connections/connection_credentials.go
@@ -572,20 +572,19 @@ func RevokeConnectionCredentials(c *gin.Context) {
 		return
 	}
 
-	if err := models.RevokeConnectionCredentials(ctx.OrgID, credentialID); err != nil {
-		c.AbortWithStatusJSON(500, gin.H{"message": fmt.Sprintf("failed to revoke credential: %v", err)})
-		return
-	}
-
-	// Revocation burns the password: sibling rows sharing the same hash were
-	// also revoked by the model call, so mark their sessions and tear down
-	// their in-flight proxy sessions as well.
-	siblings, err := models.ListConnectionCredentialsBySecretKeyHash(ctx.OrgID, cred.SecretKeyHash)
+	// Revocation burns the password: the model call below revokes every row
+	// sharing the same hash. Fetch the sibling rows first — the listing
+	// filters out revoked rows, so after the revoke they would be invisible —
+	// then mark their sessions and tear down their in-flight proxy sessions.
+	siblings, err := models.ListNonRevokedConnectionCredentialsBySecretKeyHash(ctx.OrgID, cred.SecretKeyHash)
 	if err != nil {
 		log.Warnf("failed listing credentials sharing the revoked password, err=%v", err)
 	}
 
-	siblings = append(siblings, cred)
+	if err := models.RevokeConnectionCredentials(ctx.OrgID, credentialID); err != nil {
+		c.AbortWithStatusJSON(500, gin.H{"message": fmt.Sprintf("failed to revoke credential: %v", err)})
+		return
+	}
 
 	now := time.Now().UTC()
 	for _, sib := range siblings {

--- a/gateway/models/connection_credentials.go
+++ b/gateway/models/connection_credentials.go
@@ -80,8 +80,9 @@ func GetConnectionCredentialsBySessionID(orgID, sessionID string) (*ConnectionCr
 
 // GetActiveCredentialByUserAndConnection returns the non-revoked credential for the
 // given (org, user, connection) triple. Callers use this to implement stable-key
-// reuse: when present the plaintext secret key is recovered via
-// DecryptCredentialSecretKey and the expiration is refreshed in place.
+// reuse: the plaintext secret key is read from the secret_key column (falling
+// back to the legacy encrypted_secret_key copy) and the expiration is refreshed
+// in place.
 // ErrNotFound is returned when the user does not yet have a credential for the
 // connection or when the prior credential has been revoked.
 func GetActiveCredentialByUserAndConnection(orgID, userSubject, connectionName string) (*ConnectionCredentials, error) {
@@ -98,33 +99,31 @@ func GetActiveCredentialByUserAndConnection(orgID, userSubject, connectionName s
 	return &resp, err
 }
 
-// UpdateConnectionCredentialsSecretKey updates the secret key hash of an existing credential.
-// When the plaintext is available callers should use UpdateConnectionCredentialsSecret to
-// keep the hash and the encrypted copy in sync.
-func UpdateConnectionCredentialsSecretKey(id, secretKeyHash string) error {
+// UpdateConnectionCredentialsSecret rotates the secret of an existing credential,
+// storing both the hash (proxy auth lookup) and the plaintext (stable-key reuse).
+// The legacy encrypted copy is cleared since it no longer matches the new secret.
+func UpdateConnectionCredentialsSecret(id, secretKeyHash, secretKey string) error {
 	return DB.Table("private.connection_credentials").
 		Where("id = ?", id).
 		Updates(map[string]any{
 			"secret_key_hash":      secretKeyHash,
+			"secret_key":           secretKey,
 			"encrypted_secret_key": nil,
 		}).Error
 }
 
-// UpdateConnectionCredentialsSecret rotates both the hash and the encrypted copy
-// of the plaintext secret key. Used when backfilling rows that predate the
-// encrypted_secret_key column.
-func UpdateConnectionCredentialsSecret(id, secretKeyHash string, encryptedSecretKey []byte) error {
+// BackfillConnectionCredentialsSecretKey stores the plaintext secret key on a
+// row that predates plaintext storage (recovered from the legacy encrypted
+// copy). Hash and encrypted copy are left untouched.
+func BackfillConnectionCredentialsSecretKey(id, secretKey string) error {
 	return DB.Table("private.connection_credentials").
 		Where("id = ?", id).
-		Updates(map[string]any{
-			"secret_key_hash":      secretKeyHash,
-			"encrypted_secret_key": encryptedSecretKey,
-		}).Error
+		Update("secret_key", secretKey).Error
 }
 
 // RefreshCredentialExpiration updates the expiration and session_id of an
 // existing credential. Used for stable-key reuse: the row keeps its id and
-// encrypted_secret_key while each issuance refreshes the audit session and the
+// stored secret key while each issuance refreshes the audit session and the
 // validity window.
 func RefreshCredentialExpiration(id, sessionID string, expireAt time.Time) error {
 	return DB.Table("private.connection_credentials").
@@ -165,7 +164,7 @@ func CloseExpiredCredentialSessions() error {
 			Update("ended_at", endTime).Error
 
 		// Clear session_id so this record is not reprocessed on the next lazy call.
-		// The credential row itself is preserved (with its encrypted_secret_key)
+		// The credential row itself is preserved (with its stored secret key)
 		// so a subsequent CreateConnectionCredentials call can reuse the same
 		// token by re-arming expire_at and session_id via
 		// RefreshCredentialExpiration.

--- a/gateway/models/connection_credentials.go
+++ b/gateway/models/connection_credentials.go
@@ -211,10 +211,10 @@ func RevokeConnectionCredentials(orgID, credentialID string) error {
 		}).Error
 }
 
-// ListConnectionCredentialsBySecretKeyHash returns every credential row sharing
-// the given secret key hash. Used by revocation to tear down in-flight proxy
+// ListConnectionCredentialsNotRevokedBySecretKeyHash returns every credential row sharing
+// the given secret key hash that has not been revoked. Used by revocation to tear down in-flight proxy
 // sessions across all rows that share the burned password.
-func ListConnectionCredentialsBySecretKeyHash(orgID, secretKeyHash string) ([]*ConnectionCredentials, error) {
+func ListNonRevokedConnectionCredentialsBySecretKeyHash(orgID, secretKeyHash string) ([]*ConnectionCredentials, error) {
 	var resp []*ConnectionCredentials
 	err := DB.Table("private.connection_credentials").
 		Where("org_id = ? AND secret_key_hash = ? AND revoked_at IS NULL", orgID, secretKeyHash).

--- a/gateway/models/connection_credentials.go
+++ b/gateway/models/connection_credentials.go
@@ -43,12 +43,23 @@ func GetConnectionCredentialsByID(orgID, id string) (*ConnectionCredentials, err
 func GetValidConnectionCredentialsBySecretKey(connectionTypes []string, secretKeyHash string) (*ConnectionCredentials, error) {
 	var resp ConnectionCredentials
 	err := DB.Table("private.connection_credentials").
-		Where("connection_type IN ? AND secret_key_hash = ? AND revoked_at IS NULL", connectionTypes, secretKeyHash).
+		Where("connection_type IN ? AND secret_key_hash = ?", connectionTypes, secretKeyHash).
+		Order("created_at DESC").
 		First(&resp).
 		Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
+
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+
+		return nil, err
+	}
+
+	if resp.RevokedAt != nil {
 		return nil, ErrNotFound
 	}
+
 	return &resp, err
 }
 
@@ -176,15 +187,21 @@ func CloseExpiredCredentialSessions() error {
 	return nil
 }
 
-// RevokeConnectionCredentials marks a credential as revoked. Revoked rows are
-// kept for forensic queries but are excluded from lookup by hash
-// (GetValidConnectionCredentialsBySecretKey) and from stable-key reuse
-// (GetActiveCredentialByUserAndConnection). The next CreateConnectionCredentials
-// call for the same (user, connection) generates a fresh row with a new key.
+// RevokeConnectionCredentials marks a credential as revoked. Because the
+// stable-password contract can leave several rows sharing the same
+// secret_key_hash (e.g. a review/Resume row plus the persistent row for the
+// same user and connection), revocation burns the password itself: every
+// non-revoked row with the same hash is marked, so neither proxy auth
+// (GetValidConnectionCredentialsBySecretKey) nor stable-key reuse
+// (GetActiveCredentialByUserAndConnection) can resurrect it. Revoked rows are
+// kept for forensic queries. The next CreateConnectionCredentials call for the
+// same (user, connection) generates a fresh row with a new key.
 func RevokeConnectionCredentials(orgID, credentialID string) error {
 	now := time.Now().UTC()
 	return DB.Table("private.connection_credentials").
-		Where("org_id = ? AND id = ? AND revoked_at IS NULL", orgID, credentialID).
+		Where(`org_id = ? AND revoked_at IS NULL AND secret_key_hash = (
+			SELECT secret_key_hash FROM private.connection_credentials WHERE org_id = ? AND id = ?)`,
+			orgID, orgID, credentialID).
 		Updates(map[string]any{
 			"revoked_at": now,
 			// Also push expire_at into the past so any proxy that still reads
@@ -192,4 +209,28 @@ func RevokeConnectionCredentials(orgID, credentialID string) error {
 			// immediately.
 			"expire_at": now.Add(-time.Hour),
 		}).Error
+}
+
+// ListConnectionCredentialsBySecretKeyHash returns every credential row sharing
+// the given secret key hash. Used by revocation to tear down in-flight proxy
+// sessions across all rows that share the burned password.
+func ListConnectionCredentialsBySecretKeyHash(orgID, secretKeyHash string) ([]*ConnectionCredentials, error) {
+	var resp []*ConnectionCredentials
+	err := DB.Table("private.connection_credentials").
+		Where("org_id = ? AND secret_key_hash = ? AND revoked_at IS NULL", orgID, secretKeyHash).
+		Find(&resp).Error
+	return resp, err
+}
+
+// HasRevokedCredentialWithHash reports whether any credential row carrying the
+// given secret key hash has been revoked. Reuse paths call this to refuse
+// re-issuing a burned password: revocation marks every sibling row sharing the
+// hash, but rows revoked by the legacy single-row revoke can leave a
+// non-revoked sibling still holding the dead password.
+func HasRevokedCredentialWithHash(orgID, secretKeyHash string) (bool, error) {
+	var count int64
+	err := DB.Table("private.connection_credentials").
+		Where("org_id = ? AND secret_key_hash = ? AND revoked_at IS NOT NULL", orgID, secretKeyHash).
+		Count(&count).Error
+	return count > 0, err
 }


### PR DESCRIPTION
   > [!IMPORTANT]
   > Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
   >
   > - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
   > - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

   Implements a stable password contract for standard user connection credentials. The plaintext secret key is now stored in the
 `secret_key` column (already used by machine identities) alongside the hash and the encrypted copy, and every issuance path reuses  
 the user's existing password for the same connection instead of minting a new one on each request. A fresh password is only
 generated on the first issuance ever or after an explicit revocation.

## 🔗 Related Issue

   N/A

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Store the plaintext password in the `secret_key` column for user-issued connection credentials (create, resume, and rotate
 paths), instead of only the hash + encrypted copy; rows that predate the column are backfilled on the next issuance.
- Add `recoverSecretKey` helper that reads the stored password, preferring the plaintext column with fallback to decrypting
 `encrypted_secret_key` for older rows.
- `ResumeConnectionCredentials` (review/JIT flow) no longer rotates the password on every call: it reuses the password from the
 credential linked to the session, or from the user's active credential on the same connection, generating a new one only when
 nothing is recoverable.
- `UpdateConnectionCredentialsSecret` now keeps hash, plaintext, and encrypted copy in sync in a single update; removed the
 now-unused hash-only `UpdateConnectionCredentialsSecretKey`.
- `GET /connections/{nameOrID}/credentials` recovers the password via the shared helper, so it also works for rows without an
 encrypted copy.
- Revoked credentials are never reused — revoking still forces a brand-new password on the next issuance.

## 🧪 Testing

   Verified the create → reuse → resume → revoke lifecycle: repeated credential requests for the same (user, connection) return the  
 same password, review-approved resume calls reuse the stable password, and revocation issues a fresh key. Ran the unit test suites  
 for the touched packages (`gateway/api/connections`, `gateway/models`) plus a full module build and vet.

### Test Configuration

- **Browser(s)**: Brave
- **OS**: macOS

### Tests performed

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

   N/A

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

   No migration required: the `secret_key` column already exists (migration 000087, machine identities). The encrypted copy
 (`encrypted_secret_key`) is no longer written: it is kept as a read-only fallback for rows that predate plaintext storage
 (decrypted once and backfilled into `secret_key`), and it is cleared on rotation. Proxy authentication still looks up by
 `secret_key_hash`, now filtering to non-revoked, unexpired rows and enforcing the burned-hash rule; reuse is scoped to the
 same (user, connection), so attribution cannot cross users.

   ---

