### PR TITLE
refactor: optimize ListSessions query and add session index creation

### DIFF
--- a/gateway/migrations/000109_session_list_indexes.down.sql
+++ b/gateway/migrations/000109_session_list_indexes.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+SET search_path TO private;
+
+DROP INDEX IF EXISTS index_sessions_org_created_at;
+
+COMMIT;

--- a/gateway/migrations/000109_session_list_indexes.up.sql
+++ b/gateway/migrations/000109_session_list_indexes.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+SET search_path TO private;
+
+CREATE INDEX IF NOT EXISTS index_sessions_org_created_at
+    ON sessions (org_id, created_at DESC, id DESC);
+
+COMMIT;

--- a/gateway/models/session.go
+++ b/gateway/models/session.go
@@ -284,22 +284,12 @@ func GetSessionByID(orgID, sid string) (*Session, error) {
 	return session, nil
 }
 
-func ListSessions(orgID string, userId string, isAuditorOrAdmin bool, opt SessionOption) (*SessionList, error) {
-	sessionList := &SessionList{Items: []Session{}}
-	// Prepare lowercase jira issue keys array
-	var jiraIssueKeysLower pq.StringArray
-	if len(opt.JiraIssueKey) > 0 {
-		jiraIssueKeysLower = make(pq.StringArray, len(opt.JiraIssueKey))
-		for i, key := range opt.JiraIssueKey {
-			jiraIssueKeysLower[i] = strings.ToLower(key)
-		}
-	}
-	return sessionList, DB.Transaction(func(tx *gorm.DB) error {
-		err := tx.Raw(`
-		SELECT COUNT(s.id)
-		FROM private.sessions s
-		LEFT JOIN private.reviews AS rv ON rv.session_id = s.id
-		WHERE s.org_id = @org_id AND
+// sessionListFilterConditions is the WHERE clause shared by the count and the
+// page queries in ListSessions. It MUST stay identical in both so the reported
+// total always matches the returned rows. It references `s` (private.sessions)
+// and `rv` (private.reviews, LEFT JOINed on org_id + session_id).
+const sessionListFilterConditions = `
+		s.org_id = @org_id AND
 		CASE WHEN (@is_auditor_or_admin) = false AND s.user_id != @user_id
 				THEN
 					EXISTS (
@@ -341,26 +331,65 @@ func ListSessions(orgID string, userId string, isAuditorOrAdmin bool, opt Sessio
 				THEN s.created_at BETWEEN @start_date AND @end_date
 				ELSE true
 			END
-		)`, map[string]any{
-			"org_id":                orgID,
-			"filter_user_id":        opt.User,
-			"connection":            opt.ConnectionName,
-			"connection_type":       opt.ConnectionType,
-			"review_status":         opt.ReviewStatus,
-			"review_approver_email": opt.ReviewApproverEmail,
-			"batch_id":              opt.BatchID,
-			"correlation_id":        opt.CorrelationID,
-			"jira_issue_keys":       jiraIssueKeysLower,
-			"start_date":            opt.StartDate,
-			"end_date":              opt.EndDate,
-			"is_auditor_or_admin":   isAuditorOrAdmin,
-			"user_id":               userId,
-		}).First(&sessionList.Total).Error
+		)`
+
+func ListSessions(orgID string, userId string, isAuditorOrAdmin bool, opt SessionOption) (*SessionList, error) {
+	sessionList := &SessionList{Items: []Session{}}
+	// Prepare lowercase jira issue keys array
+	var jiraIssueKeysLower pq.StringArray
+	if len(opt.JiraIssueKey) > 0 {
+		jiraIssueKeysLower = make(pq.StringArray, len(opt.JiraIssueKey))
+		for i, key := range opt.JiraIssueKey {
+			jiraIssueKeysLower[i] = strings.ToLower(key)
+		}
+	}
+	queryAttrs := map[string]any{
+		"org_id":                orgID,
+		"filter_user_id":        opt.User,
+		"connection":            opt.ConnectionName,
+		"connection_type":       opt.ConnectionType,
+		"review_status":         opt.ReviewStatus,
+		"review_approver_email": opt.ReviewApproverEmail,
+		"batch_id":              opt.BatchID,
+		"correlation_id":        opt.CorrelationID,
+		"jira_issue_keys":       jiraIssueKeysLower,
+		"start_date":            opt.StartDate,
+		"end_date":              opt.EndDate,
+		"is_auditor_or_admin":   isAuditorOrAdmin,
+		"user_id":               userId,
+		"limit":                 opt.Limit,
+		"offset":                opt.Offset,
+	}
+	return sessionList, DB.Transaction(func(tx *gorm.DB) error {
+		err := tx.Raw(`
+		SELECT COUNT(s.id)
+		FROM private.sessions s
+		LEFT JOIN private.reviews AS rv ON rv.org_id = s.org_id AND rv.session_id = s.id
+		WHERE`+sessionListFilterConditions, queryAttrs).First(&sessionList.Total).Error
 		if err != nil {
 			return fmt.Errorf("unable to obtain total count of sessions, reason=%v", err)
 		}
 
+		// Resolve the page of session ids first over sessions + reviews only,
+		// then join the heavy parts (connections, blobs, review JSON) against
+		// that page. The expensive projections — detoasting the input blob for
+		// octet_length and building the review jsonb with its correlated
+		// review_groups aggregate — therefore run for at most @limit rows
+		// instead of every session matching the filter.
+		//
+		// The org_id predicates on the blobs/reviews joins are required for
+		// index use: neither table has an index on its id/session_id column
+		// alone, only UNIQUE(org_id, ...) composite ones.
 		err = tx.Raw(`
+		WITH page AS (
+			SELECT s.id
+			FROM private.sessions s
+			LEFT JOIN private.reviews AS rv ON rv.org_id = s.org_id AND rv.session_id = s.id
+			WHERE`+sessionListFilterConditions+`
+			ORDER BY s.created_at DESC, s.id DESC
+			LIMIT @limit
+			OFFSET @offset
+		)
 		SELECT
 			s.id, s.org_id, s.connection, s.connection_type, s.connection_subtype, s.connection_tags, s.verb, s.labels, s.exit_code,
 			s.user_id, s.user_name, s.user_email, s.status, s.metadata, s.integrations_metadata, s.metrics, s.session_batch_id,
@@ -398,73 +427,13 @@ func ListSessions(orgID string, userId string, isAuditorOrAdmin bool, opt Sessio
 				)
 			END AS review,
 			s.created_at, s.ended_at
-		FROM private.sessions s
+		FROM page
+		INNER JOIN private.sessions s ON s.id = page.id
 		LEFT JOIN private.connections c ON c.org_id = s.org_id AND c.name = s.connection
-		LEFT JOIN private.blobs b ON b.id = s.blob_input_id
-		LEFT JOIN private.reviews AS rv ON rv.session_id = s.id
-		WHERE s.org_id = @org_id AND
-		CASE WHEN (@is_auditor_or_admin) = false AND s.user_id != @user_id
-				THEN
-					EXISTS (
-						SELECT 1 FROM private.users u
-						INNER JOIN private.user_groups ug ON ug.user_id = u.id
-						INNER JOIN private.review_groups rg ON rg.group_name = ug.name
-						WHERE rg.review_id = rv.id AND u.subject = @user_id
-					)
-				ELSE true
-		END AND
-		(
-			COALESCE(s.user_id::text, '') LIKE @filter_user_id AND
-			COALESCE(s.connection::text, '') LIKE @connection AND
-			COALESCE(s.connection_type::text, '')::TEXT LIKE @connection_type AND
-			COALESCE(rv.status::text, '')::TEXT LIKE @review_status AND
-			CASE WHEN (@review_approver_email)::TEXT IS NOT NULL
-				THEN
-					EXISTS (
-						SELECT 1 FROM private.users u
-						INNER JOIN private.user_groups ug ON ug.user_id = u.id
-						INNER JOIN private.review_groups rg ON rg.group_name = ug.name
-						WHERE rg.review_id = rv.id AND u.email = @review_approver_email
-					)
-				ELSE true
-			END AND
-			CASE WHEN (@batch_id)::TEXT IS NOT NULL
-				THEN s.session_batch_id = @batch_id
-				ELSE true
-			END AND
-			CASE WHEN (@correlation_id)::TEXT IS NOT NULL
-				THEN s.correlation_id = @correlation_id
-				ELSE true
-			END AND
-			CASE WHEN (@jira_issue_keys)::text[] IS NOT NULL AND array_length((@jira_issue_keys)::text[], 1) > 0
-				THEN LOWER(s.integrations_metadata->>'jira_issue_key') = ANY((@jira_issue_keys)::text[])
-				ELSE true
-			END AND
-			CASE WHEN (@start_date)::text IS NOT NULL
-				THEN s.created_at BETWEEN @start_date AND @end_date
-				ELSE true
-			END
-		)
-		ORDER BY s.created_at DESC
-		LIMIT @limit
-		OFFSET @offset
-		`, map[string]any{
-			"org_id":                orgID,
-			"filter_user_id":        opt.User,
-			"connection":            opt.ConnectionName,
-			"connection_type":       opt.ConnectionType,
-			"review_status":         opt.ReviewStatus,
-			"review_approver_email": opt.ReviewApproverEmail,
-			"batch_id":              opt.BatchID,
-			"correlation_id":        opt.CorrelationID,
-			"jira_issue_keys":       jiraIssueKeysLower,
-			"start_date":            opt.StartDate,
-			"end_date":              opt.EndDate,
-			"limit":                 opt.Limit,
-			"offset":                opt.Offset,
-			"is_auditor_or_admin":   isAuditorOrAdmin,
-			"user_id":               userId,
-		}).Find(&sessionList.Items).Error
+		LEFT JOIN private.blobs b ON b.org_id = s.org_id AND b.id = s.blob_input_id
+		LEFT JOIN private.reviews AS rv ON rv.org_id = s.org_id AND rv.session_id = s.id
+		ORDER BY s.created_at DESC, s.id DESC
+		`, queryAttrs).Find(&sessionList.Items).Error
 		if err == nil {
 			sessionList.HasNextPage = len(sessionList.Items) == opt.Limit
 		}


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
>
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Optimizes the `ListSessions` query in the gateway to avoid running the expensive projections (input blob detoasting for `octet_length` and the review `jsonb` construction with its correlated `review_groups` aggregate) for every session matching the filter. The query now resolves the page of session IDs first in a `page` CTE over `sessions` + `reviews` only, and joins the heavy parts (`connections`, `blobs`, review JSON) against that page — so the costly work runs for at most `limit` rows instead of the full filtered set.

A new composite index `index_sessions_org_created_at ON sessions (org_id, created_at DESC, id DESC)` supports the pagination
ordering, and `org_id` predicates were added to the `blobs`/`reviews` joins so their `UNIQUE(org_id, ...)` composite indexes can be
used.

## 🔗 Related Issue

N/A

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [x] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Added migration `000109_session_list_indexes` creating `index_sessions_org_created_at` on `sessions (org_id, created_at DESC, id DESC)` (with matching down migration).
- Rewrote the `ListSessions` page query to resolve session IDs in a `page` CTE first, then join `connections`, `blobs`, and `reviews` only against the paged rows.
- Extracted the shared WHERE clause into a `sessionListFilterConditions` constant so the count and page queries can never drift apart, and deduplicated the query parameters into a single `queryAttrs` map.
- Added `org_id` to the `blobs` and `reviews` join predicates to enable their composite `UNIQUE(org_id, ...)` indexes.
- Made the ordering deterministic by adding `s.id DESC` as a tiebreaker to `ORDER BY s.created_at DESC`.

## 🧪 Testing

Manually validated the sessions list end-to-end: ran the migration, exercised the sessions page in the webapp (pagination, user/connection/type/review status/date range/Jira issue key filters) as both admin and non-admin users, and confirmed the returned rows, totals, and ordering match the previous behavior.

### Test Configuration:

- **Browser(s)**: Brave
- **OS**: macOS

### Tests performed:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- The count query and the page CTE intentionally share the exact same WHERE clause (`sessionListFilterConditions`) so `total` always matches the returned rows.
- Non-admin/non-auditor access control semantics are unchanged: users still only see their own sessions or sessions whose review groups they belong to.
