### PR TITLE
fix(rdp): apply connection data masking rules

### DIFF
--- a/agentrs/src/piigate/analyze.rs
+++ b/agentrs/src/piigate/analyze.rs
@@ -557,7 +557,8 @@ mod tests {
             presidio_url: base.to_string(),
             params: AnalysisParams {
                 score_threshold: 0.5,
-                entity_denylist: vec![],
+                entity_allowlist: vec!["US_SSN".into()],
+                entity_denylist: Vec::new(),
                 band_padding: 8,
                 max_ocr_concurrency: 4,
             },

--- a/agentrs/src/piigate/config.rs
+++ b/agentrs/src/piigate/config.rs
@@ -1,10 +1,10 @@
 //! Resolving the agent-side PII guard configuration for a session.
 //!
-//! Policy (enable decision, score threshold, denylist, band padding) is sent
-//! by the gateway in the SessionStarted metadata. Endpoints (Presidio
-//! analyzer, OCR sidecar) come from the agent's own environment — the
-//! sidecar and analyzer live in the customer network next to the agent, so
-//! their addresses are deliberately NOT carried on the wire or held in
+//! The enable decision, resource entity allowlist, score threshold, and band
+//! padding are sent by the gateway in SessionStarted metadata. Endpoints
+//! (Presidio analyzer, OCR sidecar) come from the agent's own environment —
+//! the sidecar and analyzer live in the customer network next to the agent,
+//! so their addresses are deliberately NOT carried on the wire or held in
 //! gateway state. This mirrors the Go agent's terminal-DLP precedent, where
 //! the agent reads MSPRESIDIO_ANALYZER_URL from its environment.
 
@@ -95,11 +95,16 @@ impl GuardConfig {
         if let Some(v) = metadata.get("pii_band_padding").and_then(|s| s.parse().ok()) {
             params.band_padding = v;
         }
-        if let Some(list) = metadata.get("pii_entity_denylist") {
-            // JSON array (entity names are an external vocabulary, not
-            // guaranteed comma-free). A malformed value keeps the default
-            // denylist rather than failing the session — the policy is
-            // advisory, the enforcement is the gate itself.
+        if let Some(list) = metadata.get("pii_entity_allowlist") {
+            // JSON array: entity names use Presidio's external vocabulary and
+            // must not rely on being comma-free.
+            match serde_json::from_str::<Vec<String>>(list) {
+                Ok(entities) => params.entity_allowlist = entities,
+                Err(e) => warn!(%sid, "piigate: ignoring malformed pii_entity_allowlist: {e}"),
+            }
+        } else if let Some(list) = metadata.get("pii_entity_denylist") {
+            // Compatibility with gateways predating connection-scoped
+            // allowlists. The v2 allowlist takes precedence when both exist.
             match serde_json::from_str::<Vec<String>>(list) {
                 Ok(entities) => params.entity_denylist = entities,
                 Err(e) => warn!(%sid, "piigate: ignoring malformed pii_entity_denylist: {e}"),
@@ -197,7 +202,7 @@ mod tests {
                     ("pii_guard", "enabled"),
                     ("pii_score_threshold", "0.75"),
                     ("pii_band_padding", "30"),
-                    ("pii_entity_denylist", r#"["DATE_TIME","NRP"]"#),
+                    ("pii_entity_allowlist", r#"["DATE_TIME","PERSON"]"#),
                 ]),
                 "sid",
             )
@@ -207,6 +212,24 @@ mod tests {
             assert_eq!(cfg.ocr_url, "http://ocr:8868");
             assert_eq!(cfg.params.score_threshold, 0.75);
             assert_eq!(cfg.params.band_padding, 30);
+            assert_eq!(cfg.params.entity_allowlist, vec!["DATE_TIME", "PERSON"]);
+            assert!(cfg.params.entity_denylist.is_empty());
+        });
+    }
+
+    #[test]
+    fn resolves_legacy_gateway_denylist_when_allowlist_is_absent() {
+        with_endpoints(Some("http://p"), Some("http://o"), || {
+            let cfg = GuardConfig::resolve(
+                &md(&[
+                    ("pii_guard", "enabled"),
+                    ("pii_entity_denylist", r#"["DATE_TIME","NRP"]"#),
+                ]),
+                "sid",
+            )
+            .unwrap()
+            .unwrap();
+            assert!(cfg.params.entity_allowlist.is_empty());
             assert_eq!(cfg.params.entity_denylist, vec!["DATE_TIME", "NRP"]);
         });
     }
@@ -240,6 +263,7 @@ mod tests {
             assert_eq!(cfg.params.score_threshold, d.score_threshold);
             assert_eq!(cfg.params.band_padding, d.band_padding);
             assert_eq!(cfg.params.entity_denylist, d.entity_denylist);
+            assert_eq!(cfg.params.entity_allowlist, d.entity_allowlist);
         });
     }
 

--- a/agentrs/src/piigate/presidio.rs
+++ b/agentrs/src/piigate/presidio.rs
@@ -1,7 +1,7 @@
 //! Presidio analyzer client and the post-OCR analysis stage.
 //!
 //! Port of `gateway/rdp/analyzer/presidio.go` and the `analyzeText` stage of
-//! `gateway/rdp/analyzer/worker.go`: Presidio analysis, denylist filtering,
+//! `gateway/rdp/analyzer/worker.go`: Presidio analysis, entity-policy filtering,
 //! and mapping entity character ranges back to pixel bounding boxes.
 
 use std::collections::HashMap;
@@ -18,6 +18,8 @@ struct AnalyzerRequest<'a> {
     text: &'a str,
     language: &'a str,
     score_threshold: f64,
+    #[serde(skip_serializing_if = "<[String]>::is_empty")]
+    entities: &'a [String],
 }
 
 /// A single PII entity found by Presidio.
@@ -76,24 +78,24 @@ impl PresidioClient {
         })
     }
 
