### PR TITLE
DEP-91 (3/7): add opt-in hoophq/hoopdev-minimal agent image

### DIFF
--- a/.github/workflows/minimal-image-build.yml
+++ b/.github/workflows/minimal-image-build.yml
@@ -1,0 +1,76 @@
+# Build-only smoke check for the minimal agent image (hoophq/hoopdev-minimal).
+#
+# The release workflow (release.yml) is the ONLY place Dockerfile.minimal is
+# otherwise built, and only after a tag push once the release binaries exist.
+# That leaves a gap where a broken Dockerfile.minimal can reach main and only
+# fail post-merge at release time. This workflow closes it: on PRs touching the
+# minimal image inputs it builds the same Dockerfile for both release platforms
+# (amd64+arm64) WITHOUT pushing, then loads the amd64 image and asserts the
+# runtime user is the unprivileged 'hoop' user (uid 10001) — the same guard the
+# OCR smoke workflow applies.
+#
+# The image extracts the release tar from dist/binaries/ (glob
+# hoop_*_<uname -s>_<uname -m>.tar.gz), which is produced by the release build
+# and is absent at PR time. We stage a throwaway placeholder binary under that
+# exact name so the Dockerfile's `tar -xf` and layout steps exercise for real;
+# this is a Dockerfile-correctness gate, not a functional agent build.
+name: Minimal Agent Image Build
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile.minimal'
+      - '.github/workflows/minimal-image-build.yml'
+
+jobs:
+  build-minimal-agent:
+    name: Build Minimal Agent Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      # Stage placeholder release tars under the names the Dockerfile's glob
+      # expects, for every arch the build matrix covers. `uname -m` inside the
+      # build reports aarch64/x86_64, so name the tars to match.
+      - name: Stage placeholder release tars
+        run: |
+          mkdir -p dist/binaries stage
+          printf '#!/bin/sh\necho hoop (pr-smoke placeholder)\n' > stage/hoop
+          chmod +x stage/hoop
+          for arch in x86_64 aarch64; do
+            tar -C stage -czf "dist/binaries/hoop_pr-smoke_Linux_${arch}.tar.gz" hoop
+          done
+      - name: Build (multiarch, no push)
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.minimal
+          context: '.'
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
+          push: false
+      # Multiarch builds cannot be --load'ed; rebuild amd64 from the warm
+      # buildx cache to run the runtime-privilege assertion below.
+      - name: Build (amd64, load for runtime check)
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.minimal
+          context: '.'
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          push: false
+          load: true
+          tags: hoopdev-minimal:pr-smoke
+      # The image must run as the unprivileged 'hoop' user (uid 10001) so a
+      # missing 'USER hoop' can never ship.
+      - name: Verify runtime user is unprivileged
+        run: |
+          uid="$(docker run --rm --entrypoint id hoopdev-minimal:pr-smoke -u)"
+          echo "runtime uid: ${uid}"
+          test "${uid}" = "10001"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -889,6 +889,131 @@ jobs:
           docker manifest push hoophq/hoopdev:${{ env.GIT_TAG }}
           docker manifest push hoophq/hoopdev:latest
 
