### PR TITLE
DEP-91 (2/5): gate hoopagent vulnerabilities and add govulncheck

### DIFF
--- a/.github/workflows/agent-tools-build.yml
+++ b/.github/workflows/agent-tools-build.yml
@@ -198,6 +198,30 @@ jobs:
             --image "hoophq/agent-tools:${{ steps.p.outputs.tag }}" \
             --train "${{ matrix.train }}"
 
+      # DEP-91: report-only vulnerability visibility. This fat image bundles
+      # upstream CLIs (kubectl, gcloud, aws, node, oracle) whose own CVEs cannot
+      # be rebuilt away here, so enforcing a CRITICAL/HIGH gate would only force
+      # a large ignore-list — the suppression sprawl this effort exists to end.
+      # The STRICT fixable CRITICAL/HIGH gate lives on the minimal image
+      # (minimal-image-build.yml); here we only surface the fixable count/trend.
+      - name: Report fixable CRITICAL/HIGH vulnerabilities (Trivy, non-blocking)
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy:0.72.0 image \
+            --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed \
+            --quiet --format json \
+            "hoophq/agent-tools:${{ steps.p.outputs.tag }}" > trivy-vuln.json || true
+          n=$(jq '[.Results[]?.Vulnerabilities // []]|add|length' trivy-vuln.json 2>/dev/null || echo "?")
+          {
+            echo "### agent-tools ${{ matrix.train }} (amd64) — fixable CRITICAL/HIGH: ${n} (report-only)"
+            echo ""
+            echo "Strict gate is on hoophq/hoopagent. Top packages:"
+            echo '```'
+            jq -r '[.Results[]?.Vulnerabilities // []]|add|group_by(.PkgName)|map({p:.[0].PkgName,c:length})|sort_by(-.c)|.[]|"\(.c)\t\(.p)"' trivy-vuln.json 2>/dev/null | head -20
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Login to Docker Hub
         if: needs.meta.outputs.publish == 'true'
         uses: docker/login-action@v2
@@ -312,6 +336,26 @@ jobs:
             --image "hoophq/agent-tools:${{ steps.p.outputs.tag }}" \
             --train "${{ matrix.train }}"
 
+      # DEP-91: report-only vuln visibility (see the amd64 job for rationale).
+      # The strict CRITICAL/HIGH gate is on the minimal image, not the fat base.
+      - name: Report fixable CRITICAL/HIGH vulnerabilities (Trivy, non-blocking)
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy:0.72.0 image \
+            --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed \
+            --quiet --format json \
+            "hoophq/agent-tools:${{ steps.p.outputs.tag }}" > trivy-vuln.json || true
+          n=$(jq '[.Results[]?.Vulnerabilities // []]|add|length' trivy-vuln.json 2>/dev/null || echo "?")
+          {
+            echo "### agent-tools ${{ matrix.train }} (arm64) — fixable CRITICAL/HIGH: ${n} (report-only)"
+            echo ""
+            echo "Strict gate is on hoophq/hoopagent. Top packages:"
+            echo '```'
+            jq -r '[.Results[]?.Vulnerabilities // []]|add|group_by(.PkgName)|map({p:.[0].PkgName,c:length})|sort_by(-.c)|.[]|"\(.c)\t\(.p)"' trivy-vuln.json 2>/dev/null | head -20
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Push
         if: needs.meta.outputs.publish == 'true'
         run: docker push "hoophq/agent-tools:${{ steps.p.outputs.tag }}"
@@ -370,8 +414,6 @@ jobs:
         run: |
           set -euo pipefail
           branch="ci/agent-tools-bump-${TAG}"
-          # Dockerfile.agent is intentionally absent: hoophq/hoopagent is a
-          # clean-only repository and derives from no agent-tools base.
           sed -i "s|^ARG AGENT_TOOLS_TAG=.*|ARG AGENT_TOOLS_TAG=${TAG}|" Dockerfile.dev
           sed -i "s|^FROM hoophq/agent-tools:.*|FROM hoophq/agent-tools:${TAG}|" scripts/dev/Dockerfile
 

--- a/.github/workflows/hoopagent-image-build.yml
+++ b/.github/workflows/hoopagent-image-build.yml
@@ -1,0 +1,114 @@
+# Build-only smoke check and vulnerability gate for the slim agent image
+# (hoophq/hoopagent, both flavours).
+#
+# release.yml and pullrequest-release.yml are otherwise the only places
+# Dockerfile.agent is built, and only after the release binaries exist. That
+# leaves a gap where a broken Dockerfile.agent reaches main and fails
+# post-merge. This workflow closes it: on PRs touching the image inputs it
+# builds BOTH targets for both release platforms without pushing, asserts the
+# runtime user is unprivileged, and gates the OS layer on fixable
+# CRITICAL/HIGH vulnerabilities.
+#
+# hoophq/hoopagent is the low-CVE agent image, so unlike the fat
+# hoophq/agent-tools image (report-only: its bundled upstream CLIs carry CVEs
+# that cannot be rebuilt away) the gate here is ENFORCING — that property is
+# the reason the image exists.
+#
+# Dockerfile.agent extracts the release tar from dist/binaries/ using
+# hoop_*_Linux_${TARGETARCH}.tar.gz, which is produced by the release build and
+# absent at PR time. We stage throwaway placeholder tars under those exact
+# names so the extraction and layout steps exercise for real; this is a
+# Dockerfile-correctness and base-layer gate, not a functional agent build.
+name: Slim Agent Image Build
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile.agent'
+      - '.github/workflows/hoopagent-image-build.yml'
+
+jobs:
+  build-hoopagent:
+    name: Build Slim Agent Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [minimal, distroless]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      # Dockerfile.agent globs hoop_*_Linux_${TARGETARCH}.tar.gz, so the tars
+      # are named for Go's GOARCH values (amd64/arm64), not `uname -m`.
+      - name: Stage placeholder release tars
+        run: |
+          mkdir -p dist/binaries stage
+          printf '#!/bin/sh\necho "hoop (pr-smoke placeholder)"\n' > stage/hoop
+          chmod +x stage/hoop
+          for arch in amd64 arm64; do
+            tar -C stage -czf "dist/binaries/hoop_pr-smoke_Linux_${arch}.tar.gz" hoop
+          done
+
+      - name: Build (multiarch, no push)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          file: ./Dockerfile.agent
+          context: '.'
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
+          push: false
+
+      # Multiarch builds cannot be --load'ed; rebuild amd64 from the warm
+      # buildx cache to run the assertions below.
+      - name: Build (amd64, load for checks)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          file: ./Dockerfile.agent
+          context: '.'
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          load: true
+          push: false
+          tags: hoopagent:pr-smoke-${{ matrix.target }}
+
+      # Both flavours must run as the unprivileged uid 10001, but they declare
+      # it differently: distroless sets `USER 10001:10001` numerically, while
+      # minimal sets `USER hoop` (uid 10001, created via useradd). Resolve a
+      # named user through the image's own passwd database so both are checked
+      # as a real uid rather than trusting the string.
+      - name: Assert unprivileged runtime user
+        run: |
+          img="hoopagent:pr-smoke-${{ matrix.target }}"
+          user="$(docker image inspect --format '{{.Config.User}}' "$img")"
+          echo "configured user: ${user}"
+          uid="${user%%:*}"
+          if ! printf '%s' "$uid" | grep -qE '^[0-9]+$'; then
+            uid="$(docker run --rm --entrypoint sh "$img" -c "id -u ${uid}")"
+            echo "resolved '${user}' to uid ${uid}"
+          fi
+          test "${uid}" = "10001" \
+            || { echo "::error::expected uid 10001, got '${uid}'"; exit 1; }
+
+      # ENFORCING: this is the low-CVE image, so a fixable CRITICAL/HIGH in its
+      # base layer fails the PR. --ignore-unfixed keeps it actionable: only
+      # vulnerabilities with an available upstream fix block.
+      - name: Gate on fixable CRITICAL/HIGH vulnerabilities (Trivy)
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f image \
+            --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed \
+            --exit-code 1 --no-progress \
+            "hoopagent:pr-smoke-${{ matrix.target }}"

--- a/.github/workflows/hoopagent-image-build.yml
+++ b/.github/workflows/hoopagent-image-build.yml
@@ -5,9 +5,10 @@
 # Dockerfile.agent is built, and only after the release binaries exist. That
 # leaves a gap where a broken Dockerfile.agent reaches main and fails
 # post-merge. This workflow closes it: on PRs touching the image inputs it
-# builds BOTH targets for both release platforms without pushing, asserts the
+# builds every target/architecture combination without pushing, asserts the
 # runtime user is unprivileged, and gates the OS layer on fixable
-# CRITICAL/HIGH vulnerabilities.
+# CRITICAL/HIGH vulnerabilities — per architecture, because the package set
+# differs between them.
 #
 # hoophq/hoopagent is the low-CVE agent image, so unlike the fat
 # hoophq/agent-tools image (report-only: its bundled upstream CLIs carry CVEs
@@ -26,6 +27,10 @@ on:
     paths:
       - 'Dockerfile.agent'
       - '.github/workflows/hoopagent-image-build.yml'
+      # The fixture below imitates the release archive layout that
+      # `make build-tar-files` produces; if that recipe changes its member
+      # naming, this is the workflow that catches the mismatch.
+      - 'Makefile'
 
 jobs:
   build-hoopagent:
@@ -36,6 +41,10 @@ jobs:
       fail-fast: false
       matrix:
         target: [minimal, distroless]
+        # Both released architectures are gated, not just the native one: apt
+        # resolves a different package set per arch, so an arm64-only fixable
+        # CVE would otherwise pass here and ship.
+        arch: [amd64, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -48,40 +57,45 @@ jobs:
 
       # Dockerfile.agent globs hoop_*_Linux_${TARGETARCH}.tar.gz, so the tars
       # are named for Go's GOARCH values (amd64/arm64), not `uname -m`.
+      #
+      # The archive LAYOUT has to match the release one too, not just the file
+      # name: `make build-tar-files` runs `tar -czf ... -C <dir> .`, so every
+      # member is stored with a `./` prefix and Dockerfile.agent extracts the
+      # member `./hoop` by name. Archiving `hoop` instead stores the member as
+      # `hoop`, and GNU tar does not treat the two spellings as interchangeable
+      # — extraction fails with "./hoop: Not found in archive". Stage `.` for
+      # the same reason the release does, and carry the `hoop_rs` sibling so the
+      # fixture exercises the real "extract one member, leave the rest" path.
       - name: Stage placeholder release tars
         run: |
           mkdir -p dist/binaries stage
           printf '#!/bin/sh\necho "hoop (pr-smoke placeholder)"\n' > stage/hoop
-          chmod +x stage/hoop
+          printf '#!/bin/sh\necho "hoop_rs (pr-smoke placeholder)"\n' > stage/hoop_rs
+          chmod +x stage/hoop stage/hoop_rs
           for arch in amd64 arm64; do
-            tar -C stage -czf "dist/binaries/hoop_pr-smoke_Linux_${arch}.tar.gz" hoop
+            tar -czf "dist/binaries/hoop_pr-smoke_Linux_${arch}.tar.gz" -C stage .
           done
+          # Fail loudly here rather than inside the build if the layout drifts
+          # from what Dockerfile.agent extracts.
+          tar -tzf dist/binaries/hoop_pr-smoke_Linux_amd64.tar.gz | grep -qx './hoop' \
+            || { echo "::error::staged fixture does not contain the './hoop' member the Dockerfile extracts"; exit 1; }
 
-      - name: Build (multiarch, no push)
+      # One single-platform build per matrix cell, loaded so the assertions
+      # below run against the very image that was built. A multiarch build
+      # cannot be --load'ed, which is why the platforms are a matrix dimension
+      # rather than one combined build.
+      - name: Build (load for checks)
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           file: ./Dockerfile.agent
           context: '.'
           target: ${{ matrix.target }}
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          sbom: false
-          push: false
-
-      # Multiarch builds cannot be --load'ed; rebuild amd64 from the warm
-      # buildx cache to run the assertions below.
-      - name: Build (amd64, load for checks)
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          file: ./Dockerfile.agent
-          context: '.'
-          target: ${{ matrix.target }}
-          platforms: linux/amd64
+          platforms: linux/${{ matrix.arch }}
           provenance: false
           sbom: false
           load: true
           push: false
-          tags: hoopagent:pr-smoke-${{ matrix.target }}
+          tags: hoopagent:pr-smoke-${{ matrix.target }}-${{ matrix.arch }}
 
       # Both flavours must run as the unprivileged uid 10001, but they declare
       # it differently: distroless sets `USER 10001:10001` numerically, while
@@ -90,7 +104,7 @@ jobs:
       # as a real uid rather than trusting the string.
       - name: Assert unprivileged runtime user
         run: |
-          img="hoopagent:pr-smoke-${{ matrix.target }}"
+          img="hoopagent:pr-smoke-${{ matrix.target }}-${{ matrix.arch }}"
           user="$(docker image inspect --format '{{.Config.User}}' "$img")"
           echo "configured user: ${user}"
           uid="${user%%:*}"
@@ -111,4 +125,4 @@ jobs:
             aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f image \
             --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed \
             --exit-code 1 --no-progress \
-            "hoopagent:pr-smoke-${{ matrix.target }}"
+            "hoopagent:pr-smoke-${{ matrix.target }}-${{ matrix.arch }}"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.work
+          go-version: '>=1.26.0'
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -150,7 +150,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.work
+          go-version: '>=1.26.0'
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -203,7 +203,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.work
+          go-version: '>=1.26.0'
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -232,7 +232,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.work
+          go-version: '>=1.26.0'
 
       # Boots a throwaway postgres:17.6 via testcontainers; ubuntu-latest
       # runners have Docker pre-installed, so no services: block is needed.
@@ -257,7 +257,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.work
+          go-version: '>=1.26.0'
 
       - name: Gateway Smoke Test (pglite)
         run: make test-gateway-pglite
@@ -279,7 +279,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.work
+          go-version: '>=1.26.0'
 
       - name: Standalone Mode Test
         run: make test-standalone
@@ -301,7 +301,48 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.work
+          go-version: '>=1.26.0'
 
       - name: Standalone Single-Binary E2E
         run: make test-standalone-e2e
+
+  govulncheck:
+    name: Go Vulnerability Gate
+    needs: resolve-libhoop
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout Hoop
+        uses: actions/checkout@v3
+
+      # DEP-91: source-level Go vulnerability gate. This is the counterpart to
+      # the Trivy image gate on hoophq/hoopagent: the slim-image PR smoke
+      # scans a placeholder-binary image (OS layer only), so the SHIPPED Go
+      # binary's dependency/toolchain CVEs are gated here instead, on every PR.
+      # govulncheck must compile the workspace, which imports the enterprise
+      # libhoop; check it out at ./libhoop like the integration jobs.
+      - name: Checkout libhoop
+        uses: actions/checkout@v3
+        with:
+          repository: hoophq/libhoop
+          path: "./libhoop"
+          token: ${{ secrets.GH_TOKEN }}
+          ref: ${{ needs.resolve-libhoop.outputs.sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.26.0'
+
+      # Pinned (not @latest) so the merge gate is deterministic; bump intentionally.
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+
+      # Gate the shipped multi-call hoop binary (the client module wires the
+      # client/agent/gateway/standalone entrypoints) on reachable vulnerabilities.
+      # Fails the PR if a vulnerable dependency or Go toolchain is reachable from
+      # the shipped code, catching regressions an image scan would miss.
+      - name: govulncheck (shipped hoop binary)
+        working-directory: client
+        run: '"$(go env GOPATH)/bin/govulncheck" ./...'


### PR DESCRIPTION
## Stack (DEP-91)

Split from #1662 for reviewability, then **rescoped**: `main` has since landed #1681 (dependency/toolchain CVEs) and #1693 (`hoophq/hoopagent`), which superseded two PRs of the original stack.

- ~~#1683 — Go dependency + toolchain CVE bumps~~ — closed, superseded by #1681
- ~~#1685 — opt-in `hoophq/hoopdev-minimal`~~ — closed, superseded by #1693

- #1684 — 1. agent-tools: drop kernel-header CVEs, modernize clean train
- #1686 — 2. Vulnerability gates for hoopagent + govulncheck **← you are here**
- #1687 — 3. SBOM + bundled-tool manifest on releases
- #1688 — 4. Weekly base-OS rebuild of hoopagent
- #1689 — 5. Image release integrity hardening

Merge in order, bottom-up. Each PR targets the one below it.

The remaining work is what `main` still lacks: the fat image's kernel-header CVEs, and any vulnerability gate, SBOM, or scheduled OS patching for `hoophq/hoopagent`.

---

## What
Adds the vulnerability gating `hoophq/hoopagent` currently has none of:

- **Build smoke check** for `Dockerfile.agent`, both flavours, both platforms. It was previously only built after a tag push, so a broken Dockerfile could reach `main` and fail post-merge.
- **Enforcing Trivy gate** on fixable CRITICAL/HIGH for both flavours.
- **Unprivileged-user assertion** — resolves `USER` to a real uid, handling `distroless` (`10001:10001`, numeric) and `minimal` (`hoop`, by name) correctly.
- **Report-only Trivy** on `agent-tools`, which bundles upstream CLIs whose CVEs cannot be rebuilt away.
- **govulncheck** (pinned v1.6.0) on every PR for the shipped Go binary.

## Why
`hoophq/hoopagent` is the low-CVE image, but nothing enforced that. `main` runs Trivy with `--scanners license` only — there is no vulnerability gate anywhere, and no source-level Go gate.

## Risk
Adds blocking checks. The fat image stays report-only, so existing releases are not newly gated.

## Note on the placeholder binary
The release tarballs do not exist at PR time, so the smoke build stages placeholder tars named `hoop_*_Linux_${TARGETARCH}.tar.gz` — matching `Dockerfile.agent`'s glob, which uses GOARCH values, not `uname -m`. This gates Dockerfile correctness and the base layer, not a functional agent.

## How to test
Open any PR touching `Dockerfile.agent`: **Build Slim Agent Image** runs for both flavours and must pass. **Go Vulnerability Gate** runs on every PR.

Part of DEP-91.

Automated by MisterMal