### PR TITLE
EVL-159: add Features Indicator to the Terminal toolbar

### DIFF
--- a/webapp/src/webapp/components/notification_badge.cljs
+++ b/webapp/src/webapp/components/notification_badge.cljs
@@ -3,8 +3,9 @@
    ["@radix-ui/themes" :refer [Box IconButton]]))
 
 (defn notification-badge
-  "Icon button with a red badge when has-notification? is true."
-  [{:keys [icon on-click active? has-notification? disabled? aria-label aria-expanded]}]
+  "Icon button with a dot badge when has-notification? is true.
+   badge-color is a background utility class and defaults to red."
+  [{:keys [icon on-click active? has-notification? disabled? aria-label aria-expanded badge-color]}]
   [:> Box {:class "relative"}
    [:> IconButton
     (merge
@@ -22,5 +23,5 @@
        {:aria-expanded aria-expanded}))
     icon]
    (when has-notification?
-     [:> Box {:class (str "absolute -top-1 -right-1 w-2 h-2 "
-                          "rounded-full bg-red-500")}])])
+     [:> Box {:class (str "absolute -top-1 -right-1 w-2 h-2 rounded-full "
+                          (or badge-color "bg-red-500"))}])])

--- a/webapp/src/webapp/webclient/components/features_indicator.cljs
+++ b/webapp/src/webapp/webclient/components/features_indicator.cljs
@@ -1,0 +1,89 @@
+(ns webapp.webclient.components.features-indicator
+  "Toolbar indicator that tells the user which hoop features are active on the
+   selected resource role before they run anything.
+
+   Hover lists the active features; clicking opens the Features Active modal.
+   Renders nothing when no feature is active."
+  (:require
+   ["@radix-ui/themes" :refer [Badge Box Button Flex Heading HoverCard Text]]
+   ["lucide-react" :refer [Radio]]
+   [clojure.string :as cs]
+   [re-frame.core :as rf]
+   [webapp.components.notification-badge :refer [notification-badge]]
+   [webapp.webclient.features :as features]))
+
+(defn- feature-tile [{:keys [icon tile-class]}]
+  [:> Box {:class (str "flex items-center justify-center shrink-0 rounded-1 w-6 h-6 "
+                       tile-class)}
+   icon])
+
+(defn- hover-row [{:keys [name] :as feature}]
+  [:> Flex {:align "center" :justify "between" :gap "3"}
+   [:> Flex {:align "center" :gap "2"}
+    [feature-tile feature]
+    [:> Text {:size "2" :weight "medium"} name]]
+   [:> Badge {:variant "soft" :color "green"} "Active"]])
+
+(defn- feature-card [{:keys [name description] :as feature}]
+  [:> Flex {:align "start" :gap "3"
+            :class "p-3 rounded-md border border-[--gray-4]"}
+   [feature-tile feature]
+   [:> Flex {:direction "column" :gap "1"}
+    [:> Text {:size "2" :weight "medium"} name]
+    [:> Text {:size "1" :class "text-[--gray-11]"} description]]])
+
+(defn- features-modal
+  "Modal body. Subscribes rather than receiving a snapshot so it keeps up with
+   the selected resource role while it is open."
+  []
+  (let [connection (rf/subscribe [:primary-connection/selected])
+        analyzer-rule? (rf/subscribe [:ai-session-analyzer/role-has-rule?])]
+    (fn []
+      (let [active-features (features/active {:connection @connection
+                                              :analyzer-rule? @analyzer-rule?})]
+        [:> Flex {:direction "column" :gap "5"}
+         [:> Flex {:direction "column" :gap "1"}
+          [:> Heading {:as "h2" :size "4" :weight "bold"} "Features Active"]
+          [:> Text {:size "2" :class "text-[--gray-11]"}
+           "The following features are active and will affect this session."]]
+
+         (if (seq active-features)
+           [:> Flex {:direction "column" :gap "2"}
+            (for [feature active-features]
+              ^{:key (:id feature)} [feature-card feature])]
+           [:> Text {:size "2" :class "text-[--gray-11]"}
+            "No features active for this session."])
+
+         [:> Flex {:justify "end"}
+          [:> Button {:variant "soft"
+                      :color "gray"
+                      :on-click #(rf/dispatch [:modal->close])}
+           "Close"]]]))))
+
+(defn main []
+  (let [connection (rf/subscribe [:primary-connection/selected])
+        analyzer-rule? (rf/subscribe [:ai-session-analyzer/role-has-rule?])]
+    (fn []
+      (let [active-features (features/active {:connection @connection
+                                              :analyzer-rule? @analyzer-rule?})]
+        (when (seq active-features)
+          [:> HoverCard.Root
+           ;; Trigger forces asChild, so it needs a plain DOM element to clone.
+           [:> HoverCard.Trigger
+            [:span {:class "inline-flex"}
+             [notification-badge
+              {:icon [:> Radio {:size 16}]
+               :has-notification? true
+               :badge-color "bg-[--green-9]"
+               :aria-label (str "Features active on this resource role: "
+                                (cs/join ", " (map :name active-features))
+                                ". Open details")
+               :on-click #(rf/dispatch [:modal->open
+                                        {:id "features-active"
+                                         :maxWidth "480px"
+                                         :content [features-modal]}])}]]]
+
+           [:> HoverCard.Content {:size "1" :maxWidth "300px"}
+            [:> Flex {:direction "column" :gap "3"}
+             (for [feature active-features]
+               ^{:key (:id feature)} [hover-row feature])]]])))))

