### PR TITLE
EVL-185: onboarding "How did you hear about Hoop?" survey

### DIFF
--- a/gateway/analytics/events.go
+++ b/gateway/analytics/events.go
@@ -71,6 +71,9 @@ const (
 	EventUpdateOrgAnalyticsMode    = "hoop-update-org-analytics-mode"
 	EventProtectionProfileSelected = "hoop-protection-profile-selected"
 
+	// onboarding
+	EventOnboardingOriginAnswered = "hoop-onboarding-origin-answered"
+
 	// search api
 	EventSearch = "hoop-search"
 

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -10255,6 +10255,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/self/signup-origin": {
+            "post": {
+                "description": "Record how the authenticated user heard about Hoop. Each user may answer only once; a second attempt returns 409.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User Management"
+                ],
+                "summary": "Answer Signup Origin Survey",
+                "parameters": [
+                    {
+                        "description": "The request body resource",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/openapi.UserSignupOriginRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Answer recorded"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/users/self/slack": {
             "patch": {
                 "description": "Patch own user's slack id",
@@ -18551,6 +18612,10 @@ const docTemplate = `{
                     "readOnly": true,
                     "example": "standard"
                 },
+                "show_origin_survey": {
+                    "description": "Whether the \"How did you hear about Hoop?\" survey should still be offered.\nTrue only while the user has not answered it and is within 7 days of their\nuser record being created. Always false for anonymous users.",
+                    "type": "boolean"
+                },
                 "slack_id": {
                     "description": "The identifier of slack to send messages to users",
                     "type": "string",
@@ -18598,6 +18663,34 @@ const docTemplate = `{
                 "slack_id": {
                     "type": "string",
                     "example": "U053ELZHB53"
+                }
+            }
+        },
+        "openapi.UserSignupOriginRequest": {
+            "type": "object",
+            "required": [
+                "origin"
+            ],
+            "properties": {
+                "origin": {
+                    "description": "The acquisition channel the user picked",
+                    "type": "string",
+                    "enum": [
+                        "search-engine",
+                        "ai-discovery",
+                        "referral",
+                        "already-in-use-at-company",
+                        "tech-community",
+                        "social-media",
+                        "hoop-free-tools",
+                        "other"
+                    ],
+                    "example": "ai-discovery"
+                },
+                "origin_other": {
+                    "description": "Free text detail. Required when origin is \"other\", ignored and stored as\nnull for every other option.",
+                    "type": "string",
+                    "example": "Saw it in a conference talk"
                 }
             }
         },

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -8076,6 +8076,10 @@
             "readOnly": true,
             "type": "string"
           },
+          "show_origin_survey": {
+            "description": "Whether the \"How did you hear about Hoop?\" survey should still be offered.\nTrue only while the user has not answered it and is within 7 days of their\nuser record being created. Always false for anonymous users.",
+            "type": "boolean"
+          },
           "slack_id": {
             "description": "The identifier of slack to send messages to users",
             "example": "U053ELZHB53",
@@ -8127,6 +8131,34 @@
         },
         "required": [
           "slack_id"
+        ],
+        "type": "object"
+      },
+      "openapi.UserSignupOriginRequest": {
+        "properties": {
+          "origin": {
+            "description": "The acquisition channel the user picked",
+            "enum": [
+              "search-engine",
+              "ai-discovery",
+              "referral",
+              "already-in-use-at-company",
+              "tech-community",
+              "social-media",
+              "hoop-free-tools",
+              "other"
+            ],
+            "example": "ai-discovery",
+            "type": "string"
+          },
+          "origin_other": {
+            "description": "Free text detail. Required when origin is \"other\", ignored and stored as\nnull for every other option.",
+            "example": "Saw it in a conference talk",
+            "type": "string"
+          }
+        },
+        "required": [
+          "origin"
         ],
         "type": "object"
       },
@@ -21282,6 +21314,82 @@
           }
         },
         "summary": "Delete User Group",
