### PR TITLE
EVL-115: PR 0.2 — scaffolding deletion + webapp_v2 doc reorg (single owner per topic)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,13 +304,12 @@ together (recommended). Individual targets:
 | shadow-cljs (CLJS) | 8280 | `cd webapp && npm run dev` |
 | Gateway (backend) | 8009 | see `Makefile` |
 
-Hot reload: Vite HMRs React sources instantly. shadow-cljs rebuilds
-`/js/app.js` and `/css/site.css`, which Vite **proxies** — so CLJS/Tailwind
-edits do NOT propagate as HMR into the running page. Hard-reload the tab
-(Cmd+Shift+R) after a CLJS change.
+Hot reload: CLJS/Tailwind edits do NOT propagate as HMR through the Vite
+proxy — hard-reload the tab (Cmd+Shift+R) after a CLJS change; details in
+`webapp_v2/README.md`.
 
-A `.env` in `webapp_v2/` is optional — `vite.config.js` defaults all dev
-proxy targets. Same goes for `webapp/.env`: only override `SENTRY_DSN`,
+A `.env` in `webapp_v2/` is optional — see `webapp_v2/README.md` (Environment
+Variables). Same goes for `webapp/.env`: only override `SENTRY_DSN`,
 `SEGMENT_WRITE_KEY` or `API_URL` if you need to (closure-defines in
 `shadow-cljs.edn` already supply usable defaults).
 

--- a/webapp_v2/CLAUDE.md
+++ b/webapp_v2/CLAUDE.md
@@ -1,15 +1,14 @@
 # Hoop WebApp V2 - Development Guidelines
 
 ## Stack
-- **React 19** + JavaScript (no TypeScript)
-- **Vite** - Build tool
-- **Mantine v8** - Component library (sole styling solution, no Tailwind)
-- **Zustand** - State management
-- **Axios** - HTTP client
-- **React Router v7** - Routing
+
+React 19 + JavaScript (no TypeScript) · Vite · Mantine v8 (sole styling — no
+Tailwind) · Zustand · Axios · React Router v7 · lucide-react. Setup and
+details: `README.md`.
 
 ## Commands
-- Development: `npm run dev`
+- Development (recommended): `npm run dev:full` — Vite + shadow-cljs together; ports, proxy and HMR caveats in `README.md`
+- Development (Vite only): `npm run dev`
 - Build: `npm run build`
 - Lint: `npm run lint`
 - Preview production: `npm run preview`
@@ -180,8 +179,7 @@ Authentication follows the same logic as the original webapp (ClojureScript):
 6. **OAuth Signup**: On `/signup/callback`, extract token, redirect to `/signup` for org setup
 
 ### Environment Variables
-- `VITE_API_URL` (optional): Custom API endpoint. Defaults to `/api` (relative to current domain)
-- `SEGMENT_WRITE_KEY` (optional, build-time): Segment write key baked into the bundle at `npm run build`. Same env var as the CLJS bundle, so a single setting controls both webapps. Defaults to the hoop.dev production key — override only when pointing a build at a different Segment workspace.
+Env vars (`VITE_API_URL`, `SEGMENT_WRITE_KEY`, `API_URL`, `VITE_CLJS_URL`): see the table in `README.md` (Environment Variables).
 
 ## Re-frame Interop (CLJS ↔ React)
 

--- a/webapp_v2/CLJS_PATTERNS.md
+++ b/webapp_v2/CLJS_PATTERNS.md
@@ -266,6 +266,24 @@ Common mappings:
 
 ---
 
+## Recurring CLJS features → shared React building blocks
+
+Several CLJS patterns recur across feature pages and already have shared React
+equivalents. **Reach for these before writing a new one** (full props in `COMPONENTS.md`):
+
+| CLJS pattern | React building block | Use it for |
+|--------------|----------------------|------------|
+| `features/promotion` (`*-promotion`) | `components/FeaturePromotion` + `layout/FullBleed` | Empty/gated feature pages (split marketing panel + illustration). |
+| `resource-role-filter` / `attribute-filter` (full list) | `components/ValueFilter` | Single-value table/list filter over a fully loaded array. |
+| `resource-role-filter` (paginated) | `components/AsyncValueFilter` | Single-value filter over a paginated, server-searched source. |
+| `components/multiselect` `paginated` | `components/PaginatedMultiSelect` | Generic multi-select over a paginated, server-searched source. |
+| `components/connections-select` | `components/ConnectionsMultiSelect` | Resource-role (connection) picker with infinite scroll + search. |
+| `:connections->pagination` slice | `hooks/usePaginatedConnections` | Paginated connection option source (data layer for the two above). |
+
+Infinite scroll uses Mantine's built-in `useIntersection` (sentinel at list bottom) — no bespoke component. The full `/connections` load stays only where a page must resolve every `connection_ids → name` (e.g. list displays); dropdowns paginate.
+
+---
+
 ## Finding CLJS Source Files
 
 Common locations:

