### PR TITLE
EVL-116: Track A1 — safety prep before the dead-CLJS deletions

### DIFF
--- a/webapp/src/webapp/app.cljs
+++ b/webapp/src/webapp/app.cljs
@@ -47,6 +47,7 @@
    [webapp.events.agents]
    [webapp.events.ask-ai]
    [webapp.events.audit]
+   [webapp.events.auth]
    [webapp.events.clarity]
    [webapp.events.components.dialog]
    [webapp.events.components.draggable-card]

--- a/webapp/src/webapp/events/connections.cljs
+++ b/webapp/src/webapp/events/connections.cljs
@@ -78,21 +78,14 @@
 
 (rf/reg-event-fx
  :connections->get-connections
- (fn [{:keys [db]} [_ {:keys [filters on-success on-failure force-refresh?]
+ (fn [{:keys [db]} [_ {:keys [on-success on-failure force-refresh?]
                        :or {on-success [:connections->set-connections]
                             on-failure [:connections->set-connections-error]}}]]
 
-   (cond
-     filters
-     ;; If filters are provided, delegate to filter-connections
-     {:fx [[:dispatch [:connections->filter-connections filters]]]}
-
-     (and (not force-refresh?) (cache-valid? db))
+   (if (and (not force-refresh?) (cache-valid? db))
      ;; Use cached data if valid
      (let [cached-connections (get-cached-connections db)]
        {:fx [[:dispatch (conj on-success cached-connections)]]})
-
-     :else
      ;; Make fresh request
      {:db (assoc-in db [:connections :loading] true)
       :fx [[:dispatch [:fetch {:method "GET"

--- a/webapp/src/webapp/events/users.cljs
+++ b/webapp/src/webapp/events/users.cljs
@@ -1,6 +1,5 @@
 (ns webapp.events.users
-  (:require [clojure.string :as cs]
-            [re-frame.core :as rf]))
+  (:require [re-frame.core :as rf]))
 
 (rf/reg-event-fx
  :users->get-users
@@ -139,10 +138,7 @@
                    (rf/dispatch [:users->get-users])
                    (rf/dispatch [:users->get-user-groups])
                    (rf/dispatch [:show-snackbar {:level :success
-                                                 :text "User slack id updated!"}])
-                   (rf/dispatch [:slack->send-message->user {:slackMessage "You have registered successfully your user with slack hoop.dev app."
-                                                             :slackTeamId (first (cs/split (:slack-id user) #"-"))
-                                                             :slackUserId (second (cs/split (:slack-id user) #"-"))}]))]
+                                                 :text "User slack id updated!"}]))]
      {:fx [[:dispatch [:fetch
                        {:method "PATCH"
                         :uri (str "/users/self/slack")

--- a/webapp/src/webapp/shared_ui/sidebar/constants.cljs
+++ b/webapp/src/webapp/shared_ui/sidebar/constants.cljs
@@ -1,7 +1,7 @@
 (ns webapp.shared-ui.sidebar.constants
   (:require
    ["@radix-ui/themes" :refer [Badge Flex Text]]
-   ["lucide-react" :refer [BookMarked Boxes BrainCog CircleCheckBig GalleryVerticalEnd
+   ["lucide-react" :refer [BookMarked Boxes CircleCheckBig GalleryVerticalEnd
                            Inbox LayoutDashboard PackageSearch Package Search
                            ShieldCheck SquareCode UserRoundCheck VenetianMask BookUp2
                            Sparkles KeyRound]]
@@ -46,8 +46,6 @@
                          [:> KeyRound {:size size}])
    "ResourceDiscovery" (fn [& [{:keys [size] :or {size 24}}]]
                          [:> PackageSearch {:size size}])
-   "Agents" (fn [& [{:keys [size] :or {size 24}}]]
-              [:> BrainCog {:size size}])
    "authentication" (fn [& [{:keys [size] :or {size 24}}]]
                       [:> ShieldCheck {:size size}])
    "jira" (fn [& [{:keys [size] :or {size 24}}]]
@@ -57,12 +55,6 @@
                              "w-6 h-6")]
               [:img {:src (str config/webapp-url "/icons/icon-jira.svg")
                      :class css-size}]))
-   "infrastructure" (fn [& [{:keys [size] :or {size 24}}]]
-                      [:> LayoutDashboard {:size size}])
-   "license" (fn [& [{:keys [size] :or {size 24}}]]
-               [:> ShieldCheck {:size size}])
-   "users" (fn [& [{:keys [size] :or {size 24}}]]
-             [:> UserRoundCheck {:size size}])
    "Search" (fn [& [{:keys [size] :or {size 24}}]]
               [:> Search {:size size}])
    "Provisioning" (fn [& [{:keys [size] :or {size 24}}]]
@@ -187,13 +179,11 @@
     :license-feature "machine-identities"}])
 
 ;; Seção Settings
+;; Emptied by EVL-116 (Track A1) ahead of the route deletions in A2/A3 —
+;; /agents is served by the React shell and lives in its sidebar/palette.
+;; The def itself is removed with its consumers in A3.
 (def organization-routes
-  [{:name "Agents"
-    :label "Agents"
-    :icon (get icons-registry "Agents")
-    :uri (routes/url-for :agents)
-    :navigate :agents
-    :admin-only? true}])
+  [])
 
 ;; Integrations
 (def integrations-management
@@ -205,49 +195,9 @@
     :selfhosted-only? true}])
 
 ;; Settings
+;; Emptied by EVL-116 (Track A1) ahead of the route deletions in A2/A3 — every
+;; entry pointed at a /settings route the React shell already serves. The def
+;; and its consumers (navigation.cljs, main.cljs, command_palette_constants.cljs)
+;; are removed in A3.
 (def settings-management
-  [{:name "api-keys"
-    :label "API Keys"
-    :uri (routes/url-for :settings-api-keys)
-    :navigate :settings-api-keys
-    :admin-only? true
-    :selfhosted-only? false
-    :badge "NEW"}
-   {:name "attributes"
-    :label "Attributes"
-    :uri (routes/url-for :settings-attributes)
-    :navigate :settings-attributes
-    :admin-only? true
-    :selfhosted-only? false
-    :badge "NEW"}
-   {:name "infrastructure"
-    :label "Infrastructure"
-    :uri (routes/url-for :settings-infrastructure)
-    :navigate :settings-infrastructure
-    :admin-only? true
-    :selfhosted-only? true}
-   {:name "experimental"
-    :label "Experimental"
-    :uri (routes/url-for :settings-experimental)
-    :navigate :settings-experimental
-    :admin-only? true
-    :selfhosted-only? false
-    :badge "BETA"}
-   {:name "audit-logs"
-    :label "Internal Audit Logs"
-    :uri (routes/url-for :settings-audit-logs)
-    :navigate :settings-audit-logs
-    :admin-only? true
-    :selfhosted-only? false}
-   {:name "license"
-    :label "License"
-    :uri (routes/url-for :license-management)
-    :navigate :license-management
-    :admin-only? true
-    :selfhosted-only? false}
-   {:name "users"
-    :label "Users"
-    :uri (routes/url-for :users)
-    :navigate :users
-    :admin-only? true
-    :selfhosted-only? false}])
+  [])

--- a/webapp_v2/MIGRATION_ROADMAP.md
+++ b/webapp_v2/MIGRATION_ROADMAP.md
@@ -192,6 +192,19 @@ activation-journey templates), `:login-hoop`/`:auth-callback-hoop`/
 - `features/attributes/{main.cljs,views/form.cljs}` — **keep** `events.cljs` +
   `subs.cljs` (used by live guardrails, resource setup/configure, machine
   identities, access control until those migrate).
+- **The sidebar scaffolding A1 left empty** — `organization-routes` and
+  `settings-management` in `shared_ui/sidebar/constants.cljs`, plus all five
+  consumers: `navigation.cljs:98` (the `organization-routes` loop) and `:158-197`
+  (the Settings disclosure), `main.cljs:186-198` and `:210-219` (their
+  collapsed-rail twins), and the four references in
+  `command_palette_constants.cljs:24,26,70,72`. Until this lands, an admin opening
+  the raw shadow-cljs dev server (`:8280`, `react-shell` unset) sees a "Settings"
+  disclosure that expands to nothing and a collapsed-rail gear that opens an empty
+  panel. Nothing throws and no deployment is affected — every packaging path
+  (`Makefile:256-258`, `scripts/dev/build-webapp.sh`) merges React's `index.html`
+  over the CLJS resources, so `STATIC_UI_PATH` always serves the shell and
+  `app.cljs:288` never runs. Flagged by Qodo on PR #1655; deliberately deferred
+  here rather than patched with a `(seq …)` guard on a literal `[]`.
 - **Deferred:** `events/reviews_plugin.cljs` (46 LOC) — session details still
   approves/rejects reviews through it; delete in Wave 6's cleanup commit.
 

--- a/webapp_v2/MIGRATION_ROADMAP.md
+++ b/webapp_v2/MIGRATION_ROADMAP.md
@@ -90,24 +90,30 @@ Two ordering constraints govern everything:
 
 1. **bidi fails *silently*, so route deletions need a manual grep gate.**
    `bidi/path-for` does **not** throw on an unknown handler (verified against the
-   bidi 2.1.6 jar: `bidi.cljc:391-397` `path-for*` throws only for a literally `nil`
+   bidi 2.1.6 jar: `bidi.cljc:391-398` `path-for*` throws only for a literally `nil`
    handler; `bidi.cljc:324-326` `unmatch-pair` uses `when-let` and returns `nil`
    otherwise). `routes.cljs:114-116` `url-for` is a thin `bidi/path-for` wrapper, so
-   a stale reference yields `nil` → `<a href=nil>` (dead link), and
-   `routes.cljs:126-136` `navigate!` computes `(str nil "")` = `""` →
+   a stale reference yields `nil` — the anchor renders with no `href` at all (dead
+   link) — and `routes.cljs:126-136` `navigate!` computes `(str nil "")` = `""` →
    `pushy/set-token! ""` → **silent misnavigation**. Nothing — not the compiler, not
    the runtime, not CI — catches a missed reference.
    Consequence: **before deleting any route entry**,
    `grep -rn "url-for :<kw>\|:navigate :<kw>" webapp/src` must return zero hits
    outside the files that PR deletes, with the output pasted into the PR
-   description. `shared_ui/sidebar/constants.cljs` calls `(routes/url-for …)` at
-   load time for `:agents :settings-api-keys :settings-attributes
-   :settings-infrastructure :settings-experimental :settings-audit-logs
-   :license-management :users :ai-data-masking :integrations-authentication`, so its
-   prune still lands **strictly before** the route-entry removal — for
-   reviewability, not because bidi throws.
-   Worked example already waiting for A3: `features/attributes/events.cljs:74,108,131`
-   each dispatch `[:navigate :settings-attributes]`, and A3 **keeps** that file.
+   description. **The gate — not PR ordering — is the safety mechanism**, so a route
+   entry and its sidebar entry may be removed in the *same* PR (EVL-119 did exactly
+   that for `:dashboard`). A1's separate prune of `shared_ui/sidebar/constants.cljs`
+   (which calls `(routes/url-for …)` at load time for `:agents :settings-api-keys
+   :settings-attributes :settings-infrastructure :settings-experimental
+   :settings-audit-logs :license-management :users :ai-data-masking
+   :integrations-authentication`) is kept for reviewability, not because bidi throws.
+   Worked example waiting for A3: `features/attributes/events.cljs:74,108,131` each
+   dispatch `[:navigate :settings-attributes]` in a file A3 **keeps**. It is not a
+   live risk — those three `-success` handlers fire only from
+   `features/attributes/views/form.cljs:52,53,80`, which A3 deletes in the same PR
+   (live callers use `:attributes/create-inline`, which does not navigate) — so the
+   gate hit must be resolved by **deleting the three handlers**, not by repointing
+   them at a surviving route.
 2. **`webapp.events.auth` is load-bearing but only required by dead code.**
    `auth/views/signup.cljs` (dead) is the only app-reachable require of
    `events/auth`, which powers live flows (`:auth->logout` from onboarding pages and
@@ -125,20 +131,30 @@ Two ordering constraints govern everything:
   (`"Agents" "infrastructure" "license" "users"`) and the now-unused `BrainCog`
   refer. Do **not** touch `:ai-data-masking` or `:integrations-authentication`
   (still needed — see keep-list below), nor the `"authentication"` icon.
-  `organization-routes` and `settings-management` are left as empty vectors: their
-  five consumers are all `for`/`mapcat`/`concat` and inert over `[]`. Deleting the
-  defs, the dead Settings disclosure in `navigation.cljs:158-197`, and the
-  pre-existing `icons-registry` orphans (`"Reviews" "JiraTemplates" "jira"`) is A3.
+  `organization-routes` and `settings-management` are left as empty vectors. Their
+  five consumers iterate with `for`/`mapcat`/`concat` and emit nothing, but two of
+  them still render their own chrome over an empty vector: the Settings disclosure
+  at `navigation.cljs:158-197` and its collapsed-sidebar twin at
+  `main.cljs:210-219` (icon + "Settings" label + empty panel). No user sees it
+  because `app.cljs:260` drops `sidebar/main` entirely in shell mode — the defs are
+  harmless because the CLJS sidebar is unreachable, not because the consumers
+  degrade gracefully. The legacy `app.cljs:288` (`STATIC_UI_PATH`) path would show
+  the empty section. Deleting the defs, those two consumers, and the pre-existing
+  `icons-registry` orphans (`"Reviews" "JiraTemplates" "jira"`) is A3.
 - Remove two latent no-op dispatches (their registering namespaces are never
   loaded into the bundle): `events/users.cljs:143`
   (`:slack->send-message->user`) and `events/connections.cljs:88`
   (`:connections->filter-connections`).
-- Close the ⌘K gap the prune opens. The CLJS palette is still live in shell mode
-  (`app.cljs` renders it in the `react-shell` branch; `spotlight.js` delegates to it
-  on every CLJS route) and its Quick Access list is built from the pruned vectors.
-  Add the four entries React's palette lacks — API Keys, Attributes, Experimental,
+- Add the four entries React's palette lacks — API Keys, Attributes, Experimental,
   Internal Audit Logs — to `features/CommandPalette/constants.js`, gating mirrored
-  from `layout/Sidebar/constants.js`.
+  from `layout/Sidebar/constants.js`. **This closes a separate, pre-existing gap in
+  the React palette — it does not restore what the prune removes.** The CLJS palette
+  is still the only one rendered on CLJS routes (`app.cljs` renders it in the
+  `react-shell` branch; `spotlight.js` delegates to it there) and builds its Quick
+  Access from the pruned vectors, so it does lose 8 entries. All 8 pages stay one
+  click away in the React sidebar, which is the shell and renders on every route, so
+  the loss is ⌘K discoverability on CLJS routes only — accepted, and it disappears
+  as those routes migrate.
 
 ### PR A2 — Dead settings/admin panels + routes (M) — EVL-117
 
@@ -178,6 +194,30 @@ activation-journey templates), `:login-hoop`/`:auth-callback-hoop`/
   identities, access control until those migrate).
 - **Deferred:** `events/reviews_plugin.cljs` (46 LOC) — session details still
   approves/rejects reviews through it; delete in Wave 6's cleanup commit.
+
+**Traps found while landing A1 — read before starting A3:**
+
+- `navigation.cljs:158-197` is **not** a whole-line deletion. The disclosure form
+  closes at line 197 *column 60*; the trailing `]])` on that same line closes the
+  enclosing `[:ul]` (95), `[:li]` (93) and `(when admin?)` (92). Those three closers
+  must survive.
+- Removing that disclosure leaves `navigation.cljs:94`'s
+  `[section-title "Organization"]` hollow — delete it too, or the section renders a
+  heading with no items.
+- The `:settings-attributes` grep-gate hit is resolved by **deleting** the three
+  `-success` handlers in `features/attributes/events.cljs` (74, 108, 131), not by
+  repointing them — see Track A constraint #1.
+- A3 must state explicitly that it removes the corresponding `routes.cljs` entries;
+  the grep gate also flags `features/users/main.cljs:27` and the users
+  `views/empty_state`.
+- `events/connections_filters.cljs` is now 100% dead (A1 removed its last dangling
+  dispatch site); confirm the deletion above actually lands, or the file lingers as
+  a false signal that connection filtering flows through it.
+- **Cross-PR orphan:** `LayoutDashboard` in the `lucide-react` refer of
+  `shared_ui/sidebar/constants.cljs` had two consumers — the `"Dashboard"` icon key
+  (removed by EVL-119) and `"infrastructure"` (removed by A1). Each PR is correct
+  alone; once both are merged the refer has zero consumers. Sweep it with the other
+  `icons-registry` orphans here.
 
 ---
 

--- a/webapp_v2/MIGRATION_ROADMAP.md
+++ b/webapp_v2/MIGRATION_ROADMAP.md
@@ -88,13 +88,26 @@ is still compiled into the bundle. Deleting early shrinks the bundle and reduces
 
 Two ordering constraints govern everything:
 
-1. **bidi throws at namespace load.** `shared_ui/sidebar/constants.cljs` calls
-   `(routes/url-for …)` at load time for `:agents :settings-api-keys
-   :settings-attributes :settings-infrastructure :settings-experimental
-   :settings-audit-logs :license-management :users :ai-data-masking
-   :integrations-authentication`. `bidi/path-for` throws on an unknown handler, so
-   sidebar constants must be pruned in a PR that lands **strictly before** the
-   route-entry removal.
+1. **bidi fails *silently*, so route deletions need a manual grep gate.**
+   `bidi/path-for` does **not** throw on an unknown handler (verified against the
+   bidi 2.1.6 jar: `bidi.cljc:391-397` `path-for*` throws only for a literally `nil`
+   handler; `bidi.cljc:324-326` `unmatch-pair` uses `when-let` and returns `nil`
+   otherwise). `routes.cljs:114-116` `url-for` is a thin `bidi/path-for` wrapper, so
+   a stale reference yields `nil` → `<a href=nil>` (dead link), and
+   `routes.cljs:126-136` `navigate!` computes `(str nil "")` = `""` →
+   `pushy/set-token! ""` → **silent misnavigation**. Nothing — not the compiler, not
+   the runtime, not CI — catches a missed reference.
+   Consequence: **before deleting any route entry**,
+   `grep -rn "url-for :<kw>\|:navigate :<kw>" webapp/src` must return zero hits
+   outside the files that PR deletes, with the output pasted into the PR
+   description. `shared_ui/sidebar/constants.cljs` calls `(routes/url-for …)` at
+   load time for `:agents :settings-api-keys :settings-attributes
+   :settings-infrastructure :settings-experimental :settings-audit-logs
+   :license-management :users :ai-data-masking :integrations-authentication`, so its
+   prune still lands **strictly before** the route-entry removal — for
+   reviewability, not because bidi throws.
+   Worked example already waiting for A3: `features/attributes/events.cljs:74,108,131`
+   each dispatch `[:navigate :settings-attributes]`, and A3 **keeps** that file.
 2. **`webapp.events.auth` is load-bearing but only required by dead code.**
    `auth/views/signup.cljs` (dead) is the only app-reachable require of
    `events/auth`, which powers live flows (`:auth->logout` from onboarding pages and
@@ -102,20 +115,32 @@ Two ordering constraints govern everything:
    `/idplogin` panel). Add `[webapp.events.auth]` to `app.cljs` requires **before**
    deleting signup, or logout/idplogin silently break.
 
-### PR A1 — Safety prep (S) — must land first
+### PR A1 — Safety prep (S) — EVL-116 — must land first
 
 - Add `[webapp.events.auth]` to `webapp/src/webapp/app.cljs` requires.
 - Prune from `shared_ui/sidebar/constants.cljs` the entries whose `url-for` targets
   A2/A3 will delete: `:agents :settings-api-keys :settings-attributes
   :settings-infrastructure :settings-experimental :settings-audit-logs
-  :license-management :users`. Do **not** touch `:ai-data-masking` or
-  `:integrations-authentication` (still needed — see keep-list below).
+  :license-management :users`, plus the 4 `icons-registry` keys this orphans
+  (`"Agents" "infrastructure" "license" "users"`) and the now-unused `BrainCog`
+  refer. Do **not** touch `:ai-data-masking` or `:integrations-authentication`
+  (still needed — see keep-list below), nor the `"authentication"` icon.
+  `organization-routes` and `settings-management` are left as empty vectors: their
+  five consumers are all `for`/`mapcat`/`concat` and inert over `[]`. Deleting the
+  defs, the dead Settings disclosure in `navigation.cljs:158-197`, and the
+  pre-existing `icons-registry` orphans (`"Reviews" "JiraTemplates" "jira"`) is A3.
 - Remove two latent no-op dispatches (their registering namespaces are never
   loaded into the bundle): `events/users.cljs:143`
   (`:slack->send-message->user`) and `events/connections.cljs:88`
   (`:connections->filter-connections`).
+- Close the ⌘K gap the prune opens. The CLJS palette is still live in shell mode
+  (`app.cljs` renders it in the `react-shell` branch; `spotlight.js` delegates to it
+  on every CLJS route) and its Quick Access list is built from the pruned vectors.
+  Add the four entries React's palette lacks — API Keys, Attributes, Experimental,
+  Internal Audit Logs — to `features/CommandPalette/constants.js`, gating mirrored
+  from `layout/Sidebar/constants.js`.
 
-### PR A2 — Dead settings/admin panels + routes (M)
+### PR A2 — Dead settings/admin panels + routes (M) — EVL-117
 
 Delete files + their `app.cljs` requires/defmethods + `routes.cljs` entries:
 
@@ -137,7 +162,7 @@ activation-journey templates), `:login-hoop`/`:auth-callback-hoop`/
 `:signup-callback-hoop` (url-for in `events/auth` + logout view),
 `:onboarding-protection-rules` (navigated from onboarding effects).
 
-### PR A3 — Dead auth/users/org (M)
+### PR A3 — Dead auth/users/org (M) — EVL-118
 
 - `auth/local/*`, `auth/views/login_panel.cljs` (fully orphaned — zero requires),
   `auth/views/signup.cljs` (safe: A1 landed), `events/localauth.cljs`.
@@ -330,7 +355,10 @@ Now ──► Wave 1 + Sentry ────┘
 2. **Playback fidelity (Wave 6)** — RDP RLE canvas and SSE tail are
    behavior-fragile; vendor `rle.js` unchanged, port the fetch-ReadableStream
    pattern verbatim, add side-by-side manual comparison to the test plan.
-3. **bidi load-time throws during cleanup** — sidebar constants prune (A1) strictly
-   before route deletions (A2/A3); never delete the keep-list route entries.
+3. **bidi silent failures during cleanup** — a deleted route entry produces a dead
+   link or a no-op navigation, never an error, and CI cannot catch it. A2/A3 must run
+   the `url-for` / `:navigate` grep gate per deleted keyword (see Track A constraint
+   #1) and never delete the keep-list route entries. The sidebar constants prune (A1)
+   still lands before the route deletions.
 4. **Pending product decision** — Machine Identities has a default outcome (stays
    on CLJS) so no wave stalls, but it must close before the Endgame.

--- a/webapp_v2/src/features/CommandPalette/constants.js
+++ b/webapp_v2/src/features/CommandPalette/constants.js
@@ -14,6 +14,10 @@ import {
   ExternalLink,
   Layers,
   Users,
+  KeyRound,
+  Tags,
+  FlaskConical,
+  ScrollText,
 } from 'lucide-react'
 
 // Gating flags (adminOnly / selfhostedOnly / featureFlag / licenseFeature)
@@ -42,4 +46,8 @@ export const QUICK_ACCESS_ITEMS = [
   { id: 'settings-infra', label: 'Infrastructure', description: 'Infrastructure settings', icon: LayoutDashboard, path: '/settings/infrastructure', adminOnly: true, selfhostedOnly: true },
   { id: 'license', label: 'License', description: 'License management', icon: ShieldCheck, path: '/settings/license', adminOnly: true },
   { id: 'users', label: 'Users', description: 'Manage organization users', icon: Users, path: '/organization/users', adminOnly: true },
+  { id: 'settings-api-keys', label: 'API Keys', description: 'Manage API keys', icon: KeyRound, path: '/settings/api-keys', adminOnly: true },
+  { id: 'settings-attributes', label: 'Attributes', description: 'Manage user attributes', icon: Tags, path: '/settings/attributes', adminOnly: true },
+  { id: 'settings-experimental', label: 'Experimental', description: 'Toggle experimental features', icon: FlaskConical, path: '/settings/experimental', adminOnly: true },
+  { id: 'settings-audit-logs', label: 'Internal Audit Logs', description: 'Browse internal audit logs', icon: ScrollText, path: '/settings/audit-logs', adminOnly: true },
 ]


### PR DESCRIPTION
## 📝 Description

First of three sequential PRs in **Track A — Dead-CLJS Cleanup** ([EVL-116](https://linear.app/hoophq/issue/EVL-116)). This is the gate: [EVL-117](https://linear.app/hoophq/issue/EVL-117) (A2) and [EVL-118](https://linear.app/hoophq/issue/EVL-118) (A3) depend on it and cannot land together.

Two things must move out of the way before A2/A3 delete dead panels and their bidi route entries, or live behavior breaks **silently**:

1. **`webapp.events.auth` is load-bearing but only required by dead code.** It registers `:auth->logout`, `:auth->get-auth-link`, `:auth->get-saml-link` (+2). Its only app-reachable require is `auth/views/signup.cljs:9` — a file A3 deletes. The other requirer, `auth/views/login_panel.cljs:7`, is a total orphan. Live consumers are the sidebar profile logout, the onboarding logout links, and the `/login`, **`/idplogin`** and `/register` panels — none of which require the namespace themselves.
2. **`shared_ui/sidebar/constants.cljs` calls `routes/url-for` at load time** for 8 handlers whose route entries A2/A3 remove.

### ⚠️ The roadmap's stated rationale was wrong — corrected here

Track A claimed *"bidi throws at namespace load"*, so a missed reference in A2/A3 would be caught at build/boot time. **It isn't.** Verified against the bidi 2.1.6 jar:

- `bidi.cljc:391-397` `path-for*` throws **only** when the handler is literally `nil`
- `bidi.cljc:324-326` `unmatch-pair` uses `when-let` and returns `nil` for an unresolvable handler

`routes.cljs:114-116` `url-for` is a thin wrapper, so a stale reference yields `nil` → `<a href=nil>` (dead link), and `routes.cljs:126-136` `navigate!` computes `(str nil "")` = `""` → `pushy/set-token! ""` — a **silent misnavigation**. No compiler error, no runtime exception.

This makes the A1→A2→A3 split *more* justified, not less: when the failure mode is silent, small independently-verifiable PRs are the only control. So this PR also rewrites constraint #1 and Top Risk #3 and makes a **grep gate** part of A2/A3's definition of done — for every deleted route handler, `grep -rn "url-for :<kw>\|:navigate :<kw>" webapp/src` must return zero hits outside the files that PR deletes. A violation is already waiting for A3: `features/attributes/events.cljs:74,108,131` dispatch `[:navigate :settings-attributes]` in a file A3 **keeps**.

## 📣 User-facing impact

None. The sidebar prune does remove 8 entries from the **CLJS** ⌘K palette (still live on CLJS routes — `spotlight.js` delegates whenever `react-shell` is set), so the four with no React equivalent — API Keys, Attributes, Experimental, Internal Audit Logs — were added to the React palette in the same PR. Net capability is unchanged; all eight also remain in the React sidebar.

## 🔗 Related Issue

[EVL-116](https://linear.app/hoophq/issue/EVL-116/track-a1-safety-prep-load-eventsauth-from-appcljs-prune-dead-sidebar) · blocks [EVL-117](https://linear.app/hoophq/issue/EVL-117) (A2) → [EVL-118](https://linear.app/hoophq/issue/EVL-118) (A3)

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [x] 🧹 Chore

## 📋 Changes Made

One commit per change, so a revert stays surgical:

- **`load webapp.events.auth directly from app.cljs`** — one line, breaking the sole dependency on `signup.cljs`.
- **`prune sidebar constants for routes deleted in A2/A3`** — removes the 8 entries (`:agents` + all seven `settings-management` handlers), the 4 `icons-registry` keys they orphan (`"Agents"`, `"infrastructure"`, `"license"`, `"users"`) and the now-unused `BrainCog` refer.
- **`drop dispatch to never-registered :slack->send-message->user`** — `events/users.cljs`; `clojure.string` goes with it (`cs/split` was its only use).
- **`drop unreachable filters branch from :connections->get-connections`** — the whole `cond` clause (a `cond` needs test/expr pairs); with only `:else` left the `cond` collapses to an `if`, matching `:connections->check-batch-complete` just above.
- **`close the command palette gap left by the sidebar prune`** — 4 entries in `features/CommandPalette/constants.js`, gating mirrored from `layout/Sidebar/constants.js`.
- **`correct the bidi failure mode in the migration roadmap`** — constraint #1, Top Risk #3, the grep gate, and the EVL ticket IDs for A1/A2/A3.

### Kept on purpose

- `:ai-data-masking` and `:integrations-authentication` route entries + the `"authentication"` icon (roadmap keep-list). Asserted: still exactly 1 `url-for` hit each.
- `:users->update-user-slack-id` — live via `slack/slack_new_user.cljs:10`.
- `events/slack.cljs`, `events/connections_filters.cljs`, `login_panel.cljs` — deletion is A3's job.
- `organization-routes` / `settings-management` are left as **empty vectors**. Their five consumers (`navigation.cljs:98,180`, `main.cljs:186`, `command_palette_constants.cljs:24,26,70,72`) are all `for`/`mapcat`/`concat` and inert over `[]`, which keeps this PR at "no behavior change". Deleting the `def`s and the now-dead Settings disclosure is A3.
- Pre-existing `icons-registry` orphans (`"Reviews"`, `"JiraTemplates"`, `"jira"`) — not created by this prune, out of scope.

### Known cosmetic leftover (intentional)

On the raw shadow-cljs dev server (`:8280`, `react-shell` unset) the legacy CLJS sidebar now shows a **"Settings" disclosure that expands to nothing**. That sidebar is unreachable in production — `app.cljs` only renders it in the `when-not react-shell?` branch, and `ClojureApp.jsx` always sets the flag. Removed in A3.

## 🧪 Testing

See **How to test** below.

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS (Darwin 25.5), Node 22.22.2

### Tests performed:
- [ ] Unit tests pass *(no unit tests cover these paths)*
- [x] Integration tests pass *(`shadow-cljs compile` + `release hoop-ui`, both 0 warnings; `webapp_v2` `npm run build`)*
- [ ] Manual testing completed *(non-interactive checks all run and passed; the interactive browser steps were not — see the note at the end of How to test)*

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**Reviewer focus:** the two paren rewrites (`events/users.cljs`, `events/connections.cljs`) are the only places this PR could break. Both were engineered so the closing tail is unchanged, and both are backed by a reader form-count assertion (14 / 30 / 7, unchanged) plus a clean `:advanced` release build.

**`npm run lint` reports 16 pre-existing problems** in `CommandPaletteRoot.jsx`, `Auth/Login`, `EventRouting/Form`. The count is byte-identical with and without this PR, and `npx eslint src/features/CommandPalette/constants.js` is clean. Not fixed here — unrelated debt.

**Parallel worktree:** the Dashboard migration (Wave 1 / B1.1) also touches `app.cljs`, `routes.cljs` and `constants.cljs` (the `:dashboard` entry in `main-routes`, which this PR does not touch). Conflicts would be textual only; whoever merges second rebases.

## How to test

This PR is dead-code prep with **no intended behavior change**. Most of it is proven
mechanically (below); the browser steps exist to confirm the two live flows it protects
and the palette parity it adds.

### Setup

```bash
# 1. Backend (skip if you already have a gateway on :8009)
make run-dev-postgres
make run-dev

# 2. Frontend — Vite (:5173) + shadow-cljs (:8280) together
cd webapp_v2 && npm run dev:full
```

`webapp/` needs **Node 22** (`nvm use 22` — `re2` fails to build on 25). If `webapp/node_modules`
is absent, run `cd webapp && npm ci && npm run genversion` first: `src/webapp/version.js` is
gitignored and required by `config.cljs`, so shadow-cljs won't build without it.

Remember to hard-reload the tab (Cmd+Shift+R) after a CLJS rebuild — Vite proxies the bundle
and can't HMR it.

### Steps

**1. Build gates**

```bash
cd webapp && npx shadow-cljs compile hoop-ui && npx shadow-cljs release hoop-ui
cd ../webapp_v2 && npm run lint && npm run build
```

*Expected:* both CLJS builds report `0 warnings`. `npm run build` succeeds. `npm run lint`
reports **16 problems (15 errors, 1 warning)** — all pre-existing on `main` (CommandPaletteRoot,
Auth/Login, EventRouting/Form); the count is identical with and without this PR, and
`npx eslint src/features/CommandPalette/constants.js` is clean.

**2. Logout still works** — the flow commit 1 protects

Log in, open the sidebar profile dropdown (bottom-left), click **Log out**.

*Expected:* session is cleared and you land on `/login`. In DevTools console there is **no**
`re-frame: no :event handler registered for: :auth->logout`.

**3. `/idplogin` still works** — the other flow commit 1 protects

Navigate to `http://localhost:5173/idplogin`. This route is not in the React router, so it
falls through to the CLJS panel.

*Expected:* the panel renders and redirects to the IdP (or shows the provider link). Console
shows no `no :event handler registered for: :auth->get-saml-link` / `:auth->get-auth-link`.
**Needs an IdP-configured gateway** (`AUTH_METHOD=oidc` or `saml`). On a `local`-auth gateway
the panel will report no IdP configured — that is the correct response, not a regression;
what matters is that the handlers fire rather than being silently dropped.

**4. React command palette gained the four entries** — commit 5

On any React route (e.g. `/agents`), press ⌘K as an **admin**.

*Expected:* Quick Access now lists **API Keys**, **Attributes**, **Experimental** and
**Internal Audit Logs** alongside the existing entries. Each navigates to
`/settings/api-keys`, `/settings/attributes`, `/settings/experimental`,
`/settings/audit-logs` respectively.

*Negative path:* log in as a **non-admin** and press ⌘K — none of the four appear (all are
`adminOnly`, mirroring `layout/Sidebar/constants.js`).

**5. CLJS command palette lost the eight entries** — commit 2 (intended)

On a CLJS-owned route (e.g. `/sessions` or `/resources`), press ⌘K. This opens the *CLJS*
palette — `spotlight.js` delegates whenever `react-shell` is set.

*Expected:* Quick Access no longer lists Agents, API Keys, Attributes, Infrastructure,
Experimental, Internal Audit Logs, License, Users. It **still** lists **Live Data Masking**
and **Authentication** (the keep-list). All eight remain reachable from the React sidebar,
and all eight are now in the React palette on React routes.

**6. Connections still load** — commit 4 removed a branch in `:connections->get-connections`

Visit `/dashboard` and `/onboarding`.

*Expected:* connection data loads as before. Console shows no
`no :event handler registered for: :connections->filter-connections` (it used to appear when
that branch was hit — it never was, which is the point).

**7. Slack user linking** — commit 3's handler — *optional, needs a Slack-linked account*

Open `/slack/user/new/:slack-id` and submit.

*Expected:* the `PATCH /users/self/slack` succeeds and the "User slack id updated!" toast
appears. The removed dispatch only ever produced a console warning, so the visible flow is
unchanged. **Skip if no Slack workspace is wired up** — steps 1 and the mechanical proof
below fully cover this change.

**8. CLJS sidebar (dev-only cosmetic leftover)** — expected, not a bug

Open `http://localhost:8280` directly and run `localStorage.removeItem('react-shell')`, then
reload. This renders the legacy CLJS sidebar, which is unreachable in production (the React
shell always sets the flag).

*Expected:* the "Organization" section keeps its Integrations disclosure; the **"Settings"
disclosure now expands to nothing** because `settings-management` is an empty vector. This is
intentional — the `def`s and the disclosure block are deleted in A3 (EVL-118). Nothing throws.

### Regression check

- `/agents`, `/settings/license`, `/organization/users` still load from the React sidebar
  (their CLJS sidebar entries were removed, but the React routes are untouched).
- `/features/data-masking` and `/integrations/authentication` still load — these are the two
  keep-list entries whose `url-for` calls must survive in `constants.cljs`.

### Mechanical proof already run on this branch

- `shadow-cljs compile` and `shadow-cljs release hoop-ui`: **0 warnings** each.
- Reader form counts unchanged after the two paren rewrites: `users.cljs` 14, `connections.cljs` 30,
  `constants.cljs` 7. `app.cljs` requires 154 → 155 with `[webapp.events.auth]` present.
- **The two removed dispatches were provably dead:**
  `ls resources/public/js/cljs-runtime/ | grep -E "webapp\.events\.(slack|connections_filters)\.js"`
  returns nothing — shadow-cljs only compiles namespaces reachable from `webapp.core/init`, so
  neither handler was ever registered.
- **Commit 1 proven by counterfactual.** A1 does not delete `signup.cljs`, so no smoke test can
  detect a regression today; I simulated A3 instead (removed `app.cljs`'s signup require + its
  `:signup-hoop-panel` defmethod, uncommitted) and rebuilt twice:
  - with `[webapp.events.auth]` → `cljs-runtime/webapp.events.auth.js` **present**
  - without it → **absent**, and the only remaining files mentioning `auth->logout` are the
    onboarding *dispatch* sites, with nothing registering it. That is exactly the silent
    breakage this PR prevents.
- **Prune verified at the artifact level:** the compiled
  `cljs-runtime/webapp.shared_ui.sidebar.constants.js` now contains only `"Authentication"` and
  `"Live Data Masking"` out of the ten labels checked — the eight pruned ones are gone from the
  namespace that feeds both the CLJS sidebar and the CLJS palette.
- Keep-list assertions: `url-for :ai-data-masking` and `url-for :integrations-authentication`
  still 1 hit each; all 8 pruned handlers 0 hits; `BrainCog`, `cs/`, `clojure.string` 0 hits;
  the surviving `filters` bindings all belong to `:connections/get-connections-paginated`.

**Not verified locally:** steps 2–8 (interactive browser flows). The only dev stack running on
this machine belongs to a different worktree, and I did not tear it down. Everything
non-interactive above was run and passed.