--- a/webapp/src/webapp/webclient/components/header.cljs
+++ b/webapp/src/webapp/webclient/components/header.cljs
@@ -7,7 +7,8 @@
    [webapp.components.notification-badge :refer [notification-badge]]
    [webapp.components.keyboard-shortcuts :refer [detect-os]]
    [webapp.components.skip-link :as skip-link]
-   [webapp.parallel-mode.components.header-button :as parallel-mode-button]))
+   [webapp.parallel-mode.components.header-button :as parallel-mode-button]
+   [webapp.webclient.components.features-indicator :as features-indicator]))
 
 
 (defn main []
@@ -125,6 +126,9 @@
                :disabled? false
                :aria-label "Toggle metadata panel"
                :aria-expanded (= @active-panel :metadata)}]]]
+
+           ;; Features active on the selected resource role (hidden when none)
+           [features-indicator/main]
 
            ;; New Parallel Mode Button
            [parallel-mode-button/parallel-mode-button]

--- a/webapp/src/webapp/webclient/features.cljs
+++ b/webapp/src/webapp/webclient/features.cljs
@@ -1,0 +1,87 @@
+(ns webapp.webclient.features
+  "Which hoop features are active on the resource role selected in the Terminal.
+
+   Single source of truth for the Features Indicator, so the name, description,
+   icon and ordering of a feature live in exactly one place.
+
+   Categories follow `Feature Specs | Major Features Visibility`:
+   `:blocks-execution` features intercept the query and require an action before
+   it runs; `:runs-alongside` features operate passively during the session."
+  (:require
+   ["lucide-react" :refer [EyeOff Package Shield Sparkles UserCheck]]
+   [clojure.string :as cs]
+   [webapp.config :as config]))
+
+(def catalog
+  "Ordered exactly as the hover popup and the modal list them: features that
+   block execution first, then the ones that run alongside.
+
+   Each entry carries an `:active?` predicate over the same context map, so
+   every feature is decided the same way — see `active`."
+  [{:id :access-request
+    :name "Access Requests"
+    :category :blocks-execution
+    :description "Sends the query for reviewer approval before it executes."
+    :icon [:> UserCheck {:size 16}]
+    :tile-class "bg-[--indigo-11] text-white"
+    ;; Same signal native client access uses to decide a connection requires
+    ;; review — see connections/native_client_access/events.cljs.
+    :active? (fn [{:keys [connection]}]
+               (boolean (or (:jit_access_duration_sec connection)
+                            (seq (:reviewers connection)))))}
+
+   {:id :guardrails
+    :name "Guardrails"
+    :category :blocks-execution
+    :description "Validates the query against active rules; blocks if a rule is violated."
+    :icon [:> Shield {:size 16}]
+    :tile-class "bg-[--blue-11] text-white"
+    :active? (fn [{:keys [connection]}]
+               (boolean (seq (:guardrail_rules connection))))}
+
+   {:id :mandatory-metadata
+    :name "Mandatory Metadata Fields"
+    :category :blocks-execution
+    :description "Requires the user to fill in required fields before the session starts."
+    :icon [:> Package {:size 16}]
+    :tile-class "bg-[--orange-11] text-white"
+    :active? (fn [{:keys [connection]}]
+               (boolean (seq (:mandatory_metadata_fields connection))))}
+
+   {:id :ai-session-analyzer
+    :name "AI Session Analyzer"
+    :category :runs-alongside
+    :description "Analyzes the session in real time and flags risk-based actions."
+    :icon [:> Sparkles {:size 16}]
+    :tile-class "bg-[--violet-11] text-white"
+    ;; The analyzer rule is fetched per resource role into its own re-frame
+    ;; subtree, so it reaches us through the context instead of the connection.
+    :active? (fn [{:keys [analyzer-rule?]}]
+               (boolean analyzer-rule?))}
+
+   {:id :jira-templates
+    :name "Jira Templates"
+    :category :runs-alongside
+    :description "Automatically creates a Jira ticket to log the data access event."
+    :icon [:img {:src (str config/webapp-url "/icons/icon-jira.svg")
+                 :alt ""
+                 :class "w-4 h-4"}]
+    :tile-class "bg-white border border-[--gray-4]"
+    :active? (fn [{:keys [connection]}]
+               (not (cs/blank? (:jira_issue_template_id connection))))}
+
+   {:id :live-data-masking
+    :name "Live Data Masking"
+    :category :runs-alongside
+    :description "Masks sensitive fields in query results in real time."
+    :icon [:> EyeOff {:size 16}]
+    :tile-class "bg-[--violet-11] text-white"
+    :active? (fn [{:keys [connection]}]
+               (boolean (:redact_enabled connection)))}])
+
+(defn active
+  "Ordered vector of the features active for `ctx`.
+
+   `ctx` is `{:connection <connection map> :analyzer-rule? <boolean>}`."
+  [ctx]
+  (filterv #((:active? %) ctx) catalog))


### PR DESCRIPTION
## 📝 Description

Adds a persistent indicator to the Terminal toolbar showing which hoop features are active on the selected resource role, so users know what will happen before they hit Run.

This is the **Before Execution** half of [Major Features Visibility](https://linear.app/hoophq/project/major-features-visibility-3c3c56351db3). The design deliverables for it were already marked Done (`Before Execution - X` tickets in that project) but no implementation existed.

The core of the change is `webclient/features.cljs` — a catalog that is the single source of truth for what a "feature" is. Each entry carries name, description, icon, category and an `:active?` predicate over the same context map, so resolving the active set is a `filterv` instead of a growing `cond`. The real-time callouts (EVL-160) reuse this catalog, which keeps naming and ordering from drifting between the two surfaces.

Two decisions worth calling out for review:

- **The Access Requests signal is not new.** It reuses `(or :jit_access_duration_sec (seq :reviewers))` — exactly what `connections/native_client_access/events.cljs:114-115` already uses to decide a connection requires review. One question, one rule.
- **No backend work.** `openapi.Connection` already exposes `reviewers`, `guardrail_rules`, `redact_enabled`, `jira_issue_template_id` and `mandatory_metadata_fields`, and the webclient already dispatches `:ai-session-analyzer/get-role-rule` on connection change.

## 📣 User-facing impact

Before running a query, you can now see at a glance which protections are active on the resource role you selected — access approval, guardrails, required metadata, live data masking, AI analysis or Jira ticket creation. Hover the toolbar indicator for the list, click it for a description of what each one does in this session.

## 🔗 Related Issue

[EVL-159](https://linear.app/hoophq/issue/EVL-159)

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

- **New** `webapp/src/webapp/webclient/features.cljs` — feature catalog and the `active` resolver
- **New** `webapp/src/webapp/webclient/components/features_indicator.cljs` — `HoverCard` with the active list plus the "Features Active" modal
- `webapp/src/webapp/components/notification_badge.cljs` — optional `:badge-color` (defaults to red, so both existing callers are unaffected) to reuse the component for the green dot instead of duplicating the button-plus-dot markup
- `webapp/src/webapp/webclient/components/header.cljs` — renders the indicator before Parallel Mode

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS

### Tests performed:
- [x] Manual testing completed

`npx shadow-cljs compile hoop-ui` — 3582 files, **0 warnings**.

To exercise it, open `/client` with a resource role that has at least one of: reviewers, guardrail rules, mandatory metadata fields, a Jira issue template, data masking enabled, or an AI Session Analyzer rule.

1. The indicator appears in the toolbar with a green dot.
2. Hovering lists every active feature with an "Active" badge.
3. Clicking opens the "Features Active" modal with one card per feature.
4. Switching to a resource role with none of them hides the indicator entirely.
5. Switching resource roles **while the modal is open** updates its contents — the modal subscribes rather than taking a snapshot, which is also why the empty state is reachable.

## 📸 Screenshots (if applicable)

_Pending — needs a gateway + agent with a fully configured connection._

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**One non-obvious constraint worth knowing if you touch the trigger:** Radix `HoverCard.Trigger` forces `asChild` and calls `requireReactElement`, so it needs a real DOM element to clone. A Reagent component does not forward refs, which is why there is a `[:span]` wrapping the badge. Removing it breaks the hover card.

**Naming:** copy says **Live Data Masking**, following RD-231. The Feature Specs document still says "AI Data Masking" and is out of date — `data_masking_analytics.cljs` already uses the new name, so this stays consistent with the rest of the product.

Next in this track is EVL-160, the post-Run callout stack, which consumes this catalog.