--- a/webapp_v2/COMPONENTS.md
+++ b/webapp_v2/COMPONENTS.md
@@ -608,53 +608,58 @@ Returns `{ options ([{value,label}]), loading, hasMore, searchValue, setSearch, 
 
 ## Stores (`src/stores/`)
 
-| Hook | Responsibility | Key state / actions |
-|------|---------------|---------------------|
-| `useAuthStore` | JWT token lifecycle | `token`, `setToken()`, `logout()`, `redirectUrl` |
-| `useUserStore` | Current user data | `user`, `isAdmin`, `isFreeLicense`, `fetchUser()` |
-| `useUIStore` | Sidebar open/collapsed | `sidebarOpened`, `toggle()`, `pendingSection` |
-| `useBridgeStore` | Cross-cutting CLJS re-frame dispatches | `showSnackbar()`, `refreshLegacyUser()`, `openNativeClientAccess()`, `openNativeClientAccessWhenReady()` |
-| `useConfigStatusStore` | Sidebar setup-checklist snapshot (admin only) | `status`, `checks`, `execConnectionName`, `fetchStatus({force})` |
-| `useAgentStore` | Agents CRUD | `agents`, `loading`, `error`, `agentKey`, `fetchAgents()`, `createAgent()`, `deleteAgent()` |
-| `useCommandPaletteStore` | Command palette state | `page`, `context`, `searchStatus`, `results`, `search()` |
+One Zustand store per concern — **the filesystem is the source of truth**
+(`ls src/stores/`); store names describe their responsibility. Check the
+directory before creating a new store.
 
 Access store state outside React (e.g., inside another store action):
 ```js
 useAuthStore.getState().token
 ```
 
+Non-obvious notes only:
+
+- `useBridgeStore` — wraps `window.hoopDispatch` re-frame bridge calls; never
+  call `hoopDispatch` from a component (rule in `CLAUDE.md` "Re-frame Interop").
+  Current methods: `refreshLegacyUser()`, `openNativeClientAccess()`,
+  `openNativeClientAccessWhenReady()`, `syncPrimaryConnectionFromUrl()`.
+  Snackbars are NOT bridged — use `showSnackbar` from `@/utils/snackbar`.
+- `useConfigStatusStore` — sidebar setup-checklist snapshot, admin only;
+  refreshes on the `hoop:session-executed` DOM event from the CLJS terminal.
+- `useConnectionsMetadataStore` — loaded once at app start (`App.jsx`); feeds
+  credential field schemas + connection icons; `load()` is idempotent.
+
 ---
 
 ## Services (`src/services/`)
 
-| File | What it wraps |
-|------|--------------|
-| `api.js` | Base Axios instance — adds Bearer token, handles 401 logout |
-| `auth.js` | Login, register, OAuth, user info, server info |
-| `agents.js` | CRUD `/agents` and `/agents/:id` |
-| `connections.js` | GET `/connections` (full list) + `getConnectionsPaginated({page,pageSize,search,connectionIds})` for infinite-scroll dropdowns |
-| `connections.js` | GET/PATCH/DELETE `/connections`, POST `/connections/:name/test` |
-| `guardrails.js` | GET `/guardrails` |
-| `sessions.js` | GET `/sessions` (`list(params)` — e.g. `{ limit: 1 }` as a cheap existence/total probe) |
-| `jiraTemplates.js` | GET `/integrations/jira/issuetemplates` |
-| `attributes.js` | CRUD `/attributes` |
-| `search.js` | GET `/search?term=` |
-| `infrastructure.js` | GET/PUT `/serverconfig/misc` |
-| `license.js` | GET `/serverinfo` (extracts `license_info`), PUT `/orgs/license` |
-| `protectionProfiles.js` | GET/PUT `/orgs/protection-profile` (protection rules profile; `profile: null` = manual) |
+One Axios service file per API domain — **the filesystem is the source of
+truth** (`ls src/services/`). Check the directory before creating a new file;
+when adding one, follow the pattern in `services/agents.js`.
 
-When adding a new service file, follow the pattern in `services/agents.js`.
+Non-obvious notes only:
+
+- `api.js` — the base Axios instance (Bearer-token interceptor + 401 → saved
+  URL + logout). Every other service imports it; never call axios directly.
+- `analytics.js` — Segment (`identify()` only today), not a gateway API
+  wrapper; the write key is a build-time define (see the env table in
+  `README.md`).
+- `connections.js` — both `getConnections()` (full list — only for resolving
+  every `connection_ids → name`, e.g. list displays) and
+  `getConnectionsPaginated({page,pageSize,search,connectionIds})` for
+  infinite-scroll dropdowns.
+- `eventRouting.js` — normalizes the backend's snake_case JSON to camelCase at
+  the service boundary.
+- `sessions.js` — `list(params)`; `{ limit: 1 }` doubles as a cheap
+  existence/total probe.
 
 ---
 
 ## Notifications — `showSnackbar`
 
-Use the `showSnackbar` helper from `@/utils/snackbar`. It is backed by `sonner` — the
-same library the legacy CLJS app uses — and renders through
-`src/components/Snackbar/Toast.jsx`, a one-to-one port of the legacy
-`webapp.components.toast`, so snackbars appear at the **top-right** and look
-identical across React and CLJS routes.
-The single `<Toaster>` is mounted in `src/App.jsx`.
+Use the `showSnackbar` helper from `@/utils/snackbar`. Rules (never
+`@mantine/notifications`, single `<Toaster>` in `App.jsx`, never via the CLJS
+bridge): see `CLAUDE.md` "Snackbars / Toasts".
 
 ```js
 import { showSnackbar } from '@/utils/snackbar'
