### PR TITLE
fix: get request rule based on attribute

### DIFF
--- a/gateway/api/connections/connection_credentials.go
+++ b/gateway/api/connections/connection_credentials.go
@@ -3,7 +3,6 @@ package apiconnections
 import (
 	"database/sql"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"net/url"
 	"slices"
@@ -26,8 +25,8 @@ import (
 	"github.com/hoophq/hoop/gateway/proxyproto/postgresproxy"
 	"github.com/hoophq/hoop/gateway/proxyproto/sshproxy"
 	"github.com/hoophq/hoop/gateway/proxyproto/ssmproxy"
+	"github.com/hoophq/hoop/gateway/services"
 	"github.com/hoophq/hoop/gateway/storagev2"
-	"gorm.io/gorm"
 )
 
 var validConnectionTypes = []string{
@@ -114,7 +113,12 @@ func CreateConnectionCredentials(c *gin.Context) {
 	}
 
 	// Check if connection requires review/JIT approval
-	requiresReview, accessRule := checkConnectionRequiresReview(ctx, conn)
+	requiresReview, accessRule, err := checkConnectionRequiresReview(ctx, conn)
+	if err != nil {
+		log.Errorf("failed checking review requirement for connection %s, err=%v", conn.Name, err)
+		c.AbortWithStatusJSON(500, gin.H{"message": "failed checking review requirements"})
+		return
+	}
 
 	// Determine the audit status of the credential-issuance session.
 	// Persistent credentials (no review, no access_duration_seconds) mint a
@@ -743,7 +747,7 @@ func loadCredentialForMutation(ctx *storagev2.Context, connNameOrID, credentialI
 // terminateActiveCredentialSessions tears down any in-flight proxy sessions for
 // the given credential. Shared by Revoke (with DB invalidation) and Close
 // (without DB invalidation).
-func terminateActiveCredentialSessions(cred *models.ConnectionCredentials, conn *models.Connection) {
+func terminateActiveCredentialSessions(cred *models.ConnectionCredentials, _conn *models.Connection) {
 	connType := proto.ConnectionType(cred.ConnectionType)
 	switch connType {
 	case proto.ConnectionTypePostgres:
@@ -1100,35 +1104,28 @@ func createConnectionCredentialsReview(ctx *storagev2.Context, conn *models.Conn
 	return reviewID, nil
 }
 
-// checkConnectionRequiresReview checks if a connection requires review/JIT approval
-// It checks both OSS reviewers and Enterprise access request rules
-func checkConnectionRequiresReview(ctx *storagev2.Context, conn *models.Connection) (bool, *models.AccessRequestRule) {
+// checkConnectionRequiresReview checks if a connection requires review/JIT approval.
+// It checks OSS reviewers and Enterprise access request rules (both name-targeted
+// and attribute-targeted, e.g. protection profiles). A non-nil error means the
+// requirement could not be determined — callers must fail closed, not issue credentials.
+func checkConnectionRequiresReview(ctx *storagev2.Context, conn *models.Connection) (bool, *models.AccessRequestRule, error) {
 	// Check OSS reviewers
 	if len(conn.Reviewers) > 0 {
-		return true, nil
+		return true, nil, nil
 	}
 
 	// Check Enterprise access request rules for JIT access
 	orgID, err := uuid.Parse(ctx.OrgID)
 	if err != nil {
-		log.Warnf("failed parsing org_id %s, err=%v", ctx.OrgID, err)
-		return false, nil
+		return false, nil, fmt.Errorf("failed parsing org id %s: %w", ctx.OrgID, err)
 	}
 
-	accessRule, err := models.GetAccessRequestRuleByResourceNameAndAccessType(models.DB, orgID, conn.Name, "jit")
+	accessRule, err := services.GetRuleForConnection(orgID, conn.Name, "jit")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return false, nil
-		}
-		log.Warnf("failed checking access request rules for connection %s, err=%v", conn.Name, err)
-		return false, nil
+		return false, nil, fmt.Errorf("failed checking access request rules for connection %s: %w", conn.Name, err)
 	}
 
-	if accessRule != nil {
-		return true, accessRule
-	}
-
-	return false, nil
+	return accessRule != nil, accessRule, nil
 }
 
 // recoverSecretKey returns the plaintext secret key stored on the credential.


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
>
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Native-client credential issuance (`POST /api/connections/:name/credentials`) skipped JIT review for connections governed by protection profiles.
This PR switches the resolver to the attribute-aware `services.GetRuleForConnection` (the same one the access-request interceptor uses) and makes lookup failures fail closed: any error determining the review requirement now aborts with a 500 instead of silently issuing credentials.

## 🔗 Related Issue

EVL-174

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- `gateway/api/connections/connection_credentials.go` — `checkConnectionRequiresReview` now resolves JIT rules via
`services.GetRuleForConnection` (attribute junction first, name-targeted fallback) and returns `(bool, *models.AccessRequestRule,
error)`. The org-ID parse failure and rule lookup errors are returned instead of logged-and-ignored; the dead
`gorm.ErrRecordNotFound` branch is removed (the resolver filters it internally). Dropped now-unused `errors`/`gorm` imports.
- `gateway/api/connections/connection_credentials.go` — the sole caller (`CreateConnectionCredentials`) fails closed: a resolver
error returns 500 with no credentials, before the audit session is created (no orphan session rows).
- `gateway/api/connections/evl174_smoke_test.go` — new manual smoke test (build tag `smoke`, skips without `EVL174_SMOKE_DB`),
mirroring the `protection_profiles_smoke_test.go` convention: runs full migrations on a scratch PostgreSQL DB and covers
attribute-attached rule detection, name-targeted rules, no-rule pass-through, OSS reviewers short-circuit, and fail-closed on bad
org ID.

## 🧪 Testing

- Reproduction confirmed on a seeded scratch DB: the old name-only filter (`connection_names @> '{attr-conn}' AND access_type =
'jit'`) returns **zero rows** for an attribute-governed connection, while the attribute join finds `Hoop-JIT_8_hours` — the exact
miss that let credentials through without review.
- Smoke test passes all 5 cases against real PostgreSQL with full migrations: attribute-attached rule now requires review (the
fix), name-targeted rules still detected (regression), no rule → `(false, nil, nil)` (credentials still issued normally), OSS
`reviewers` short-circuit, unparseable org ID → error / fail closed.
- `go build ./gateway/...`, `go vet`, package unit tests, and `gofmt` all clean.

### Test Configuration

- **Browser(s)**: Brave
- **OS**: macOS

### Tests performed

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

N/A — backend-only change.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- Scope intentionally excludes the interceptor's `ApprovalRequiredGroups` intersection check (`accessrequest.go`): a matching JIT
rule requires review for every user on the credentials path. That divergence is pre-existing and out of scope for this fix.
- Intended behavior shift: profile-governed connections that previously received persistent credentials silently now hit the
`access_duration_seconds`-required 400 — review-required connections always need a bounded window. Review creation works with OSS
`reviewers` empty because profile-created rules carry the org admin group in `ReviewersGroups`.

---