+        "tags": [
+          "User Management"
+        ]
+      }
+    },
+    "/users/self/signup-origin": {
+      "post": {
+        "description": "Record how the authenticated user heard about Hoop. Each user may answer only once; a second attempt returns 409.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi.UserSignupOriginRequest"
+              }
+            }
+          },
+          "description": "The request body resource",
+          "required": true,
+          "x-originalParamName": "request"
+        },
+        "responses": {
+          "204": {
+            "description": "Answer recorded"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Answer Signup Origin Survey",
         "tags": [
           "User Management"
         ]

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -89,6 +89,16 @@ type UserPatchSlackID struct {
 	SlackID string `json:"slack_id" binding:"required" example:"U053ELZHB53"`
 }
 
+// UserSignupOriginRequest carries the answer to the onboarding
+// "How did you hear about Hoop?" survey. A user may answer only once.
+type UserSignupOriginRequest struct {
+	// The acquisition channel the user picked
+	Origin string `json:"origin" binding:"required" enums:"search-engine,ai-discovery,referral,already-in-use-at-company,tech-community,social-media,hoop-free-tools,other" example:"ai-discovery"`
+	// Free text detail. Required when origin is "other", ignored and stored as
+	// null for every other option.
+	OriginOther string `json:"origin_other" example:"Saw it in a conference talk"`
+}
+
 type UserGroup struct {
 	// Name of the user group
 	Name string `json:"name" binding:"required" example:"engineering"`
@@ -133,6 +143,10 @@ type UserInfo struct {
 	// Pending organization invitations for this user. When non-empty, the user can migrate
 	// to one of these organizations. Only populated in multi-tenant environments.
 	PendingOrgInvitations []PendingOrgInvitation `json:"pending_org_invitations,omitempty"`
+	// Whether the "How did you hear about Hoop?" survey should still be offered.
+	// True only while the user has not answered it and is within 7 days of their
+	// user record being created. Always false for anonymous users.
+	ShowOriginSurvey bool `json:"show_origin_survey"`
 }
 
 type ServiceAccountStatusType string

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -312,6 +312,19 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		api.TrackRequest(analytics.EventUpdateUser),
 		userapi.PatchSlackID)
+	// Every role answers the onboarding origin survey, which is what
+	// ReadOnlyAccessRole grants: omitting the role middleware would deny
+	// auditors, since isGroupAllowed only lets that group through routes that
+	// name it. GET /userinfo above offers the survey under the same role, so
+	// both ends of the flow have to agree.
+	//
+	// It emits EventOnboardingOriginAnswered from the handler instead of
+	// TrackRequest, which runs before the body is validated and could not carry
+	// the chosen option.
+	r.POST("/users/self/signup-origin",
+		apiroutes.ReadOnlyAccessRole,
+		r.AuthMiddleware,
+		userapi.PostSignupOrigin)
 	r.DELETE("/users/:emailOrID",
 		apiroutes.AdminOnlyAccessRole,
 		r.AuthMiddleware,

--- a/gateway/api/user/originsurvey.go
+++ b/gateway/api/user/originsurvey.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 	"github.com/hoophq/hoop/gateway/analytics"
@@ -34,8 +35,9 @@ var validSignupOrigins = []string{
 	signupOriginOther,
 }
 
-// maxSignupOriginOtherLength matches the users.signup_origin_other column width
-// so an oversized payload fails with a 400 instead of a database error.
+// maxSignupOriginOtherLength matches the users.signup_origin_other column
+// width, in characters, so an oversized payload fails with a 400 instead of a
+// database error.
 const maxSignupOriginOtherLength = 255
 
 // PostSignupOrigin
@@ -80,7 +82,10 @@ func PostSignupOrigin(c *gin.Context) {
 		case detail == "":
 			c.JSON(http.StatusBadRequest, gin.H{"message": "origin_other is required when origin is 'other'"})
 			return
-		case len(detail) > maxSignupOriginOtherLength:
+		// Counted in characters, not bytes: the column is a VARCHAR(255) and
+		// Postgres measures it in characters, so len() would turn a perfectly
+		// storable non-ASCII answer into a 400.
+		case utf8.RuneCountInString(detail) > maxSignupOriginOtherLength:
 			c.JSON(http.StatusBadRequest, gin.H{"message": "origin_other must not exceed 255 characters"})
 			return
 		}

--- a/gateway/api/user/originsurvey.go
+++ b/gateway/api/user/originsurvey.go
@@ -1,0 +1,114 @@
+package userapi
+
+import (
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/gateway/analytics"
+	"github.com/hoophq/hoop/gateway/api/httputils"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2"
+	"gorm.io/gorm"
+)
+
+// signupOriginOther is the single option that also carries free text.
+const signupOriginOther = "other"
+
+// validSignupOrigins are the accepted answers of the onboarding
+// "How did you hear about Hoop?" survey. These identifiers are the analytics
+// contract: renaming one breaks the acquisition-channel reports, so add new
+// options instead of repurposing existing ones. The user-facing labels live in
+// the webapp.
+var validSignupOrigins = []string{
+	"search-engine",
+	"ai-discovery",
+	"referral",
+	"already-in-use-at-company",
+	"tech-community",
+	"social-media",
+	"hoop-free-tools",
+	signupOriginOther,
+}
+
+// maxSignupOriginOtherLength matches the users.signup_origin_other column width
+// so an oversized payload fails with a 400 instead of a database error.
+const maxSignupOriginOtherLength = 255
+
+// PostSignupOrigin
+//
+//	@Summary		Answer Signup Origin Survey
+//	@Description	Record how the authenticated user heard about Hoop. Each user may answer only once; a second attempt returns 409.
+//	@Tags			User Management
+//	@Accept			json
+//	@Produce		json
+//	@Param			request				body	openapi.UserSignupOriginRequest	true	"The request body resource"
+//	@Success		204					"Answer recorded"
+//	@Failure		400,403,404,409,500	{object}	openapi.HTTPError
+//	@Router			/users/self/signup-origin [post]
+func PostSignupOrigin(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	// Anonymous users have no record in the users table yet, so there is
+	// nothing to attach the answer to. The survey is offered after signup.
+	if ctx.IsAnonymous() {
+		c.JSON(http.StatusForbidden, gin.H{"message": "the signup must be completed before answering the survey"})
+		return
+	}
+
+	var req openapi.UserSignupOriginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+	if !slices.Contains(validSignupOrigins, req.Origin) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid origin, accepted values are " + strings.Join(validSignupOrigins, ", "),
+		})
+		return
+	}
+
+	// The free text belongs to the 'other' option only. For any other answer it
+	// is dropped rather than rejected, so the stored columns always agree on
+	// which option was picked regardless of what the client kept in its state.
+	var otherText *string
+	if req.Origin == signupOriginOther {
+		detail := strings.TrimSpace(req.OriginOther)
+		switch {
+		case detail == "":
+			c.JSON(http.StatusBadRequest, gin.H{"message": "origin_other is required when origin is 'other'"})
+			return
+		case len(detail) > maxSignupOriginOtherLength:
+			c.JSON(http.StatusBadRequest, gin.H{"message": "origin_other must not exceed 255 characters"})
+			return
+		}
+		otherText = &detail
+	}
+
+	err := models.SetUserSignupOrigin(models.DB, ctx.OrgID, ctx.UserID, req.Origin, otherText)
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"message": "user not found"})
+		return
+	case errors.Is(err, models.ErrAlreadyExists):
+		c.JSON(http.StatusConflict, gin.H{"message": "the signup origin survey was already answered"})
+		return
+	case err != nil:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed recording the signup origin answer")
+		return
+	}
+
+	// The free text is intentionally left out of the event: it is user supplied
+	// and may contain personal data, which would bypass the organization's
+	// analytics mode. Read it from the database when the answers are reviewed.
+	trackClient := analytics.New()
+	defer trackClient.Close()
+	trackClient.Track(ctx.UserID, analytics.EventOnboardingOriginAnswered, map[string]any{
+		"org-id": ctx.OrgID,
+		"origin": req.Origin,
+	})
+
+	c.Status(http.StatusNoContent)
+}

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -485,6 +485,20 @@ func GetUserInfo(c *gin.Context) {
 		userInfoData.Name = ctx.UserAnonProfile
 		userInfoData.Picture = ctx.UserAnonPicture
 		userInfoData.ID = ctx.UserAnonSubject
+	} else {
+		// Anonymous users have no record in the users table, so there is no
+		// creation date to measure the survey window from. Neither do API keys
+		// and service accounts, which authenticate with a subject that never
+		// reaches this table — not found is their normal state here, so it stays
+		// silent. Any other failure only means the survey is not offered on this
+		// request, it must not fail the whole response.
+		showOriginSurvey, err := models.ShouldShowOriginSurvey(models.DB, ctx.OrgID, ctx.UserID)
+		switch {
+		case err == nil:
+			userInfoData.ShowOriginSurvey = showOriginSurvey
+		case !errors.Is(err, gorm.ErrRecordNotFound):
+			log.Warnf("failed resolving the signup origin survey state, err=%v", err)
+		}
 	}
 
 	if isOrgMultiTenant && !ctx.IsAnonymous() {

--- a/gateway/migrations/000108_users_signup_origin.down.sql
+++ b/gateway/migrations/000108_users_signup_origin.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+SET search_path TO private;
+
+ALTER TABLE users DROP COLUMN IF EXISTS signup_origin_other;
+ALTER TABLE users DROP COLUMN IF EXISTS signup_origin;
+
+COMMIT;

--- a/gateway/migrations/000108_users_signup_origin.up.sql
+++ b/gateway/migrations/000108_users_signup_origin.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+SET search_path TO private;
+
+-- Answer to the onboarding "How did you hear about Hoop?" survey, used to
+-- measure which acquisition channel (free tools, AI assistants, communities)
+-- originated each sign up.
+--
+-- One answer per user: the column stays NULL until the user submits and the
+-- API refuses to overwrite a non-NULL value, so the first answer wins.
+-- NULL therefore means "never answered", which is also what drives whether the
+-- survey is still shown (together with the 7 day window measured from
+-- created_at).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS signup_origin VARCHAR(64) NULL;
+
+-- Free text detail captured for the 'other' option. NULL for every other
+-- answer, so the two columns can never disagree about which option was picked.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS signup_origin_other VARCHAR(255) NULL;
+
+COMMIT;

--- a/gateway/models/user_signup_origin.go
+++ b/gateway/models/user_signup_origin.go
@@ -1,0 +1,78 @@
+package models
+
+import (
+	"gorm.io/gorm"
+)
+
+// originSurveyWindowDays bounds for how long the onboarding "How did you hear
+// about Hoop?" survey keeps being offered, counted from the moment the user
+// record was created.
+const originSurveyWindowDays = 7
+
+// The signup_origin columns are deliberately absent from the User struct.
+// UpdateUser persists through DB.Save, which writes every mapped column, and
+// gateway/api/signup builds a partial User literal before calling it — mapping
+// these columns would let such a call silently reset a stored answer. Keeping
+// them out of the struct makes that impossible, and the two functions below are
+// the only read/write path.
+
+// ShouldShowOriginSurvey reports whether the user still has to answer the
+// signup origin survey: no answer recorded yet and still inside the
+// originSurveyWindowDays window.
+//
+// The window is evaluated by Postgres on purpose. users.created_at is a
+// TIMESTAMP WITHOUT TIME ZONE written by NOW(), so comparing it against the
+// gateway's own clock would drift by the database's UTC offset. Both sides of
+// this comparison come from the same clock instead.
+//
+// Propagates gorm.ErrRecordNotFound when no such user exists.
+func ShouldShowOriginSurvey(db *gorm.DB, orgID, subject string) (bool, error) {
+	var showSurvey bool
+	res := db.Raw(`
+		SELECT signup_origin IS NULL AND created_at > NOW() - make_interval(days => ?)
+		FROM private.users
+		WHERE org_id = ? AND subject = ?`,
+		originSurveyWindowDays, orgID, subject,
+	).Scan(&showSurvey)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return false, gorm.ErrRecordNotFound
+	}
+	return showSurvey, nil
+}
+
+// SetUserSignupOrigin records the survey answer for a user. otherText carries
+// the free text of the 'other' option and must be nil for every other answer.
+//
+// The update is conditional on signup_origin still being NULL so the first
+// answer wins even when two tabs submit concurrently — the survey allows a
+// single answer per user.
+//
+// Returns ErrAlreadyExists when an answer was already recorded and
+// gorm.ErrRecordNotFound when no such user exists.
+func SetUserSignupOrigin(db *gorm.DB, orgID, subject, origin string, otherText *string) error {
+	res := db.Exec(`
+		UPDATE private.users
+		SET signup_origin = ?, signup_origin_other = ?, updated_at = NOW()
+		WHERE org_id = ? AND subject = ? AND signup_origin IS NULL`,
+		origin, otherText, orgID, subject)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 1 {
+		return nil
+	}
+	// No row matched: either the user is unknown or the answer was already
+	// recorded. Disambiguate so the caller can tell those two apart.
+	var found bool
+	lookup := db.Raw(`SELECT true FROM private.users WHERE org_id = ? AND subject = ?`, orgID, subject).Scan(&found)
+	if lookup.Error != nil {
+		return lookup.Error
+	}
+	if lookup.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return ErrAlreadyExists
+}

--- a/gateway/models/user_signup_origin.go
+++ b/gateway/models/user_signup_origin.go
@@ -25,11 +25,16 @@ const originSurveyWindowDays = 7
 // gateway's own clock would drift by the database's UTC offset. Both sides of
 // this comparison come from the same clock instead.
 //
