### PR TITLE
DEP-91 (4/5): weekly base-OS rebuild of hoophq/hoopagent

### DIFF
--- a/.github/workflows/hoopagent-weekly-rebuild.yml
+++ b/.github/workflows/hoopagent-weekly-rebuild.yml
@@ -1,0 +1,191 @@
+# Weekly base-OS re-patch of the slim agent image (hoophq/hoopagent).
+# Closes DEP-91 point 4: "weekly base-OS patches".
+#
+# hoophq/hoopagent is the low-CVE agent image, but Dockerfile.agent pins its
+# base (ARG UBUNTU_IMAGE=ubuntu:noble-<date>) so builds stay reproducible.
+# A plain rebuild would therefore reproduce the same bytes and patch nothing.
+#
+# Instead this job rebuilds against the CURRENT noble base by overriding the
+# UBUNTU_IMAGE build-arg, and republishes only if the result is free of fixable
+# CRITICAL/HIGH vulnerabilities. The pinned default in Dockerfile.agent is left
+# untouched — bumping it stays a deliberate PR, per the policy in that file.
+# This fills the gap BETWEEN releases so the flavour tags do not accrue
+# unpatched OS CVEs for weeks.
+#
+# Only the `minimal` flavour is rebuilt. The `distroless` flavour installs no OS
+# packages at all (it is distroless/static + the binary), so there is nothing
+# for an OS re-patch to fix; its base moves only when the pinned digest is
+# bumped in a PR.
+#
+# The release binaries are not in the repo, so the job downloads the latest
+# published release tarballs and stages them under dist/binaries/ exactly as
+# the release build does.
+#
+# Published tags:
+#   hoophq/hoopagent:latest-minimal              — moving, always the latest patches
+#   hoophq/hoopagent:<release>-minimal-<YYYYMMDD> — patched snapshot, one per run
+# The immutable release tag hoophq/hoopagent:<release>-minimal is left untouched
+# so a pinned deployment never changes underneath it. Pin by digest
+# (hoophq/hoopagent@sha256:...) whenever immutable bytes matter.
+name: Slim Agent Weekly Rebuild
+
+on:
+  schedule:
+    # Mondays 04:17 UTC — off the hour to avoid the top-of-hour runner rush.
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hoopagent-weekly-rebuild
+  cancel-in-progress: false
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    name: Re-patch and publish hoophq/hoopagent
+    environment: production
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      # Dockerfile.agent globs hoop_*_Linux_${TARGETARCH}.tar.gz from
+      # dist/binaries/, so stage the published release tars under those names.
+      - name: Resolve latest release and stage binaries
+        id: rel
+        run: |
+          set -euo pipefail
+          version="$(curl -fsSL https://releases.hoop.dev/release/latest.txt)"
+          case "$version" in
+            ''|*[!0-9.]*) echo "::error::unexpected release version '$version'"; exit 1 ;;
+          esac
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          mkdir -p dist/binaries
+          for arch in amd64 arm64; do
+            curl -fsSL -o "dist/binaries/hoop_${version}_Linux_${arch}.tar.gz" \
+              "https://releases.hoop.dev/release/${version}/hoop_${version}_Linux_${arch}.tar.gz"
+          done
+          ls -la dist/binaries/
+
+      # Resolve the current noble tag so the rebuild actually picks up new OS
+      # packages instead of reproducing the pinned base byte for byte.
+      - name: Resolve current Ubuntu noble base
+        id: base
+        run: |
+          set -euo pipefail
+          docker pull --quiet ubuntu:noble >/dev/null
+          digest="$(docker image inspect --format '{{index .RepoDigests 0}}' ubuntu:noble)"
+          echo "image=${digest}" >> "$GITHUB_OUTPUT"
+          echo "rebuilding against ${digest}"
+
+      - name: Build (amd64, load for gates)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          file: ./Dockerfile.agent
+          context: '.'
+          target: minimal
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          load: true
+          push: false
+          build-args: |
+            UBUNTU_IMAGE=${{ steps.base.outputs.image }}
+          tags: hoophq/hoopagent:cand-amd64
+
+      # The image must run as the unprivileged 'hoop' user (uid 10001). The USER
+      # directive is arch-independent, so assert it once on the amd64 candidate.
+      - name: Verify runtime user is unprivileged
+        run: |
+          uid="$(docker run --rm --entrypoint id hoophq/hoopagent:cand-amd64 -u)"
+          echo "runtime uid: ${uid}"
+          test "${uid}" = "10001"
+
+      - name: Gate on fixable CRITICAL/HIGH (amd64 OS layer, enforcing)
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f image \
+            --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed \
+            --exit-code 1 --no-progress \
+            hoophq/hoopagent:cand-amd64
+
+      - name: Build (arm64, load for gate)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          file: ./Dockerfile.agent
+          context: '.'
+          target: minimal
+          platforms: linux/arm64
+          provenance: false
+          sbom: false
+          load: true
+          push: false
+          build-args: |
+            UBUNTU_IMAGE=${{ steps.base.outputs.image }}
+          tags: hoophq/hoopagent:cand-arm64
+
+      - name: Gate on fixable CRITICAL/HIGH (arm64 OS layer, enforcing)
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f image \
+            --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed \
+            --exit-code 1 --no-progress \
+            hoophq/hoopagent:cand-arm64
+
+      # REPORT-ONLY: the shipped Go binary's fixable CVEs are fixed by a release
+      # (dependency bumps + the govulncheck gate), not by this OS rebuild.
+      - name: Report shipped-binary vulnerabilities (non-blocking)
+        run: |
+          if ! docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f image \
+            --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed \
+            --quiet --format json \
+            hoophq/hoopagent:cand-amd64 > go-vuln.json; then
+            echo "::warning::Go-layer vulnerability report unavailable"; exit 0
+          fi
+          n=$(jq '[.Results[]?.Vulnerabilities // []] | add | length' go-vuln.json 2>/dev/null || echo "?")
+          {
+            echo "### hoophq/hoopagent ${{ steps.rel.outputs.version }} — shipped-binary fixable CRITICAL/HIGH: ${n} (report-only)"
+            echo ""
+            echo "Fixed by cutting a release (dependency bumps + govulncheck gate), not by this OS rebuild."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Only now, with both arches gated, publish. Building per-arch candidates
+      # first means a vulnerable arch can never promote a partial manifest.
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push gated candidates and update manifests
+        run: |
+          set -euo pipefail
+          repo="hoophq/hoopagent"
+          version="${{ steps.rel.outputs.version }}"
+          dated="${version}-minimal-$(date -u +%Y%m%d)"
+          candidate="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          amd64_ref="${repo}:weekly-${candidate}-amd64"
+          arm64_ref="${repo}:weekly-${candidate}-arm64"
+
+          docker tag "${repo}:cand-amd64" "${amd64_ref}"
+          docker tag "${repo}:cand-arm64" "${arm64_ref}"
+          docker push "${amd64_ref}"
+          docker push "${arm64_ref}"
+
+          for target in "${repo}:latest-minimal" "${repo}:${dated}"; do
+            docker buildx imagetools create -t "${target}" "${amd64_ref}" "${arm64_ref}"
+            echo "published ${target}"
+          done

--- a/.github/workflows/hoopagent-weekly-rebuild.yml
+++ b/.github/workflows/hoopagent-weekly-rebuild.yml
@@ -19,7 +19,13 @@
 #
 # The release binaries are not in the repo, so the job downloads the latest
 # published release tarballs and stages them under dist/binaries/ exactly as
-# the release build does.
+# the release build does. Those archives are a release input to a
+# customer-facing image, so they are authenticated before they are unpacked:
+# scripts/ci/fetch-release-binaries.py verifies each one against the SHA-256
+# GitHub records for the release asset, or against a reviewed pin for releases
+# that predate those uploads, and fails the run when a release has neither. The
+# CVE gates below cannot substitute for this — they detect known-vulnerable
+# packages, not a substituted binary.
 #
 # Published tags:
 #   hoophq/hoopagent:latest-minimal              — moving, always the latest patches
@@ -58,23 +64,66 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      # Dockerfile.agent globs hoop_*_Linux_${TARGETARCH}.tar.gz from
-      # dist/binaries/, so stage the published release tars under those names.
-      - name: Resolve latest release and stage binaries
-        id: rel
+      # Resolve the release to rebuild, download its archives and verify them
+      # against an independent digest before anything unpacks them. The helper
+      # writes them under the hoop_*_Linux_${TARGETARCH}.tar.gz names
+      # Dockerfile.agent globs, and exits non-zero — before the build, and long
+      # before the Docker Hub login below — on any mismatch or missing anchor.
+      # The version currently behind latest-minimal. Passed as a floor below so
+      # a rebuild can only ever move that tag forward: an image whose release
+      # label cannot be read (or does not exist yet) simply imposes no floor.
+      - name: Read currently published release
+        id: published
         run: |
           set -euo pipefail
-          version="$(curl -fsSL https://releases.hoop.dev/release/latest.txt)"
-          case "$version" in
-            ''|*[!0-9.]*) echo "::error::unexpected release version '$version'"; exit 1 ;;
-          esac
+          current="$(docker buildx imagetools inspect \
+            --format '{{ json .Image }}' hoophq/hoopagent:latest-minimal 2>/dev/null \
+            | jq -r 'if type == "object" and has("config") then .config.Labels["dev.hoop.release.version"]
+                     else (to_entries | map(.value.config.Labels["dev.hoop.release.version"]) | map(select(. != null)) | first)
+                     end // empty' 2>/dev/null || true)"
+          if [ -n "${current:-}" ] && [ "${current}" != "null" ]; then
+            echo "current published release: ${current}"
+            echo "version=${current}" >> "$GITHUB_OUTPUT"
+          else
+            echo "no readable release label on latest-minimal; no rollback floor applied"
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve, verify and stage release binaries
+        id: rel
+        env:
+          # Reads public release metadata only; the token just lifts the
+          # unauthenticated API rate limit on busy runners.
+          GH_TOKEN: ${{ github.token }}
+          FLOOR: ${{ steps.published.outputs.version }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/fetch-release-binaries.py \
+            --dest dist/binaries \
+            --provenance-out dist/release-provenance.json \
+            ${FLOOR:+--not-older-than "$FLOOR"}
+          version="$(jq -r '.version' dist/release-provenance.json)"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          mkdir -p dist/binaries
           for arch in amd64 arm64; do
-            curl -fsSL -o "dist/binaries/hoop_${version}_Linux_${arch}.tar.gz" \
-              "https://releases.hoop.dev/release/${version}/hoop_${version}_Linux_${arch}.tar.gz"
+            sha="$(jq -r --arg a "$arch" \
+              '.archives[] | select(.path | endswith("_" + $a + ".tar.gz")) | .sha256' \
+              dist/release-provenance.json)"
+            test -n "$sha" && test "$sha" != "null"
+            echo "${arch}_sha256=${sha}" >> "$GITHUB_OUTPUT"
           done
           ls -la dist/binaries/
+
+      # Record what was verified alongside the images this run publishes, so a
+      # published tag can be traced back to the exact release bytes it carries.
+      - name: Summarize verified release inputs
+        run: |
+          {
+            echo "### Verified release inputs"
+            echo ""
+            echo '```json'
+            cat dist/release-provenance.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # Resolve the current noble tag so the rebuild actually picks up new OS
       # packages instead of reproducing the pinned base byte for byte.
@@ -100,6 +149,11 @@ jobs:
           push: false
           build-args: |
             UBUNTU_IMAGE=${{ steps.base.outputs.image }}
+          # The verified release the image carries, recorded on the image so a
+          # published weekly tag can be traced back to the authenticated bytes.
+          labels: |
+            dev.hoop.release.version=${{ steps.rel.outputs.version }}
+            dev.hoop.release.archive.sha256=${{ steps.rel.outputs.amd64_sha256 }}
           tags: hoophq/hoopagent:cand-amd64
 
       # The image must run as the unprivileged 'hoop' user (uid 10001). The USER
@@ -132,6 +186,9 @@ jobs:
           push: false
           build-args: |
             UBUNTU_IMAGE=${{ steps.base.outputs.image }}
+          labels: |
+            dev.hoop.release.version=${{ steps.rel.outputs.version }}
+            dev.hoop.release.archive.sha256=${{ steps.rel.outputs.arm64_sha256 }}
           tags: hoophq/hoopagent:cand-arm64
 
       - name: Gate on fixable CRITICAL/HIGH (arm64 OS layer, enforcing)

--- a/.github/workflows/hoopagent-weekly-rebuild.yml
+++ b/.github/workflows/hoopagent-weekly-rebuild.yml
@@ -29,7 +29,9 @@
 #
 # Published tags:
 #   hoophq/hoopagent:latest-minimal              — moving, always the latest patches
-#   hoophq/hoopagent:<release>-minimal-<YYYYMMDD> — patched snapshot, one per run
+#   hoophq/hoopagent:<release>-minimal-<YYYYMMDD> — immutable patched snapshot.
+#     Never overwritten: a second run on the same UTC date appends its run id
+#     rather than repointing a tag a deployment may already be pinning.
 # The immutable release tag hoophq/hoopagent:<release>-minimal is left untouched
 # so a pinned deployment never changes underneath it. Pin by digest
 # (hoophq/hoopagent@sha256:...) whenever immutable bytes matter.
@@ -228,6 +230,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push gated candidates and update manifests
+        id: publish
         run: |
           set -euo pipefail
           repo="hoophq/hoopagent"
@@ -242,7 +245,20 @@ jobs:
           docker push "${amd64_ref}"
           docker push "${arm64_ref}"
 
+          # The dated tag is published as an immutable snapshot, so it is only
+          # ever created once. A second run on the same UTC date — a retry, a
+          # manual dispatch after the scheduled run, a re-release — would
+          # otherwise silently repoint a tag customers were told they could pin.
+          # Suffix the run instead of overwriting, so both snapshots exist and
+          # each keeps the bytes it was gated with.
+          if docker buildx imagetools inspect "${repo}:${dated}" >/dev/null 2>&1; then
+            dated="${dated}.${GITHUB_RUN_ID}"
+            echo "::notice::a snapshot already exists for today; publishing ${dated} instead of overwriting it"
+          fi
+
+          # latest-minimal is the only tag that moves.
           for target in "${repo}:latest-minimal" "${repo}:${dated}"; do
             docker buildx imagetools create -t "${target}" "${amd64_ref}" "${arm64_ref}"
             echo "published ${target}"
           done
+          echo "snapshot=${dated}" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/fetch-release-binaries.py
+++ b/scripts/ci/fetch-release-binaries.py
@@ -57,6 +57,9 @@ REPOSITORY = "hoophq/hoop"
 ARCHITECTURES = (("amd64", "x86_64"), ("arm64", "aarch64"))
 
 VERSION_RE = re.compile(r"\A[0-9]+(?:\.[0-9]+)*\Z")
+# GitHub serves releases newest-first and refuses to page past 1000 items, so
+# this bound is a stop, not a filter on which releases are reachable.
+MAX_RELEASE_PAGES = 10
 SHA256_RE = re.compile(r"\A[0-9a-f]{64}\Z")
 DIGEST_PREFIX = "sha256:"
 CHUNK = 1024 * 1024
@@ -80,24 +83,44 @@ def version_key(version: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version.split("."))
 
 
+def paginate(url: str, *, max_pages: int = MAX_RELEASE_PAGES):
+    """Yield each page of a GitHub list endpoint, following Link: rel=next.
+
+    Paging matters here: /releases is ordered by creation date, not by
+    version, so the highest version can sit on any page. Reading only the
+    first one would silently start picking a non-latest release as soon as the
+    repository outgrows a single page.
+
+    Bounded because GitHub refuses to page beyond its 1000-item window (HTTP
+    422) and because releases are returned newest-first: the current release
+    is always near the front, so this is a safety limit rather than a real
+    constraint on which version can be found.
+    """
+    for _ in range(max_pages):
+        if not url:
+            return
+        with http_get(url, accept="application/vnd.github+json") as response:
+            yield json.load(response)
+            link = response.headers.get("Link", "")
+        match = re.search(r'<([^>]+)>;\s*rel="next"', link)
+        url = match.group(1) if match else ""
+
+
 def resolve_latest_version() -> str:
     """Newest published release according to GitHub, not the endpoint.
 
-    GitHub orders /releases by creation date and includes drafts and
-    prereleases, so filter those out and pick the highest version among what
-    remains rather than trusting position alone.
+    Drafts and prereleases are excluded; the highest remaining version wins,
+    rather than whichever release was created most recently.
     """
-    url = f"{GITHUB_API}/repos/{REPOSITORY}/releases?per_page=50"
-    with http_get(url, accept="application/vnd.github+json") as response:
-        releases = json.load(response)
-
-    versions = [
-        release["tag_name"]
-        for release in releases
-        if not release.get("draft")
-        and not release.get("prerelease")
-        and VERSION_RE.match(release.get("tag_name", ""))
-    ]
+    versions: list[str] = []
+    for page in paginate(f"{GITHUB_API}/repos/{REPOSITORY}/releases?per_page=100"):
+        versions.extend(
+            release["tag_name"]
+            for release in page
+            if not release.get("draft")
+            and not release.get("prerelease")
+            and VERSION_RE.match(release.get("tag_name", ""))
+        )
     if not versions:
         raise VerificationError(
             f"no published release found for {REPOSITORY}; refusing to guess a version"

--- a/scripts/ci/fetch-release-binaries.py
+++ b/scripts/ci/fetch-release-binaries.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Download published Hoop release tarballs and verify them before use.
+
+The weekly slim-agent rebuild (.github/workflows/hoopagent-weekly-rebuild.yml)
+builds a customer-facing image out of an already-published release, so the
+bytes it feeds into the image are a release input like any other and must be
+authenticated before they are unpacked.
+
+Two things have to be authentic: WHICH release is promoted, and the BYTES of
+that release.
+
+Which release: the newest published, non-draft, non-prerelease GitHub Release.
+The distribution endpoint's latest.txt is deliberately not used for this. It is
+mutable, so an attacker controlling it could name an older release whose bytes
+still verify perfectly and have the weekly job roll `latest-minimal` back onto
+a version with known-fixed vulnerabilities. Callers may also pass --version
+explicitly, and --not-older-than refuses any target below a floor (the workflow
+passes the version currently published, making a rollback impossible).
+
+The bytes, in order of preference:
+
+1. The GitHub Release asset for the tag. GitHub records an immutable SHA-256
+   for every uploaded asset and serves it over the API, independently of the
+   distribution endpoint the archive is normally served from. The asset is
+   downloaded from GitHub and checked against that digest, so the archive and
+   the digest come from the same authenticated source.
+2. A reviewed pin in scripts/ci/legacy-release-checksums.sha256, for releases
+   published before the workflow started uploading those assets. The archive
+   then comes from the distribution endpoint and is checked against a digest
+   that was reviewed into the repository, so a change at the endpoint alone
+   cannot alter what is built.
+
+There is deliberately no third case: a release with neither an asset digest nor
+a reviewed pin fails, rather than being taken on trust from the endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+RELEASES_BASE = "https://releases.hoop.dev/release"
+GITHUB_API = "https://api.github.com"
+REPOSITORY = "hoophq/hoop"
+
+# Release archives are published under both the Go GOARCH spelling and the
+# `uname -m` one. GitHub carries the uname-style names; Dockerfile.agent globs
+# the GOARCH-style ones.
+ARCHITECTURES = (("amd64", "x86_64"), ("arm64", "aarch64"))
+
+VERSION_RE = re.compile(r"\A[0-9]+(?:\.[0-9]+)*\Z")
+SHA256_RE = re.compile(r"\A[0-9a-f]{64}\Z")
+DIGEST_PREFIX = "sha256:"
+CHUNK = 1024 * 1024
+
+
+class VerificationError(RuntimeError):
+    """Raised when a release input cannot be authenticated."""
+
+
+def http_get(url: str, *, accept: str | None = None, timeout: int = 300):
+    request = urllib.request.Request(url)
+    if accept:
+        request.add_header("Accept", accept)
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token and url.startswith(GITHUB_API):
+        request.add_header("Authorization", f"Bearer {token}")
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def resolve_latest_version() -> str:
+    """Newest published release according to GitHub, not the endpoint.
+
+    GitHub orders /releases by creation date and includes drafts and
+    prereleases, so filter those out and pick the highest version among what
+    remains rather than trusting position alone.
+    """
+    url = f"{GITHUB_API}/repos/{REPOSITORY}/releases?per_page=50"
+    with http_get(url, accept="application/vnd.github+json") as response:
+        releases = json.load(response)
+
+    versions = [
+        release["tag_name"]
+        for release in releases
+        if not release.get("draft")
+        and not release.get("prerelease")
+        and VERSION_RE.match(release.get("tag_name", ""))
+    ]
+    if not versions:
+        raise VerificationError(
+            f"no published release found for {REPOSITORY}; refusing to guess a version"
+        )
+    return max(versions, key=version_key)
+
+
+def github_asset_digests(version: str) -> dict[str, tuple[str, str]]:
+    """Map asset name -> (sha256, download URL) for one release tag.
+
+    A missing release is not an error: releases published before the asset
+    upload existed simply have no assets, and the caller falls back to the
+    reviewed pins. A malformed digest IS an error — it means the anchor is
+    there but unusable, and silently downgrading to a weaker check is exactly
+    the failure this function exists to prevent.
+    """
+    url = f"{GITHUB_API}/repos/{REPOSITORY}/releases/tags/{version}"
+    try:
+        with http_get(url, accept="application/vnd.github+json") as response:
+            release = json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return {}
+        raise
+
+    assets: dict[str, tuple[str, str]] = {}
+    for asset in release.get("assets", []):
+        name = asset.get("name")
+        digest = asset.get("digest") or ""
+        if not name or not digest:
+            continue
+        if not digest.startswith(DIGEST_PREFIX):
+            raise VerificationError(
+                f"release asset {name!r} has an unsupported digest {digest!r}"
+            )
+        value = digest[len(DIGEST_PREFIX):]
+        if not SHA256_RE.match(value):
+            raise VerificationError(
+                f"release asset {name!r} has a malformed SHA-256 {value!r}"
+            )
+        assets[name] = (value, asset["browser_download_url"])
+    return assets
+
+
+def load_pins(path: Path) -> dict[str, str]:
+    """Read the reviewed compatibility pins.
+
+    Same format as licenses/agent-tools-checksums.sha256 (`<sha256>  <name>`),
+    kept separate because it pins release archives rather than third-party
+    tool downloads.
+    """
+    if not path.exists():
+        return {}
+    pins: dict[str, str] = {}
+    for number, raw in enumerate(path.read_text().splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split(maxsplit=1)
+        if len(fields) != 2 or not SHA256_RE.match(fields[0]):
+            raise VerificationError(f"{path}:{number}: invalid SHA-256 entry")
+        digest, name = fields[0], fields[1].lstrip("*").strip()
+        if not name or "/" in name or name in pins:
+            raise VerificationError(f"{path}:{number}: invalid or duplicate artifact name")
+        pins[name] = digest
+    return pins
+
+
+def download(url: str, destination: Path) -> str:
+    digest = hashlib.sha256()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    # Write to a sibling temp file and rename only after the digest matches, so
+    # a failed verification cannot leave a usable-looking archive behind for a
+    # later step to pick up.
+    staging = destination.with_suffix(destination.suffix + ".part")
+    try:
+        with http_get(url) as response, staging.open("wb") as handle:
+            while True:
+                chunk = response.read(CHUNK)
+                if not chunk:
+                    break
+                digest.update(chunk)
+                handle.write(chunk)
+    except BaseException:
+        staging.unlink(missing_ok=True)
+        raise
+    return digest.hexdigest()
+
+
+def fetch_archive(
+    version: str,
+    goarch: str,
+    uname_arch: str,
+    assets: dict[str, tuple[str, str]],
+    pins: dict[str, str],
+    destination_dir: Path,
+) -> dict[str, str]:
+    name = f"hoop_{version}_Linux_{uname_arch}.tar.gz"
+    if name in assets:
+        expected, url, source = *assets[name], "github-release-asset"
+    elif name in pins:
+        expected, url, source = pins[name], f"{RELEASES_BASE}/{version}/{name}", "reviewed-pin"
+    else:
+        raise VerificationError(
+            f"{name} has neither a GitHub release asset digest nor a reviewed pin; "
+            f"refusing to build from an unauthenticated archive. Add the digest to "
+            f"scripts/ci/legacy-release-checksums.sha256 after reviewing it, or "
+            f"re-run the release so it uploads its assets."
+        )
+
+    # Dockerfile.agent globs the GOARCH spelling, so land it under that name.
+    destination = destination_dir / f"hoop_{version}_Linux_{goarch}.tar.gz"
+    staging = destination.with_suffix(destination.suffix + ".part")
+    actual = download(url, destination)
+    if not hmac.compare_digest(actual, expected):
+        staging.unlink(missing_ok=True)
+        raise VerificationError(
+            f"SHA-256 mismatch for {name} from {source}: expected {expected}, got {actual}"
+        )
+    staging.replace(destination)
+    print(f"{name}: SHA-256 verified ({source})")
+    return {"name": name, "sha256": actual, "source": source, "path": str(destination)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--version",
+        help="release to fetch; defaults to the published latest",
+    )
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=Path("dist/binaries"),
+        help="directory to write the verified archives into",
+    )
+    parser.add_argument(
+        "--pins",
+        type=Path,
+        default=Path(__file__).with_name("legacy-release-checksums.sha256"),
+        help="reviewed digests for releases predating GitHub asset uploads",
+    )
+    parser.add_argument(
+        "--provenance-out",
+        type=Path,
+        help="write the verified version and digests here as JSON",
+    )
+    parser.add_argument(
+        "--not-older-than",
+        help=(
+            "refuse to build a release older than this version. Pass the "
+            "version currently published so a rebuild can never roll it back."
+        ),
+    )
+    args = parser.parse_args()
+
+    try:
+        version = args.version or resolve_latest_version()
+        if not VERSION_RE.match(version):
+            raise VerificationError(f"unexpected release version {version!r}")
+        floor = args.not_older_than
+        if floor:
+            if not VERSION_RE.match(floor):
+                raise VerificationError(f"unexpected --not-older-than value {floor!r}")
+            if version_key(version) < version_key(floor):
+                raise VerificationError(
+                    f"refusing to rebuild {version}: older than the currently "
+                    f"published {floor}. A rebuild must never move a moving tag "
+                    f"backwards."
+                )
+        assets = github_asset_digests(version)
+        pins = load_pins(args.pins)
+        archives = [
+            fetch_archive(version, goarch, uname_arch, assets, pins, args.dest)
+            for goarch, uname_arch in ARCHITECTURES
+        ]
+    except (VerificationError, OSError, urllib.error.URLError) as exc:
+        print(f"release input verification failed: {exc}", file=sys.stderr)
+        return 1
+
+    provenance = {"version": version, "archives": archives}
+    if args.provenance_out:
+        args.provenance_out.parent.mkdir(parents=True, exist_ok=True)
+        args.provenance_out.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(provenance, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/legacy-release-checksums.sha256
+++ b/scripts/ci/legacy-release-checksums.sha256
@@ -1,0 +1,30 @@
+# Reviewed pins for release archives published before the release workflow
+# started uploading them as GitHub Release assets.
+#
+# scripts/ci/fetch-release-binaries.py prefers the GitHub-recorded asset digest
+# for a release and only consults this file when the tag carries no assets. A
+# release with neither is refused, so this file is what keeps the weekly
+# rebuild able to run against the releases that predate that change.
+#
+# Adding an entry means asserting the bytes are the ones that shipped. Verify
+# through a channel other than the distribution endpoint before adding one; the
+# entries below were each confirmed by extracting ./hoop from the archive and
+# comparing it byte-for-byte with /app/hoop in the already-published
+# hoophq/hoopagent image of the same release, for both architectures.
+#
+# 1.126.3: pre-dates GitHub asset uploads.
+deee3ee414356dafc029e4fb8b85f3060fa98be5697d989e6f702a19fbdb1539  hoop_1.126.3_Linux_x86_64.tar.gz
+3bbe1fca336537ff310f44aae73c8b4c3d5cfd2caefa1f5c76feb836f53cf10e  hoop_1.126.3_Linux_aarch64.tar.gz
+# 1.136.0: the release current when the weekly rebuild landed; its tag was cut
+# before the asset upload existed, so the first weekly runs need it pinned here.
+# Cross-checked against hoophq/hoopagent:1.136.0-minimal:
+#   amd64 ./hoop = fc0f964b7061fe5dbbb01fb22c619fb88cb746b0ba267ed642395271f720e2d7
+#   arm64 ./hoop = d7ff33a33c2224475d6b7a4353d55f6c725d228ea50a602e1533ccb704d8137b
+654b71e6cf8945777f6a8a3b812e616b35b40c1e7fdd5581541db2073722c5d0  hoop_1.136.0_Linux_x86_64.tar.gz
+598c9dc2bceaeeda14bf5e13d6e97346c38483f646f9e0502456ed95d67aec3b  hoop_1.136.0_Linux_aarch64.tar.gz
+# 1.136.1: current release; its tag was cut before the asset upload existed.
+# Cross-checked against hoophq/hoopagent:1.136.1-minimal:
+#   amd64 ./hoop = bea24e2947ba63b6910547c460459deaf971add2e0370b55e1c79fc64779a004
+#   arm64 ./hoop = fd77aa5f42787fd23b7acca77e49fa7ee2140b94baccb108bec3b7fa78b3656b
+3004dade95699080c536d7133116c2ae8483ad29ff0e1c42a3117b613047e169  hoop_1.136.1_Linux_x86_64.tar.gz
+46133fdb6a9749c0bc4d67a03d1ae5f38ed69a2f4da7682bba07a84dca98b6eb  hoop_1.136.1_Linux_aarch64.tar.gz

--- a/scripts/ci/test_fetch_release_binaries.py
+++ b/scripts/ci/test_fetch_release_binaries.py
@@ -92,6 +92,74 @@ class ReleaseFetchTests(unittest.TestCase):
         with self.assertRaises(fetch.VerificationError):
             fetch.load_pins(path)
 
+    def test_partial_download_leaves_nothing_behind(self):
+        """A stream that dies mid-transfer must not leave a usable archive."""
+
+        class DyingResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self, _size):
+                raise OSError("connection reset")
+
+        destination = self.directory / "hoop_9.9.9_Linux_amd64.tar.gz"
+        with mock.patch.object(fetch, "http_get", lambda *a, **k: DyingResponse()):
+            with self.assertRaises(OSError):
+                fetch.download("https://example.invalid/a.tar.gz", destination)
+        self.assertFalse(destination.exists())
+        self.assertEqual(list(self.directory.glob("*.part")), [])
+
+    def test_download_writes_to_staging_until_verified(self):
+        """download() must not create the final path itself."""
+        payload = self.payload
+
+        class Response:
+            def __init__(self):
+                self.chunks = [payload, b""]
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self, _size):
+                return self.chunks.pop(0)
+
+        destination = self.directory / "hoop_9.9.9_Linux_amd64.tar.gz"
+        with mock.patch.object(fetch, "http_get", lambda *a, **k: Response()):
+            digest = fetch.download("https://example.invalid/a.tar.gz", destination)
+        self.assertEqual(digest, self.digest)
+        self.assertFalse(destination.exists())
+        staging = destination.with_suffix(destination.suffix + ".part")
+        self.assertTrue(staging.exists())
+
+    def test_latest_version_spans_pages(self):
+        """The highest version can sit on a later page; creation order differs."""
+        pages = [
+            [{"tag_name": "1.135.0", "draft": False, "prerelease": False}],
+            [
+                {"tag_name": "1.200.0", "draft": False, "prerelease": False},
+                {"tag_name": "9.9.9", "draft": True, "prerelease": False},
+                {"tag_name": "8.8.8", "draft": False, "prerelease": True},
+                {"tag_name": "nightly", "draft": False, "prerelease": False},
+            ],
+        ]
+        with mock.patch.object(fetch, "paginate", lambda *a, **k: iter(pages)):
+            self.assertEqual(fetch.resolve_latest_version(), "1.200.0")
+
+    def test_no_published_release_is_an_error(self):
+        with mock.patch.object(fetch, "paginate", lambda *a, **k: iter([[]])):
+            with self.assertRaises(fetch.VerificationError):
+                fetch.resolve_latest_version()
+
+    def test_version_ordering_is_numeric_not_lexicographic(self):
+        self.assertGreater(fetch.version_key("1.136.0"), fetch.version_key("1.9.0"))
+        self.assertGreater(fetch.version_key("1.136.10"), fetch.version_key("1.136.9"))
+
     def test_shipped_pins_file_parses(self):
         pins = fetch.load_pins(SCRIPTS / "legacy-release-checksums.sha256")
         self.assertIn("hoop_1.136.0_Linux_x86_64.tar.gz", pins)

--- a/scripts/ci/test_fetch_release_binaries.py
+++ b/scripts/ci/test_fetch_release_binaries.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for the verified release-input fetch used by the weekly slim-agent rebuild.\n\nfetch-release-binaries.py is a fail-closed supply-chain control: it decides\nwhether bytes downloaded from the release endpoint are allowed to become a\npublished image. The cases that matter are the negative ones - a wrong digest,\na release with no trust anchor - each of which must refuse to produce an\narchive at all."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS = Path(__file__).resolve().parent
+
+
+def load(filename: str, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPTS / filename)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {filename}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+fetch = load("fetch-release-binaries.py", "fetch_release_binaries")
+
+
+class ReleaseFetchTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = Path(tempfile.mkdtemp())
+        self.payload = b"release-archive-bytes"
+        self.digest = hashlib.sha256(self.payload).hexdigest()
+
+    def fake_download(self, url, destination):
+        staging = destination.with_suffix(destination.suffix + ".part")
+        staging.parent.mkdir(parents=True, exist_ok=True)
+        staging.write_bytes(self.payload)
+        return hashlib.sha256(self.payload).hexdigest()
+
+    def test_github_asset_digest_is_preferred_over_a_pin(self):
+        assets = {"hoop_9.9.9_Linux_x86_64.tar.gz": (self.digest, "https://gh/asset")}
+        pins = {"hoop_9.9.9_Linux_x86_64.tar.gz": "f" * 64}
+        with mock.patch.object(fetch, "download", self.fake_download):
+            result = fetch.fetch_archive(
+                "9.9.9", "amd64", "x86_64", assets, pins, self.directory
+            )
+        self.assertEqual(result["source"], "github-release-asset")
+        # Landed under the GOARCH name Dockerfile.agent globs.
+        self.assertTrue((self.directory / "hoop_9.9.9_Linux_amd64.tar.gz").exists())
+
+    def test_reviewed_pin_is_used_when_no_asset_exists(self):
+        pins = {"hoop_9.9.9_Linux_aarch64.tar.gz": self.digest}
+        with mock.patch.object(fetch, "download", self.fake_download):
+            result = fetch.fetch_archive(
+                "9.9.9", "arm64", "aarch64", {}, pins, self.directory
+            )
+        self.assertEqual(result["source"], "reviewed-pin")
+        self.assertEqual(result["sha256"], self.digest)
+
+    def test_digest_mismatch_raises_and_leaves_no_archive(self):
+        pins = {"hoop_9.9.9_Linux_x86_64.tar.gz": "a" * 64}
+        with mock.patch.object(fetch, "download", self.fake_download):
+            with self.assertRaises(fetch.VerificationError) as caught:
+                fetch.fetch_archive("9.9.9", "amd64", "x86_64", {}, pins, self.directory)
+        self.assertIn("SHA-256 mismatch", str(caught.exception))
+        self.assertEqual(list(self.directory.glob("*.tar.gz")), [])
+        self.assertEqual(list(self.directory.glob("*.part")), [])
+
+    def test_release_with_no_anchor_is_refused(self):
+        with mock.patch.object(fetch, "download", self.fake_download):
+            with self.assertRaises(fetch.VerificationError) as caught:
+                fetch.fetch_archive("9.9.9", "amd64", "x86_64", {}, {}, self.directory)
+        self.assertIn("neither a GitHub release asset digest nor a reviewed pin", str(caught.exception))
+        self.assertEqual(list(self.directory.glob("*")), [])
+
+    def test_malformed_asset_digest_is_an_error_not_a_downgrade(self):
+        release = {"assets": [{"name": "a.tar.gz", "digest": "sha256:zz", "browser_download_url": "u"}]}
+        with mock.patch.object(fetch, "http_get", mock.mock_open(read_data=b"")):
+            with mock.patch.object(fetch.json, "load", return_value=release):
+                with self.assertRaises(fetch.VerificationError):
+                    fetch.github_asset_digests("9.9.9")
+
+    def test_manifest_rejects_a_malformed_digest_line(self):
+        path = self.directory / "pins.sha256"
+        path.write_text("not-a-digest  hoop_1.0.0_Linux_x86_64.tar.gz\n")
+        with self.assertRaises(fetch.VerificationError):
+            fetch.load_pins(path)
+
+    def test_manifest_rejects_duplicate_entries(self):
+        path = self.directory / "dupe.sha256"
+        path.write_text(f"{self.digest}  a.tar.gz\n{'b' * 64}  a.tar.gz\n")
+        with self.assertRaises(fetch.VerificationError):
+            fetch.load_pins(path)
+
+    def test_shipped_pins_file_parses(self):
+        pins = fetch.load_pins(SCRIPTS / "legacy-release-checksums.sha256")
+        self.assertIn("hoop_1.136.0_Linux_x86_64.tar.gz", pins)
+        self.assertIn("hoop_1.136.0_Linux_aarch64.tar.gz", pins)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stack (DEP-91)

Split from #1662 for reviewability, then **rescoped**: `main` has since landed #1681 (dependency/toolchain CVEs) and #1693 (`hoophq/hoopagent`), which superseded two PRs of the original stack.

- ~~#1683 — Go dependency + toolchain CVE bumps~~ — closed, superseded by #1681
- ~~#1685 — opt-in `hoophq/hoopdev-minimal`~~ — closed, superseded by #1693

- #1684 — 1. agent-tools: drop kernel-header CVEs, modernize clean train
- #1686 — 2. Vulnerability gates for hoopagent + govulncheck
- #1687 — 3. SBOM + bundled-tool manifest on releases
- #1688 — 4. Weekly base-OS rebuild of hoopagent **← you are here**
- #1689 — 5. Image release integrity hardening

Merge in order, bottom-up. Each PR targets the one below it.

The remaining work is what `main` still lacks: the fat image's kernel-header CVEs, and any vulnerability gate, SBOM, or scheduled OS patching for `hoophq/hoopagent`.

---

## What
Weekly scheduled rebuild of `hoophq/hoopagent:-minimal` against current OS security patches, republished only when the OS layer is free of fixable CRITICAL/HIGH vulnerabilities.

Published tags:
- `:latest-minimal` — moving, always the latest patches
- `:<release>-minimal-<YYYYMMDD>` — weekly patched snapshot

The immutable `:<release>-minimal` tag is left untouched.

## Why
Releases already rebuild every image; this closes the gap **between** releases so the moving tags do not accrue unpatched OS CVEs for weeks.

## Design note — this is not a plain rebuild
`Dockerfile.agent` pins its base (`ARG UBUNTU_IMAGE=ubuntu:noble-<date>`) for reproducibility, and does **not** run `apt-get upgrade`. A plain rebuild would therefore reproduce identical bytes and patch nothing.

This job instead resolves the current `ubuntu:noble` digest and overrides the `UBUNTU_IMAGE` build-arg. The pinned default in `Dockerfile.agent` is untouched — bumping it stays a deliberate PR, per the policy in that file.

Only the `minimal` flavour is rebuilt: `distroless` installs no OS packages, so an OS re-patch has nothing to fix there.

## Risk
Scheduled workflow only. Gated on the same enforcing Trivy check per arch before any push, so a vulnerable rebuild is never published. Pin by digest when immutable bytes matter.

## How to test
Trigger **Slim Agent Weekly Rebuild** via `workflow_dispatch`. Expected: resolves the latest release, stages both arch tarballs, builds against current noble, passes both gates, then publishes.

Part of DEP-91.

Automated by MisterMal