### PR TITLE
fix(mssql): forward DLP provider config for native guardrails

### DIFF
--- a/agent/controller/mssql.go
+++ b/agent/controller/mssql.go
@@ -46,25 +46,15 @@ func (a *Agent) processMSSQLProtocol(pkt *pb.Packet) {
 	}
 
 	log.Infof("session=%v - starting mssql connection at %v:%v", sessionID, connenv.host, connenv.port)
-	// Forward the connection's guardrail rules to libhoop, which enforces input
-	// rules on the native TDS path (and fails closed at construction on what it
-	// cannot evaluate, e.g. output rules). The gateway ships rules only when the
-	// connection has them configured, so an empty value here means a plain
-	// passthrough. Output data masking is not yet supported for MSSQL, so no DLP
-	// opts are set.
-	var guardRailRules string
-	if connParams.GuardRailRules != nil {
-		guardRailRules = string(connParams.GuardRailRules)
-	}
 	opts := map[string]string{
-		"sid":              sessionID,
-		"hostname":         connenv.host,
-		"port":             connenv.port,
-		"username":         connenv.user,
-		"password":         connenv.pass,
-		"insecure":         fmt.Sprintf("%v", connenv.insecure),
-		"guard_rail_rules": guardRailRules,
+		"sid":      sessionID,
+		"hostname": connenv.host,
+		"port":     connenv.port,
+		"username": connenv.user,
+		"password": connenv.pass,
+		"insecure": fmt.Sprintf("%v", connenv.insecure),
 	}
