### PR TITLE
chore(deps): alcatraz v0.16.0 for the Brazilian identifiers

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hoophq/hoop/agent v0.0.0-20260730225053-339623147f24
 	github.com/hoophq/hoop/gateway v0.0.0-20260414143915-f3c4a85dcd3b
-	github.com/lib/pq v1.12.3
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.54.0
 	golang.org/x/mod v0.37.0
@@ -131,7 +130,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/honeycombio/honeycomb-opentelemetry-go v0.11.0 // indirect
 	github.com/honeycombio/otel-config-go v1.17.0 // indirect
-	github.com/hoophq/alcatraz v0.7.0 // indirect
+	github.com/hoophq/alcatraz v0.16.0 // indirect
 	github.com/hoophq/mcpproxy v0.1.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -146,6 +145,7 @@ require (
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/lib/pq v1.12.3 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect

--- a/client/go.sum
+++ b/client/go.sum
@@ -295,8 +295,8 @@ github.com/honeycombio/honeycomb-opentelemetry-go v0.11.0 h1:x0DndAGP+m1rk9JrlPL
 github.com/honeycombio/honeycomb-opentelemetry-go v0.11.0/go.mod h1:2DZt7DdTnnd1o7biwC9Ab0Z3OAGXId56gYVPR7LsLQs=
 github.com/honeycombio/otel-config-go v1.17.0 h1:3/zig0L3IGnfgiCrEfAwBsM0rF57+TKTyJ/a8yqW2eM=
 github.com/honeycombio/otel-config-go v1.17.0/go.mod h1:g2mMdfih4sYKfXBtz2mNGvo3HiQYqX4Up4pdA8JOF2s=
-github.com/hoophq/alcatraz v0.7.0 h1:qn71feGi++3QaAFsVi7Y/AvXTSxGrQ1OUCMrtlJleWY=
-github.com/hoophq/alcatraz v0.7.0/go.mod h1:B5ZNcwna5qCRZpVN6MMjmUbzEDpk5Q04jnKxqfZucdM=
+github.com/hoophq/alcatraz v0.16.0 h1:WJzaKH6fGcfUKfFrI+FR8RkCxUPVZeT5Ne30KGdFhUc=
+github.com/hoophq/alcatraz v0.16.0/go.mod h1:B5ZNcwna5qCRZpVN6MMjmUbzEDpk5Q04jnKxqfZucdM=
 github.com/hoophq/mcpproxy v0.1.1 h1:Zj9/vOMAKSOTuGuuSLl/v01iKdQ1+yiYZLNNz2T1npQ=
 github.com/hoophq/mcpproxy v0.1.1/go.mod h1:Wi7Z5bo0hJRwKa/gFaC9vRAWFCy3dxcYS2n28/TTphc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/hoopinspect/cmd/go.mod
+++ b/hoopinspect/cmd/go.mod
@@ -9,8 +9,6 @@ module github.com/hoophq/hoopinspect/cmd
 
 go 1.26.5
 
-toolchain go1.26.5
-
 require (
 	github.com/hoophq/hoopinspect v0.0.0
 	github.com/hoophq/hoopinspect/config/yaml v0.0.0
@@ -24,7 +22,7 @@ require (
 )
 
 require (
-	github.com/hoophq/alcatraz v0.7.0 // indirect
+	github.com/hoophq/alcatraz v0.16.0 // indirect
 	github.com/hoophq/hoopinspect/analyzer/vertex v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/hoopinspect/cmd/go.sum
+++ b/hoopinspect/cmd/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/hoophq/alcatraz v0.7.0 h1:qn71feGi++3QaAFsVi7Y/AvXTSxGrQ1OUCMrtlJleWY=
-github.com/hoophq/alcatraz v0.7.0/go.mod h1:B5ZNcwna5qCRZpVN6MMjmUbzEDpk5Q04jnKxqfZucdM=
+github.com/hoophq/alcatraz v0.16.0 h1:WJzaKH6fGcfUKfFrI+FR8RkCxUPVZeT5Ne30KGdFhUc=
+github.com/hoophq/alcatraz v0.16.0/go.mod h1:B5ZNcwna5qCRZpVN6MMjmUbzEDpk5Q04jnKxqfZucdM=
 golang.org/x/oauth2 v0.32.0 h1:jsCblLleRMDrxMN29H3z/k1KliIvpLgCkE6R8FXXNgY=
 golang.org/x/oauth2 v0.32.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=

--- a/hoopinspect/pii/alcatraz/alcatraz.go
+++ b/hoopinspect/pii/alcatraz/alcatraz.go
@@ -175,8 +175,8 @@ func newEngine(lang string) *alcatraz.Engine {
 	return analyzer.NewEngine(reg, []string{lang})
 }
 
-// AllEntities returns every entity type this package detects: alcatraz's 45
-// plus AWS_ACCESS_KEY, JWT and PRIVATE_KEY.
+// AllEntities returns every entity type this package detects: alcatraz's
+// built-in set plus AWS_ACCESS_KEY, JWT and PRIVATE_KEY.
 //
 // Prefer naming the types your data contains. This exists so "everything" is
 // an explicit, greppable decision rather than the consequence of leaving a

--- a/hoopinspect/pii/alcatraz/go.mod
+++ b/hoopinspect/pii/alcatraz/go.mod
@@ -2,10 +2,8 @@ module github.com/hoophq/hoopinspect/pii/alcatraz
 
 go 1.26.5
 
-toolchain go1.26.5
-
 require (
-	github.com/hoophq/alcatraz v0.7.0
+	github.com/hoophq/alcatraz v0.16.0
 	github.com/hoophq/hoopinspect v0.0.0
 )
 

--- a/hoopinspect/pii/alcatraz/go.sum
+++ b/hoopinspect/pii/alcatraz/go.sum
@@ -1,2 +1,2 @@
-github.com/hoophq/alcatraz v0.7.0 h1:qn71feGi++3QaAFsVi7Y/AvXTSxGrQ1OUCMrtlJleWY=
-github.com/hoophq/alcatraz v0.7.0/go.mod h1:B5ZNcwna5qCRZpVN6MMjmUbzEDpk5Q04jnKxqfZucdM=
+github.com/hoophq/alcatraz v0.16.0 h1:WJzaKH6fGcfUKfFrI+FR8RkCxUPVZeT5Ne30KGdFhUc=
+github.com/hoophq/alcatraz v0.16.0/go.mod h1:B5ZNcwna5qCRZpVN6MMjmUbzEDpk5Q04jnKxqfZucdM=


### PR DESCRIPTION
The six Brazilian recognizers this PR originally carried are upstream as of
hoophq/alcatraz#29, so this shrinks to the version bump: v0.7.0 → v0.16.0
across the three modules that pin it, and the local `brazil.go` is deleted.

Upstream owns the checksum helpers the local copy had duplicated, and picked up
two fixes from review there — the PIX gate no longer accepts a bare "chave"
(Portuguese for "key", which matched ordinary primary-key columns), and both
context-gated patterns now score above a realistic caller threshold instead of
being silently dropped despite their gate passing.

Verified on the bumped module: 54 entity types, all six BR types detected, and
the false-positive guards hold — `chave primaria <uuid>` and a plain 8-digit
order id stay unmasked. `hoopinspect` builds and tests green.

 Generated with Mister Maluco

Co-Authored-By: MisterMal <teskeslab@lucasteske.dev>