### PR TITLE
fix: bound terminal output rendering and handle draft quota (EVL-121)

### DIFF
--- a/webapp/src/webapp/webclient/log_area/logs.cljs
+++ b/webapp/src/webapp/webclient/log_area/logs.cljs
@@ -12,10 +12,12 @@
   This panel renders output into one unvirtualized `whitespace-pre` node, and
   Chrome clamps layout at 2^25 px — which a single unwrapped line hits at ~3.8M
   characters, leaving the viewport blank behind a huge scrollbar (EVL-121).
-  Measured at 14px monospace: 1MB lays out in 29ms at 8.8M px, ~4x below the
-  clamp, where 4MB is already clamped. Full output stays reachable through the
-  output menu."
-  (* 1024 1024))
+  Measured at 14px monospace: 512KB lays out in 16ms at 4.4M px, ~8x below the
+  clamp, where 4MB is already clamped. Layout is only half the cost though —
+  scroll repaint of a very wide node degrades well before the clamp, so the
+  bound is set from what stays responsive in a real browser, not from the
+  headless numbers. Full output stays reachable through the output menu."
+  (* 512 1024))
 
 (defn- humanize-size
   "Formats a character count as a size; terminal output is effectively ASCII."

--- a/webapp/src/webapp/webclient/log_area/logs.cljs
+++ b/webapp/src/webapp/webclient/log_area/logs.cljs
@@ -31,7 +31,7 @@
   [total-chars]
   [:> Callout.Root {:color "amber"
                     :size "1"
-                    :class "mb-3 max-w-3xl whitespace-normal"}
+                    :class "mb-3 whitespace-normal"}
    [:> Callout.Icon
     [:> AlertTriangle {:size 16}]]
    [:> Callout.Text {:size "1"}

--- a/webapp/src/webapp/webclient/log_area/logs.cljs
+++ b/webapp/src/webapp/webclient/log_area/logs.cljs
@@ -1,12 +1,45 @@
 (ns webapp.webclient.log-area.logs
-  (:require ["@radix-ui/themes" :refer [Box Button Spinner Flex Text]]
-            ["lucide-react" :refer [Clock]]
+  (:require ["@radix-ui/themes" :refer [Box Button Callout Spinner Flex Text]]
+            ["lucide-react" :refer [AlertTriangle Clock]]
+            [clojure.string :as cs]
             [re-frame.core :as rf]
             [webapp.audit.views.session-details :as session-details]
             [webapp.formatters :as formatters]))
 
+(def ^:const max-rendered-chars
+  "Upper bound on how much output reaches the DOM.
+
+  This panel renders output into one unvirtualized `whitespace-pre` node, and
+  Chrome clamps layout at 2^25 px — which a single unwrapped line hits at ~3.8M
+  characters, leaving the viewport blank behind a huge scrollbar (EVL-121).
+  Measured at 14px monospace: 1MB lays out in 29ms at 8.8M px, ~4x below the
+  clamp, where 4MB is already clamped. Full output stays reachable through the
+  output menu."
+  (* 1024 1024))
+
+(defn- humanize-size
+  "Formats a character count as a size; terminal output is effectively ASCII."
+  [n]
+  (cond
+    (>= n (* 1024 1024)) (str (.toFixed (/ n 1024 1024) 1) " MB")
+    (>= n 1024) (str (.toFixed (/ n 1024) 1) " KB")
+    :else (str n " B")))
+
+(defn- truncation-notice
+  [total-chars]
+  [:> Callout.Root {:color "amber"
+                    :size "1"
+                    :class "mb-3 max-w-3xl whitespace-normal"}
+   [:> Callout.Icon
+    [:> AlertTriangle {:size 16}]]
+   [:> Callout.Text {:size "1"}
+    (str "Output truncated for display — showing the first "
+         (humanize-size max-rendered-chars) " of " (humanize-size total-chars)
+         ". Use the output menu to download or view the complete result.")]])
+
 (defn- logs-area-list
-  [status {:keys [logs logs-status execution-time has-review? session-id]}]
+  [status {:keys [logs logs-status logs-truncated? logs-total-chars
+                  execution-time has-review? session-id]}]
   (case status
     :success (if has-review?
                [:div {:class "group relative py-regular pl-regular pr-large whitespace-pre"
@@ -22,6 +55,8 @@
                  (str (formatters/current-time) " [cost " (formatters/time-elapsed execution-time) "]")]]
 
                [:div {:class " group relative py-regular pl-regular pr-large whitespace-pre"}
+                (when logs-truncated?
+                  [truncation-notice logs-total-chars])
                 [:div {:class "text-sm mb-1"}
                  logs]
                 [:div {:class (str (if (= logs-status "success")
@@ -66,13 +101,28 @@
   "config is a map with the following fields:
       :status -> possible values are :success :running :loading :failure. Anything different will be default to an generic error message
       :id -> id to differentiate more than one log on the same page.
-      :logs -> the actual string with the logs"
+      :logs -> the actual string with the logs
+
+   Output above `max-rendered-chars` is cut before it reaches the DOM; the full
+   string stays in the app db for the output menu."
   [type config]
-  (let [line-count (when (:response config)
-                     (count (clojure.string/split-lines (:response config))))
+  (let [full-response (:response config)
+        total-chars (count full-response)
+        truncated? (> total-chars max-rendered-chars)
+        ;; Derived from the bounded string, so no render walks the full payload.
+        display-response (if truncated?
+                           (subs full-response 0 max-rendered-chars)
+                           full-response)
+        line-count (when display-response
+                     (count (cs/split-lines display-response)))
         aria-label-text (str "Execution output. "
                              (case (:status config)
-                               :success (str "Status: success. " line-count " lines")
+                               :success (str "Status: success. "
+                                             line-count " lines"
+                                             (when truncated?
+                                               (str ", truncated for display out of "
+                                                    (humanize-size total-chars)
+                                                    " total")))
                                :running "Status: still running after gateway timeout"
                                :loading "Status: executing..."
                                :failure "Status: failed"
@@ -90,7 +140,9 @@
       (case type
         :logs
         [logs-area-list (:status config)
-         {:logs (:response config)
+         {:logs display-response
+          :logs-truncated? truncated?
+          :logs-total-chars total-chars
           :logs-status (:response-status config)
           :script (:script config)
           :execution-time (:execution-time config)

--- a/webapp/src/webapp/webclient/log_area/main.cljs
+++ b/webapp/src/webapp/webclient/log_area/main.cljs
@@ -62,11 +62,15 @@
                           :classes "h-full"}
             tabular-status (:status @script-response)
             tabular-loading? (= tabular-status :loading)
-            results-transformed (transform-results->matrix response connection-type)
-            results-heads (first results-transformed)
-            results-body (next results-transformed)
             connection-type-database? (some (partial = connection-type)
                                             ["mysql" "postgres" "sql-server" "oracledb" "mssql" "database"])
+            ;; papaparse + js->clj walk the whole payload on every render, and
+            ;; only database connections consume the matrix (Tabular tab,
+            ;; CSV/JSON downloads). Everything else paid the scan for nothing.
+            results-transformed (when connection-type-database?
+                                  (transform-results->matrix response connection-type))
+            results-heads (first results-transformed)
+            results-body (next results-transformed)
             available-tabs (merge
                             {:logs "Logs"}
                             (when (and connection-type-database?

--- a/webapp/src/webapp/webclient/panel.cljs
+++ b/webapp/src/webapp/webclient/panel.cljs
@@ -53,16 +53,33 @@
         object (js->clj (.parse js/JSON item))]
     (or (get object "code") "")))
 
-(def ^:private code-saved-status (r/atom :saved)) ; :edited | :saved
+(def ^:private code-saved-status (r/atom :saved)) ; :edited | :saved | :not-saved | :save-failed
 (def ^:private is-typing (r/atom false))
 (def ^:private typing-timer (r/atom nil))
 
-(defn- save-code-to-localstorage [code-string]
-  (let [code-tmp-db {:date (.now js/Date)
-                     :code code-string}
-        code-tmp-db-json (.stringify js/JSON (clj->js code-tmp-db))]
-    (.setItem js/localStorage :code-tmp-db code-tmp-db-json)
-    (reset! code-saved-status :saved)))
+(defn- quota-exceeded?
+  "Whether a storage write failed because the store is full, as opposed to
+  storage being unavailable. Older Firefox still reports the legacy name."
+  [e]
+  (and (instance? js/DOMException e)
+       (contains? #{"QuotaExceededError" "NS_ERROR_DOM_QUOTA_REACHED"} (.-name e))))
+
+(defn- save-code-to-localstorage
+  "Persists the editor draft.
+
+  Above ~5MB `setItem` throws QuotaExceededError; the uncaught throw used to
+  skip the status reset and leave the footer spinner running forever (EVL-121).
+  The write is atomic, so a rejected one leaves the previous draft in place —
+  we keep it and report the failure rather than discard the user's work."
+  [code-string]
+  (try
+    (let [code-tmp-db {:date (.now js/Date)
+                       :code code-string}]
+      (.setItem js/localStorage :code-tmp-db (.stringify js/JSON (clj->js code-tmp-db))))
+    (reset! code-saved-status :saved)
+    (catch :default e
+      (js/console.warn "failed persisting the editor draft to localStorage:" e)
+      (reset! code-saved-status (if (quota-exceeded? e) :not-saved :save-failed)))))
 
 
 (defmulti ^:private saved-status-el identity)
@@ -83,6 +100,24 @@
     [:> Spinner {:size "1" :color "gray"}]
     [:span {:class "text-xs italic"}
      "Edited"]]])
+(defn- draft-not-saved-el [tooltip]
+  [:> Tooltip {:content tooltip}
+   [:div {:class "flex flex-row-reverse text-gray-11"
+          :role "status"
+          :aria-live "polite"}
+    [:div {:class "flex items-center gap-small"}
+     [:> hero-solid-icon/ExclamationTriangleIcon {:class "h-4 w-4 shrink-0 text-warning-9"
+                                                  :aria-hidden "true"}]
+     [:span {:class "text-xs"}
+      "Draft not saved"]]]])
+(defmethod ^:private saved-status-el :not-saved [_]
+  [draft-not-saved-el (str "This script is too large for browser storage. It runs "
+                           "normally, but reloading the page restores your last "
+                           "saved draft instead.")])
+(defmethod ^:private saved-status-el :save-failed [_]
+  [draft-not-saved-el (str "This draft could not be saved to browser storage. It runs "
+                           "normally, but reloading the page restores your last "
+                           "saved draft instead.")])
 
 (def current-sql-parser (r/atom nil))
 


### PR DESCRIPTION
## 📝 Description

The web terminal froze when a command returned a large **output** — not when a large input was pasted.

The gateway returns up to 110MB of output (`sessionwal.DefaultMaxRead`) and the log area rendered all of it into a single unvirtualized `whitespace-pre` node. Chrome clamps layout at 2^25 px (33,554,432), which a single unwrapped line reaches at roughly 3.8M characters. Past that the element cannot lay out: blank viewport, multi-million-pixel horizontal scroll, and a frozen tab on any scroll attempt.

Isolated by holding the input constant and varying only the output. Same 15,728,646-byte input, two connections:

| connection | output | result |
|---|---|---|
| `mybash-wc` (`bash -c 'wc -c'`) | small | renders fine |
| `mybash` (plain `bash`, echoes input back as `command not found`) | ~15.7MB stderr | **freezes the tab** |

Output size is independent of input size, so capping input does not fix this — a 20-byte `cat /var/log/syslog` freezes the tab just as hard.

## 📣 User-facing impact

Running a command that returns a very large output no longer freezes the terminal tab. Output above 512KB is capped for display, with a notice pointing at the output menu for the complete result. Scripts too large for browser storage now show "Draft not saved" instead of a spinner that never stops.

## 🔗 Related Issue

Fixes [EVL-121](https://linear.app/hoophq/issue/EVL-121/)

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [x] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- **`log_area/logs.cljs`** — cap output at 512KB before it reaches the DOM and show a callout pointing at the output menu. The full string stays in the app db and is what the output menu receives, so download and copy are unaffected. The screen reader label now derives from the bounded string instead of running `split-lines` over the whole payload on every render.
- **`log_area/main.cljs`** — only run `papaparse` + `js->clj` for database connections. Everything else was scanning the full payload on every render to build a matrix that only the Tabular tab and CSV/JSON downloads read, neither of which is reachable for non-database connections.
- **`panel.cljs`** — catch the `QuotaExceededError` localStorage raises above ~5MB. The uncaught throw skipped the status reset and left the footer spinner running forever, which read as a hang. Adds a `:not-saved` state for quota failures and a `:save-failed` state for anything else, so the tooltip never claims "too large" for a failure that was not about size. The stale draft is deliberately not cleared — `setItem` is atomic, so a rejected write leaves the previous draft intact, and deleting it would turn a stale restore into real data loss.

## 🧪 Testing

Setup — a `bash` connection echoes its own input back on stderr, which is the easiest way to generate large output:

```
hoop admin create connection mybash -a <agent> -- bash
openssl rand -hex 7864320 | tr -d '\n' | pbcopy
```

Paste into the web terminal on `mybash` and run.

1. **The freeze** — before: blank output area, enormous horizontal scroll, scrolling freezes the tab. After: an amber callout `Output truncated for display — showing the first 512.0 KB of 15.0 MB`, followed by readable output, scrolling stays responsive.
2. **Full output still reachable** — output menu (`···`) → *Download as TXT* returns the complete output, not the 512KB shown. *Copy logs content* copies the full string.
3. **No truncation below the cap** — output under 512KB renders in full with no callout, exactly as before.
4. **Draft quota** — paste anything above ~5MB into the editor and pause. Before: spinner next to *Edited* spins forever, uncaught `QuotaExceededError` in the console. After: *Draft not saved* with a warning icon and a tooltip explaining that a reload restores the last saved draft.
5. **No regression** — run a small query on a database connection. Tabular tab still populates, CSV/JSON downloads still work, no truncation callout.

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS 15 (Darwin 25.4.0)

### Tests performed:
- [x] Unit tests pass <!-- no CLJS test suite covers these namespaces -->
- [x] Integration tests pass <!-- N/A -->
- [x] Manual testing completed

## 📸 Screenshots

<img width="3024" height="1804" alt="CleanShot 2026-08-11 at 16 54 56@2x" src="https://github.com/user-attachments/assets/7412d211-566c-48d0-a381-92af67298fdd" />

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes <!-- no test suite covers these namespaces -->
- [x] I have checked my code and corrected any misspellings