+// COALESCE keeps the result a plain boolean: created_at carries a default but
+// no NOT NULL constraint, and a row holding NULL there would make the whole
+// predicate NULL, which fails to scan into a bool. An unknown creation time
+// reads as outside the window rather than as a broken /userinfo response.
+//
 // Propagates gorm.ErrRecordNotFound when no such user exists.
 func ShouldShowOriginSurvey(db *gorm.DB, orgID, subject string) (bool, error) {
 	var showSurvey bool
 	res := db.Raw(`
-		SELECT signup_origin IS NULL AND created_at > NOW() - make_interval(days => ?)
+		SELECT COALESCE(signup_origin IS NULL AND created_at > NOW() - make_interval(days => ?), false)
 		FROM private.users
 		WHERE org_id = ? AND subject = ?`,
 		originSurveyWindowDays, orgID, subject,

--- a/gateway/models/user_signup_origin_test.go
+++ b/gateway/models/user_signup_origin_test.go
@@ -1,0 +1,173 @@
+package models_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hoophq/hoop/gateway/models"
+	modelsbootstrap "github.com/hoophq/hoop/gateway/models/bootstrap"
+	"github.com/hoophq/hoop/gateway/pglite"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"gorm.io/gorm"
+)
+
+const testOrgID = "00000000-0000-0000-0000-0000000000a1"
+
+// startTestDB boots the embedded database, applies the migrations and points
+// models.DB at it, exactly like the gateway does on startup. The signup origin
+// helpers run raw SQL against the real schema, so an in-memory fake would not
+// exercise what actually breaks: the interval arithmetic and the conditional
+// update.
+func startTestDB(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping embedded database test in -short mode")
+	}
+	ctx := context.Background()
+	inst, err := pglite.Start(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("start embedded database: %v", err)
+	}
+	t.Cleanup(func() { inst.Close(ctx) })
+
+	if err := modelsbootstrap.MigrateDB(inst.MigrateDSN(), ""); err != nil {
+		t.Fatalf("migrations failed: %v", err)
+	}
+	// The embedded backend serves one session at a time.
+	if err := models.InitDatabaseConnection(inst.DSN(), 1); err != nil {
+		t.Fatalf("open gorm connection: %v", err)
+	}
+	if err := models.DB.Exec(
+		`INSERT INTO private.orgs (id, name) VALUES (?, 'origin-survey-test')`, testOrgID).Error; err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+}
+
+// seedUser creates an active user whose record was created createdDaysAgo days
+// ago, so the survey window can be exercised without waiting.
+func seedUser(t *testing.T, subject string, createdDaysAgo float64) {
+	t.Helper()
+	err := models.DB.Exec(`
+		INSERT INTO private.users (org_id, subject, email, name, status, created_at)
+		VALUES (?, ?, ?, ?, 'active', NOW() - make_interval(mins => ?))`,
+		testOrgID, subject, subject+"@hoop.dev", subject, int(createdDaysAgo*24*60),
+	).Error
+	if err != nil {
+		t.Fatalf("seed user %s: %v", subject, err)
+	}
+}
+
+func TestShouldShowOriginSurvey(t *testing.T) {
+	startTestDB(t)
+
+	answered := "user-answered"
+	seedUser(t, answered, 1)
+	if err := models.SetUserSignupOrigin(models.DB, testOrgID, answered, "referral", nil); err != nil {
+		t.Fatalf("record answer: %v", err)
+	}
+
+	// Bracket the 7 day boundary from both sides without landing on it, so the
+	// assertions cannot flake on clock resolution.
+	seedUser(t, "user-fresh", 0)
+	seedUser(t, "user-inside-window", 6.95)
+	seedUser(t, "user-outside-window", 7.05)
+
+	tests := []struct {
+		subject string
+		expect  bool
+	}{
+		{subject: "user-fresh", expect: true},
+		{subject: "user-inside-window", expect: true},
+		{subject: "user-outside-window", expect: false},
+		{subject: answered, expect: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.subject, func(t *testing.T) {
+			got, err := models.ShouldShowOriginSurvey(models.DB, testOrgID, tt.subject)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.expect {
+				t.Errorf("expected %v, got %v", tt.expect, got)
+			}
+		})
+	}
+
+	t.Run("unknown user propagates not found", func(t *testing.T) {
+		_, err := models.ShouldShowOriginSurvey(models.DB, testOrgID, "nobody")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Errorf("expected gorm.ErrRecordNotFound, got %v", err)
+		}
+	})
+}
+
+func TestSetUserSignupOrigin(t *testing.T) {
+	startTestDB(t)
+
+	t.Run("stores the answer and its free text", func(t *testing.T) {
+		seedUser(t, "user-other", 0)
+		detail := "Saw it in a conference talk"
+		if err := models.SetUserSignupOrigin(models.DB, testOrgID, "user-other", "other", &detail); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		origin, other := readAnswer(t, "user-other")
+		if origin != "other" || other != detail {
+			t.Errorf("expected (other, %q), got (%q, %q)", detail, origin, other)
+		}
+	})
+
+	t.Run("leaves the free text null for other options", func(t *testing.T) {
+		seedUser(t, "user-plain", 0)
+		if err := models.SetUserSignupOrigin(models.DB, testOrgID, "user-plain", "ai-discovery", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var otherIsNull bool
+		if err := models.DB.Raw(
+			`SELECT signup_origin_other IS NULL FROM private.users WHERE org_id = ? AND subject = 'user-plain'`,
+			testOrgID).Scan(&otherIsNull).Error; err != nil {
+			t.Fatalf("read answer: %v", err)
+		}
+		if !otherIsNull {
+			t.Error("expected signup_origin_other to stay null")
+		}
+	})
+
+	// "1 answer per user": the second submission must not overwrite the first.
+	t.Run("refuses a second answer", func(t *testing.T) {
+		seedUser(t, "user-twice", 0)
+		if err := models.SetUserSignupOrigin(models.DB, testOrgID, "user-twice", "referral", nil); err != nil {
+			t.Fatalf("first answer: %v", err)
+		}
+		err := models.SetUserSignupOrigin(models.DB, testOrgID, "user-twice", "social-media", nil)
+		if !errors.Is(err, models.ErrAlreadyExists) {
+			t.Fatalf("expected models.ErrAlreadyExists, got %v", err)
+		}
+		if origin, _ := readAnswer(t, "user-twice"); origin != "referral" {
+			t.Errorf("expected the first answer to win, got %q", origin)
+		}
+	})
+
+	t.Run("unknown user propagates not found", func(t *testing.T) {
+		err := models.SetUserSignupOrigin(models.DB, testOrgID, "nobody", "referral", nil)
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Errorf("expected gorm.ErrRecordNotFound, got %v", err)
+		}
+	})
+}
+
+func readAnswer(t *testing.T, subject string) (origin, other string) {
+	t.Helper()
+	var row struct {
+		SignupOrigin      string
+		SignupOriginOther string
+	}
+	err := models.DB.Raw(`
+		SELECT COALESCE(signup_origin, '') AS signup_origin,
+		       COALESCE(signup_origin_other, '') AS signup_origin_other
+		FROM private.users WHERE org_id = ? AND subject = ?`, testOrgID, subject).Scan(&row).Error
+	if err != nil {
+		t.Fatalf("read answer for %s: %v", subject, err)
+	}
+	return row.SignupOrigin, row.SignupOriginOther
+}