@@ -672,9 +677,7 @@ showSnackbar({
 ```
 
 Error toasts auto-dismiss after 10 seconds (mirrors v1); other levels use sonner's
-default. Do NOT use `@mantine/notifications` — the dependency has been removed from
-the project (it rendered a completely different visual and broke parity with v1).
-See the "Snackbars / Toasts" section of `CLAUDE.md` for the full rule.
+default.
 
 ---
 

--- a/webapp_v2/CONTEXT_MIGRATION.md
+++ b/webapp_v2/CONTEXT_MIGRATION.md
@@ -48,11 +48,10 @@ Gateway backend (port 8009)
 
 | Mechanism | Description |
 |-----------|-------------|
-| `localStorage.react-shell = true` | Set by `ClojureApp.jsx`. Signals CLJS to skip rendering its own sidebar/header |
+| `localStorage.react-shell = true` | Set by `ClojureApp.jsx`. Signals CLJS to skip rendering its own sidebar/header (guards the double-render) |
 | `window.hoopSetRoute(path)` | Called by `ClojureApp.jsx` on path change to sync React Router → Pushy (CLJS router) |
 | `window.hoopRemount()` | Called on remount to re-render Reagent without refetching user data |
 | `localStorage.jwt-token` | Shared auth token. Both apps read/write the same key |
-| `localStorage.react-shell = true` | Guards double-render of sidebar in CLJS mode |
 | `hoop:session-executed` (DOM CustomEvent on `window`) | Emitted by the CLJS web terminal on exec success (`editor_plugin.cljs`); the React Config Status widget listens and refreshes instantly |
 
 ### Routing Split (Router.jsx)
@@ -101,6 +100,9 @@ Gateway backend (port 8009)
 | `/settings/jira` | React | Done — absorbed into `/jira-templates?tab=configuration` |
 | `/integrations/slack` | React | Done |
 | `/integrations/webhooks` | React | Done |
+| `/plugins/manage/jira` | React (redirect) | Done — legacy URL → `/jira-templates?tab=configuration` |
+| `/plugins/manage/slack` | React (redirect) | Done — legacy URL → `/integrations/slack` |
+| `/plugins/manage/webhooks` | React (redirect) | Done — legacy URL → `/integrations/webhooks` |
 | `/*` (catch-all) | ClojureApp (CLJS) | Ongoing — see `MIGRATION_ROADMAP.md` for the wave plan |
 
 ---
@@ -166,82 +168,27 @@ Dead bidi entries (route exists, panel deleted — cleanup planned in
 
 ## React App Summary (`/webapp_v2`)
 
-### Stores (Zustand)
+One Zustand store per concern in `src/stores/`, one Axios service per API domain
+in `src/services/` — **the filesystem is the source of truth**, don't trust any
+enumerated list. Non-obvious notes (base API instance, bridge store methods,
+pagination variants) live in `COMPONENTS.md` (Stores / Services sections).
 
-| Store | File | Responsibility |
-|-------|------|----------------|
-| `useAuthStore` | `stores/useAuthStore.js` | Token, cookie/query extraction, redirect URL |
-| `useUserStore` | `stores/useUserStore.js` | User data, isAdmin, isFreeLicense |
-| `useUIStore` | `stores/useUIStore.js` | Sidebar open/collapsed state (persists to localStorage) |
-| `useAgentStore` | `stores/useAgentStore.js` | Agents CRUD, loading state |
-| `useCommandPaletteStore` | `stores/useCommandPaletteStore.js` | Palette page navigation, search results |
-
-### Services (Axios)
-
-| Service | File | Endpoints |
-|---------|------|-----------|
-| api | `services/api.js` | Base instance + auth interceptor + 401 handler |
-| auth | `services/auth.js` | `/publicserverinfo`, `/localauth/login`, `/userinfo`, `/serverinfo` |
-| agents | `services/agents.js` | CRUD `/agents`, `/agents/:id` |
-| dataMasking | `services/dataMasking.js` | CRUD `/datamasking-rules`, `/datamasking-rules/:id` |
-| connections | `services/connections.js` | `getConnections()` (full list) + `getConnectionsPaginated({page,pageSize,search,connectionIds})` (`page`/`page_size`/`search`/`connection_ids` → `{pages,data}`) for infinite-scroll dropdowns |
-| search | `services/search.js` | `/search?term=` |
-
-### Dev Ports
-
-| Service | Port |
-|---------|------|
-| Vite (React app) | 5173 |
-| Gateway backend | 8009 (`VITE_GATEWAY_URL`) |
-| shadow-cljs (CLJS bundle) | 8280 (`VITE_CLJS_URL`) |
-
-### Env Variables
-
-All optional — `vite.config.js` provides working defaults, so a `.env` file
-is not required to run `npm run dev` or `npm run dev:full`.
-
-```
-VITE_API_URL       Optional. Overrides the /api default base URL
-VITE_GATEWAY_URL   Dev only. Backend proxy target (default: localhost:8009)
-VITE_CLJS_URL      Dev only. shadow-cljs proxy target (default: localhost:8280)
-```
+Dev servers, ports, and env variables: see `README.md` (Development /
+Environment Variables).
 
 ---
 
 ## Migration Pattern (Reference: `/pages/Agents/`)
 
-The Agents page is the reference implementation. Follow this pattern for every new migration:
+The Agents page (`pages/Agents/`) is the reference implementation. Follow
+`MIGRATION_CHECKLIST.md` for the full step-by-step — it includes Step 0
+(read the CLJS source first) and Steps 7–8 (behavior-parity verification and
+doc updates), which any shortened summary tends to skip.
 
-```
-pages/FeatureName/
-├── index.jsx             # List page
-├── Create/
-│   └── index.jsx         # Create/edit form
-└── store.js              # Local store (only if state is page-scoped)
-```
-
-Steps to migrate a page:
-1. Create service file: `services/featureName.js` (one function per endpoint)
-2. Create store: `stores/useFeatureNameStore.js` or `pages/Page/store.js`
-3. Build page components using Mantine only
-4. Add route in `Router.jsx` above the `/*` catch-all
-5. Sidebar link in `layout/Sidebar.jsx` is already there — just confirm `to` path matches
-
-### Reusable building blocks (don't re-derive these per migration)
-
-Several CLJS patterns recur across feature pages and already have shared React
-equivalents. **Reach for these before writing a new one** (full props in `COMPONENTS.md`):
-
-| CLJS pattern | React building block | Use it for |
-|--------------|----------------------|------------|
-| `features/promotion` (`*-promotion`) | `components/FeaturePromotion` + `layout/FullBleed` | Empty/gated feature pages (split marketing panel + illustration). |
-| `resource-role-filter` / `attribute-filter` (full list) | `components/ValueFilter` | Single-value table/list filter over a fully loaded array. |
-| `resource-role-filter` (paginated) | `components/AsyncValueFilter` | Single-value filter over a paginated, server-searched source. |
-| `components/multiselect` `paginated` | `components/PaginatedMultiSelect` | Generic multi-select over a paginated, server-searched source. |
-| `components/connections-select` | `components/ConnectionsMultiSelect` | Resource-role (connection) picker with infinite scroll + search. |
-| `:connections->pagination` slice | `hooks/usePaginatedConnections` | Paginated connection option source (data layer for the two above). |
-
-Infinite scroll uses Mantine's built-in `useIntersection` (sentinel at list bottom) — no bespoke component. The full `/connections` load stays only where a page must resolve every `connection_ids → name` (e.g. list displays); dropdowns paginate.
+Recurring CLJS features already have shared React building blocks
+(FeaturePromotion, ValueFilter, PaginatedMultiSelect, …) — the mapping table
+lives in `CLJS_PATTERNS.md` ("Recurring CLJS features → shared React building
+blocks"); full props in `COMPONENTS.md`.
 
 ---
 
@@ -263,15 +210,12 @@ Infinite scroll uses Mantine's built-in `useIntersection` (sentinel at list bott
 - ClojureApp bridge component
 - Re-frame dispatch bridge — React can trigger CLJS actions via `window.hoopDispatch` (wrapped in Zustand stores)
 - Vite proxy setup for CLJS and backend
-- Onboarding flow 
-- Auth pages
 - Slack & Webhooks integration pages (`/integrations/slack`, `/integrations/webhooks`) — legacy `/plugins/manage/*` route removed from CLJS
 
 ### In Progress / Known Gaps 🔄
 - No shared ConfirmDialog component yet (pages build ad-hoc confirmations)
 - Native-client-access flow still lives in CLJS and the React CommandPalette depends on it via the bridge
 - Sentry, MS Clarity, Segment `track()`, document-level clipboard blocking and the org-migration dialog exist only in CLJS
-- Slack/Webhooks plugin pages are being migrated on EVL-101 (PR #1633, in review — adds `/integrations/{slack,webhooks}` + legacy redirects)
 
 ### Migration order
 
@@ -292,6 +236,6 @@ this section — when scheduling migration work.
 - **Free vs Enterprise license** is checked from `/api/serverinfo` in `useUserStore`. Some nav items are hidden or locked for free tier.
 - **`isAdmin` is derived** from user data (`user.role === 'admin'`). Admin-only routes are guarded in Sidebar and ProtectedRoute.
 - **`window.hoopRemount()`** must be called on ClojureApp remount (not initial mount) to avoid re-fetching user data when React Router re-renders the component.
-- **Radix → Mantine gray mapping**: the `gray` scale in `webapp_v2/src/theme.js` is a slate-tinted ramp (`gray.0` `#f0f0f3` … `gray.9` `#4d4d60`); the Radix Slate text steps live outside the array as semantic tokens set in `cssVariablesResolver()` — `--mantine-color-dimmed` = slate11 `#60646c` and `--mantine-color-text` = slate12 `#1c2024` — so `c="dimmed"` works out of the box. Note `gray.9` is a mid slate, not near-black: to get body-text black, omit the color prop and inherit `--mantine-color-text`.
-- **CSS Layers for Mantine vs CSS Modules**: `main.jsx` imports `@mantine/core/styles.layer.css` (not `styles.css`), and `src/layers.css` declares `@layer mantine, app;`. Mantine's built-in CSS lives in the `mantine` layer; CSS Modules stay unlayered, so they always win the cascade. Without this, `classes.item` of a CSS Module would compete with `.mantine-Accordion-item` at equal specificity and the result would depend on bundle order.
-- **CLJS stylesheet toggle**: `ClojureApp.jsx` loads `/css/site.css` as a `<link data-cljs-css>` and toggles `link.disabled` on mount/unmount. This keeps the parsed stylesheet in memory (no re-fetch, no flash) but removes its rules from the cascade while a React-only route is active — otherwise Tailwind/Radix rules persist in `<head>` after any visit to a CLJS route and override every React page. Do NOT replace the `<link>` with `<style>@import url(...)</style>` — that serializes the fetch through the CSS parser and produces a visible FOUC.
+- **Radix → Mantine gray mapping**: the gray scale is slate-tinted; `dimmed`/`text` are semantic tokens set in `cssVariablesResolver()` — see `CLAUDE.md` "Text color".
+- **CSS Layers**: Mantine loads via `styles.layer.css` + `@layer mantine, app;` so CSS Modules always win the cascade — see `CLAUDE.md` "CSS Layers — do not disable".
+- **CLJS stylesheet toggle**: `ClojureApp.jsx` toggles the `<link data-cljs-css>` on mount/unmount so Tailwind/Radix rules never leak into React-only routes — see `CLAUDE.md` "CLJS stylesheet isolation".

--- a/webapp_v2/MIGRATION_CHECKLIST.md
+++ b/webapp_v2/MIGRATION_CHECKLIST.md
@@ -40,7 +40,7 @@ export const featureService = {
 }
 ```
 
-Only add the methods the page actually uses. Check `CONTEXT_MIGRATION.md` for existing services before creating a new file.
+Only add the methods the page actually uses. Check `src/services/` for an existing domain file before creating a new one (non-obvious service notes are in `COMPONENTS.md`).
 
 ---
 
@@ -163,9 +163,10 @@ Compare with the running CLJS app:
 
 ---
 
-## Step 8 — Update CONTEXT_MIGRATION.md
+## Step 8 — Update the migration docs
 
 After completing the migration:
-1. Update the **Routing Split** table — change the route status to `Done`
-2. Update **What's Done vs Pending** section
-3. If any global CLJS component was removed, update the **Global Components** table
+1. Update the **Routing Split** table in `CONTEXT_MIGRATION.md` — change the route status to `Done`
+2. Update the **What's Done vs Pending** section in `CONTEXT_MIGRATION.md`
+3. If any global CLJS component was removed, update the **Global Components** table in `CONTEXT_MIGRATION.md`
+4. Mark the ticket/wave row done in `MIGRATION_ROADMAP.md`

--- a/webapp_v2/MIGRATION_ROADMAP.md
+++ b/webapp_v2/MIGRATION_ROADMAP.md
@@ -12,16 +12,15 @@ one draft PR, branch names from Linear. Every PR gates on: webapp compiles
 (shadow-cljs release), `npm run lint && npm run build` in `webapp_v2`, and smoke
 navigation of touched routes.
 
-**Excluded — in flight elsewhere:**
-- `/plugins/manage/:name` (Slack + Webhooks) is being migrated on EVL-101
-  (PR #1633): adds `pages/Integrations/{Slack,Webhooks}` at
+**Landed elsewhere (context):**
+- `/plugins/manage/:name` (Slack + Webhooks) migrated on EVL-101 (PR #1633,
+  merged): `pages/Integrations/{Slack,Webhooks}` live at
   `/integrations/{slack,webhooks}` with legacy redirects for
-  `/plugins/manage/{slack,webhooks}`, deletes the `Plugins/` stub, and removes the
-  CLJS `:manage-plugin` route/panel + plugin views + `events/slack_plugin.cljs`.
-  It does **not** redirect `/plugins/manage/jira` (still PR 0.1) and keeps the
-  `:manage-jira`/`:reviews-plugin-details` bidi entries (still Track A2). Nothing
-  in this roadmap touches `pages/Integrations` or `pages/Plugins` until it merges.
-- Snackbar unification is done on EVL-104 (PR #1638): all
+  `/plugins/manage/{slack,webhooks}`; the `Plugins/` stub and the CLJS
+  `:manage-plugin` route/panel + plugin views + `events/slack_plugin.cljs` are
+  gone. The `:manage-jira`/`:reviews-plugin-details` bidi entries remain
+  (still Track A2).
+- Snackbar unification landed on EVL-104 (PR #1638): all
   `@mantine/notifications` call sites moved to `showSnackbar`, the dependency
   removed, and `useBridgeStore.showSnackbar` deleted (the `show-snackbar` bridge
   event no longer exists).
@@ -30,7 +29,7 @@ navigation of touched routes.
 
 ## Phase 0 — Quick Wins (2 PRs, no dependencies)
 
-### PR 0.1 — Shell bug fixes (S) — EVL-105, PR #1641 (in review)
+### PR 0.1 — Shell bug fixes (S) — EVL-105, PR #1641 (merged)
 
 Bugs found by the audit; all in `webapp_v2` except one CLJS one-liner:
 
@@ -59,13 +58,19 @@ Bugs found by the audit; all in `webapp_v2` except one CLJS one-liner:
   `/plugins/manage/{slack,webhooks}` — the jira gap is ours; expect a trivial
   `Router.jsx` merge conflict with #1633 in the redirect block.
 
-### PR 0.2 — Scaffolding deletion + doc refresh (S)
+### PR 0.2 — Scaffolding deletion + doc refresh (S) — EVL-115 (this PR)
 
-- Delete the unrouted, unreferenced 7-line stubs from the initial shell commit:
+- ✅ Delete the unrouted, unreferenced 7-line stubs from the initial shell commit:
   `pages/{Connections (incl. Setup/), Dashboard, Sessions, Reviews, Guardrails,
   Resources}`. Verified: zero imports anywhere; Sidebar/CommandPalette reference
-  those features by *path* only (they land in the CLJS catch-all).
-  Integrations/Plugins stubs are EVL-101 turf — untouched.
+  those features by *path* only (they land in the CLJS catch-all). Also deleted
+  the orphaned `pages/Integrations/Authentication` stub — EVL-101 merged without
+  touching it, and B3.7 rebuilds that page from scratch.
+- ✅ Reorganize the webapp_v2 docs to "single owner per topic": each topic lives
+  in exactly one of the 7 md files (see the Documentation map in `README.md`);
+  store/service inventories replaced by pointers to `src/stores/`/`src/services/`
+  (the filesystem is the source of truth) plus non-obvious notes in
+  `COMPONENTS.md`.
 - ~~Switch the bridge snackbar call sites to `@/utils/snackbar`~~ — resolved:
   `Roles/Configure` by EVL-104 (PR #1638, which also deletes
   `useBridgeStore.showSnackbar`), `Onboarding/ProtectionRules` already local since
@@ -122,8 +127,8 @@ Delete files + their `app.cljs` requires/defmethods + `routes.cljs` entries:
   initial-state key).
 - Orphan `:audit-plugin-panel` defmethod (no route points at it).
 - Route entries `:404 :runbooks-edit :hoop-app :reviews-plugin-details` (bidi
-  entries with no panel and no references) and `:manage-jira` — the latter **only
-  after** PR 0.1's React redirect is merged.
+  entries with no panel and no references) and `:manage-jira` — gate satisfied:
+  PR 0.1's React redirect merged with EVL-105/#1641.
 
 Route entries that must **stay** (url-for/`:navigate` from live code):
 `:configure-role` (navigated from live `/resources` pages), the `:ai-data-masking`
@@ -183,7 +188,7 @@ All follow the same list/new/edit pattern with ConfirmDialog from B1.3:
 | B3.4 Access Request | `/features/access-request(+new,edit)`. Free-license gate (1 rule) | M | Independent |
 | B3.5 Runbooks Setup | `/features/runbooks/setup` + rules new/edit (git repo config + path rules) | M | Independent of the runbooks *runner* (Wave 5) |
 | B3.6 Machine Identities | **Decision gate — see below** | S or M | |
-| B3.7 Integrations Authentication | `/integrations/authentication` (~324 LOC but **sensitive**: switches gateway auth method, rotates API key; admin + selfhosted only). Land **after EVL-101 merges**; requires a dedicated manual test pass on a selfhosted instance — CI green is not enough. Only afterwards may `:integrations-authentication` be pruned from CLJS sidebar/routes | M | |
+| B3.7 Integrations Authentication | `/integrations/authentication` (~324 LOC but **sensitive**: switches gateway auth method, rotates API key; admin + selfhosted only). EVL-101 merged — unblocked; requires a dedicated manual test pass on a selfhosted instance — CI green is not enough. Only afterwards may `:integrations-authentication` be pruned from CLJS sidebar/routes | M | |
 
 **Decision gate — Machine Identities (product decision pending):**
 CLJS `/features/machine-identities` (API `/machineidentities`, 812 LOC) and React
@@ -208,7 +213,7 @@ decision must close before the Endgame.
 | B4.1 Resources list + wizard core | `/resources` list (537 LOC) + multi-step wizard skeleton (state machine, step chrome); port `events/connections.cljs`; reuse the kept `agents/deployment` logic as a React service | XL pt.1 | Everything below |
 | B4.2 Resources new/configure/add-role | `/resources/new`, `/resources/configure/:id`, `/resources/:id/add-role`: federation OAuth, MCP OAuth popup + polling, terminal/native access tabs (needs B4.0). Reuse patterns from the already-React `/roles/:name/configure` — don't duplicate | XL pt.2 | Onboarding reuse |
 | B4.3 Resource catalog + onboarding | `/resource-catalog` (562 LOC, no API — seeds wizard state) + `/onboarding(+setup, setup/resource, setup/agent, resource-providers)` chrome (~700 LOC) on a no-sidebar layout, reusing the B4.1/B4.2 wizard | L | Kills the `/onboarding/*` ClojureApp route in `Router.jsx` |
-| B4.4 AWS Connect wizard | One shared wizard, two modes: `/integrations/aws-connect(+setup)` + `/onboarding/aws-connect` (~1,660 LOC). Port `events/jobs.cljs` 5s polling as a shared `useJobPolling` hook. **After EVL-101** (Integrations dir) | L | `useJobPolling` reused by Provisioning |
+| B4.4 AWS Connect wizard | One shared wizard, two modes: `/integrations/aws-connect(+setup)` + `/onboarding/aws-connect` (~1,660 LOC). Port `events/jobs.cljs` 5s polling as a shared `useJobPolling` hook. | L | `useJobPolling` reused by Provisioning |
 
 ### Wave 5 — Runner stack + Provisioning (parallel lanes)
 
@@ -297,7 +302,7 @@ after EVL-104: `users->get-user` (refreshLegacyUser), `command-palette->toggle`
   `MIGRATION_CHECKLIST.md`; update root `CLAUDE.md` / `DEV.md`.
 
 **Exit checklist before E1 starts:** all wave tickets merged; Parity table complete;
-Machine Identities decision closed; EVL-101 merged; one full week of production
+Machine Identities decision closed; EVL-101 merged (✅ done); one full week of production
 traffic with catch-all hit-count telemetry at zero (add a cheap counter/log to
 `ClojureApp.jsx` mount during Wave 7 to prove it).
 
@@ -311,7 +316,6 @@ Now ──► Track A (A1→A2→A3) ─┤ parallel
 Now ──► Wave 1 + Sentry ────┘
         Wave 2 + Segment track + clipboard + Clarity
         Wave 3 (parallel CRUD) + org-migration dialog + MI decision gate
-                                        [B3.7 & B4.4 wait for EVL-101]
         Wave 4 (B4.0 first, then wizard chain)
         Wave 5 (runner lane ∥ provisioning lane)
         Wave 6 (session details, 2 PRs)
@@ -321,16 +325,12 @@ Now ──► Wave 1 + Sentry ────┘
 
 ## Top Risks
 
-1. **EVL-101 collisions** — PR 0.1's jira redirect, B3.7 and B4.4 touch Integrations
-   territory; all are gated on the EVL-101 merge (PR #1633, in review), everything
-   else avoids those directories. Both #1633 and #1638 also edit
-   `CONTEXT_MIGRATION.md` — whoever merges last rebases the doc tables.
-2. **Resource wizard scope (Wave 4)** — 6,614 LOC + OAuth popups; mitigated by the
+1. **Resource wizard scope (Wave 4)** — 6,614 LOC + OAuth popups; mitigated by the
    4-way PR split and reusing the already-React `/roles/:name/configure` patterns.
-3. **Playback fidelity (Wave 6)** — RDP RLE canvas and SSE tail are
+2. **Playback fidelity (Wave 6)** — RDP RLE canvas and SSE tail are
    behavior-fragile; vendor `rle.js` unchanged, port the fetch-ReadableStream
    pattern verbatim, add side-by-side manual comparison to the test plan.
-4. **bidi load-time throws during cleanup** — sidebar constants prune (A1) strictly
+3. **bidi load-time throws during cleanup** — sidebar constants prune (A1) strictly
    before route deletions (A2/A3); never delete the keep-list route entries.
-5. **Pending product decision** — Machine Identities has a default outcome (stays
+4. **Pending product decision** — Machine Identities has a default outcome (stays
    on CLJS) so no wave stalls, but it must close before the Endgame.

--- a/webapp_v2/README.md
+++ b/webapp_v2/README.md
@@ -2,6 +2,21 @@
 
 Modern React-based web application for Hoop.
 
+## Documentation map
+
+| File | Read it for |
+|------|-------------|
+| `README.md` | Setup, dev servers/ports, HMR caveats, env vars (this file) |
+| `CLAUDE.md` | Coding + styling rules, auth flow, snackbar/CSS-layer rules |
+| `CONTEXT_MIGRATION.md` | Shell/bridge architecture, routing split, migration status |
+| `COMPONENTS.md` | Catalog of components/hooks + non-obvious store/service notes |
+| `MIGRATION_CHECKLIST.md` | Step-by-step process for migrating one CLJS page |
+| `CLJS_PATTERNS.md` | CLJS → React rosetta stone (incl. reusable building blocks) |
+| `MIGRATION_ROADMAP.md` | Wave plan — what's left, in what order |
+
+Each topic has exactly one owner file (the one listed above); everything else
+is a pointer. When updating docs, edit the owner — don't re-duplicate content.
+
 ## Tech Stack
 
 - **React 19** - UI framework
@@ -10,6 +25,7 @@ Modern React-based web application for Hoop.
 - **Zustand** - State management
 - **React Router v7** - Client-side routing
 - **Axios** - HTTP client
+- **lucide-react** - Icons (the only icon library)
 
 ## Getting Started
 
@@ -79,31 +95,23 @@ npm run preview
 
 ### Environment Variables
 
-A `.env` file is **optional**. All variables documented in `.env.sample` have
-working defaults baked into `vite.config.js`, so the dev server runs out of
-the box with no setup. Only create a `.env` if you need to override one of:
+A `.env` file is **optional** — `vite.config.js` bakes in working defaults for
+everything, so the dev server runs out of the box with no setup (see also
+`.env.sample`). Only create a `.env` if you need to override one of:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `VITE_API_URL` | `/api` (relative) | Custom backend base URL at runtime |
-| `VITE_GATEWAY_URL` | `http://localhost:8009` | Vite dev proxy target for `/api` |
-| `VITE_CLJS_URL` | `http://localhost:8280` | Vite dev proxy target for CLJS assets |
+| `VITE_API_URL` | `/api` (relative) | Custom backend base URL at runtime (`services/api.js`) |
+| `API_URL` | `http://localhost:8009` | Vite dev proxy target for `/api` — same env var the CLJS build reads via shadow-cljs closure-defines |
+| `VITE_CLJS_URL` | `http://localhost:8280` | Vite dev proxy target for CLJS assets (`/js`, `/css`, `/images`, …) |
+| `SEGMENT_WRITE_KEY` | hoop.dev production key | Build-time: Segment write key baked into the bundle at `npm run build`. Same env var as the CLJS bundle, so one setting controls both webapps — override only when pointing a build at a different Segment workspace |
 
 ## Authentication
 
-This app supports two authentication methods:
-
-1. **Local Auth**: Email/password authentication via `/localauth/login`
-2. **OAuth/IDP**: SSO authentication via configured identity providers
-
-The authentication method is automatically detected from the gateway configuration.
-
-### Auth Flow
-
-- Token is stored in localStorage as `jwt-token`
-- Token can be received via cookies (`hoop_access_token`) or query params (`?token=xxx`)
-- On 401 responses, the app saves the current URL and redirects to login
-- After successful auth, redirects back to the saved URL
+Supports local auth (email/password) and OAuth/IDP, auto-detected from the
+gateway configuration. The token lives in `localStorage.jwt-token` (shared
+with the legacy CLJS app). Full flow, key files, and 401 handling:
+`CLAUDE.md` "Authentication Flow".
 
 ## Project Structure
 

--- a/webapp_v2/src/pages/Connections/Setup/index.jsx
+++ b/webapp_v2/src/pages/Connections/Setup/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function ConnectionsSetup() {
-  return <Title order={2}>Connection Setup</Title>
-}
-
-export default ConnectionsSetup

--- a/webapp_v2/src/pages/Connections/index.jsx
+++ b/webapp_v2/src/pages/Connections/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function Connections() {
-  return <Title order={2}>Connections</Title>
-}
-
-export default Connections

--- a/webapp_v2/src/pages/Dashboard/index.jsx
+++ b/webapp_v2/src/pages/Dashboard/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function Dashboard() {
-  return <Title order={2}>Dashboard</Title>
-}
-
-export default Dashboard

--- a/webapp_v2/src/pages/Guardrails/Create/index.jsx
+++ b/webapp_v2/src/pages/Guardrails/Create/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function GuardrailsCreate() {
-  return <Title order={2}>Create Guardrail</Title>
-}
-
-export default GuardrailsCreate

--- a/webapp_v2/src/pages/Guardrails/index.jsx
+++ b/webapp_v2/src/pages/Guardrails/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function Guardrails() {
-  return <Title order={2}>Guardrails</Title>
-}
-
-export default Guardrails

--- a/webapp_v2/src/pages/Integrations/Authentication/index.jsx
+++ b/webapp_v2/src/pages/Integrations/Authentication/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function IntegrationsAuthentication() {
-  return <Title order={2}>Authentication Integrations</Title>
-}
-
-export default IntegrationsAuthentication

--- a/webapp_v2/src/pages/Resources/Configure/index.jsx
+++ b/webapp_v2/src/pages/Resources/Configure/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function ResourcesConfigure() {
-  return <Title order={2}>Configure Resource</Title>
-}
-
-export default ResourcesConfigure

--- a/webapp_v2/src/pages/Resources/Create/index.jsx
+++ b/webapp_v2/src/pages/Resources/Create/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function ResourcesCreate() {
-  return <Title order={2}>Create Resource</Title>
-}
-
-export default ResourcesCreate

--- a/webapp_v2/src/pages/Resources/index.jsx
+++ b/webapp_v2/src/pages/Resources/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function Resources() {
-  return <Title order={2}>Resources</Title>
-}
-
-export default Resources

--- a/webapp_v2/src/pages/Reviews/index.jsx
+++ b/webapp_v2/src/pages/Reviews/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function Reviews() {
-  return <Title order={2}>Reviews</Title>
-}
-
-export default Reviews

--- a/webapp_v2/src/pages/Sessions/index.jsx
+++ b/webapp_v2/src/pages/Sessions/index.jsx
@@ -1,7 +1,0 @@
-import { Title } from '@mantine/core'
-
-function Sessions() {
-  return <Title order={2}>Sessions</Title>
-}
-
-export default Sessions


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Executes roadmap **PR 0.2 — Scaffolding deletion + doc refresh** (`webapp_v2/MIGRATION_ROADMAP.md`, Phase 0), plus the migration-doc debt that accumulated while EVL-101/EVL-104/EVL-105 merged.

**Commit 1 — code (pure deletion, no behavior change):** removes the 11 unrouted, unreferenced 7-line page stubs from the initial shell commit — `pages/{Connections (+Setup), Dashboard, Sessions, Reviews, Guardrails (+Create), Resources (+Configure, +Create)}` and the orphaned `pages/Integrations/Authentication` (EVL-101 merged without touching it; roadmap B3.7 rebuilds that page fresh). Zero imports anywhere, no routes in `Router.jsx` (untouched — empty diff). Sidebar/CommandPalette reference these features by URL path only, so those routes keep landing on the CLJS catch-all exactly as before.

**Commit 2 — docs ("single owner per topic"):** each topic now lives in exactly one of the 7 `webapp_v2/*.md` files; other files carry one-line pointers (see the new **Documentation map** in `README.md`). The rot-prone store/service inventories (which listed 6 of 27 services and disagreed between files) are replaced by pointers to `src/stores/`/`src/services/` — the filesystem is the source of truth — plus non-obvious notes in `COMPONENTS.md`.

Staleness fixed along the way:
- EVL-101 (#1633), EVL-104 (#1638), EVL-105 (#1641) marked merged; B3.7/B4.4 unblocked; roadmap Top Risk 1 retired
- The deleted `useBridgeStore.showSnackbar` is no longer documented; the current bridge methods are (incl. the previously undocumented `syncPrimaryConnectionFromUrl`)
- Duplicate `react-shell` contract row removed; `/plugins/manage/*` redirect routes added to the routing table
- Phantom `VITE_GATEWAY_URL` env var replaced by the real `API_URL` proxy var (verified against `vite.config.js`); `SEGMENT_WRITE_KEY` documented in the README env table
- The reusable-building-blocks table **moved** (not lost) from `CONTEXT_MIGRATION.md` to `CLJS_PATTERNS.md`

## 📣 User-facing impact

None.

## 🔗 Related Issue

Linear: [EVL-115](https://linear.app/hoophq/issue/EVL-115/pr-02-delete-unrouted-shell-page-stubs-reorganize-webapp-v2-docs)

## 🚀 Type of Change

- [x] 📚 Documentation update
- [x] 🧹 Chore

## 📋 Changes Made

- Deleted 11 unrouted 7-line page stubs (77 LOC) — `Router.jsx` untouched
- Reorganized the 7 webapp_v2 markdown docs to single-owner-per-topic with a Documentation map in `README.md`
- Replaced exhaustive store/service tables with filesystem pointers + non-obvious notes
- Fixed post-merge staleness (EVL-101/104/105) and the phantom `VITE_GATEWAY_URL` env var
- Marked roadmap PR 0.1 and PR 0.2 done; unblocked B3.7/B4.4

## 🧪 Testing

## How to test

### Setup

```bash
cd webapp_v2 && npm install
```

For the UI smoke test you need the full dev stack (gateway + both frontends — see `DEV.md`):

```bash
make run-dev-postgres   # skip if you have your own PG
make run-dev            # gateway on :8009
cd webapp_v2 && npm run dev:full   # Vite :5173 + shadow-cljs :8280 (shadow-cljs needs Node 22)
```

### Steps

1. Build gates:
   ```bash
   cd webapp_v2 && npm run build
   ```
2. Deletion is exactly the 11 stubs and nothing references them:
   ```bash
   git diff --stat main -- webapp_v2/src/Router.jsx          # empty
   git diff --diff-filter=D --name-only main -- webapp_v2/src # exactly 11 paths
   grep -rn "pages/Connections\|pages/Dashboard\|pages/Sessions\|pages/Reviews\|pages/Guardrails\|pages/Resources\|Integrations/Authentication" webapp_v2/src --include="*.js*"   # no output
   ```
3. Doc gates:
   ```bash
   grep -rn "showSnackbar()" webapp_v2/*.md                                        # no output
   grep -n "in review" webapp_v2/MIGRATION_ROADMAP.md webapp_v2/CONTEXT_MIGRATION.md # no output
   grep -rn "VITE_GATEWAY_URL" webapp_v2/*.md                                      # no output
   grep -n "building block" webapp_v2/CLJS_PATTERNS.md                             # table moved here
   ```
4. UI smoke (at `http://localhost:5173`, logged in): visit `/dashboard`, `/sessions`, `/resources`, `/guardrails`.

### Expected

- Step 1: `vite build` finishes green (`✓ built`).
- Step 2/3: outputs exactly as annotated.
- Step 4: every route renders the **CLJS page inside the React shell, identical to main** — these URLs never hit the deleted stubs (they were unrouted), so there is nothing user-visible to change.

### Regression check

- `/integrations/slack` and `/integrations/webhooks` still render the React pages (sibling dirs of the deleted `Integrations/Authentication` stub — untouched).
- `/plugins/manage/slack` still redirects to `/integrations/slack` (redirect block in `Router.jsx` untouched).

### Not validated locally

`npm run lint` currently fails with 15 pre-existing errors (`vite.config.js`, `CommandPaletteRoot.jsx`, `Auth/Login`, `EventRouting/Form`) — all four files are **byte-identical to main** (`git diff main` on them is empty); this PR only deletes files and edits markdown, so it cannot introduce lint errors. Worth a separate ticket.

### Tests performed:
- [x] Manual testing completed (build + grep gates above)

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## 📄 Additional Notes

Reviewer tip: read commit 1 (pure deletion diffstat) separately from commit 2 (markdown only). The anti-loss check for the doc dedupe: the building-blocks table now lives in `CLJS_PATTERNS.md`, `SEGMENT_WRITE_KEY` in the README env table, and the `showSnackbar` `details:{}`/10s-auto-dismiss notes stayed in `COMPONENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
