### PR TITLE
Add selectable RDP desktop resolutions

### DIFF
--- a/gateway/rdp/irongw.go
+++ b/gateway/rdp/irongw.go
@@ -56,6 +56,13 @@ func (r *IronRDPGateway) handleClient(c *gin.Context) {
 		c.String(http.StatusBadRequest, "Invalid request")
 		return
 	}
+	desktopSize, ok := rdpDesktopSizeFromPreset(c.PostForm("desktop_size"))
+	if !ok {
+		log.Errorf("invalid RDP desktop size preset")
+		c.String(http.StatusBadRequest, "Invalid request")
+		return
+	}
+
 	secretKeyHash, err := keys.Hash256Key(rdpCredential)
 	if err != nil {
 		log.Errorf("failed hashing rdp secret key, reason=%v", err)
@@ -94,7 +101,7 @@ func (r *IronRDPGateway) handleClient(c *gin.Context) {
 
 	// We don't need to do extended checks now because websocket will do it.
 
-	data := renderWebClientTemplate("RDP Connection", rdpCredential)
+	data := renderWebClientTemplate("RDP Connection", rdpCredential, desktopSize)
 	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(data))
 }
 

--- a/gateway/rdp/irongw.go
+++ b/gateway/rdp/irongw.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -49,6 +50,32 @@ func (r *IronRDPGateway) AttachHandlers(router gin.IRouter) {
 	router.Handle(http.MethodPost, "/client", r.handleClient)
 }
 