+  # --- Minimal agent line (DEP-91): hoophq/hoopdev-minimal --------------------
+  # Additive, opt-in "bring-your-own-tools" agent image built from
+  # Dockerfile.minimal. Mirrors the hoopagent (hoophq/hoopdev) publish graph
+  # exactly — same build-tar-files dependency, same per-arch + multiarch
+  # manifest scheme — but is NOT a dependency of publish-release: the default
+  # fat image stays the gating artifact, and a hiccup here must not block a
+  # release of the established images.
+  docker-publish-hoopdev-minimal-arm64:
+    runs-on: GitHub-Linux-Arm-Runner
+    name: Dck Publish Minimal Agent (arm64)
+    environment: production
+    # Additive line: a hiccup here must never fail the release of the
+    # established images (mirrors the -ng clean line below).
+    continue-on-error: true
+    needs:
+      - build-tar-files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoopdev-minimal
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-artifacts-*
+          merge-multiple: true
+          path: dist/
+      - name: Build and Push
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.minimal
+          context: '.'
+          platforms: linux/arm64
+          provenance: false
+          sbom: false
+          push: true
+          tags: |
+            hoophq/hoopdev-minimal:${{ github.sha }}-arm64
+
+  docker-publish-hoopdev-minimal-amd64:
+    runs-on: ubuntu-latest
+    name: Dck Publish Minimal Agent (amd64)
+    environment: production
+    continue-on-error: true
+    needs:
+      - build-tar-files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoopdev-minimal
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-artifacts-*
+          merge-multiple: true
+          path: dist/
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile.minimal
+          context: '.'
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          push: true
+          tags: |
+            hoophq/hoopdev-minimal:${{ github.sha }}-amd64
+
+  docker-publish-hoopdev-minimal-multiarch:
+    runs-on: ubuntu-latest
+    name: Publish Minimal Agent Image
+    environment: production
+    continue-on-error: true
+    needs:
+      - docker-publish-hoopdev-minimal-amd64
+      - docker-publish-hoopdev-minimal-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hoophq/hoopdev-minimal
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set Git Tag
+        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Create SHA manifest and push
+        env:
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: |
+          docker manifest create hoophq/hoopdev-minimal:${{ env.GIT_TAG }} \
+            --amend hoophq/hoopdev-minimal:${{ github.sha }}-amd64 \
+            --amend hoophq/hoopdev-minimal:${{ github.sha }}-arm64
+          docker manifest create hoophq/hoopdev-minimal:latest \
+            --amend hoophq/hoopdev-minimal:${{ github.sha }}-amd64 \
+            --amend hoophq/hoopdev-minimal:${{ github.sha }}-arm64
+          docker manifest push hoophq/hoopdev-minimal:${{ env.GIT_TAG }}
+          docker manifest push hoophq/hoopdev-minimal:latest
+
   # --- Clean image line (DEP-66): hoophq/hoop-ng + hoophq/hoopdev-ng ----------
   # Bright-line, clean-only repos (no dirty history) that the hoop-ng helm chart
   # points at. Every job here is continue-on-error and NOT a dependency of

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,0 +1,79 @@
+# hoophq/hoopdev-minimal — minimal, opt-in agent image (DEP-91, workstream D).
+#
+# A "bring-your-own-tools" production base: the hoop agent binary plus only the
+# runtime bits the agent process itself needs. It bundles NO database or cloud
+# CLIs (psql/mysql/mongosh/kubectl/aws/gcloud/...), no Node, no OCR/tesseract
+# and no -dev/header packages — so it does NOT carry the CVE surface those
+# stacks drag in.
+#
+# This image is ADDITIVE. The default fat agent image (hoophq/hoopdev, built
+# from Dockerfile.dev on the agent-tools base) is unchanged and stays the
+# default everywhere. Extend this one when you want a lean agent and add only
+# the clients your connections actually use — see docs/custom-agent-image.md.
+#
+# Connection types that work out of the box: native DB proxy (postgres, mysql,
+# mssql, mongo, oracle via libhoop), plus HTTP and TCP proxying. Exec-based
+# sessions and any connection that shells out to a client binary
+# (clickhouse-client, cloud CLIs, ...) need that binary added in a derived
+# image.
+FROM ubuntu:noble-20251013
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ACCEPT_EULA=y
+
+# Unprivileged runtime user (mirrors Dockerfile) and the minimal runtime the
+# agent process actually needs:
+#   tini            — PID 1 / signal reaping (ENTRYPOINT)
+#   ca-certificates — TLS trust store for the gateway gRPC/WS connection
+#   locales         — en_US.UTF-8 (matches Dockerfile; multi-byte-safe output)
+# The agent reaches targets via libhoop's in-process proxies and native Go SSH
+# (golang.org/x/crypto/ssh); it does not shell out to `ssh` or `envsubst` here
+# (the `ssh` exec lives in the client/`hoop connect` side, and rootfs — the only
+# envsubst consumer — is not copied). Deliberately NO openssh-client, gettext-base,
+# curl, xz-utils, procps, tesseract, DB/cloud CLIs, or any -dev/header package
+# (no linux-libc-dev / libc6-dev). Extenders add the client binaries their
+# connections need — see docs/custom-agent-image.md.
+RUN groupadd --gid 10001 hoop && \
+    useradd --uid 10001 --gid 10001 --no-create-home --shell /sbin/nologin hoop && \
+    mkdir -p /app && \
+    mkdir -p /opt/hoop/sessions && \
+    mkdir -p /opt/hoop/bin && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        tini \
+        ca-certificates \
+        locales && \
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+# NOTE: rootfs/ is intentionally NOT copied. Every file it carries is a
+# fat-image integration shim for a bundled third-party CLI (kubectl, mongo,
+# mysql, bq/gcloud, aws ecs/ssm, PRE_EXEC bash) that execs a backing binary
+# this image does not ship, plus two docker-compose-only helpers. Copying them
+# would put broken DB/cloud CLI names on PATH — the exact opposite of a minimal
+# bring-your-own-tools agent. The OOTB connection types (native DB proxy,
+# HTTP, TCP) are served entirely by the hoop binary and need nothing from
+# rootfs. Extenders add the client binary (and any wrapper they need) in their
+# own layer — see docs/custom-agent-image.md.
+#
+# Agent-only image: no gateway/migrations. Binary is sourced exactly like
+# Dockerfile.dev — the release tar is staged under dist/binaries/ and extracted
+# in place (glob matches hoop_<version>_<uname -s>_<uname -m>.tar.gz).
+COPY dist/binaries/ /tmp/
+RUN tar -xf /tmp/hoop_*_$(uname -s)_$(uname -m).tar.gz -C /app/ && \
+    chown -R hoop:hoop /app /opt/hoop && \
+    chmod 755 /app/hoop* && \
+    rm -rf /tmp/*
+
+ENV PATH="/app:${PATH}"
+ENV PATH="/opt/hoop/bin:${PATH}"
+
+USER hoop
+
+ENTRYPOINT ["tini", "--"]
+CMD ["hoop", "start", "agent"]

--- a/deploy/helm-chart/chart/agent/templates/deployment.yaml
+++ b/deploy/helm-chart/chart/agent/templates/deployment.yaml
@@ -34,7 +34,14 @@ spec:
       serviceAccountName: hoopagent
       {{- end }}
       containers:
-      - image: '{{ .Values.image.repository |default "hoophq/hoopdev" }}:{{ .Values.image.tag |default "latest" }}'
+      # Default image is the fat agent (hoophq/hoopdev). Opt into the minimal,
+      # bring-your-own-tools image (hoophq/hoopdev-minimal) by setting
+      # image.minimal: true; an explicit image.repository always wins.
+      {{- $defaultImage := "hoophq/hoopdev" }}
+      {{- if .Values.image.minimal }}
+      {{- $defaultImage = "hoophq/hoopdev-minimal" }}
+      {{- end }}
+      - image: '{{ .Values.image.repository | default $defaultImage }}:{{ .Values.image.tag | default "latest" }}'
         name: agent
         imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
         {{- if .Values.resources }}

--- a/deploy/helm-chart/chart/agent/values.yaml
+++ b/deploy/helm-chart/chart/agent/values.yaml
@@ -10,6 +10,18 @@ image: {}
   # pullPolicy: Always
   # tag: latest
   #
+  # Opt into the minimal, bring-your-own-tools agent image
+  # (hoophq/hoopdev-minimal) instead of the default fat image
+  # (hoophq/hoopdev). The minimal image ships only the agent binary plus a
+  # small runtime; it bundles NO database or cloud CLIs, so it supports the
+  # native DB proxy (postgres/mysql/mssql/mongo/oracle), HTTP and TCP
+  # connection types out of the box, while exec-based sessions and connections
+  # that shell out to a client (clickhouse-client, cloud CLIs, ...) require a
+  # custom image built FROM hoophq/hoopdev-minimal. See
+  # docs/custom-agent-image.md. An explicit `repository` above overrides this
+  # toggle.
+  # minimal: true
+  #
   # Realtime RDP PII guard: to enable agent-side PII analysis, use the
   # bundled-OCR agent image (the OCR engine runs on loopback inside the
   # container — screen pixels never leave the agent). Provide

--- a/docs/custom-agent-image.md
+++ b/docs/custom-agent-image.md
@@ -1,0 +1,78 @@
+# Custom agent images (`hoophq/hoopdev-minimal`)
+
+Hoop publishes two agent images:
+
+| Image | Contents | Use it when |
+| --- | --- | --- |
+| `hoophq/hoopdev` (default) | Agent binary **plus** a broad set of bundled database and cloud CLIs (psql, mysql, mongosh, kubectl, aws, gcloud/bq, ...). | You want everything preinstalled and accept the larger image / CVE surface those stacks carry. |
+| `hoophq/hoopdev-minimal` | Agent binary plus a small runtime only (tini, ca-certificates, locales). **No** bundled database or cloud CLIs, no `ssh`/`envsubst`, no Node, no OCR, no build/-dev packages. | You want a lean, low-CVE production base and will add only the client binaries your connections actually need. |
+
+`hoophq/hoopdev-minimal` is **opt-in and additive** — the default image and every
+existing deployment are unchanged.
+
+## What works out of the box
+
+The minimal image serves any connection type that the agent handles inside its
+own binary (via the embedded `libhoop` proxy), with no external client process:
+
+- **Native database proxy** — `postgres`, `mysql`, `mssql`, `mongodb`, `oracle`.
+  The agent speaks the wire protocol directly; it does **not** shell out to a CLI.
+- **HTTP proxy** connections.
+- **TCP proxy** connections.
+
+## What needs extra binaries
+
+Anything where the agent shells out to a third-party client is **not** included
+and must be added in a derived image:
+
+- **Exec / shell-based sessions** (`bash`, `python`, custom command connections)
+  and their runtimes.
+- **CLI database clients** the native proxy does not cover, e.g.
+  `clickhouse-client`.
+- **Cloud CLIs and their session helpers** — `kubectl` (kubernetes-exec),
+  `aws` (ECS Exec / SSM), `gcloud`/`bq` (BigQuery), etc.
+
+If you need a large set of these, use the default `hoophq/hoopdev` image instead
+of re-adding them to the minimal one.
+
+## Building a custom agent
+
+Extend the minimal image and install only the clients you use. The base already
+runs as the unprivileged `hoop` user (uid/gid 10001), so switch to `root` for
+`apt-get` and switch back before the end.
+
+```dockerfile
+# Pin to a released tag (e.g. the version you deploy).
+FROM hoophq/hoopdev-minimal:<tag>
+
+# Add only the client(s) your connections need. Example: the PostgreSQL CLI
+# for exec-based postgres sessions (the native DB proxy does NOT need this).
+USER root
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends postgresql-client && \
+    rm -rf /var/lib/apt/lists/*
+USER hoop
+
+# ENTRYPOINT/CMD are inherited from the base:
+#   ENTRYPOINT ["tini", "--"]
+#   CMD ["hoop", "start", "agent"]
+```
+
+Build and push it to your own registry, then point the agent Helm chart at it:
+
+```yaml
+# values.yaml for the agent chart
+image:
+  repository: myorg/hoop-agent-custom
+  tag: <your-tag>
+```
+
+To run the stock minimal image (no extra clients) via the chart, use the opt-in
+toggle instead of overriding the repository:
+
+```yaml
+image:
+  minimal: true
+```
+
+An explicit `image.repository` always takes precedence over `image.minimal`.


### PR DESCRIPTION
## Stack (DEP-91)

Split from #1662 at Sando's request — that PR was too large to review.

- #1683 — 1. Go dependency + toolchain CVE bumps
- #1684 — 2. agent-tools: drop kernel-header CVEs, modernize clean train
- #1685 — 3. Opt-in `hoophq/hoopdev-minimal` agent image **← you are here**
- #1686 — 4. Trivy vulnerability gate + govulncheck
- #1687 — 5. SBOM + bundled-tool manifest on releases
- #1688 — 6. Weekly base-OS rebuild of the minimal image
- #1689 — 7. Image release integrity hardening

Merge in order, bottom-up. Each PR targets the one below it.

---

## What
Adds `hoophq/hoopdev-minimal`: the agent binary plus only the runtime it needs (tini, ca-certificates, locales). No database or cloud CLIs, no Node, no OCR, no `-dev`/header packages.

Also adds the `image.minimal: true` opt-in toggle to the agent Helm chart and `docs/custom-agent-image.md`.

## Why
Gives security-sensitive deployments a low-CVE base without forcing the bundled toolchain on anyone.

## Risk
**Additive and opt-in.** `hoophq/hoopdev` remains the default everywhere; an explicit `image.repository` always wins over `image.minimal`.

Works out of the box: native DB proxy (postgres/mysql/mssql/mongo/oracle), HTTP, TCP. Exec-based sessions and connections that shell out to a client need that binary added in a derived image — documented.

## How to test
```bash
helm template t ./deploy/helm-chart/chart/agent | grep 'image:'
helm template t ./deploy/helm-chart/chart/agent --set image.minimal=true | grep 'image:'
helm template t ./deploy/helm-chart/chart/agent --set image.minimal=true --set image.repository=myorg/custom | grep 'image:'
```
Expected: `hoophq/hoopdev`, then `hoophq/hoopdev-minimal`, then `myorg/custom` (explicit repository wins).

Part of DEP-91.

Automated by MisterMal