--- a/gateway/models/user_signup_origin_test.go
+++ b/gateway/models/user_signup_origin_test.go
@@ -73,6 +73,19 @@ func TestShouldShowOriginSurvey(t *testing.T) {
 	seedUser(t, "user-inside-window", 6.95)
 	seedUser(t, "user-outside-window", 7.05)
 
+	// created_at has a default but no NOT NULL constraint, so a row can hold
+	// NULL there. Without a guard the window predicate evaluates to NULL and
+	// fails to scan into a bool, breaking /userinfo for that user.
+	noCreationTime := "user-without-created-at"
+	err := models.DB.Exec(`
+		INSERT INTO private.users (org_id, subject, email, name, status, created_at)
+		VALUES (?, ?, ?, ?, 'active', NULL)`,
+		testOrgID, noCreationTime, noCreationTime+"@hoop.dev", noCreationTime,
+	).Error
+	if err != nil {
+		t.Fatalf("seed user without created_at: %v", err)
+	}
+
 	tests := []struct {
 		subject string
 		expect  bool
@@ -81,6 +94,7 @@ func TestShouldShowOriginSurvey(t *testing.T) {
 		{subject: "user-inside-window", expect: true},
 		{subject: "user-outside-window", expect: false},
 		{subject: answered, expect: false},
+		{subject: noCreationTime, expect: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.subject, func(t *testing.T) {

--- a/webapp_v2/src/App.jsx
+++ b/webapp_v2/src/App.jsx
@@ -1,6 +1,7 @@
 import { Toaster } from 'sonner'
 import { useEffect } from 'react'
 import Router from './Router'
+import OriginSurvey from '@/features/OriginSurvey'
 import { useConnectionsMetadataStore } from '@/stores/useConnectionsMetadataStore'
 
 // Clears the global header so toasts never cover the Native Connections button
@@ -20,6 +21,10 @@ function App() {
   return (
     <>
       <Router />
+      {/* Mounted outside the Router so it also reaches the onboarding routes,
+          which render without the app Layout. Renders nothing until /userinfo
+          reports the survey is still due. */}
+      <OriginSurvey />
       <Toaster position="top-right" offset={TOAST_OFFSET} mobileOffset={TOAST_OFFSET} />
     </>
   )

--- a/webapp_v2/src/features/OriginSurvey/OriginSurvey.module.css
+++ b/webapp_v2/src/features/OriginSurvey/OriginSurvey.module.css
@@ -1,6 +1,49 @@
-/* Sits above page content but below PageLoader (200), the Native Connections
-   drawer (300) and its modals (400), so the survey never covers a dialog the
-   user opened. Mantine has no style prop for z-index. */
-.card {
+/* The launcher is the anchor of the whole widget: it is vertically centred
+   while collapsed and drops a quarter of the viewport when the survey opens,
+   so the card has room to grow upward without leaving the screen.
+
+   The anchor is a vh length rather than a percentage on purpose — the card
+   reuses it to cap its own height, and a percentage there would resolve
+   against the launcher instead of the viewport.
+
+   Mantine has no style prop for z-index, for a viewport-relative anchor, or
+   for the transition between the two positions. */
+.widget {
+  --survey-anchor: 50vh;
+
+  position: fixed;
+  top: var(--survey-anchor);
+  right: var(--mantine-spacing-lg);
+  transform: translateY(-50%);
+  transition: top 200ms ease;
+
+  /* Above page content but below PageLoader (200), the Native Connections
+     drawer (300) and its modals (400), so the survey never covers a dialog
+     the user opened. */
   z-index: 100;
+}
+
+.widget[data-open] {
+  --survey-anchor: 75vh;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .widget {
+    transition: none;
+  }
+}
+
+.launcher {
+  box-shadow: var(--mantine-shadow-md);
+}
+
+/* Grows upward from just above the launcher, sharing its right edge. The cap
+   keeps the top of the card on screen on short viewports; the space above the
+   launcher is the anchor minus its own half-height and the gap. */
+.card {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + var(--mantine-spacing-sm));
+  max-height: calc(var(--survey-anchor) - var(--mantine-spacing-xxl));
+  overflow-y: auto;
 }

--- a/webapp_v2/src/features/OriginSurvey/OriginSurvey.module.css
+++ b/webapp_v2/src/features/OriginSurvey/OriginSurvey.module.css
@@ -1,0 +1,6 @@
+/* Sits above page content but below PageLoader (200), the Native Connections
+   drawer (300) and its modals (400), so the survey never covers a dialog the
+   user opened. Mantine has no style prop for z-index. */
+.card {
+  z-index: 100;
+}

--- a/webapp_v2/src/features/OriginSurvey/constants.js
+++ b/webapp_v2/src/features/OriginSurvey/constants.js
@@ -1,0 +1,27 @@
+// Answers of the onboarding "How did you hear about Hoop?" survey. The `value`
+// of each entry is the analytics contract shared with the gateway
+// (validSignupOrigins in gateway/api/user/originsurvey.go) — keep both lists in
+// sync and never repurpose an existing value, it would corrupt the historical
+// acquisition-channel reports.
+export const ORIGIN_OPTIONS = [
+  { value: 'search-engine', label: 'Search on Google or another search engine' },
+  { value: 'ai-discovery', label: 'AI discovery (Claude, ChatGPT, etc.)' },
+  { value: 'referral', label: 'Referral from someone (colleague, friend)' },
+  { value: 'already-in-use-at-company', label: 'It was already in use at the company I work for' },
+  { value: 'tech-community', label: 'Tech community (Hacker News, Reddit, etc.)' },
+  { value: 'social-media', label: 'Social media (LinkedIn, X/Twitter, etc.)' },
+  { value: 'hoop-free-tools', label: "Using one of Hoop's free tools" },
+  { value: 'other', label: 'Other (please specify)' },
+]
+
+// The only option that also asks for free text.
+export const ORIGIN_OTHER = 'other'
+
+// Matches the users.signup_origin_other column width; the API rejects longer
+// values with a 400.
+export const ORIGIN_OTHER_MAX_LENGTH = 255
+
+// Dismissing with the X hides the survey for the current tab session only. It
+// comes back on the next visit while the user is still inside the 7 day window
+// the gateway enforces, so a dismissal never costs us the answer permanently.
+export const SNOOZE_STORAGE_KEY = 'hoop:origin-survey-snoozed'

--- a/webapp_v2/src/features/OriginSurvey/constants.js
+++ b/webapp_v2/src/features/OriginSurvey/constants.js
@@ -20,8 +20,3 @@ export const ORIGIN_OTHER = 'other'
 // Matches the users.signup_origin_other column width; the API rejects longer
 // values with a 400.
 export const ORIGIN_OTHER_MAX_LENGTH = 255
-
-// Dismissing with the X hides the survey for the current tab session only. It
-// comes back on the next visit while the user is still inside the 7 day window
-// the gateway enforces, so a dismissal never costs us the answer permanently.
-export const SNOOZE_STORAGE_KEY = 'hoop:origin-survey-snoozed'

--- a/webapp_v2/src/features/OriginSurvey/index.jsx
+++ b/webapp_v2/src/features/OriginSurvey/index.jsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react'
+import { Group, Paper, Stack, Text } from '@mantine/core'
+import { X } from 'lucide-react'
+import ActionIcon from '@/components/ActionIcon'
+import Button from '@/components/Button'
+import Radio from '@/components/Radio'
+import TextInput from '@/components/TextInput'
+import { useUserStore } from '@/stores/useUserStore'
+import { originSurveyService } from '@/services/originSurvey'
+import { showSnackbar } from '@/utils/snackbar'
+import {
+  ORIGIN_OPTIONS,
+  ORIGIN_OTHER,
+  ORIGIN_OTHER_MAX_LENGTH,
+  SNOOZE_STORAGE_KEY,
+} from './constants'
+import classes from './OriginSurvey.module.css'
+
+// Both webapps boot Intercom with hide_default_launcher, so nothing else
+// occupies the bottom-right corner. The offset matches the 1.5rem the global
+// Toaster uses on the opposite corner.
+const EDGE_OFFSET = 24
+
+const CARD_WIDTH = 340
+
+// How long the "Answer received" acknowledgement stays on screen before the
+// card removes itself.
+const ACK_DURATION_MS = 2500
+
+/**
+ * Onboarding "How did you hear about Hoop?" survey — a non-blocking card in the
+ * bottom-right corner, mounted globally so it also reaches the chrome-less
+ * onboarding routes that render outside the app Layout.
+ *
+ * Visibility is owned by the gateway: /userinfo returns show_origin_survey,
+ * which is true only while the user has not answered and is within 7 days of
+ * their user record being created. Dismissing with the X only snoozes the card
+ * for the current tab session.
+ */
+function OriginSurvey() {
+  const user = useUserStore((state) => state.user)
+
+  // 'form' → collecting the answer, 'ack' → showing the acknowledgement,
+  // 'closed' → done for this page load, whether answered or dismissed. The
+  // local phase outranks the server flag so the acknowledgement survives on
+  // screen after the answer is recorded.
+  const [phase, setPhase] = useState(() =>
+    sessionStorage.getItem(SNOOZE_STORAGE_KEY) === 'true' ? 'closed' : 'form',
+  )
+  const [origin, setOrigin] = useState(null)
+  const [otherText, setOtherText] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (phase !== 'ack') return
+    const timer = setTimeout(() => setPhase('closed'), ACK_DURATION_MS)
+    return () => clearTimeout(timer)
+  }, [phase])
+
+  function handleDismiss() {
+    sessionStorage.setItem(SNOOZE_STORAGE_KEY, 'true')
+    setPhase('closed')
+  }
+
+  async function handleSubmit() {
+    setSubmitting(true)
+    try {
+      await originSurveyService.answer({ origin, originOther: otherText.trim() })
+    } catch (err) {
+      // 409 means this user already answered from another tab or device. The
+      // desired state is reached either way, so acknowledge instead of asking
+      // again — any other failure keeps the form open so the answer is not lost.
+      if (err.response?.status !== 409) {
+        showSnackbar({
+          level: 'error',
+          text: 'Failed to send your answer',
+          description: err.response?.data?.message,
+        })
+        setSubmitting(false)
+        return
+      }
+    }
+    setPhase('ack')
+  }
+
+  if (phase === 'closed') return null
+  if (phase === 'form' && !user?.show_origin_survey) return null
+
+  const otherSelected = origin === ORIGIN_OTHER
+  const canSubmit = origin !== null && (!otherSelected || otherText.trim() !== '')
+
+  return (
+    <Paper
+      shadow="md"
+      radius="sm"
+      p="md"
+      w={CARD_WIDTH}
+      pos="fixed"
+      bottom={EDGE_OFFSET}
+      right={EDGE_OFFSET}
+      className={classes.card}
+      role="dialog"
+      aria-label="How did you hear about Hoop?"
+    >
+      <Stack gap="lg">
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
+          <Text fw={500}>Help us out</Text>
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            onClick={handleDismiss}
+            aria-label="Dismiss survey"
+          >
+            <X size={16} />
+          </ActionIcon>
+        </Group>
+
+        {phase === 'ack' ? (
+          <Text size="sm">Answer received</Text>
+        ) : (
+          <>
+            <Radio.Group
+              value={origin}
+              onChange={setOrigin}
+              label="How did you hear about Hoop?"
+              labelProps={{ fw: 400 }}
+            >
+              <Stack gap="sm" mt="sm">
+                {ORIGIN_OPTIONS.map((option) => (
+                  <Radio key={option.value} value={option.value} label={option.label} size="xs" />
+                ))}
+              </Stack>
+            </Radio.Group>
+
+            {otherSelected && (
+              <TextInput
+                placeholder="Specify"
+                value={otherText}
+                onChange={(event) => setOtherText(event.currentTarget.value)}
+                maxLength={ORIGIN_OTHER_MAX_LENGTH}
+                aria-label="Specify how you heard about Hoop"
+              />
+            )}
+
+            <Group justify="flex-end">
+              <Button size="xs" disabled={!canSubmit} loading={submitting} onClick={handleSubmit}>
+                Submit
+              </Button>
+            </Group>
+          </>
+        )}
+      </Stack>
+    </Paper>
+  )
+}
+
+export default OriginSurvey

--- a/webapp_v2/src/features/OriginSurvey/index.jsx
+++ b/webapp_v2/src/features/OriginSurvey/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Group, Paper, Stack, Text } from '@mantine/core'
+import { Box, Group, Indicator, Paper, Stack, Text } from '@mantine/core'
 import { X } from 'lucide-react'
 import ActionIcon from '@/components/ActionIcon'
 import Button from '@/components/Button'
@@ -8,45 +8,34 @@ import TextInput from '@/components/TextInput'
 import { useUserStore } from '@/stores/useUserStore'
 import { originSurveyService } from '@/services/originSurvey'
 import { showSnackbar } from '@/utils/snackbar'
-import {
-  ORIGIN_OPTIONS,
-  ORIGIN_OTHER,
-  ORIGIN_OTHER_MAX_LENGTH,
-  SNOOZE_STORAGE_KEY,
-} from './constants'
+import { ORIGIN_OPTIONS, ORIGIN_OTHER, ORIGIN_OTHER_MAX_LENGTH } from './constants'
 import classes from './OriginSurvey.module.css'
-
-// Both webapps boot Intercom with hide_default_launcher, so nothing else
-// occupies the bottom-right corner. The offset matches the 1.5rem the global
-// Toaster uses on the opposite corner.
-const EDGE_OFFSET = 24
 
 const CARD_WIDTH = 340
 
 // How long the "Answer received" acknowledgement stays on screen before the
-// card removes itself.
+// widget removes itself.
 const ACK_DURATION_MS = 2500
 
 /**
- * Onboarding "How did you hear about Hoop?" survey — a non-blocking card in the
- * bottom-right corner, mounted globally so it also reaches the chrome-less
- * onboarding routes that render outside the app Layout.
+ * Onboarding "How did you hear about Hoop?" survey — a floating launcher on the
+ * right edge of the viewport that expands into a non-blocking card. Mounted
+ * globally so it also reaches the chrome-less onboarding routes that render
+ * outside the app Layout.
  *
  * Visibility is owned by the gateway: /userinfo returns show_origin_survey,
  * which is true only while the user has not answered and is within 7 days of
- * their user record being created. Dismissing with the X only snoozes the card
- * for the current tab session.
+ * their user record being created. The X collapses the card back to the
+ * launcher, so a mis-click never costs us the answer.
  */
 function OriginSurvey() {
   const user = useUserStore((state) => state.user)
 
-  // 'form' → collecting the answer, 'ack' → showing the acknowledgement,
-  // 'closed' → done for this page load, whether answered or dismissed. The
-  // local phase outranks the server flag so the acknowledgement survives on
+  // 'collapsed' → launcher only, 'open' → collecting the answer, 'ack' →
+  // showing the acknowledgement, 'closed' → answered, gone for this page load.
+  // The local phase outranks the server flag so the acknowledgement survives on
   // screen after the answer is recorded.
-  const [phase, setPhase] = useState(() =>
-    sessionStorage.getItem(SNOOZE_STORAGE_KEY) === 'true' ? 'closed' : 'form',
-  )
+  const [phase, setPhase] = useState('collapsed')
   const [origin, setOrigin] = useState(null)
   const [otherText, setOtherText] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -57,9 +46,11 @@ function OriginSurvey() {
     return () => clearTimeout(timer)
   }, [phase])
 
-  function handleDismiss() {
-    sessionStorage.setItem(SNOOZE_STORAGE_KEY, 'true')
-    setPhase('closed')
+  function handleToggle() {
+    // Inert while acknowledging: the answer is already recorded, reopening the
+    // form would only invite a second submission the gateway would reject.
+    if (phase === 'ack') return
+    setPhase(phase === 'open' ? 'collapsed' : 'open')
   }
 
   async function handleSubmit() {
@@ -84,73 +75,99 @@ function OriginSurvey() {
   }
 
   if (phase === 'closed') return null
-  if (phase === 'form' && !user?.show_origin_survey) return null
+  if (phase === 'collapsed' && !user?.show_origin_survey) return null
 
+  const expanded = phase !== 'collapsed'
   const otherSelected = origin === ORIGIN_OTHER
   const canSubmit = origin !== null && (!otherSelected || otherText.trim() !== '')
 
   return (
-    <Paper
-      shadow="md"
-      radius="sm"
-      p="md"
-      w={CARD_WIDTH}
-      pos="fixed"
-      bottom={EDGE_OFFSET}
-      right={EDGE_OFFSET}
-      className={classes.card}
-      role="dialog"
-      aria-label="How did you hear about Hoop?"
-    >
-      <Stack gap="lg">
-        <Group justify="space-between" align="flex-start" wrap="nowrap">
-          <Text fw={500}>Help us out</Text>
-          <ActionIcon
-            variant="subtle"
-            color="gray"
-            onClick={handleDismiss}
-            aria-label="Dismiss survey"
-          >
-            <X size={16} />
-          </ActionIcon>
-        </Group>
-
-        {phase === 'ack' ? (
-          <Text size="sm">Answer received</Text>
-        ) : (
-          <>
-            <Radio.Group
-              value={origin}
-              onChange={setOrigin}
-              label="How did you hear about Hoop?"
-              labelProps={{ fw: 400 }}
-            >
-              <Stack gap="sm" mt="sm">
-                {ORIGIN_OPTIONS.map((option) => (
-                  <Radio key={option.value} value={option.value} label={option.label} size="xs" />
-                ))}
-              </Stack>
-            </Radio.Group>
-
-            {otherSelected && (
-              <TextInput
-                placeholder="Specify"
-                value={otherText}
-                onChange={(event) => setOtherText(event.currentTarget.value)}
-                maxLength={ORIGIN_OTHER_MAX_LENGTH}
-                aria-label="Specify how you heard about Hoop"
-              />
-            )}
-
-            <Group justify="flex-end">
-              <Button size="xs" disabled={!canSubmit} loading={submitting} onClick={handleSubmit}>
-                Submit
-              </Button>
+    <Box className={classes.widget} data-open={expanded || undefined}>
+      {expanded && (
+        <Paper
+          shadow="md"
+          radius="md"
+          p="md"
+          w={CARD_WIDTH}
+          className={classes.card}
+          role="dialog"
+          aria-label="How did you hear about Hoop?"
+        >
+          <Stack gap="lg">
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+              <Text fw={500}>Help us out</Text>
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                onClick={() => setPhase('collapsed')}
+                aria-label="Collapse survey"
+              >
+                <X size={16} />
+              </ActionIcon>
             </Group>
-          </>
-        )}
-      </Stack>
-    </Paper>
+
+            {phase === 'ack' ? (
+              <Text size="sm">Answer received</Text>
+            ) : (
+              <>
+                <Radio.Group
+                  value={origin}
+                  onChange={setOrigin}
+                  label="How did you hear about Hoop?"
+                  labelProps={{ fw: 400 }}
+                >
+                  <Stack gap="sm" mt="sm">
+                    {ORIGIN_OPTIONS.map((option) => (
+                      <Radio key={option.value} value={option.value} label={option.label} size="xs" />
+                    ))}
+                  </Stack>
+                </Radio.Group>
+
+                {otherSelected && (
+                  <TextInput
+                    placeholder="Specify"
+                    value={otherText}
+                    onChange={(event) => setOtherText(event.currentTarget.value)}
+                    maxLength={ORIGIN_OTHER_MAX_LENGTH}
+                    aria-label="Specify how you heard about Hoop"
+                  />
+                )}
+
+                <Group justify="flex-end">
+                  <Button size="xs" disabled={!canSubmit} loading={submitting} onClick={handleSubmit}>
+                    Submit
+                  </Button>
+                </Group>
+              </>
+            )}
+          </Stack>
+        </Paper>
+      )}
+
+      {/* The dot marks the survey as still pending, and stays on while the card
+          is open — it only goes away with the whole widget, once answered. */}
+      <Indicator color="red" size={8} offset={4} withBorder>
+        <ActionIcon
+          variant="default"
+          radius="xl"
+          size="lg"
+          className={classes.launcher}
+          onClick={handleToggle}
+          aria-expanded={expanded}
+          aria-label="How did you hear about Hoop?"
+        >
+          {/* The symbol SVG carries a viewBox but no width/height, so both axes
+              are given here — with only a height it has no layout width to fall
+              back on if the asset fails to load. viewBox is square. */}
+          <img
+            src="/images/hoop-branding/SVG/hoop-symbol_black.svg"
+            alt=""
+            width={18}
+            height={18}
+          />
+        </ActionIcon>
+      </Indicator>
+    </Box>
   )
 }
 

--- a/webapp_v2/src/features/OriginSurvey/index.jsx
+++ b/webapp_v2/src/features/OriginSurvey/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Box, Group, Indicator, Paper, Stack, Text } from '@mantine/core'
 import { X } from 'lucide-react'
 import ActionIcon from '@/components/ActionIcon'
@@ -11,6 +11,14 @@ import { ORIGIN_OPTIONS, ORIGIN_OTHER, ORIGIN_OTHER_MAX_LENGTH } from './constan
 import classes from './OriginSurvey.module.css'
 
 const CARD_WIDTH = 340
+
+// Large enough to read as a call to action on the launcher rather than as a
+// decorative dot.
+const PENDING_DOT_SIZE = 12
+
+// How long the acknowledgement stays on screen before the widget removes
+// itself. Long enough to read a two-word message without lingering.
+const ACK_DURATION_MS = 3000
 
 /**
  * Onboarding "How did you hear about Hoop?" survey — a floating launcher on the
@@ -26,31 +34,52 @@ const CARD_WIDTH = 340
 function OriginSurvey() {
   const user = useUserStore((state) => state.user)
 
-  // 'collapsed' → launcher only, 'open' → collecting the answer, 'closed' →
-  // answered, gone for this page load. The local phase outranks the server
-  // flag, which is only re-read on the next load.
+  // 'collapsed' → launcher only, 'open' → collecting the answer, 'ack' →
+  // acknowledging it, 'closed' → gone for this page load. The local phase
+  // outranks the server flag, which is only re-read on the next load.
   const [phase, setPhase] = useState('collapsed')
   const [origin, setOrigin] = useState(null)
   const [otherText, setOtherText] = useState('')
 
+  useEffect(() => {
+    if (phase !== 'ack') return
+    const timer = setTimeout(() => setPhase('closed'), ACK_DURATION_MS)
+    return () => clearTimeout(timer)
+  }, [phase])
+
   function handleSubmit() {
-    // Fire and forget: the widget closes on the click without waiting for the
-    // gateway, so a slow or lost response can never hold the UI. If the write
-    // does not land, /userinfo keeps reporting show_origin_survey on the next
-    // load and the user is simply asked again — there is nothing for them to
-    // act on in the meantime, so a failure toast would be pure noise. It still
-    // reaches the console for anyone debugging the flow.
+    // Fire and forget: the acknowledgement shows on the click without waiting
+    // for the gateway, so a slow or lost response can never hold the UI. If the
+    // write does not land, /userinfo keeps reporting show_origin_survey on the
+    // next load and the user is simply asked again — there is nothing for them
+    // to act on in the meantime, so a failure toast would be pure noise. It
+    // still reaches the console for anyone debugging the flow.
     originSurveyService
       .answer({ origin, originOther: otherText.trim() })
       .catch((err) => console.warn('[origin-survey] failed recording the answer:', err))
 
-    setPhase('closed')
+    setPhase('ack')
+  }
+
+  // Once answered there is nothing left to come back to, so the X retires the
+  // widget instead of collapsing it — it only reappears if the gateway still
+  // reports the survey on the next load.
+  function handleDismiss() {
+    setPhase(phase === 'ack' ? 'closed' : 'collapsed')
+  }
+
+  function handleToggle() {
+    // Inert while acknowledging: the answer is already on its way, reopening
+    // the form would only invite a second submission.
+    if (phase === 'ack') return
+    setPhase(phase === 'open' ? 'collapsed' : 'open')
   }
 
   if (phase === 'closed') return null
   if (phase === 'collapsed' && !user?.show_origin_survey) return null
 
-  const expanded = phase === 'open'
+  const answered = phase === 'ack'
+  const expanded = phase === 'open' || answered
   const otherSelected = origin === ORIGIN_OTHER
   const canSubmit = origin !== null && (!otherSelected || otherText.trim() !== '')
 
@@ -72,54 +101,65 @@ function OriginSurvey() {
               <ActionIcon
                 variant="subtle"
                 color="gray"
-                onClick={() => setPhase('collapsed')}
-                aria-label="Collapse survey"
+                onClick={handleDismiss}
+                aria-label={answered ? 'Dismiss survey' : 'Collapse survey'}
               >
                 <X size={16} />
               </ActionIcon>
             </Group>
 
-            <Radio.Group
-              value={origin}
-              onChange={setOrigin}
-              label="How did you hear about Hoop?"
-              labelProps={{ fw: 400 }}
-            >
-              <Stack gap="sm" mt="sm">
-                {ORIGIN_OPTIONS.map((option) => (
-                  <Radio key={option.value} value={option.value} label={option.label} size="xs" />
-                ))}
-              </Stack>
-            </Radio.Group>
+            {answered ? (
+              // The message replaces the form asynchronously, so it is
+              // announced rather than silently swapped in.
+              <Text size="sm" role="status">
+                Answer received
+              </Text>
+            ) : (
+              <>
+                <Radio.Group
+                  value={origin}
+                  onChange={setOrigin}
+                  label="How did you hear about Hoop?"
+                  labelProps={{ fw: 400 }}
+                >
+                  <Stack gap="sm" mt="sm">
+                    {ORIGIN_OPTIONS.map((option) => (
+                      <Radio key={option.value} value={option.value} label={option.label} size="xs" />
+                    ))}
+                  </Stack>
+                </Radio.Group>
 
-            {otherSelected && (
-              <TextInput
-                placeholder="Specify"
-                value={otherText}
-                onChange={(event) => setOtherText(event.currentTarget.value)}
-                maxLength={ORIGIN_OTHER_MAX_LENGTH}
-                aria-label="Specify how you heard about Hoop"
-              />
+                {otherSelected && (
+                  <TextInput
+                    placeholder="Specify"
+                    value={otherText}
+                    onChange={(event) => setOtherText(event.currentTarget.value)}
+                    maxLength={ORIGIN_OTHER_MAX_LENGTH}
+                    aria-label="Specify how you heard about Hoop"
+                  />
+                )}
+
+                <Group justify="flex-end">
+                  <Button size="xs" disabled={!canSubmit} onClick={handleSubmit}>
+                    Submit
+                  </Button>
+                </Group>
+              </>
             )}
-
-            <Group justify="flex-end">
-              <Button size="xs" disabled={!canSubmit} onClick={handleSubmit}>
-                Submit
-              </Button>
-            </Group>
           </Stack>
         </Paper>
       )}
 
-      {/* The dot marks the survey as still pending, and stays on while the card
-          is open — it only goes away with the whole widget, once answered. */}
-      <Indicator color="red" size={8} offset={4} withBorder>
+      {/* The dot marks the survey as still pending, so it goes out as soon as
+          the answer is in — the launcher itself lingers only for the
+          acknowledgement. */}
+      <Indicator color="red" size={PENDING_DOT_SIZE} offset={4} withBorder disabled={answered}>
         <ActionIcon
           variant="default"
           radius="xl"
           size="lg"
           className={classes.launcher}
-          onClick={() => setPhase(expanded ? 'collapsed' : 'open')}
+          onClick={handleToggle}
           aria-expanded={expanded}
           aria-label="How did you hear about Hoop?"
         >

--- a/webapp_v2/src/features/OriginSurvey/index.jsx
+++ b/webapp_v2/src/features/OriginSurvey/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Box, Group, Indicator, Paper, Stack, Text } from '@mantine/core'
 import { X } from 'lucide-react'
 import ActionIcon from '@/components/ActionIcon'
@@ -7,15 +7,10 @@ import Radio from '@/components/Radio'
 import TextInput from '@/components/TextInput'
 import { useUserStore } from '@/stores/useUserStore'
 import { originSurveyService } from '@/services/originSurvey'
-import { showSnackbar } from '@/utils/snackbar'
 import { ORIGIN_OPTIONS, ORIGIN_OTHER, ORIGIN_OTHER_MAX_LENGTH } from './constants'
 import classes from './OriginSurvey.module.css'
 
 const CARD_WIDTH = 340
-
-// How long the "Answer received" acknowledgement stays on screen before the
-// widget removes itself.
-const ACK_DURATION_MS = 2500
 
 /**
  * Onboarding "How did you hear about Hoop?" survey — a floating launcher on the
@@ -31,56 +26,31 @@ const ACK_DURATION_MS = 2500
 function OriginSurvey() {
   const user = useUserStore((state) => state.user)
 
-  // 'collapsed' → launcher only, 'open' → collecting the answer, 'ack' →
-  // showing the acknowledgement, 'closed' → answered, gone for this page load.
-  // The local phase outranks the server flag so the acknowledgement survives on
-  // screen after the answer is recorded.
+  // 'collapsed' → launcher only, 'open' → collecting the answer, 'closed' →
+  // answered, gone for this page load. The local phase outranks the server
+  // flag, which is only re-read on the next load.
   const [phase, setPhase] = useState('collapsed')
   const [origin, setOrigin] = useState(null)
   const [otherText, setOtherText] = useState('')
-  const [submitting, setSubmitting] = useState(false)
 
-  useEffect(() => {
-    if (phase !== 'ack') return
-    const timer = setTimeout(() => setPhase('closed'), ACK_DURATION_MS)
-    return () => clearTimeout(timer)
-  }, [phase])
+  function handleSubmit() {
+    // Fire and forget: the widget closes on the click without waiting for the
+    // gateway, so a slow or lost response can never hold the UI. If the write
+    // does not land, /userinfo keeps reporting show_origin_survey on the next
+    // load and the user is simply asked again — there is nothing for them to
+    // act on in the meantime, so a failure toast would be pure noise. It still
+    // reaches the console for anyone debugging the flow.
+    originSurveyService
+      .answer({ origin, originOther: otherText.trim() })
+      .catch((err) => console.warn('[origin-survey] failed recording the answer:', err))
 
-  function handleToggle() {
-    // Inert while acknowledging: the answer is already recorded, reopening the
-    // form would only invite a second submission the gateway would reject.
-    if (phase === 'ack') return
-    setPhase(phase === 'open' ? 'collapsed' : 'open')
-  }
-
-  async function handleSubmit() {
-    setSubmitting(true)
-    try {
-      await originSurveyService.answer({ origin, originOther: otherText.trim() })
-    } catch (err) {
-      // 409 means the answer is already recorded — from another tab or device,
-      // or from an earlier attempt whose response never made it back. The
-      // desired state is reached either way, so acknowledge instead of asking
-      // again. Any other failure re-enables the form so the answer is not lost;
-      // a timeout carries no response, hence the fallback to the axios message.
-      if (err.response?.status !== 409) {
-        showSnackbar({
-          level: 'error',
-          text: 'Failed to send your answer',
-          description: err.response?.data?.message ?? err.message,
-        })
-        setSubmitting(false)
-        return
-      }
-    }
-    setSubmitting(false)
-    setPhase('ack')
+    setPhase('closed')
   }
 
   if (phase === 'closed') return null
   if (phase === 'collapsed' && !user?.show_origin_survey) return null
 
-  const expanded = phase !== 'collapsed'
+  const expanded = phase === 'open'
   const otherSelected = origin === ORIGIN_OTHER
   const canSubmit = origin !== null && (!otherSelected || otherText.trim() !== '')
 
@@ -109,40 +79,34 @@ function OriginSurvey() {
               </ActionIcon>
             </Group>
 
-            {phase === 'ack' ? (
-              <Text size="sm">Answer received</Text>
-            ) : (
-              <>
-                <Radio.Group
-                  value={origin}
-                  onChange={setOrigin}
-                  label="How did you hear about Hoop?"
-                  labelProps={{ fw: 400 }}
-                >
-                  <Stack gap="sm" mt="sm">
-                    {ORIGIN_OPTIONS.map((option) => (
-                      <Radio key={option.value} value={option.value} label={option.label} size="xs" />
-                    ))}
-                  </Stack>
-                </Radio.Group>
+            <Radio.Group
+              value={origin}
+              onChange={setOrigin}
+              label="How did you hear about Hoop?"
+              labelProps={{ fw: 400 }}
+            >
+              <Stack gap="sm" mt="sm">
+                {ORIGIN_OPTIONS.map((option) => (
+                  <Radio key={option.value} value={option.value} label={option.label} size="xs" />
+                ))}
+              </Stack>
+            </Radio.Group>
 
-                {otherSelected && (
-                  <TextInput
-                    placeholder="Specify"
-                    value={otherText}
-                    onChange={(event) => setOtherText(event.currentTarget.value)}
-                    maxLength={ORIGIN_OTHER_MAX_LENGTH}
-                    aria-label="Specify how you heard about Hoop"
-                  />
-                )}
-
-                <Group justify="flex-end">
-                  <Button size="xs" disabled={!canSubmit} loading={submitting} onClick={handleSubmit}>
-                    Submit
-                  </Button>
-                </Group>
-              </>
+            {otherSelected && (
+              <TextInput
+                placeholder="Specify"
+                value={otherText}
+                onChange={(event) => setOtherText(event.currentTarget.value)}
+                maxLength={ORIGIN_OTHER_MAX_LENGTH}
+                aria-label="Specify how you heard about Hoop"
+              />
             )}
+
+            <Group justify="flex-end">
+              <Button size="xs" disabled={!canSubmit} onClick={handleSubmit}>
+                Submit
+              </Button>
+            </Group>
           </Stack>
         </Paper>
       )}
@@ -155,7 +119,7 @@ function OriginSurvey() {
           radius="xl"
           size="lg"
           className={classes.launcher}
-          onClick={handleToggle}
+          onClick={() => setPhase(expanded ? 'collapsed' : 'open')}
           aria-expanded={expanded}
           aria-label="How did you hear about Hoop?"
         >

--- a/webapp_v2/src/features/OriginSurvey/index.jsx
+++ b/webapp_v2/src/features/OriginSurvey/index.jsx
@@ -58,19 +58,22 @@ function OriginSurvey() {
     try {
       await originSurveyService.answer({ origin, originOther: otherText.trim() })
     } catch (err) {
-      // 409 means this user already answered from another tab or device. The
+      // 409 means the answer is already recorded — from another tab or device,
+      // or from an earlier attempt whose response never made it back. The
       // desired state is reached either way, so acknowledge instead of asking
-      // again — any other failure keeps the form open so the answer is not lost.
+      // again. Any other failure re-enables the form so the answer is not lost;
+      // a timeout carries no response, hence the fallback to the axios message.
       if (err.response?.status !== 409) {
         showSnackbar({
           level: 'error',
           text: 'Failed to send your answer',
-          description: err.response?.data?.message,
+          description: err.response?.data?.message ?? err.message,
         })
         setSubmitting(false)
         return
       }
     }
+    setSubmitting(false)
     setPhase('ack')
   }
 

--- a/webapp_v2/src/services/originSurvey.js
+++ b/webapp_v2/src/services/originSurvey.js
@@ -1,9 +1,23 @@
 import api from './api'
 
+// The shared axios instance has no timeout on purpose — some endpoints
+// (runbook exec, database explorer) legitimately run for minutes. The survey is
+// the opposite: a small, optional write that must never leave the user staring
+// at a spinner if a response goes missing. Bounding it here keeps that
+// guarantee without touching the long-running endpoints.
+//
+// Retrying after a timeout is safe: if the first attempt did reach the gateway
+// the second returns 409, which the caller treats as answered.
+const REQUEST_TIMEOUT_MS = 15000
+
 export const originSurveyService = {
   // POST /users/self/signup-origin → 204 No Content.
   // origin_other is only read by the API when origin is 'other'.
   // Answering twice returns 409 — the first answer wins.
   answer: ({ origin, originOther }) =>
-    api.post('/users/self/signup-origin', { origin, origin_other: originOther ?? '' }),
+    api.post(
+      '/users/self/signup-origin',
+      { origin, origin_other: originOther ?? '' },
+      { timeout: REQUEST_TIMEOUT_MS },
+    ),
 }

--- a/webapp_v2/src/services/originSurvey.js
+++ b/webapp_v2/src/services/originSurvey.js
@@ -1,0 +1,9 @@
+import api from './api'
+
+export const originSurveyService = {
+  // POST /users/self/signup-origin → 204 No Content.
+  // origin_other is only read by the API when origin is 'other'.
+  // Answering twice returns 409 — the first answer wins.
+  answer: ({ origin, originOther }) =>
+    api.post('/users/self/signup-origin', { origin, origin_other: originOther ?? '' }),
+}

--- a/webapp_v2/src/services/originSurvey.js
+++ b/webapp_v2/src/services/originSurvey.js
@@ -1,23 +1,9 @@
 import api from './api'
 
-// The shared axios instance has no timeout on purpose — some endpoints
-// (runbook exec, database explorer) legitimately run for minutes. The survey is
-// the opposite: a small, optional write that must never leave the user staring
-// at a spinner if a response goes missing. Bounding it here keeps that
-// guarantee without touching the long-running endpoints.
-//
-// Retrying after a timeout is safe: if the first attempt did reach the gateway
-// the second returns 409, which the caller treats as answered.
-const REQUEST_TIMEOUT_MS = 15000
-
 export const originSurveyService = {
   // POST /users/self/signup-origin → 204 No Content.
   // origin_other is only read by the API when origin is 'other'.
   // Answering twice returns 409 — the first answer wins.
   answer: ({ origin, originOther }) =>
-    api.post(
-      '/users/self/signup-origin',
-      { origin, origin_other: originOther ?? '' },
-      { timeout: REQUEST_TIMEOUT_MS },
-    ),
+    api.post('/users/self/signup-origin', { origin, origin_other: originOther ?? '' }),
 }


### PR DESCRIPTION
## 📝 Description

Adds the onboarding **"How did you hear about Hoop?"** survey — a floating launcher on the right edge of the viewport that expands into a non-blocking card, offered once per user for 7 days after their user record is created.

Business driver: we are shipping free standalone tools as a Product Led Growth strategy, and need to measure how many OSS sign ups those tools originate versus the other channels.

**Where the data lives.** Both places, each for a different job:

- **Postgres** (`private.users.signup_origin`, `signup_origin_other`) is the source of truth for *who answered what* — joinable to email, org and subject, and durable regardless of the org's analytics mode.
- **Segment** gets `hoop-onboarding-origin-answered` with `org-id` and the chosen option, so the acquisition funnel is queryable in PostHog/Mixpanel alongside the rest of the funnel.

The free-text "other" answer is deliberately **not** in the event: it is user supplied and may contain personal data, which would bypass the organization's `analytics_mode` contract. Read it from the database when reviewing answers.

**The 7-day window needs no new state.** It is derived from the existing `users.created_at`, and evaluated *in Postgres* (`created_at > NOW() - make_interval(days => 7)`) rather than in Go — `created_at` is `TIMESTAMP WITHOUT TIME ZONE` written by `NOW()`, so comparing it against the gateway's own clock would drift by the database's UTC offset. Both sides of the comparison now come from the same clock.

## 📣 User-facing impact

New users are asked how they heard about Hoop during their first week, through a small floating button that expands into a card and never blocks the product. Answering takes one click and the question does not come back.

## 🔗 Related Issue

[EVL-185](https://linear.app/hoophq/issue/EVL-185/onboarding-include-origin-question)

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

**Gateway**

- `gateway/migrations/000108_users_signup_origin.{up,down}.sql` — two nullable columns on `private.users`. `NULL` means "never answered", which is what drives whether the survey is still offered.
- `gateway/models/user_signup_origin.go` — `ShouldShowOriginSurvey` and `SetUserSignupOrigin`, the only read/write path for these columns. The write is a conditional `UPDATE ... WHERE signup_origin IS NULL`, so the first answer wins even when two tabs submit concurrently.
- `gateway/api/user/originsurvey.go` — `POST /users/self/signup-origin`, with an allowlist of the 8 options and validation of the free text. The length check counts characters (`utf8.RuneCountInString`), matching what `VARCHAR(255)` enforces — `len()` would have rejected a 255-character non-ASCII answer that stores fine.
- `gateway/api/user/user.go` — `GET /userinfo` now returns `show_origin_survey`.
- `gateway/analytics/events.go` — new `EventOnboardingOriginAnswered`.
- OpenAPI regenerated.

**Frontend (`webapp_v2`)**

- `features/OriginSurvey/` — the launcher and the card, mounted globally in `App.jsx` so it also reaches the chrome-less onboarding routes that render outside the app `Layout`. The launcher is the positioning anchor: vertically centred while collapsed, dropping to 75vh when open, with the card growing upward from just above it.
- `services/originSurvey.js` — the POST call.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

**Automated**

- `make test-oss` → **1579 pass / 0 fail**, including `TestHoopMigrations`, which applies the full migration chain (now including `000108`) against embedded Postgres.
- 10 new DB-backed subtests in `gateway/models/user_signup_origin_test.go`, running against real Postgres via the pglite harness so the interval arithmetic and the conditional update are actually exercised. They cover: fresh user, inside window, outside window, `NULL` `created_at`, already answered, unknown user → `gorm.ErrRecordNotFound`, free-text storage, `NULL` free text for non-`other` answers, and first-answer-wins → `ErrAlreadyExists`.
  - Mutation-verified twice: setting the window to 700 days correctly fails `user-outside-window`, and dropping the `COALESCE` correctly fails `user-without-created-at` with `couldn't convert <nil> into type bool`.
  - The boundary is bracketed at 6.95 and 7.05 days rather than sitting on 7, so the assertions cannot flake on clock resolution.
- Migration rollback verified explicitly: `migrate down 1` drops both columns and re-running `up` restores them.
- `npm run lint` — no new problems (the 16 reported are pre-existing on `main`, in `vite.config.js` and `EventRouting`); `npm run build` succeeds.

**How to test manually**

1. `make run-dev-postgres && make run-dev`, then `cd webapp_v2 && npm run dev:full`.
2. Sign in as a user created less than 7 days ago. The launcher appears on the right edge, vertically centred, with a red pending dot — on any page, including the post-resource-creation and Terminal screens.
3. Click it. The launcher drops to 75vh and the card opens above it. Click it again (or the **X**) to collapse back.
4. Pick an option and press **Submit** → the form is replaced by "Answer received" straight away, without waiting for the gateway, and the whole widget retires ~3s later. Pressing the **X** during that window retires it immediately; clicking the launcher does not reopen the form.
5. Confirm it is recorded and cannot be overwritten:
   ```sql
   SELECT email, signup_origin, signup_origin_other FROM private.users WHERE subject = '<your-subject>';
   ```
   Reload — the launcher must not come back. `GET /api/userinfo` should now report `"show_origin_survey": false`.
6. Answer twice (e.g. replay the POST with curl) → the second call returns **409** and the stored answer is unchanged.
7. Pick **Other**, leave the text empty → Submit stays disabled. Type something → it is stored in `signup_origin_other`.
8. Shrink the window height to ~600px with the card open → the card scrolls internally instead of running off the top of the screen.
9. Ageing a user past the window hides it:
   ```sql
   UPDATE private.users SET created_at = NOW() - INTERVAL '8 days' WHERE subject = '<your-subject>';
   ```

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**Reviewers, the design decision worth your attention:** the two new columns are deliberately **absent** from the `models.User` struct. `models.UpdateUser` persists via `DB.Save`, which writes every mapped column, and `gateway/api/signup` builds a partial `models.User{}` literal before calling it — so mapping these columns would let a future signup path silently wipe a stored answer. Keeping them off the struct makes that class of bug structurally impossible. A reviewable alternative is GORM's read-only field tag (`gorm:"->"`), which would make the columns discoverable on the struct while still excluding them from every write; happy to switch if reviewers prefer that trade-off.

**Analytics contract:** `hoop-onboarding-origin-answered` is a brand-new event constant. No existing `Event*` constant was renamed, removed, or orphaned, so no current metric or dashboard is affected.

**Feature flag:** not gated. Per the `CLAUDE.md` policy the decision is stated explicitly — nothing here is experimental, the survey is inert for users outside the 7-day window, and the write path is idempotent.

**Deliberate deviations:**
- The ticket says the survey persists for 7 days "after the user sees the onboarding screen"; this anchors the window to `users.created_at` instead. Matching the ticket literally would need a new `onboarding_seen_at` column written on a render, and the two anchors only diverge for a user who signs up and then does not open the app for days. The survey is also offered on every page for the whole window, not just on the onboarding screen, so reaching that screen never gates it.
- The design's button reads **"Submit"**; the ticket text said "send". Followed the design.
- The mock leaves clearance for the Intercom launcher bubble, but both webapps boot Intercom with `hide_default_launcher: true`, so that corner is empty in the real product.

**Submit is fire-and-forget.** The acknowledgement shows on the click without waiting for the response, so a slow or lost reply can never hold the UI. It is feedback for the click, not a claim that the write landed. Recovery is free and needs no client state: if the write does not land, the next `/userinfo` still reports `show_origin_survey` and the user is asked again. Because there is nothing for them to act on in the meantime, a failure raises no toast — it goes to the console only.

**Dismissal semantics:** the **X** collapses the card back to the launcher rather than hiding the survey — the launcher persists until the user answers or the 7 days elapse. This is what the mock shows (the launcher stays visible next to the open card) and it removes the earlier `sessionStorage` snooze key entirely, along with the shared-machine caveat that key carried.