+func isRDPDesktopDimension(value string) bool {
+	if len(value) == 0 || len(value) > 4 {
+		return false
+	}
+	for i := range len(value) {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func invalidRDPDesktopSizeDimensions(preset string) (width, height int, ok bool) {
+	widthText, heightText, found := strings.Cut(preset, "x")
+	if !found || !isRDPDesktopDimension(widthText) || !isRDPDesktopDimension(heightText) {
+		return 0, 0, false
+	}
+
+	width, widthErr := strconv.Atoi(widthText)
+	height, heightErr := strconv.Atoi(heightText)
+	if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
+		return 0, 0, false
+	}
+	return width, height, true
+}
+
 func (r *IronRDPGateway) handleClient(c *gin.Context) {
 	rdpCredential := c.PostForm("credential")
 	if rdpCredential == "" {
@@ -56,9 +83,21 @@ func (r *IronRDPGateway) handleClient(c *gin.Context) {
 		c.String(http.StatusBadRequest, "Invalid request")
 		return
 	}
-	desktopSize, ok := rdpDesktopSizeFromPreset(c.PostForm("desktop_size"))
+	desktopSizePreset := c.PostForm("desktop_size")
+	desktopSize, ok := rdpDesktopSizeFromPreset(desktopSizePreset)
 	if !ok {
-		log.Errorf("invalid RDP desktop size preset")
+		if width, height, dimensions := invalidRDPDesktopSizeDimensions(desktopSizePreset); dimensions {
+			log.With(
+				"desktop-size-category", "unsupported-dimensions",
+				"desktop-width", width,
+				"desktop-height", height,
+			).Warnf("invalid RDP desktop size preset")
+		} else {
+			log.With(
+				"desktop-size-category", "invalid-format",
+				"desktop-size-length", len(desktopSizePreset),
+			).Warnf("invalid RDP desktop size preset")
+		}
 		c.String(http.StatusBadRequest, "Invalid request")
 		return
 	}

--- a/gateway/rdp/webclient.go
+++ b/gateway/rdp/webclient.go
@@ -6,8 +6,36 @@ import (
 )
 
 type webclientTemplateData struct {
-	Title      string
-	Credential string
+	Title         string
+	Credential    string
+	DesktopWidth  int
+	DesktopHeight int
+}
+
+type rdpDesktopSize struct {
+	width  int
+	height int
+}
+
+func rdpDesktopSizeFromPreset(preset string) (rdpDesktopSize, bool) {
+	switch preset {
+	case "", "fit":
+		return rdpDesktopSize{}, true
+	case "1280x720":
+		return rdpDesktopSize{width: 1280, height: 720}, true
+	case "1366x768":
+		return rdpDesktopSize{width: 1366, height: 768}, true
+	case "1600x900":
+		return rdpDesktopSize{width: 1600, height: 900}, true
+	case "1920x1080":
+		return rdpDesktopSize{width: 1920, height: 1080}, true
+	case "2560x1440":
+		return rdpDesktopSize{width: 2560, height: 1440}, true
+	case "3840x2160":
+		return rdpDesktopSize{width: 3840, height: 2160}, true
+	default:
+		return rdpDesktopSize{}, false
+	}
 }
 
 const webclientTemplateHTML = `
@@ -28,18 +56,20 @@ const webclientTemplateHTML = `
     </div>
 	<script type="module">
 		import "/rdpclient/index.js";
-		initializeApp("{{.Credential}}");
+		initializeApp("{{.Credential}}", {{.DesktopWidth}}, {{.DesktopHeight}});
 	</script>
 </body>
 </html>`
 
 var webclientTemplate = template.Must(template.New("webclient").Parse(webclientTemplateHTML))
 
-func renderWebClientTemplate(title string, credential string) string {
+func renderWebClientTemplate(title string, credential string, desktopSize rdpDesktopSize) string {
 	// Apply template and return, assume no errors since the template is static
 	data := webclientTemplateData{
-		Title:      title,
-		Credential: credential,
+		Title:         title,
+		Credential:    credential,
+		DesktopWidth:  desktopSize.width,
+		DesktopHeight: desktopSize.height,
 	}
 	var buf bytes.Buffer
 	if err := webclientTemplate.Execute(&buf, data); err != nil {

--- a/gateway/rdp/webclient_test.go
+++ b/gateway/rdp/webclient_test.go
@@ -1,8 +1,14 @@
 package rdp
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"regexp"
+	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestRDPDesktopSizeFromPreset(t *testing.T) {
@@ -31,6 +37,64 @@ func TestRDPDesktopSizeFromPreset(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("desktop size = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInvalidRDPDesktopSizeDimensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		preset     string
+		wantWidth  int
+		wantHeight int
+		wantOK     bool
+	}{
+		{name: "unsupported dimensions", preset: "4096x4096", wantWidth: 4096, wantHeight: 4096, wantOK: true},
+		{name: "unsupported aspect ratio", preset: "1280x800", wantWidth: 1280, wantHeight: 800, wantOK: true},
+		{name: "credential-like value", preset: "xagt-secret", wantOK: false},
+		{name: "multiple separators", preset: "1280x720x32", wantOK: false},
+		{name: "oversized component", preset: "12345x720", wantOK: false},
+		{name: "signed component", preset: "+1x2", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			width, height, ok := invalidRDPDesktopSizeDimensions(tt.preset)
+			if ok != tt.wantOK || width != tt.wantWidth || height != tt.wantHeight {
+				t.Fatalf(
+					"dimensions = (%d, %d, %v), want (%d, %d, %v)",
+					width, height, ok, tt.wantWidth, tt.wantHeight, tt.wantOK,
+				)
+			}
+		})
+	}
+}
+
+func TestHandleClientRejectsInvalidDesktopSize(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []string{"4096x4096", "xagt-secret"}
+
+	for _, desktopSize := range tests {
+		t.Run(desktopSize, func(t *testing.T) {
+			form := url.Values{
+				"credential":   {"test-credential"},
+				"desktop_size": {desktopSize},
+			}
+			request := httptest.NewRequest(
+				http.MethodPost,
+				"/client",
+				strings.NewReader(form.Encode()),
+			)
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			response := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(response)
+			ctx.Request = request
+
+			(&IronRDPGateway{}).handleClient(ctx)
+
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
 			}
 		})
 	}

--- a/gateway/rdp/webclient_test.go
+++ b/gateway/rdp/webclient_test.go
@@ -1,0 +1,52 @@
+package rdp
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestRDPDesktopSizeFromPreset(t *testing.T) {
+	tests := []struct {
+		name   string
+		preset string
+		want   rdpDesktopSize
+		valid  bool
+	}{
+		{name: "omitted uses browser window", want: rdpDesktopSize{}, valid: true},
+		{name: "fit uses browser window", preset: "fit", want: rdpDesktopSize{}, valid: true},
+		{name: "HD", preset: "1280x720", want: rdpDesktopSize{width: 1280, height: 720}, valid: true},
+		{name: "laptop", preset: "1366x768", want: rdpDesktopSize{width: 1366, height: 768}, valid: true},
+		{name: "HD plus", preset: "1600x900", want: rdpDesktopSize{width: 1600, height: 900}, valid: true},
+		{name: "full HD", preset: "1920x1080", want: rdpDesktopSize{width: 1920, height: 1080}, valid: true},
+		{name: "QHD", preset: "2560x1440", want: rdpDesktopSize{width: 2560, height: 1440}, valid: true},
+		{name: "4K", preset: "3840x2160", want: rdpDesktopSize{width: 3840, height: 2160}, valid: true},
+		{name: "unknown preset", preset: "4096x4096", valid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, valid := rdpDesktopSizeFromPreset(tt.preset)
+			if valid != tt.valid {
+				t.Fatalf("valid = %v, want %v", valid, tt.valid)
+			}
+			if got != tt.want {
+				t.Fatalf("desktop size = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderWebClientTemplatePassesDesktopSize(t *testing.T) {
+	got := renderWebClientTemplate(
+		"RDP Connection",
+		"credential",
+		rdpDesktopSize{width: 1280, height: 720},
+	)
+
+	initializeCall := regexp.MustCompile(
+		`initializeApp\("credential",\s+1280\s*,\s+720\s*\);`,
+	)
+	if !initializeCall.MatchString(got) {
+		t.Fatalf("rendered client does not initialize the requested desktop size: %s", got)
+	}
+}

--- a/webapp/resources/public/rdpclient/index.js
+++ b/webapp/resources/public/rdpclient/index.js
@@ -27,7 +27,7 @@ async function initWasm() {
     }
 }
 
-async function initializeApp(rdpCredential) {
+async function initializeApp(rdpCredential, requestedDesktopWidth = 0, requestedDesktopHeight = 0) {
     console.log('Initializing app...');
     const mod = await initWasm();
     console.log('App initialized.');
@@ -59,20 +59,38 @@ async function initializeApp(rdpCredential) {
     // Authoritative enforcement at the gateway/agent boundary is tracked in
     // DEP-70.
     const MAX_DESKTOP_DIM = 4096;
-    const viewportWidth = Number.isFinite(window.innerWidth)
-        ? Math.max(1, Math.floor(window.innerWidth)) : 1;
-    const viewportHeight = Number.isFinite(window.innerHeight)
-        ? Math.max(1, Math.floor(window.innerHeight)) : 1;
-    const dpr = (Number.isFinite(window.devicePixelRatio) && window.devicePixelRatio > 0)
-        ? window.devicePixelRatio : 1;
-    const scale = Math.min(
-        dpr,
-        MAX_DESKTOP_DIM / viewportWidth,
-        MAX_DESKTOP_DIM / viewportHeight,
-    );
-    console.log(`Window Size: ${viewportWidth} x ${viewportHeight}, DPR: ${dpr}, scale: ${scale}`);
-    rdpCanvas.width = Math.max(1, Math.min(MAX_DESKTOP_DIM, Math.round(viewportWidth * scale)));
-    rdpCanvas.height = Math.max(1, Math.min(MAX_DESKTOP_DIM, Math.round(viewportHeight * scale)));
+    const hasRequestedDesktopSize =
+        Number.isInteger(requestedDesktopWidth) &&
+        Number.isInteger(requestedDesktopHeight) &&
+        requestedDesktopWidth > 0 &&
+        requestedDesktopHeight > 0 &&
+        requestedDesktopWidth <= MAX_DESKTOP_DIM &&
+        requestedDesktopHeight <= MAX_DESKTOP_DIM;
+
+    let desktopWidth;
+    let desktopHeight;
+    if (hasRequestedDesktopSize) {
+        desktopWidth = requestedDesktopWidth;
+        desktopHeight = requestedDesktopHeight;
+        console.log(`Requested desktop size: ${desktopWidth} x ${desktopHeight}`);
+    } else {
+        const viewportWidth = Number.isFinite(window.innerWidth)
+            ? Math.max(1, Math.floor(window.innerWidth)) : 1;
+        const viewportHeight = Number.isFinite(window.innerHeight)
+            ? Math.max(1, Math.floor(window.innerHeight)) : 1;
+        const dpr = (Number.isFinite(window.devicePixelRatio) && window.devicePixelRatio > 0)
+            ? window.devicePixelRatio : 1;
+        const scale = Math.min(
+            dpr,
+            MAX_DESKTOP_DIM / viewportWidth,
+            MAX_DESKTOP_DIM / viewportHeight,
+        );
+        desktopWidth = Math.max(1, Math.min(MAX_DESKTOP_DIM, Math.round(viewportWidth * scale)));
+        desktopHeight = Math.max(1, Math.min(MAX_DESKTOP_DIM, Math.round(viewportHeight * scale)));
+        console.log(`Window Size: ${viewportWidth} x ${viewportHeight}, DPR: ${dpr}, scale: ${scale}`);
+    }
+    rdpCanvas.width = desktopWidth;
+    rdpCanvas.height = desktopHeight;
 
     const RDP = new RemoteDesktopService(rdpCanvas, mod);
     window.RDP = RDP;

--- a/webapp/resources/public/rdpclient/index.js
+++ b/webapp/resources/public/rdpclient/index.js
@@ -72,7 +72,6 @@ async function initializeApp(rdpCredential, requestedDesktopWidth = 0, requested
     if (hasRequestedDesktopSize) {
         desktopWidth = requestedDesktopWidth;
         desktopHeight = requestedDesktopHeight;
-        console.log(`Requested desktop size: ${desktopWidth} x ${desktopHeight}`);
     } else {
         const viewportWidth = Number.isFinite(window.innerWidth)
             ? Math.max(1, Math.floor(window.innerWidth)) : 1;

--- a/webapp/src/webapp/connections/native_client_access/constants.cljs
+++ b/webapp/src/webapp/connections/native_client_access/constants.cljs
@@ -15,6 +15,17 @@
    {:text "40 hours" :value 2400}
    {:text "48 hours" :value 2880}])
 
+(def rdp-desktop-size-options
+  [{:text "Fit browser window" :value "fit"}
+   {:text "1280 × 720" :value "1280x720"}
+   {:text "1366 × 768" :value "1366x768"}
+   {:text "1600 × 900" :value "1600x900"}
+   {:text "1920 × 1080" :value "1920x1080"}
+   {:text "2560 × 1440" :value "2560x1440"}
+   {:text "3840 × 2160" :value "3840x2160"}])
+
+(def default-rdp-desktop-size "fit")
+
 ;; Convert minutes to seconds for API
 (defn minutes->seconds [minutes]
   (* minutes 60))

--- a/webapp/src/webapp/connections/native_client_access/events.cljs
+++ b/webapp/src/webapp/connections/native_client_access/events.cljs
@@ -41,16 +41,21 @@
 
 (rf/reg-fx
  :open-rdp-web-client
- (fn [{:keys [username]}]
+ (fn [{:keys [username desktop-size]}]
    (let [form (.createElement js/document "form")
-         input (.createElement js/document "input")]
+         credential-input (.createElement js/document "input")
+         desktop-size-input (.createElement js/document "input")]
      (set! (.-method form) "POST")
      (set! (.-action form) "/rdpproxy/client")
      (set! (.-target form) "_blank")
-     (set! (.-type input) "hidden")
-     (set! (.-name input) "credential")
-     (set! (.-value input) username)
-     (.appendChild form input)
+     (set! (.-type credential-input) "hidden")
+     (set! (.-name credential-input) "credential")
+     (set! (.-value credential-input) username)
+     (set! (.-type desktop-size-input) "hidden")
+     (set! (.-name desktop-size-input) "desktop_size")
+     (set! (.-value desktop-size-input) desktop-size)
+     (.appendChild form credential-input)
+     (.appendChild form desktop-size-input)
      (.appendChild (.-body js/document) form)
      (.submit form)
      (.remove form))))
@@ -333,8 +338,10 @@
 ;; Event to open RDP web client
 (rf/reg-event-fx
  :native-client-access->open-rdp-web-client
- (fn [_ [_ username]]
-   {:open-rdp-web-client {:username username}}))
+ (fn [_ [_ username desktop-size]]
+   {:open-rdp-web-client
+    {:username username
+     :desktop-size (or desktop-size constants/default-rdp-desktop-size)}}))
 
 ;; Resume credentials request after review approval
 (rf/reg-event-fx

--- a/webapp/src/webapp/connections/native_client_access/main.cljs
+++ b/webapp/src/webapp/connections/native_client_access/main.cljs
@@ -1,6 +1,6 @@
 (ns webapp.connections.native-client-access.main
   (:require
-   ["@radix-ui/themes" :refer [Box Button Callout Flex Heading Spinner Tabs Text]]
+   ["@radix-ui/themes" :refer [Box Button Callout Flex Heading Select Spinner Tabs Text]]
    ["lucide-react" :refer [Info ShieldCheck]]
    [re-frame.core :as rf]
    [reagent.core :as r]
@@ -440,6 +440,7 @@
   "Step 2: Connection established - show credentials"
   [connection-name native-client-access-data minimize-fn disconnect-fn]
   (let [active-tab (r/atom "credentials")
+        rdp-desktop-size (r/atom constants/default-rdp-desktop-size)
         subtype (normalize-subtype (:connection_subtype native-client-access-data))
         has-command? (contains? #{"ssh" "rdp"} subtype)]
 
@@ -514,7 +515,7 @@
           [connect-credentials-tab native-client-access-data])]
 
        ;; Sticky footer
-       [:footer {:class "sticky bottom-0 z-30 bg-white py-4 flex justify-between items-center"}
+       [:footer {:class "sticky bottom-0 z-30 bg-white py-4 flex justify-between items-end"}
         [:> Button
          {:variant "ghost"
           :size "3"
@@ -522,20 +523,36 @@
           :on-click minimize-fn}
          "Minimize"]
 
-        (when (= subtype "rdp")
-          [:> Button
-           {:variant "solid"
-            :size "3"
-            :on-click #(rf/dispatch [:native-client-access->open-rdp-web-client
-                                     (get-in native-client-access-data [:connection_credentials :username])])}
-           "Open web client"])
+        [:> Flex {:align "end" :gap "2"}
+         (when (= subtype "rdp")
+           [:> Box {:class "space-y-1"}
+            [:> Text {:as "div" :size "1" :weight "medium" :class "text-[--gray-11]"}
+             "Desktop resolution"]
+            [:> Select.Root {:value @rdp-desktop-size
+                             :onValueChange #(reset! rdp-desktop-size %)}
+             [:> Select.Trigger {:aria-label "Desktop resolution"
+                                 :variant "surface"
+                                 :style {:min-width "170px"}}]
+             [:> Select.Content
+              (for [{:keys [text value]} constants/rdp-desktop-size-options]
+                ^{:key value}
+                [:> Select.Item {:value value} text])]]])
 
-        [:> Button
-         {:variant "solid"
-          :size "3"
-          :color "red"
-          :on-click disconnect-fn}
-         "Disconnect"]]])))
+         (when (= subtype "rdp")
+           [:> Button
+            {:variant "solid"
+             :size "3"
+             :on-click #(rf/dispatch [:native-client-access->open-rdp-web-client
+                                      (get-in native-client-access-data [:connection_credentials :username])
+                                      @rdp-desktop-size])}
+            "Open web client"])
+
+         [:> Button
+          {:variant "solid"
+           :size "3"
+           :color "red"
+           :on-click disconnect-fn}
+          "Disconnect"]]]])))
 
 (defn- session-expired-view
   "Fallback view for expired sessions"

--- a/webapp_v2/src/features/NativeConnections/SessionPanel.jsx
+++ b/webapp_v2/src/features/NativeConnections/SessionPanel.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 import { Divider, Group, ScrollArea, Stack } from '@mantine/core'
 import Button from '@/components/Button'
+import Select from '@/components/Select'
 import Tabs from '@/components/Tabs'
+import { DEFAULT_RDP_DESKTOP_SIZE, RDP_DESKTOP_SIZE_OPTIONS } from './constants'
 import { pickCredentialRenderer } from './credentials'
 import { normalizeSubtype, openRdpWebClient } from './helpers'
 import classes from './NativeConnections.module.css'
@@ -29,6 +31,7 @@ function ScrollableBody({ children }) {
 export function SessionPanel({ credentials, onDisconnect }) {
   const rule = pickCredentialRenderer(credentials.connection_subtype)
   const [tab, setTab] = useState(rule.tabs?.[0]?.value ?? 'credentials')
+  const [rdpDesktopSize, setRdpDesktopSize] = useState(DEFAULT_RDP_DESKTOP_SIZE)
 
   // Capitalised aliases so JSX treats them as components rather than DOM tags.
   // Renderers are mounted as elements, not invoked as functions, so a renderer
@@ -78,15 +81,32 @@ export function SessionPanel({ credentials, onDisconnect }) {
           deliberately not surfaced here — it was never rendered in the CLJS UI
           either, and adding a new destructive action alongside the redesign is
           a separate product decision. */}
-      <Group justify="flex-end" gap="sm">
+      <Group justify="flex-end" align="flex-end" gap="sm">
         {subtype === 'rdp' && (
-          <Button
-            size="sm"
-            variant="default"
-            onClick={() => openRdpWebClient(credentials.connection_credentials?.username)}
-          >
-            Open web client
-          </Button>
+          <>
+            <Select
+              label="Desktop resolution"
+              aria-label="Desktop resolution"
+              data={RDP_DESKTOP_SIZE_OPTIONS}
+              value={rdpDesktopSize}
+              onChange={setRdpDesktopSize}
+              allowDeselect={false}
+              size="sm"
+              w={190}
+            />
+            <Button
+              size="sm"
+              variant="default"
+              onClick={() =>
+                openRdpWebClient(
+                  credentials.connection_credentials?.username,
+                  rdpDesktopSize,
+                )
+              }
+            >
+              Open web client
+            </Button>
+          </>
         )}
         <Button color="red" size="sm" onClick={onDisconnect}>
           Disconnect

--- a/webapp_v2/src/features/NativeConnections/constants.js
+++ b/webapp_v2/src/features/NativeConnections/constants.js
@@ -15,6 +15,18 @@ export const ACCESS_DURATION_OPTIONS = [
 
 export const DEFAULT_ACCESS_DURATION_MINUTES = '30'
 
+export const RDP_DESKTOP_SIZE_OPTIONS = [
+  { label: 'Fit browser window', value: 'fit' },
+  { label: '1280 × 720', value: '1280x720' },
+  { label: '1366 × 768', value: '1366x768' },
+  { label: '1600 × 900', value: '1600x900' },
+  { label: '1920 × 1080', value: '1920x1080' },
+  { label: '2560 × 1440', value: '2560x1440' },
+  { label: '3840 × 2160', value: '3840x2160' },
+]
+
+export const DEFAULT_RDP_DESKTOP_SIZE = 'fit'
+
 // Both halves are identical today. The shape is kept so splitting the copy for
 // admins later is a one-line change rather than a refactor.
 export const ERROR_MESSAGES = {

--- a/webapp_v2/src/features/NativeConnections/helpers.js
+++ b/webapp_v2/src/features/NativeConnections/helpers.js
@@ -1,4 +1,4 @@
-import { SUBTYPE_LABELS } from './constants'
+import { DEFAULT_RDP_DESKTOP_SIZE, SUBTYPE_LABELS } from './constants'
 
 /**
  * Collapse SSH variants to "ssh". Local-mode SSH connections carry the subtype
@@ -154,21 +154,27 @@ export function errorMessage(error, fallback) {
 
 /**
  * Opens the browser RDP client. It is a real form POST to /rdpproxy/client with
- * the credential in a hidden field, not a fetch — the gateway responds with an
- * HTML document that has to land in a new tab.
+ * the credential and requested desktop size in hidden fields, not a fetch —
+ * the gateway responds with an HTML document that has to land in a new tab.
  */
-export function openRdpWebClient(username) {
+export function openRdpWebClient(username, desktopSize = DEFAULT_RDP_DESKTOP_SIZE) {
   const form = document.createElement('form')
   form.method = 'POST'
   form.action = '/rdpproxy/client'
   form.target = '_blank'
 
-  const input = document.createElement('input')
-  input.type = 'hidden'
-  input.name = 'credential'
-  input.value = username
+  const credentialInput = document.createElement('input')
+  credentialInput.type = 'hidden'
+  credentialInput.name = 'credential'
+  credentialInput.value = username
+  form.appendChild(credentialInput)
 
-  form.appendChild(input)
+  const desktopSizeInput = document.createElement('input')
+  desktopSizeInput.type = 'hidden'
+  desktopSizeInput.name = 'desktop_size'
+  desktopSizeInput.value = desktopSize
+  form.appendChild(desktopSizeInput)
+
   document.body.appendChild(form)
   form.submit()
   form.remove()


### PR DESCRIPTION
Adds browser-fit and six fixed desktop-resolution presets to both Native Connections UIs, validates the submitted preset in the gateway, and initializes IronRDP with the selected dimensions.

RDP users can now choose a stable desktop resolution before opening the browser client; the existing browser-fit behavior remains the default.

## How to test

1. Run the focused gateway tests:
   ```bash
   cd gateway
   go test ./rdp
   ```
   Expected: the package passes; omitted/`fit` values preserve browser-fit mode, all six presets resolve to their dimensions, and unknown presets are rejected.

2. Build both web applications:
   ```bash
   cd webapp_v2
   npm ci
   npm run build

   cd ../webapp
   npm ci
   npm run genversion
   npm run shadow:release:hoop-ui
   ```
   Expected: both builds complete without errors.

3. With an online RDP connection, open **Native Connections**, expand the RDP session, choose `1280 × 720`, and click **Open web client**. Expected: the request posts `desktop_size=1280x720`, the client canvas initializes at 1280 × 720, and selecting **Fit browser window** retains the current viewport/DPR sizing. Negative check:
   ```bash
   curl -i -X POST http://localhost:8009/rdpproxy/client \
     -F 'credential=invalid' \
     -F 'desktop_size=4096x4096'
   ```
   Expected: `HTTP/1.1 400 Bad Request` with `Invalid request`.

Validated locally on macOS with Chromium against the RDP PII demo stack and an online RDP connection.

<img width="1190" height="604" alt="image" src="https://github.com/user-attachments/assets/63e73cec-5a21-42f1-a25e-b8d39da1acd4" />


Automated by MisterMal