+	addMSSQLGuardRailsOpts(opts, connParams)
 	serverWriter, err := libhoop.NewDBCore(context.Background(), streamClient, opts).MSSQL()
 	if err != nil {
 		errMsg := fmt.Sprintf("failed connecting with mssql server, err=%v", err)
@@ -78,4 +68,33 @@ func (a *Agent) processMSSQLProtocol(pkt *pb.Packet) {
 	// write the first packet when establishing the connection
 	_, _ = serverWriter.Write(pkt.Payload)
 	a.connStore.Set(clientConnectionIDKey, serverWriter)
+}
+
+// addMSSQLGuardRailsOpts threads the guardrail/DLP options into the native
+// MSSQL proxy options. Unlike addGuardRailsOpts (used by SSH and mirrored by
+// the masking-capable database proxies), it forwards ONLY the keys libhoop
+// needs to select the guardrail engine: with provider "mspresidio" and both
+// Presidio URLs set, libhoop evaluates input rules through Presidio (full PCRE,
+// e.g. lookahead); otherwise it uses the built-in local engine (substring
+// deny-words + Go RE2), which cannot compile PCRE-only patterns. Before this,
+// MSSQL forwarded none of these and was permanently stuck on the local engine,
+// unlike every other database proxy (DEP-89 / DEP-90 / #1615).
+//
+// The masking/GCP keys (dlp_gcp_credentials, dlp_info_types, data-masking
+// entity data, masking character) are deliberately omitted: the native MSSQL
+// proxy enforces INPUT guardrails only and never redacts output, so they are
+// inert here — and forwarding active GCP redaction config alongside guardrails
+// makes libhoop fail closed ("guardrails require MSPresidio"). Omitting them
+// keeps GCP-DLP orgs on the local guardrail engine instead of refusing the
+// session. An empty guard_rail_rules value is a plain passthrough.
+func addMSSQLGuardRailsOpts(opts map[string]string, connParams *pb.AgentConnectionParams) {
+	var guardRailRules string
+	if connParams.GuardRailRules != nil {
+		guardRailRules = string(connParams.GuardRailRules)
+	}
+	opts["dlp_provider"] = connParams.DlpProvider
+	opts["dlp_mode"] = connParams.DlpMode
+	opts["mspresidio_analyzer_url"] = connParams.DlpPresidioAnalyzerURL
+	opts["mspresidio_anonymizer_url"] = connParams.DlpPresidioAnonymizerURL
+	opts["guard_rail_rules"] = guardRailRules
 }

--- a/agent/controller/mssql_guardrails_test.go
+++ b/agent/controller/mssql_guardrails_test.go
@@ -1,0 +1,67 @@
+package controller
+
+import (
+	"testing"
+
+	pb "github.com/hoophq/hoop/common/proto"
+)
+
+// TestAddMSSQLGuardRailsOpts locks in which opts the native MSSQL proxy forwards
+// to libhoop. The MSSQL proxy enforces input guardrails only; it must forward
+// the provider-selection keys so guardrail regex is evaluated through Presidio
+// when configured, but must NOT forward the masking/GCP keys, which would push
+// a GCP-DLP org onto libhoop's "guardrails require MSPresidio" fail-closed path.
+func TestAddMSSQLGuardRailsOpts(t *testing.T) {
+	connParams := &pb.AgentConnectionParams{
+		DlpProvider:                "mspresidio",
+		DlpMode:                    "best-effort",
+		DlpPresidioAnalyzerURL:     "http://analyzer:3000",
+		DlpPresidioAnonymizerURL:   "http://anonymizer:3000",
+		DlpGcpRawCredentialsJSON:   `{"type":"service_account"}`,
+		DLPInfoTypes:               []string{"EMAIL_ADDRESS"},
+		DataMaskingEntityTypesData: []byte(`{"foo":"bar"}`),
+		GuardRailRules:             []byte(`{"input_rules":[{"rules":[]}]}`),
+	}
+
+	opts := map[string]string{}
+	addMSSQLGuardRailsOpts(opts, connParams)
+
+	wantSet := map[string]string{
+		"dlp_provider":              "mspresidio",
+		"dlp_mode":                  "best-effort",
+		"mspresidio_analyzer_url":   "http://analyzer:3000",
+		"mspresidio_anonymizer_url": "http://anonymizer:3000",
+		"guard_rail_rules":          `{"input_rules":[{"rules":[]}]}`,
+	}
+	for k, want := range wantSet {
+		if got := opts[k]; got != want {
+			t.Errorf("opts[%q] = %q, want %q", k, got, want)
+		}
+	}
+
+	// Masking/GCP keys must never be forwarded: MSSQL does no output masking,
+	// and their presence alongside guardrails trips libhoop's fail-closed path.
+	forbidden := []string{
+		"dlp_gcp_credentials",
+		"dlp_info_types",
+		"data_masking_entity_data",
+		"dlp_masking_character",
+	}
+	for _, k := range forbidden {
+		if _, ok := opts[k]; ok {
+			t.Errorf("opts[%q] must not be forwarded to the MSSQL proxy", k)
+		}
+	}
+}
+
+// TestAddMSSQLGuardRailsOptsNilGuardRails verifies a connection without
+// guardrail rules yields an empty guard_rail_rules value (plain passthrough),
+// not a nil-deref.
+func TestAddMSSQLGuardRailsOptsNilGuardRails(t *testing.T) {
+	opts := map[string]string{}
+	addMSSQLGuardRailsOpts(opts, &pb.AgentConnectionParams{})
+
+	if got, ok := opts["guard_rail_rules"]; !ok || got != "" {
+		t.Errorf(`guard_rail_rules = %q (present=%v), want "" present`, got, ok)
+	}
+}


### PR DESCRIPTION
## Summary

- Forward the DLP provider, mode, and Presidio endpoints to native MSSQL guardrails.
- Keep GCP/data-masking options out of the input-only MSSQL proxy.
- Add regression tests for the exact option contract.

## Why

Native MSSQL forwarded guardrail rules without the configured provider. Even in MSPresidio deployments, libhoop therefore selected its local Go RE2 engine and rejected PCRE-style lookahead patterns such as `(?!...)`. PostgreSQL already forwarded this provider configuration.

The minimal option set routes configured MSPresidio sessions through Presidio while preserving the existing local-engine fallback for no-provider and GCP-DLP deployments. Native MSSQL still performs input guardrail validation only; output masking remains disabled.

## How to test

### Automated

1. Run `go test -race ./agent/controller/`.
   - Expected: the controller suite passes, including the Presidio-forwarding, GCP-key-omission, and nil-rule passthrough cases.
2. Run `go vet ./agent/controller/`.
   - Expected: no diagnostics.
3. Run `go build ./agent/...`.
   - Expected: the agent builds successfully.

### Functional

Requires an enterprise libhoop build, SQL Server, and working MSPresidio analyzer/anonymizer endpoints.

1. Configure `DLP_PROVIDER=mspresidio`, `MSPRESIDIO_ANALYZER_URL`, and `MSPRESIDIO_ANONYMIZER_URL`; start the gateway and agent.
2. Attach an MSSQL input guardrail using a lookahead pattern, for example `(?i)^\s*(UPDATE|DELETE)\s+\S+(?!.*\bWHERE\b).*`.
3. Connect through the native MSSQL proxy.
   - Expected: the connection opens; it must not fail with `local engine cannot compile (RE2)`.
4. Execute an UPDATE/DELETE without a WHERE clause.
   - Expected: the guardrail blocks the statement and the same connection remains usable.
5. Execute the corresponding statement with a WHERE clause.
   - Expected: the statement is allowed.
6. Regression: without MSPresidio, use an RE2-compatible deny-word rule.
   - Expected: the local engine still blocks matching input. A PCRE-only rule without MSPresidio must continue failing closed rather than running unguarded.

The functional scenario was not run locally because it requires the enterprise protocol implementation plus live MSSQL and Presidio services.

Closes #1615
Related: DEP-89, DEP-90

Automated by MisterMal