### PR TITLE
EVL-175: link MIGRATION_ROADMAP.md to the Linear project and state which one wins

### DIFF
--- a/webapp_v2/MIGRATION_ROADMAP.md
+++ b/webapp_v2/MIGRATION_ROADMAP.md
@@ -1,10 +1,25 @@
 # CLJS → React Migration Roadmap
 
-Status of record for finishing the `webapp/` (ClojureScript) → `webapp_v2/` (React)
+The plan for finishing the `webapp/` (ClojureScript) → `webapp_v2/` (React)
 migration. Produced from a full audit of both apps (routes, panels, dead code,
 navigation, global infra parity) on 2026-07-27. `CONTEXT_MIGRATION.md` explains the
 shell architecture; this file answers "what's left, in what order, and what can be
 deleted".
+
+## Tracked in Linear
+
+Live status lives in the **[CLJS → React Migration project](https://linear.app/hoophq/project/cljs-react-migration-webapp-v2-a3134fa1d0db)**. Every item below has a ticket, grouped into milestones that mirror the tracks and waves here, with dependencies wired so the board shows what is claimable right now.
+
+| Surface | Owns |
+|---|---|
+| The Linear project | What is claimable, who owns it, current status, and the **verified scope** of each item |
+| This file | *Why* the order is what it is — architectural reasoning, ordering constraints, the endgame plan |
+
+**Where a ticket's scope disagrees with a row below, the ticket wins.** The rows date from the 2026-07-27 audit; every near-term ticket was re-verified against the tree on 2026-07-31 and several rows turned out wrong — B3.7 is 727 LOC and not ~324 (the count omitted the whole `views/` subtree), B2.2 is *not* independent (no sidebar or palette entry — it is reachable only from Sessions surfaces), B2.1 owns ~150 of `events/audit.cljs`'s 786 LOC rather than all of it, and B1.3 has nine adoption sites rather than two.
+
+Those corrections live in the tickets deliberately. Copying them back here would give every fact two homes and start the drift over again — the problem EVL-115 removed from these docs in the first place.
+
+New work gets a ticket in the project **before** the branch. PR #1650 sat unticketed for two days and was invisible on the board the whole time.
 
 **Working model:** three parallel tracks (Cleanup, Migration, Parity) plus a Phase 0
 of quick wins and an Endgame (bundle removal). One Linear ticket = one worktree =


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

The migration now has two planning surfaces and nothing connected them:

- `webapp_v2/MIGRATION_ROADMAP.md` — the architectural reasoning, ordering constraints and endgame plan. Someone reading the repo finds this and never learns the board exists.
- The [Linear project](https://linear.app/hoophq/project/cljs-react-migration-webapp-v2-a3134fa1d0db) — 41 tickets in 11 milestones mirroring the tracks and waves here, with dependencies wired so the board shows what is claimable.

They had also started to **disagree on facts**. Every near-term ticket was re-verified against the tree on 2026-07-31 and several rows here turned out wrong: B3.7 is 727 LOC not ~324 (the count omitted the whole `views/` subtree), B2.2 is described as independent but has no sidebar or palette entry, B2.1 owns ~150 of `events/audit.cljs`'s 786 LOC rather than all of it, and B1.3 has nine ad-hoc confirmation sites rather than two.

This adds a short **Tracked in Linear** block: the link, a two-row table splitting what each surface owns, and the precedence rule — **the ticket wins on scope, this file wins on ordering and rationale.**

It deliberately does **not** copy the corrections into the wave tables. That would give every fact two homes and restart exactly the drift EVL-115 removed from these docs; the precedence rule is what keeps them honest instead.

Also states that new work gets a ticket before the branch — PR #1650 sat unticketed for two days and was invisible on the board the whole time.

## 📣 User-facing impact

None.

## 🔗 Related Issue

Linear: [EVL-175](https://linear.app/hoophq/issue/EVL-175/link-migration-roadmapmd-to-the-linear-project-and-define-which-one)

## 🚀 Type of Change

- [x] 📚 Documentation update

## 📋 Changes Made

- Added a "Tracked in Linear" section to `webapp_v2/MIGRATION_ROADMAP.md` with the project link, the ownership split, and the precedence rule
- Softened the opening line from "Status of record" to "The plan" — status is now the board's job

## 🧪 Testing

## How to test

Documentation only — one file, 16 lines added, no code touched.

```bash
git diff main --stat        # webapp_v2/MIGRATION_ROADMAP.md | 17 +-
```

Read the rendered file on the PR's Files tab and confirm:

1. The Linear project link resolves to the CLJS → React Migration project.
2. The ownership table renders (two rows: the project owns claimable/status/verified scope; the file owns reasoning/ordering/endgame).
3. Nothing below the new block changed — the "Working model" paragraph, "Landed elsewhere", Phase 0, Track A and every wave table are untouched.

### Tests performed:
- [x] Manual testing completed (rendered diff reviewed; no code paths affected)

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Held back until now on purpose: EVL-116 and EVL-119 were both editing this same file, and those two turned out to be rewriting the same paragraph with opposite conclusions without either PR conflicting against `main`. Adding a third concurrent editor would have recreated that. Both merged, and PR #1650's copy of the migration docs is now byte-identical to `main`, so this lands clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