-    /// Sends text to Presidio for PII detection. `score_threshold` is the
-    /// minimum confidence (0 falls back to 0.5, matching the Go client).
+    /// Sends text to Presidio for PII detection.
     pub async fn analyze(
         &self,
         text: &str,
         score_threshold: f64,
+        entity_allowlist: &[String],
     ) -> anyhow::Result<Vec<AnalyzerResult>> {
         if text.is_empty() {
             return Ok(Vec::new());
         }
-        let threshold = if score_threshold > 0.0 { score_threshold } else { 0.5 };
         let resp = self
             .client
             .post(format!("{}/analyze", self.analyzer_url))
             .json(&AnalyzerRequest {
                 text,
                 language: "en",
-                score_threshold: threshold,
+                score_threshold,
+                entities: entity_allowlist,
             })
             .send()
             .await
@@ -111,13 +113,14 @@ impl PresidioClient {
     }
 }
 
-/// Analysis tuning, delivered by the gateway in the session setup (mirrors
-/// the gateway's `AnalysisParams`).
+/// Analysis tuning delivered by the gateway in the session setup.
 #[derive(Debug, Clone)]
 pub struct AnalysisParams {
-    /// Minimum Presidio score (gateway default 0.9).
+    /// Minimum Presidio score.
     pub score_threshold: f64,
-    /// Entity types to exclude (gateway default DATE_TIME, NRP).
+    /// Entity types selected by the resource's DataMaskingRules.
+    pub entity_allowlist: Vec<String>,
+    /// Legacy entity exclusions sent by gateways predating resource allowlists.
     pub entity_denylist: Vec<String>,
     /// Vertical padding around dirty rects AND parallel-chunk overlap.
     pub band_padding: usize,
@@ -128,8 +131,9 @@ pub struct AnalysisParams {
 impl Default for AnalysisParams {
     fn default() -> Self {
         Self {
-            score_threshold: 0.9,
-            entity_denylist: vec!["DATE_TIME".into(), "NRP".into()],
+            score_threshold: 0.5,
+            entity_allowlist: Vec::new(),
+            entity_denylist: Vec::new(),
             band_padding: super::bands::DEFAULT_BAND_PADDING,
             max_ocr_concurrency: 8,
         }
@@ -183,8 +187,16 @@ fn map_entity_to_bbox(entity: &AnalyzerResult, ranges: &[WordRange<'_>]) -> Opti
     bbox.map(|(x, y, x2, y2)| (x, y, x2 - x, y2 - y))
 }
 
-/// The post-OCR stage: Presidio analysis, denylist filtering, and mapping
-/// entity character ranges back to pixel bounding boxes. Word coordinates
+fn entity_is_selected(entity_type: &str, params: &AnalysisParams) -> bool {
+    if params.entity_allowlist.is_empty() {
+        !params.entity_denylist.iter().any(|entity| entity == entity_type)
+    } else {
+        params.entity_allowlist.iter().any(|entity| entity == entity_type)
+    }
+}
+
+/// The post-OCR stage: Presidio entity-policy filtering and mapping entity
+/// character ranges back to pixel bounding boxes. Word coordinates
 /// must already be in full-screen space and `text` must be the words joined
 /// by single spaces (so Presidio character offsets line up with word ranges).
 pub async fn analyze_text(
@@ -193,8 +205,10 @@ pub async fn analyze_text(
     words: &[Word],
     params: &AnalysisParams,
 ) -> anyhow::Result<SnapshotResult> {
-    let mut results = presidio.analyze(text, params.score_threshold).await?;
-    results.retain(|r| !params.entity_denylist.iter().any(|d| d == &r.entity_type));
+    let mut results = presidio
+        .analyze(text, params.score_threshold, &params.entity_allowlist)
+        .await?;
+    results.retain(|result| entity_is_selected(&result.entity_type, params));
 
     let mut res = SnapshotResult::default();
     for r in &results {
@@ -222,6 +236,29 @@ pub async fn analyze_text(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn analyzer_request_includes_allowlist_and_preserves_zero_threshold() {
+        let entities = vec!["DATE_TIME".to_string(), "PERSON".to_string()];
+        let request = AnalyzerRequest {
+            text: "August 12, 2026 Lucas",
+            language: "en",
+            score_threshold: 0.0,
+            entities: &entities,
+        };
+
+        let payload = serde_json::to_value(request).unwrap();
+        assert_eq!(payload["score_threshold"], 0.0);
+        assert_eq!(payload["entities"], serde_json::json!(["DATE_TIME", "PERSON"]));
+    }
+
+    #[test]
+    fn legacy_denylist_filters_when_allowlist_is_absent() {
+        let mut params = AnalysisParams::default();
+        params.entity_denylist = vec!["DATE_TIME".into(), "NRP".into()];
+        assert!(!entity_is_selected("DATE_TIME", &params));
+        assert!(entity_is_selected("PERSON", &params));
+    }
 
     fn word(text: &str, left: usize, top: usize, w: usize, h: usize) -> Word {
         Word {

--- a/agentrs/src/ws/client.rs
+++ b/agentrs/src/ws/client.rs
@@ -189,8 +189,8 @@ impl WebSocket {
     }
 
     /// Sends the connection-scoped capability advertisement. Carries the
-    /// agent's `supports_pii_guard` flag (both Presidio + OCR endpoints set).
-    /// The frame is addressed with the well-known control sentinel sid, not a
+    /// agent's PII guard endpoint readiness and entity-policy support. The
+    /// frame is addressed with the well-known control sentinel sid, not a
     /// session id — the gateway dispatches it by message type at the
     /// connection level.
     async fn send_capabilities(ws_sender: &WsWriter) -> anyhow::Result<()> {
@@ -199,6 +199,7 @@ impl WebSocket {
             "supports_pii_guard".to_string(),
             crate::piigate::config::supports_pii_guard().to_string(),
         );
+        metadata.insert("supports_pii_entity_allowlist".to_string(), "true".to_string());
         let msg = WebSocketMessage::new(MessageType::Capabilities, metadata, Vec::new());
         let framed = msg
             .encode_with_header(CONTROL_SENTINEL_SID)

--- a/gateway/api/datamasking/datamasking.go
+++ b/gateway/api/datamasking/datamasking.go
@@ -3,6 +3,7 @@ package apigdatamasking
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -55,12 +56,67 @@ type RulePayload struct {
 	ConnectionIDs        []string
 }
 
+func rulePayloadFromRequest(req *openapi.DataMaskingRuleRequest) RulePayload {
+	supportedEntityTypes := make([]models.SupportedEntityTypesEntry, len(req.SupportedEntityTypes))
+	for i, entityType := range req.SupportedEntityTypes {
+		supportedEntityTypes[i] = models.SupportedEntityTypesEntry{
+			Name:        entityType.Name,
+			EntityTypes: entityType.EntityTypes,
+		}
+	}
+	customEntityTypes := make([]models.CustomEntityTypesEntry, len(req.CustomEntityTypesEntrys))
+	for i, entityType := range req.CustomEntityTypesEntrys {
+		customEntityTypes[i] = models.CustomEntityTypesEntry{
+			Name:     entityType.Name,
+			Regex:    entityType.Regex,
+			DenyList: entityType.DenyList,
+			Score:    entityType.Score,
+		}
+	}
+	return RulePayload{
+		SupportedEntityTypes: supportedEntityTypes,
+		CustomEntityTypes:    customEntityTypes,
+		ScoreThreshold:       req.ScoreThreshold,
+		ConnectionIDs:        req.ConnectionIDs,
+	}
+}
+
+func validateSupportedEntityTypes(name string, entityTypes []string) error {
+	if len(entityTypes) == 0 || name == "" {
+		return fmt.Errorf("missing entity types or name in supported entity types")
+	}
+	if name != strings.ToUpper(name) {
+		return fmt.Errorf("entity type name must be uppercase: %s", name)
+	}
+	for _, entityType := range entityTypes {
+		if !isCanonicalEntityType(entityType) {
+			return fmt.Errorf("entity type must contain only uppercase letters, digits, or underscores: %q", entityType)
+		}
+	}
+	return nil
+}
+
+func isCanonicalEntityType(entityType string) bool {
+	if entityType == "" {
+		return false
+	}
+	for i := 0; i < len(entityType); i++ {
+		c := entityType[i]
+		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' {
+			return false
+		}
+	}
+	return true
+}
+
 // ValidateRulePayload runs the field-level checks the HTTP API enforces on data
 // masking rule create/update requests: score range, connection ID format, entity-type
 // name shape, and required regex/deny_list/name on custom entries. Independent of
 // license type — call ValidateOSSLimits separately for OSS gating.
 func ValidateRulePayload(p RulePayload) error {
-	if p.ScoreThreshold != nil && (*p.ScoreThreshold < 0 || *p.ScoreThreshold > 1) {
+	if p.ScoreThreshold != nil &&
+		(math.IsNaN(*p.ScoreThreshold) || math.IsInf(*p.ScoreThreshold, 0) ||
+			*p.ScoreThreshold < 0 || *p.ScoreThreshold > 1) {
 		return fmt.Errorf("score threshold must be between 0 and 1")
 	}
 	for _, connID := range p.ConnectionIDs {
@@ -69,11 +125,8 @@ func ValidateRulePayload(p RulePayload) error {
 		}
 	}
 	for _, e := range p.SupportedEntityTypes {
-		if len(e.EntityTypes) == 0 || e.Name == "" {
-			return fmt.Errorf("missing entity types or name in supported entity types")
-		}
-		if e.Name != strings.ToUpper(e.Name) {
-			return fmt.Errorf("entity type name must be uppercase: %s", e.Name)
+		if err := validateSupportedEntityTypes(e.Name, e.EntityTypes); err != nil {
+			return err
 		}
 	}
 	for _, e := range p.CustomEntityTypes {
@@ -159,7 +212,7 @@ func Post(c *gin.Context) {
 		return
 	}
 	ctx := storagev2.ParseContext(c)
-	req := parseRequestPayload(c)
+	req, payload := parseRequestPayload(c)
 	if req == nil {
 		return
 	}
@@ -183,22 +236,8 @@ func Post(c *gin.Context) {
 		}
 	}
 
-	supportedEntityTypes := []models.SupportedEntityTypesEntry{}
-	for _, entityType := range req.SupportedEntityTypes {
-		supportedEntityTypes = append(supportedEntityTypes, models.SupportedEntityTypesEntry{
-			Name:        entityType.Name,
-			EntityTypes: entityType.EntityTypes,
-		})
-	}
-	customEntityTypes := []models.CustomEntityTypesEntry{}
-	for _, entityType := range req.CustomEntityTypesEntrys {
-		customEntityTypes = append(customEntityTypes, models.CustomEntityTypesEntry{
-			Name:     entityType.Name,
-			Regex:    entityType.Regex,
-			DenyList: entityType.DenyList,
-			Score:    entityType.Score,
-		})
-	}
+	supportedEntityTypes := payload.SupportedEntityTypes
+	customEntityTypes := payload.CustomEntityTypes
 
 	rule, err := models.CreateDataMaskingRule(&models.DataMaskingRule{
 		ID:                   uuid.NewString(),
@@ -259,7 +298,7 @@ func Put(c *gin.Context) {
 		return
 	}
 	ctx := storagev2.ParseContext(c)
-	req := parseRequestPayload(c)
+	req, payload := parseRequestPayload(c)
 	if req == nil {
 		return
 	}
@@ -292,22 +331,8 @@ func Put(c *gin.Context) {
 		}
 	}
 
-	supportedEntityTypes := []models.SupportedEntityTypesEntry{}
-	for _, entityType := range req.SupportedEntityTypes {
-		supportedEntityTypes = append(supportedEntityTypes, models.SupportedEntityTypesEntry{
-			Name:        entityType.Name,
-			EntityTypes: entityType.EntityTypes,
-		})
-	}
-	customEntityTypes := []models.CustomEntityTypesEntry{}
-	for _, entityType := range req.CustomEntityTypesEntrys {
-		customEntityTypes = append(customEntityTypes, models.CustomEntityTypesEntry{
-			Name:     entityType.Name,
-			Regex:    entityType.Regex,
-			DenyList: entityType.DenyList,
-			Score:    entityType.Score,
-		})
-	}
+	supportedEntityTypes := payload.SupportedEntityTypes
+	customEntityTypes := payload.CustomEntityTypes
 
 	evt := audit.NewEvent(audit.ResourceDataMasking, audit.ActionUpdate).
 		Resource(ruleID, req.Name).
@@ -482,45 +507,20 @@ func upsertDatamaskingRuleAttributes(ctx *storagev2.Context, ruleName string, at
 	return models.UpsertDatamaskingRuleAttributes(models.DB, orgID, ruleName, attributeNames)
 }
 
-// parseRequestPayload parses and validates the openapi-shaped HTTP request body.
-// Keep validation rules in sync with ValidateRulePayload, which mirrors these checks
-// for callers that work with model types (e.g. the MCP server).
-func parseRequestPayload(c *gin.Context) *openapi.DataMaskingRuleRequest {
+// parseRequestPayload parses the openapi-shaped HTTP body and validates it
+// through the same model-shaped contract used by the MCP server. The returned
+// RulePayload is also the persistence shape, avoiding a second conversion.
+func parseRequestPayload(c *gin.Context) (*openapi.DataMaskingRuleRequest, RulePayload) {
 	req := openapi.DataMaskingRuleRequest{}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		log.Errorf("failed parsing request payload, err=%v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
-		return nil
+		return nil, RulePayload{}
 	}
-	if req.ScoreThreshold != nil && (*req.ScoreThreshold < 0 || *req.ScoreThreshold > 1) {
-		c.JSON(http.StatusBadRequest, gin.H{"message": "score threshold must be between 0 and 1"})
-		return nil
+	payload := rulePayloadFromRequest(&req)
+	if err := ValidateRulePayload(payload); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return nil, RulePayload{}
 	}
-	for _, connID := range req.ConnectionIDs {
-		if _, err := uuid.Parse(connID); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"message": "invalid connection ID " + connID})
-			return nil
-		}
-	}
-	for _, e := range req.SupportedEntityTypes {
-		if len(e.EntityTypes) == 0 || e.Name == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"message": "missing entity types or name in supported entity types"})
-			return nil
-		}
-		if e.Name != strings.ToUpper(e.Name) {
-			c.JSON(http.StatusBadRequest, gin.H{"message": "entity type name must be uppercase: " + e.Name})
-			return nil
-		}
-	}
-	for _, e := range req.CustomEntityTypesEntrys {
-		if e.Name == "" || len(e.DenyList) == 0 && e.Regex == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"message": "missing name, deny_list or regex in custom entity types"})
-			return nil
-		}
-		if e.Name != strings.ToUpper(e.Name) {
-			c.JSON(http.StatusBadRequest, gin.H{"message": "entity type name must be uppercase: " + e.Name})
-			return nil
-		}
-	}
-	return &req
+	return &req, payload
 }

--- a/gateway/api/datamasking/datamasking_validation_test.go
+++ b/gateway/api/datamasking/datamasking_validation_test.go
@@ -1,0 +1,76 @@
+package apigdatamasking
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/gateway/models"
+)
+
+func TestValidateRulePayloadValidatesSupportedEntityTypeIdentifiers(t *testing.T) {
+	tests := []struct {
+		name    string
+		entity  string
+		wantErr bool
+	}{
+		{name: "canonical", entity: "DATE_TIME"},
+		{name: "empty", entity: "", wantErr: true},
+		{name: "whitespace", entity: " PERSON ", wantErr: true},
+		{name: "lowercase", entity: "person", wantErr: true},
+		{name: "punctuation", entity: "PERSON-NAME", wantErr: true},
+		{name: "non ASCII", entity: "PÉRSON", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRulePayload(RulePayload{
+				SupportedEntityTypes: []models.SupportedEntityTypesEntry{{
+					Name:        "CUSTOM_SELECTION",
+					EntityTypes: []string{tt.entity},
+				}},
+			})
+			if tt.wantErr && err == nil {
+				t.Fatal("expected invalid entity type to be rejected")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("canonical entity type rejected: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRulePayloadRejectsNonFiniteScoreThresholds(t *testing.T) {
+	for _, threshold := range []float64{math.NaN(), math.Inf(-1), math.Inf(1)} {
+		t.Run(fmt.Sprint(threshold), func(t *testing.T) {
+			if err := ValidateRulePayload(RulePayload{ScoreThreshold: &threshold}); err == nil {
+				t.Fatal("expected non-finite score threshold to be rejected")
+			}
+		})
+	}
+}
+
+func TestParseRequestPayloadRejectsNonCanonicalSupportedEntityType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/datamasking-rules", strings.NewReader(`{
+		"name": "invalid",
+		"supported_entity_types": [{"name": "CUSTOM_SELECTION", "entity_types": ["person"]}]
+	}`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	if req, _ := parseRequestPayload(ctx); req != nil {
+		t.Fatalf("non-canonical entity type parsed successfully: %#v", req)
+	}
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(recorder.Body.String(), "uppercase letters") {
+		t.Fatalf("unexpected response body: %s", recorder.Body.String())
+	}
+}

--- a/gateway/broker/headers.go
+++ b/gateway/broker/headers.go
@@ -43,6 +43,10 @@ const (
 // and OCR sidecar endpoints configured).
 const CapabilitySupportsPIIGuard = "supports_pii_guard"
 
+// CapabilitySupportsPIIEntityAllowlist distinguishes agents that understand
+// the connection-scoped entity-selection metadata from legacy guard agents.
+const CapabilitySupportsPIIEntityAllowlist = "supports_pii_entity_allowlist"
+
 // ControlSentinelSID is the well-known sid used for connection-scoped control
 // frames (those that describe the agent connection, not a session). The wire
 // format requires a non-nil, versioned UUID in every header, so these frames

--- a/gateway/broker/protocol_rdp.go
+++ b/gateway/broker/protocol_rdp.go
@@ -36,10 +36,10 @@ func (h *RDPHandler) HandleData(session *Session, msg *WebSocketMessage) error {
 // from its own environment, keeping customer-network infra out of gateway
 // state. Only the enable decision and analysis policy travel here.
 type RDPGuardConfig struct {
-	Enabled        bool
-	ScoreThreshold float64
-	EntityDenylist []string
-	BandPadding    int
+	Enabled         bool
+	ScoreThreshold  float64
+	EntityAllowlist []string
+	BandPadding     int
 	// Policy is "kill", "redact", or "redact_and_kill" (agent default kill
 	// when empty/unrecognized).
 	Policy string
@@ -125,11 +125,11 @@ func CreateRDPSession(
 		if guard.Policy != "" {
 			metadata["pii_policy"] = guard.Policy
 		}
-		if len(guard.EntityDenylist) > 0 {
+		if len(guard.EntityAllowlist) > 0 {
 			// JSON array, not a comma-join: entity names are an external
 			// (Presidio) vocabulary and must not rely on being comma-free.
-			if denylist, err := json.Marshal(guard.EntityDenylist); err == nil {
-				metadata["pii_entity_denylist"] = string(denylist)
+			if allowlist, err := json.Marshal(guard.EntityAllowlist); err == nil {
+				metadata["pii_entity_allowlist"] = string(allowlist)
 			}
 		}
 	}

--- a/gateway/rdp/irongw.go
+++ b/gateway/rdp/irongw.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hoophq/hoop/gateway/broker"
 	"github.com/hoophq/hoop/gateway/idp"
 	"github.com/hoophq/hoop/gateway/models"
-	"github.com/hoophq/hoop/gateway/rdp/analyzer"
 	"github.com/hoophq/hoop/gateway/transport/usertoken"
 )
 
@@ -197,68 +196,62 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 		recorderUserEmail = userCtx.UserEmail
 	}
 
-	// When the flag is on, the agent runs the PII gate (analysis happens
-	// where the plaintext already flows, inside the customer network) and the
-	// gateway suppresses its own gate — a single enforcement point. The
-	// analysis policy rides along; the agent supplies Presidio/OCR endpoints
-	// from its own env.
-	// forceUnguarded: the flag is on but we deliberately run this session with
-	// no guard at all (neither agent nor gateway) — set for an older agent that
-	// never advertised guard capability, to avoid bricking its connections.
-	forceUnguarded := false
-	agentGuard := broker.RDPGuardConfig{Enabled: featureflag.IsEnabled(recorderOrgID, PIIGateFlagName)}
+	// The rollout flag enables the RDP guard; the resource's DataMaskingRules
+	// decide whether this connection is masked and supply its entity selection
+	// and confidence threshold.
+	var maskingParams *rdpDataMaskingParams
+	if featureflag.IsEnabled(recorderOrgID, PIIGateFlagName) {
+		maskingParams, err = dataMaskingParamsForConnection(recorderOrgID, connectionModel.Name)
+		if err != nil {
+			log.With("sid", sessionID, "conn", cID).Errorf("failed loading RDP data masking rules: %v", err)
+			writeRDPClientError(ws, cppVersion, "Connection refused: failed to load data masking rules.")
+			return
+		}
+	}
+
+	// When a connection-scoped rule applies, the agent runs the PII gate where
+	// the plaintext already flows. The gateway sends the resource policy while
+	// the agent supplies its local Presidio/OCR endpoints. Masked sessions fail
+	// closed unless the selected agent advertises both capabilities required to
+	// enforce that policy.
+	agentGuard := broker.RDPGuardConfig{Enabled: maskingParams != nil}
 	if agentGuard.Enabled {
-		// Capability gate. Three cases:
-		//   - known + capable    -> delegate the guard (the intended path).
-		//   - known + incapable  -> a guard-capable agent build that explicitly
-		//     advertised it lacks the Presidio/OCR endpoints. Refuse with a
-		//     clear error: it is a misconfiguration of an agent that is supposed
-		//     to guard.
-		//   - unknown            -> the agent never advertised capability (an
-		//     OLDER agent that predates the handshake, or the frame has not
-		//     arrived yet). Run the session UNGUARDED rather than refusing.
-		//
-		// Unknown must NOT 403: enabling the flag would otherwise brick every
-		// RDP connection through any not-yet-upgraded agent, even connections
-		// that were never going to be guarded. An old agent cannot run the
-		// guard anyway, so falling back to a normal proxied session preserves
-		// pre-handshake behavior.
-		//
-		// This is a DELIBERATE availability-over-enforcement choice for the
-		// unknown case, not a race-free guarantee. AgentCapability waits up to
-		// AgentCapabilityWait for an in-flight frame, but a capable NEW agent
-		// that is slow to advertise (cold start, control-frame delay) can still
-		// be seen as unknown and run this one session unguarded. That is
-		// accepted: the alternative (fail closed) bricks every old-agent
-		// connection. NOTE: this intentionally overrides the generic
-		// "treat unknown as cannot / fail closed" guidance on
-		// broker.AgentCapability for this specific handler.
 		capable, known := broker.AgentCapability(connectionModel.AgentName, broker.CapabilitySupportsPIIGuard)
 		switch {
-		case known && !capable:
-			log.Errorf("refusing RDP session: %s is enabled but agent %q advertised it cannot enforce the PII guard (missing MSPRESIDIO_ANALYZER_URL and/or RDP_OCR_SERVER_URL)",
-				PIIGateFlagName, connectionModel.AgentName)
+		case !known:
+			log.Errorf("refusing RDP session: agent %q did not advertise PII guard capability",
+				connectionModel.AgentName)
+			writeRDPClientError(ws, cppVersion,
+				fmt.Sprintf("Connection refused: agent %q must be upgraded to apply this connection's Data Masking rule.",
+					connectionModel.AgentName))
+			return
+		case !capable:
+			log.Errorf("refusing RDP session: agent %q cannot enforce the PII guard (missing MSPRESIDIO_ANALYZER_URL and/or RDP_OCR_SERVER_URL)",
+				connectionModel.AgentName)
 			writeRDPClientError(ws, cppVersion,
 				fmt.Sprintf("Connection refused: PII guard is enabled but agent %q is misconfigured (missing OCR/Presidio endpoints).",
 					connectionModel.AgentName))
 			return
-		case !known:
-			// Older agent (or pre-advertisement): proxy unguarded. Suppress
-			// BOTH the agent guard and the gateway-side gate so this is a plain
-			// passthrough (pre-handshake behavior), not a fallback to the
-			// gateway gate.
-			log.With("sid", sessionID).Warnf("piigate: %s is enabled but agent %q has not advertised guard capability; running this session UNGUARDED (upgrade the agent to enable the guard)",
-				PIIGateFlagName, connectionModel.AgentName)
-			agentGuard.Enabled = false
-			forceUnguarded = true
+		}
+
+		allowlistCapable, allowlistKnown := broker.AgentCapability(
+			connectionModel.AgentName,
+			broker.CapabilitySupportsPIIEntityAllowlist,
+		)
+		if !allowlistKnown || !allowlistCapable {
+			log.Errorf("refusing RDP session: agent %q does not support connection-scoped PII entity selection",
+				connectionModel.AgentName)
+			writeRDPClientError(ws, cppVersion,
+				fmt.Sprintf("Connection refused: agent %q must be upgraded to apply this connection's Data Masking rule.",
+					connectionModel.AgentName))
+			return
 		}
 	}
 
 	if agentGuard.Enabled {
-		params := analyzer.DefaultAnalysisParams()
-		agentGuard.ScoreThreshold = params.ScoreThreshold
-		agentGuard.EntityDenylist = params.EntityDenylist
-		agentGuard.BandPadding = params.BandPadding
+		agentGuard.ScoreThreshold = maskingParams.ScoreThreshold
+		agentGuard.EntityAllowlist = maskingParams.EntityAllowlist
+		agentGuard.BandPadding = maskingParams.BandPadding
 		agentGuard.Policy = appconfig.Get().RDPPIIGuardPolicy()
 	}
 
@@ -401,11 +394,8 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 	// and latency. The gateway still records — now of clean frames.
 	var gate *PIIGate
 	switch {
-	case forceUnguarded:
-		// Flag on, but the agent never advertised guard capability (old agent):
-		// neither guard runs — this is a plain passthrough. Logged distinctly so
-		// audits don't misread it as enforced.
-		log.With("sid", sessionID).Warnf("piigate: session running UNGUARDED (agent has not advertised guard capability)")
+	case maskingParams == nil:
+		// No connection-scoped masking rule: normal passthrough.
 	case agentGuard.Enabled:
 		log.With("sid", sessionID).Infof("piigate: agent-side guard active, gateway gate suppressed")
 	default:

--- a/gateway/rdp/piigate.go
+++ b/gateway/rdp/piigate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hoophq/hoop/gateway/rdp/ocr"
 	"github.com/hoophq/hoop/gateway/rdp/parser"
 	"github.com/hoophq/hoop/gateway/rdp/rle"
+	"github.com/hoophq/hoop/gateway/services"
 )
 
 // PIIGateFlagName gates the realtime hold-and-release PII analysis on the
@@ -615,6 +616,79 @@ func (c *shadowCanvas) grow(width, height int) {
 	}
 	c.fb = newFB
 	c.w, c.h = width, height
+}
+
+type rdpDataMaskingRule struct {
+	Name                 string                             `json:"name"`
+	SupportedEntityTypes []models.SupportedEntityTypesEntry `json:"supported_entity_types"`
+	CustomEntityTypes    []models.CustomEntityTypesEntry    `json:"custom_entity_types"`
+	ScoreThreshold       *float64                           `json:"score_threshold"`
+}
+
+type rdpDataMaskingParams struct {
+	ScoreThreshold  float64
+	EntityAllowlist []string
+	BandPadding     int
+}
+
+func dataMaskingParamsForConnection(orgID, connectionName string) (*rdpDataMaskingParams, error) {
+	rules, err := services.GetDataMaskingRulesForConnection(orgID, connectionName)
+	if err != nil {
+		return nil, fmt.Errorf("get data masking rules for RDP connection: %w", err)
+	}
+	return parseRDPDataMaskingRules(rules)
+}
+
+func parseRDPDataMaskingRules(data []byte) (*rdpDataMaskingParams, error) {
+	var rules []rdpDataMaskingRule
+	if err := json.Unmarshal(data, &rules); err != nil {
+		return nil, fmt.Errorf("decode data masking rules for RDP connection: %w", err)
+	}
+
+	entitySet := make(map[string]struct{})
+	scoreThreshold := 0.0
+	hasThreshold := false
+	for _, rule := range rules {
+		if len(rule.CustomEntityTypes) > 0 {
+			return nil, fmt.Errorf("RDP masking does not support custom entity types in rule %q", rule.Name)
+		}
+		hasEntities := false
+		for _, group := range rule.SupportedEntityTypes {
+			for _, entity := range group.EntityTypes {
+				if entity == "" {
+					continue
+				}
+				entitySet[entity] = struct{}{}
+				hasEntities = true
+			}
+		}
+		if !hasEntities {
+			continue
+		}
+
+		threshold := 0.5
+		if rule.ScoreThreshold != nil {
+			threshold = *rule.ScoreThreshold
+		}
+		if !hasThreshold || threshold < scoreThreshold {
+			scoreThreshold = threshold
+			hasThreshold = true
+		}
+	}
+	if len(entitySet) == 0 {
+		return nil, nil
+	}
+
+	params := &rdpDataMaskingParams{
+		ScoreThreshold:  scoreThreshold,
+		EntityAllowlist: make([]string, 0, len(entitySet)),
+		BandPadding:     analyzer.DefaultBandPadding,
+	}
+	for entity := range entitySet {
+		params.EntityAllowlist = append(params.EntityAllowlist, entity)
+	}
+	sort.Strings(params.EntityAllowlist)
+	return params, nil
 }
 
 // newSessionPIIGate builds a PIIGate wired to a live IronRDP session: it

--- a/gateway/rdp/piigate.go
+++ b/gateway/rdp/piigate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -631,6 +632,19 @@ type rdpDataMaskingParams struct {
 	BandPadding     int
 }
 
+func isCanonicalEntityType(entityType string) bool {
+	if entityType == "" {
+		return false
+	}
+	for i := 0; i < len(entityType); i++ {
+		c := entityType[i]
+		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' {
+			return false
+		}
+	}
+	return true
+}
+
 func dataMaskingParamsForConnection(orgID, connectionName string) (*rdpDataMaskingParams, error) {
 	rules, err := services.GetDataMaskingRulesForConnection(orgID, connectionName)
 	if err != nil {
@@ -654,9 +668,12 @@ func parseRDPDataMaskingRules(data []byte) (*rdpDataMaskingParams, error) {
 		}
 		hasEntities := false
 		for _, group := range rule.SupportedEntityTypes {
+			if len(group.EntityTypes) == 0 {
+				return nil, fmt.Errorf("RDP masking rule %q has an empty supported entity group %q", rule.Name, group.Name)
+			}
 			for _, entity := range group.EntityTypes {
-				if entity == "" {
-					continue
+				if !isCanonicalEntityType(entity) {
+					return nil, fmt.Errorf("RDP masking rule %q has invalid entity type %q", rule.Name, entity)
 				}
 				entitySet[entity] = struct{}{}
 				hasEntities = true
@@ -669,6 +686,9 @@ func parseRDPDataMaskingRules(data []byte) (*rdpDataMaskingParams, error) {
 		threshold := 0.5
 		if rule.ScoreThreshold != nil {
 			threshold = *rule.ScoreThreshold
+		}
+		if math.IsNaN(threshold) || math.IsInf(threshold, 0) || threshold < 0 || threshold > 1 {
+			return nil, fmt.Errorf("RDP masking rule %q has invalid score threshold %v", rule.Name, threshold)
 		}
 		if !hasThreshold || threshold < scoreThreshold {
 			scoreThreshold = threshold

--- a/gateway/rdp/piigate_test.go
+++ b/gateway/rdp/piigate_test.go
@@ -889,3 +889,70 @@ func TestPIIGate_FragmentedUpdateHeldUntilReassembly(t *testing.T) {
 		t.Fatal("LEAK: fragments without Last rendered the signature")
 	}
 }
+
+func TestParseRDPDataMaskingRulesUsesResourceEntitiesAndThreshold(t *testing.T) {
+	params, err := parseRDPDataMaskingRules([]byte(`[
+		{
+			"supported_entity_types": [
+				{"name": "CONTACT_INFORMATION", "entity_types": ["PERSON", "EMAIL_ADDRESS"]},
+				{"name": "TIME_DATA", "entity_types": ["DATE_TIME", "PERSON"]}
+			],
+			"score_threshold": 0.85
+		},
+		{
+			"supported_entity_types": [
+				{"name": "US_DOCUMENTS", "entity_types": ["US_SSN"]}
+			],
+			"score_threshold": 0.6
+		}
+	]`))
+	if err != nil {
+		t.Fatalf("parse rules: %v", err)
+	}
+	if params == nil {
+		t.Fatal("rules with supported entities must enable masking")
+	}
+	if got, want := fmt.Sprint(params.EntityAllowlist), "[DATE_TIME EMAIL_ADDRESS PERSON US_SSN]"; got != want {
+		t.Fatalf("entity allowlist = %s, want %s", got, want)
+	}
+	if params.ScoreThreshold != 0.6 {
+		t.Fatalf("score threshold = %v, want 0.6", params.ScoreThreshold)
+	}
+
+	none, err := parseRDPDataMaskingRules([]byte(`[]`))
+	if err != nil {
+		t.Fatalf("parse empty rules: %v", err)
+	}
+	if none != nil {
+		t.Fatal("connection without data masking rules must remain unguarded")
+	}
+}
+
+func TestParseRDPDataMaskingRulesPreservesZeroThreshold(t *testing.T) {
+	params, err := parseRDPDataMaskingRules([]byte(`[
+		{
+			"name": "all-confidence",
+			"supported_entity_types": [{"name": "TIME_DATA", "entity_types": ["DATE_TIME"]}],
+			"score_threshold": 0
+		}
+	]`))
+	if err != nil {
+		t.Fatalf("parse rules: %v", err)
+	}
+	if params == nil || params.ScoreThreshold != 0 {
+		t.Fatalf("score threshold = %#v, want 0", params)
+	}
+}
+
+func TestParseRDPDataMaskingRulesRejectsCustomEntities(t *testing.T) {
+	params, err := parseRDPDataMaskingRules([]byte(`[
+		{
+			"name": "employee-id",
+			"supported_entity_types": [{"name": "CONTACT_INFORMATION", "entity_types": ["PERSON"]}],
+			"custom_entity_types": [{"name": "EMPLOYEE_ID", "regex": "EMP-[0-9]+", "score": 1}]
+		}
+	]`))
+	if err == nil {
+		t.Fatalf("custom entity rule returned params %#v; want an unsupported-rule error", params)
+	}
+}

--- a/gateway/rdp/piigate_test.go
+++ b/gateway/rdp/piigate_test.go
@@ -928,6 +928,43 @@ func TestParseRDPDataMaskingRulesUsesResourceEntitiesAndThreshold(t *testing.T) 
 	}
 }
 
+func TestParseRDPDataMaskingRulesRejectsNonCanonicalEntities(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "empty entity group",
+			data: `[{"name":"invalid","supported_entity_types":[{"name":"CUSTOM_SELECTION","entity_types":[]}]}]`,
+		},
+		{
+			name: "empty entity",
+			data: `[{"name":"invalid","supported_entity_types":[{"name":"CUSTOM_SELECTION","entity_types":[""]}]}]`,
+		},
+		{
+			name: "whitespace",
+			data: `[{"name":"invalid","supported_entity_types":[{"name":"CUSTOM_SELECTION","entity_types":[" PERSON "]}]}]`,
+		},
+		{
+			name: "lowercase",
+			data: `[{"name":"invalid","supported_entity_types":[{"name":"CUSTOM_SELECTION","entity_types":["person"]}]}]`,
+		},
+		{
+			name: "punctuation",
+			data: `[{"name":"invalid","supported_entity_types":[{"name":"CUSTOM_SELECTION","entity_types":["PERSON-NAME"]}]}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, err := parseRDPDataMaskingRules([]byte(tt.data))
+			if err == nil {
+				t.Fatalf("invalid entity configuration returned params %#v; want an error", params)
+			}
+		})
+	}
+}
+
 func TestParseRDPDataMaskingRulesPreservesZeroThreshold(t *testing.T) {
 	params, err := parseRDPDataMaskingRules([]byte(`[
 		{
@@ -941,6 +978,24 @@ func TestParseRDPDataMaskingRulesPreservesZeroThreshold(t *testing.T) {
 	}
 	if params == nil || params.ScoreThreshold != 0 {
 		t.Fatalf("score threshold = %#v, want 0", params)
+	}
+}
+
+func TestParseRDPDataMaskingRulesRejectsInvalidThresholds(t *testing.T) {
+	for _, threshold := range []float64{-0.1, 1.1} {
+		t.Run(fmt.Sprint(threshold), func(t *testing.T) {
+			data := fmt.Sprintf(`[
+				{
+					"name": "invalid-threshold",
+					"supported_entity_types": [{"name": "TIME_DATA", "entity_types": ["DATE_TIME"]}],
+					"score_threshold": %v
+				}
+			]`, threshold)
+			params, err := parseRDPDataMaskingRules([]byte(data))
+			if err == nil {
+				t.Fatalf("invalid score threshold returned params %#v; want an error", params)
+			}
+		})
 	}
 }
 

--- a/gateway/services/datamasking.go
+++ b/gateway/services/datamasking.go
@@ -2,13 +2,17 @@ package services
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/hoophq/hoop/gateway/models"
 )
 
 func GetDataMaskingRulesForConnection(orgID, connectionName string) (json.RawMessage, error) {
-	parsedOrgID := uuid.MustParse(orgID)
+	parsedOrgID, err := uuid.Parse(orgID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid organization ID %q: %w", orgID, err)
+	}
 	attributes, err := models.GetConnectionAttributes(models.DB, parsedOrgID, connectionName)
 	if err != nil {
 		return nil, err

--- a/gateway/services/datamasking_test.go
+++ b/gateway/services/datamasking_test.go
@@ -1,0 +1,16 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetDataMaskingRulesForConnectionRejectsInvalidOrganizationID(t *testing.T) {
+	result, err := GetDataMaskingRulesForConnection("not-a-uuid", "example")
+	if err == nil {
+		t.Fatalf("invalid organization ID returned rules %s; want an error", result)
+	}
+	if !strings.Contains(err.Error(), "invalid organization ID") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
RDP live masking now uses the Data Masking rules assigned to the selected connection instead of gateway-wide entity and confidence environment settings.

- Resolves direct and attribute-based rules, sends the union of `supported_entity_types[].entity_types` plus the lowest applicable `score_threshold` to the RDP agent, and restricts Presidio to that allowlist.
- Stops using gateway-wide threshold and denylist settings for live masking without changing offline analysis; masked sessions require an allowlist-capable agent, legacy gateways remain compatible with upgraded agents, and unsupported custom entities fail closed.
- Verification: the focused Go packages pass, the Rust PII-gate suite passes 230 tests, and dedicated checks cover `DATE_TIME`/`PERSON` rule resolution, zero thresholds, legacy denylist compatibility, custom-rule rejection, and the Presidio request payload.


Automated by MisterMal