### PR TITLE
fix: sync slack review messages

### DIFF
--- a/gateway/api/review/review.go
+++ b/gateway/api/review/review.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	"github.com/hoophq/hoop/gateway/events"
 	"github.com/hoophq/hoop/gateway/models"
+	slackservice "github.com/hoophq/hoop/gateway/slack"
 	"github.com/hoophq/hoop/gateway/storagev2"
 	"github.com/hoophq/hoop/gateway/storagev2/types"
 	"github.com/hoophq/hoop/gateway/utils"
@@ -198,6 +199,48 @@ func (h *handler) ReviewByIdOrSid(c *gin.Context) {
 //	@Router					/sessions/{session_id}/review [put]
 func (h *handler) ReviewBySid(c *gin.Context) { h.ReviewByIdOrSid(c) }
 
+// UpdateSlackMessage synchronizes the Slack review messages with the review
+// state after it changed outside of a Slack interaction (API, webapp or MCP
+// review). Reviews resolved from Slack itself are additionally updated via the
+// interaction callback in the slack transport plugin. Best effort: messages
+// posted by another gateway instance or before a restart are not tracked and
+// are silently skipped.
+func UpdateSlackMessage(rev *models.Review) error {
+	slackSvc := slackservice.GetServiceInstance(rev.OrgID)
+	if slackSvc == nil {
+		return nil
+	}
+
+	switch rev.Status {
+	case models.ReviewStatusPending, models.ReviewStatusApproved, models.ReviewStatusRejected:
+	default:
+		return nil
+	}
+
+	req := &slackservice.UpdateReviewMessageRequest{
+		ReviewID:    rev.ID,
+		IsApproved:  rev.Status == models.ReviewStatusApproved,
+		IsRejected:  rev.Status == models.ReviewStatusRejected,
+		TotalGroups: len(rev.ReviewGroups),
+	}
+	for _, rg := range rev.ReviewGroups {
+		if rg.Status == models.ReviewStatusPending {
+			continue
+		}
+		reviewedAt := time.Now().UTC()
+		if rg.ReviewedAt != nil {
+			reviewedAt = *rg.ReviewedAt
+		}
+		req.ReviewedGroups = append(req.ReviewedGroups, slackservice.ReviewedGroup{
+			Name:          rg.GroupName,
+			Status:        rg.Status.Str(),
+			ReviewerEmail: ptr.ToString(rg.OwnerEmail),
+			ReviewedAt:    reviewedAt,
+		})
+	}
+	return slackSvc.UpdateReviewMessage(req)
+}
+
 // DoReview updates the status of a review identified by reviewIdOrSid. The hasForced parameter
 // indicates whether the review status change was forced by an administrator or privileged user,
 // bypassing normal review validation rules or approval workflows. When the resulting status is
@@ -243,6 +286,11 @@ func DoReview(ctx *storagev2.Context, reviewIdOrSid string, status models.Review
 
 	if err := models.UpdateReview(rev); err != nil {
 		return nil, fmt.Errorf("failed updating review state, reason=%v", err)
+	}
+
+	err = UpdateSlackMessage(rev)
+	if err != nil {
+		log.Warnf("failed updating slack review, err=%v", err)
 	}
 
 	if rev.Status == models.ReviewStatusApproved || rev.Status == models.ReviewStatusRejected {

--- a/gateway/api/session/ai_review.go
+++ b/gateway/api/session/ai_review.go
@@ -93,7 +93,7 @@ func CreateReviewFromAIAnalysis(
 }
 
 func sendSlackMessage(requester AIReviewRequester, connection *models.Connection, rev *models.Review, reviewInput string, analysis *models.SessionAIAnalysis) error {
-	slackSvc := slack.GetSlackServiceInstance(rev.OrgID)
+	slackSvc := slackModel.GetServiceInstance(rev.OrgID)
 	log.With("sid", rev.SessionID).Infof("executing slack on-receive, hasinstance=%v", slackSvc != nil)
 	if slackSvc == nil {
 		return nil

--- a/gateway/slack/service.go
+++ b/gateway/slack/service.go
@@ -426,13 +426,33 @@ func (s *SlackService) UpdateReviewMessage(req *UpdateReviewMessageRequest) erro
 	return nil
 }
 
+// approverGroupsLabelPrefix matches the section SendMessageReview posts right
+// above each group's action block; dropped together with the block so no
+// orphaned label survives a terminal rewrite.
+const approverGroupsLabelPrefix = "*Approver groups:*"
+
+func reviewOutcomeSection(rg ReviewedGroup) *slack.SectionBlock {
+	return slack.NewSectionBlock(&slack.TextBlockObject{
+		Type: slack.MarkdownType,
+		Text: fmt.Sprintf("%s `%s` this session at _%v_",
+			escapeSlackText(rg.ReviewerEmail), strings.ToLower(rg.Status),
+			rg.ReviewedAt.UTC().Format(time.RFC1123)),
+	}, nil, nil)
+}
+
 // rebuildReviewBlocks recreates the message block set from the originally
 // posted blocks, replacing each reviewed group's action block with its outcome
 // and appending the final or partial status. On terminal states the remaining
-// unreviewed groups' buttons are dropped: the review no longer accepts input
-// and a click would only produce a "wrong state" error. Never mutates m.blocks.
+// unreviewed groups' buttons are dropped (with their label sections): the
+// review no longer accepts input and a click would only produce a "wrong
+// state" error. Reviewed groups that match no action block — synthetic groups
+// appended when an admin or the owner rejects, or forced-approval groups
+// outside the approver set — get their outcome appended at the end, so a
+// terminal rejection is never rendered without attribution. Never mutates
+// m.blocks.
 func rebuildReviewBlocks(m *sentReviewMessage, req *UpdateReviewMessageRequest, reviewed map[string]ReviewedGroup) []slack.Block {
 	done := req.IsApproved || req.IsRejected
+	matched := make(map[string]bool, len(reviewed))
 	blocks := make([]slack.Block, 0, len(m.blocks)+2)
 	for _, b := range m.blocks {
 		ab, ok := b.(*slack.ActionBlock)
@@ -440,19 +460,31 @@ func rebuildReviewBlocks(m *sentReviewMessage, req *UpdateReviewMessageRequest, 
 			blocks = append(blocks, b)
 			continue
 		}
-		rg, ok := reviewed[reviewGroupFromBlockID(ab.BlockID, req.ReviewID)]
+		group := reviewGroupFromBlockID(ab.BlockID, req.ReviewID)
+		rg, ok := reviewed[group]
 		if !ok {
 			if !done {
 				blocks = append(blocks, b)
+				continue
+			}
+			// drop the button and its "*Approver groups:* X" label above it
+			if n := len(blocks); n > 0 {
+				if sec, ok := blocks[n-1].(*slack.SectionBlock); ok &&
+					sec.Text != nil && strings.HasPrefix(sec.Text.Text, approverGroupsLabelPrefix) {
+					blocks = blocks[:n-1]
+				}
 			}
 			continue
 		}
-		blocks = append(blocks, slack.NewSectionBlock(&slack.TextBlockObject{
-			Type: slack.MarkdownType,
-			Text: fmt.Sprintf("%s `%s` this session at _%v_",
-				escapeSlackText(rg.ReviewerEmail), strings.ToLower(rg.Status),
-				rg.ReviewedAt.UTC().Format(time.RFC1123)),
-		}, nil, nil))
+		matched[group] = true
+		blocks = append(blocks, reviewOutcomeSection(rg))
+	}
+
+	// synthetic reviewed groups with no action block of their own
+	for _, rg := range req.ReviewedGroups {
+		if !matched[rg.Name] {
+			blocks = append(blocks, reviewOutcomeSection(rg))
+		}
 	}
 
 	switch {

--- a/gateway/slack/service.go
+++ b/gateway/slack/service.go
@@ -29,6 +29,41 @@ type SlackService struct {
 	// reject-reason modal is open. Key is review_id. Cleaned up on modal submission.
 	pendingRejectMu    sync.Mutex
 	pendingRejectItems map[string]slack.InteractionCallback
+
+	// sentReviewItems tracks review messages posted by SendMessageReview so they
+	// can be updated when the review state changes outside of a Slack
+	// interaction (API, webapp or MCP review). Key is review_id. Entries are
+	// removed on terminal updates and expire after sentReviewRetention.
+	sentReviewMu    sync.Mutex
+	sentReviewItems map[string][]sentReviewMessage
+}
+
+// instances tracks the running SlackService per organization. Registered by
+// the slack transport plugin when an org's slack integration starts and
+// consumed by API handlers that need to message Slack outside the plugin flow.
+var (
+	instancesMu sync.RWMutex
+	instances   = map[string]*SlackService{}
+)
+
+// GetServiceInstance returns the running slack service for the org, or nil
+// when the slack integration is not configured or not started.
+func GetServiceInstance(orgID string) *SlackService {
+	instancesMu.RLock()
+	defer instancesMu.RUnlock()
+	return instances[orgID]
+}
+
+func SetServiceInstance(orgID string, svc *SlackService) {
+	instancesMu.Lock()
+	defer instancesMu.Unlock()
+	instances[orgID] = svc
+}
+
+func RemoveServiceInstance(orgID string) {
+	instancesMu.Lock()
+	defer instancesMu.Unlock()
+	delete(instances, orgID)
 }
 
 const (
@@ -42,6 +77,9 @@ const (
 	// maxAITitleSize bounds the model-generated analysis title so it cannot
 	// push the analysis section past Slack's 3000-char text limit.
 	maxAITitleSize = 200
+	// sentReviewRetention bounds how long a posted review message is tracked
+	// for out-of-band updates. Reviews expire well before this.
+	sentReviewRetention = 48 * time.Hour
 )
 
 func New(slackBotToken, slackAppToken, slackChannel, instanceID, apiURL string) (*SlackService, error) {
@@ -71,6 +109,7 @@ func New(slackBotToken, slackAppToken, slackChannel, instanceID, apiURL string) 
 		ctx:                ctx,
 		cancelFn:           cancelFn,
 		pendingRejectItems: make(map[string]slack.InteractionCallback),
+		sentReviewItems:    make(map[string][]sentReviewMessage),
 	}, nil
 
 }
@@ -95,8 +134,8 @@ type MessageReviewRequest struct {
 	AITitle        string
 	// AISummary is the reviewer-facing analysis. Callers may leave it empty and
 	// set AIExplanation instead; the builder falls back to it.
-	AISummary      string
-	AIExplanation  string
+	AISummary     string
+	AIExplanation string
 }
 
 type MessageReviewResponse struct {
@@ -272,16 +311,182 @@ func (s *SlackService) SendMessageReview(msg *MessageReviewRequest) (result stri
 	}
 
 	var errs []string
+	var sent []sentReviewMessage
 	for _, slackChannel := range slackChannels {
-		_, _, err := s.apiClient.PostMessage(slackChannel, slack.MsgOptionBlocks(blocks...), metadata)
+		channelID, timestamp, err := s.apiClient.PostMessage(slackChannel, slack.MsgOptionBlocks(blocks...), metadata)
 		if err != nil {
 			errs = append(errs, fmt.Sprintf(`"%v - %v"`, slackChannel, err))
+		} else {
+			sent = append(sent, sentReviewMessage{
+				channelID: channelID,
+				timestamp: timestamp,
+				eventKind: eventKind,
+				blocks:    blocks,
+				sentAt:    time.Now().UTC(),
+			})
 		}
 
 		// Slack allows 1 post message per second. reference: https://api.slack.com/apis/rate-limits
 		time.Sleep(time.Millisecond * 1200)
 	}
+	s.trackSentReviewMessages(msg.ID, sent)
 	return fmt.Sprintf("success sent channels %v/%v, errors=%v", len(slackChannels), len(slackChannels)-len(errs), errs)
+}
+
+// sentReviewMessage records where a review message landed so it can be
+// rewritten later without a Slack interaction callback.
+type sentReviewMessage struct {
+	channelID string
+	timestamp string
+	eventKind string
+	// blocks is the block set as originally posted; treated as immutable and
+	// shared across channels. Updates rebuild a fresh slice from it.
+	blocks []slack.Block
+	sentAt time.Time
+}
+
+func (s *SlackService) trackSentReviewMessages(reviewID string, sent []sentReviewMessage) {
+	if reviewID == "" || len(sent) == 0 {
+		return
+	}
+	now := time.Now().UTC()
+	s.sentReviewMu.Lock()
+	defer s.sentReviewMu.Unlock()
+	// lazy eviction keeps the map bounded without a janitor goroutine
+	for id, items := range s.sentReviewItems {
+		if len(items) > 0 && now.Sub(items[0].sentAt) > sentReviewRetention {
+			delete(s.sentReviewItems, id)
+		}
+	}
+	s.sentReviewItems[reviewID] = sent
+}
+
+// ReviewedGroup describes one approver group's recorded outcome, used to
+// rewrite that group's action block in the review message.
+type ReviewedGroup struct {
+	Name          string
+	Status        string
+	ReviewerEmail string
+	ReviewedAt    time.Time
+}
+
+// UpdateReviewMessageRequest carries the review state used to rewrite the
+// tracked review messages.
+type UpdateReviewMessageRequest struct {
+	ReviewID       string
+	IsApproved     bool
+	IsRejected     bool
+	ReviewedGroups []ReviewedGroup
+	TotalGroups    int
+}
+
+// HasTrackedReviewMessages reports whether the review's posted messages are
+// tracked, i.e. whether UpdateReviewMessage is able to rewrite them. Callers
+// holding an interaction callback use it to decide between relying on the
+// tracked rewrite or falling back to a callback-based update.
+func (s *SlackService) HasTrackedReviewMessages(reviewID string) bool {
+	s.sentReviewMu.Lock()
+	defer s.sentReviewMu.Unlock()
+	return len(s.sentReviewItems[reviewID]) > 0
+}
+
+// UpdateReviewMessage rewrites the review messages previously posted by
+// SendMessageReview whenever the review state changes: API, webapp, MCP or a
+// Slack button click (the slack plugin skips its callback-based update when
+// the messages are tracked, so this is the single renderer). It is best
+// effort: messages posted by another gateway instance or before a restart are
+// not tracked and are silently skipped.
+func (s *SlackService) UpdateReviewMessage(req *UpdateReviewMessageRequest) error {
+	done := req.IsApproved || req.IsRejected
+	s.sentReviewMu.Lock()
+	items := s.sentReviewItems[req.ReviewID]
+	if done {
+		delete(s.sentReviewItems, req.ReviewID)
+	}
+	s.sentReviewMu.Unlock()
+	if len(items) == 0 {
+		return nil
+	}
+
+	reviewed := make(map[string]ReviewedGroup, len(req.ReviewedGroups))
+	for _, rg := range req.ReviewedGroups {
+		reviewed[rg.Name] = rg
+	}
+
+	var errs []string
+	for _, m := range items {
+		blocks := rebuildReviewBlocks(&m, req, reviewed)
+		if _, _, _, err := s.apiClient.UpdateMessage(m.channelID, m.timestamp, slack.MsgOptionBlocks(blocks...)); err != nil {
+			errs = append(errs, fmt.Sprintf(`"%v - %v"`, m.channelID, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed updating review message on channels %v", errs)
+	}
+	return nil
+}
+
+// rebuildReviewBlocks recreates the message block set from the originally
+// posted blocks, replacing each reviewed group's action block with its outcome
+// and appending the final or partial status. On terminal states the remaining
+// unreviewed groups' buttons are dropped: the review no longer accepts input
+// and a click would only produce a "wrong state" error. Never mutates m.blocks.
+func rebuildReviewBlocks(m *sentReviewMessage, req *UpdateReviewMessageRequest, reviewed map[string]ReviewedGroup) []slack.Block {
+	done := req.IsApproved || req.IsRejected
+	blocks := make([]slack.Block, 0, len(m.blocks)+2)
+	for _, b := range m.blocks {
+		ab, ok := b.(*slack.ActionBlock)
+		if !ok {
+			blocks = append(blocks, b)
+			continue
+		}
+		rg, ok := reviewed[reviewGroupFromBlockID(ab.BlockID, req.ReviewID)]
+		if !ok {
+			if !done {
+				blocks = append(blocks, b)
+			}
+			continue
+		}
+		blocks = append(blocks, slack.NewSectionBlock(&slack.TextBlockObject{
+			Type: slack.MarkdownType,
+			Text: fmt.Sprintf("%s `%s` this session at _%v_",
+				escapeSlackText(rg.ReviewerEmail), strings.ToLower(rg.Status),
+				rg.ReviewedAt.UTC().Format(time.RFC1123)),
+		}, nil, nil))
+	}
+
+	switch {
+	case req.IsApproved:
+		text := "*Session ready to be executed!*\n"
+		if m.eventKind == EventKindJit {
+			text = "*Interactive session ready!*\n"
+		}
+		blocks = append(blocks,
+			slack.NewDividerBlock(),
+			slack.NewSectionBlock(&slack.TextBlockObject{
+				Type: slack.MarkdownType,
+				Text: text,
+			}, nil, nil))
+	case !req.IsRejected:
+		blocks = append(blocks, slack.NewContextBlock("",
+			slack.NewTextBlockObject(slack.MarkdownType,
+				fmt.Sprintf("_Approved by %d of %d required group(s)_", len(req.ReviewedGroups), req.TotalGroups), false, false),
+		))
+	}
+	return blocks
+}
+
+// reviewGroupFromBlockID extracts the group name from an action block id in
+// the form "<review-id>:<group-name>:<index>" (see SendMessageReview).
+func reviewGroupFromBlockID(blockID, reviewID string) string {
+	v, ok := strings.CutPrefix(blockID, reviewID+":")
+	if !ok {
+		return ""
+	}
+	if i := strings.LastIndex(v, ":"); i >= 0 {
+		return v[:i]
+	}
+	return v
 }
 
 func (s *SlackService) UpdateMessage(msg *MessageReviewResponse, isApproved bool) error {

--- a/gateway/slack/service_test.go
+++ b/gateway/slack/service_test.go
@@ -94,9 +94,16 @@ func TestReviewGroupFromBlockID(t *testing.T) {
 // originally posted block set shared across channels.
 func TestRebuildReviewBlocks(t *testing.T) {
 	const revID = "rev-1"
+	label := func(group string) *slack.SectionBlock {
+		return slack.NewSectionBlock(&slack.TextBlockObject{
+			Type: slack.MarkdownType, Text: "*Approver groups:* " + group,
+		}, nil, nil)
+	}
 	original := []slack.Block{
 		slack.NewHeaderBlock(&slack.TextBlockObject{Type: slack.PlainTextType, Text: "Hoop Review"}),
+		label("admin"),
 		slack.NewActionBlock(revID + ":admin:0"),
+		label("sre"),
 		slack.NewActionBlock(revID + ":sre:1"),
 	}
 	m := &sentReviewMessage{eventKind: EventKindOneTime, blocks: original}
@@ -108,50 +115,72 @@ func TestRebuildReviewBlocks(t *testing.T) {
 	// partial approval: admin replaced, sre still actionable, progress context appended
 	req := &UpdateReviewMessageRequest{ReviewID: revID, ReviewedGroups: []ReviewedGroup{reviewed["admin"]}, TotalGroups: 2}
 	blocks := rebuildReviewBlocks(m, req, reviewed)
-	if len(blocks) != 4 {
-		t.Fatalf("partial: got %d blocks, want 4", len(blocks))
+	if len(blocks) != 6 {
+		t.Fatalf("partial: got %d blocks, want 6", len(blocks))
 	}
-	sec, ok := blocks[1].(*slack.SectionBlock)
+	sec, ok := blocks[2].(*slack.SectionBlock)
 	if !ok {
-		t.Fatalf("partial: reviewed group block not replaced, got %T", blocks[1])
+		t.Fatalf("partial: reviewed group block not replaced, got %T", blocks[2])
 	}
 	if !strings.Contains(sec.Text.Text, "a@a.com") || !strings.Contains(sec.Text.Text, "`approved`") {
 		t.Errorf("partial: unexpected outcome text: %s", sec.Text.Text)
 	}
-	if _, ok := blocks[2].(*slack.ActionBlock); !ok {
-		t.Errorf("partial: pending group must keep its buttons, got %T", blocks[2])
+	if _, ok := blocks[4].(*slack.ActionBlock); !ok {
+		t.Errorf("partial: pending group must keep its buttons, got %T", blocks[4])
 	}
-	if _, ok := blocks[3].(*slack.ContextBlock); !ok {
-		t.Errorf("partial: missing progress context block, got %T", blocks[3])
+	if _, ok := blocks[5].(*slack.ContextBlock); !ok {
+		t.Errorf("partial: missing progress context block, got %T", blocks[5])
 	}
 
-	// terminal approval (e.g. min_approvals reached): unreviewed sre buttons
-	// are dropped and the ready divider+section replaces the progress context
+	// terminal approval (e.g. min_approvals reached): unreviewed sre button AND
+	// its label are dropped, ready divider+section replaces the progress context
 	req.IsApproved = true
 	blocks = rebuildReviewBlocks(m, req, reviewed)
-	if len(blocks) != 4 {
-		t.Fatalf("approved: got %d blocks, want 4", len(blocks))
+	if len(blocks) != 5 {
+		t.Fatalf("approved: got %d blocks, want 5", len(blocks))
 	}
 	for _, b := range blocks {
 		if _, ok := b.(*slack.ActionBlock); ok {
 			t.Errorf("approved: terminal message must not keep buttons")
 		}
+		if sec, ok := b.(*slack.SectionBlock); ok && strings.Contains(sec.Text.Text, "sre") {
+			t.Errorf("approved: orphaned label for dropped sre button: %s", sec.Text.Text)
+		}
 	}
-	ready, ok := blocks[3].(*slack.SectionBlock)
+	ready, ok := blocks[4].(*slack.SectionBlock)
 	if !ok || !strings.Contains(ready.Text.Text, "Session ready") {
-		t.Errorf("approved: missing ready section, got %T", blocks[3])
+		t.Errorf("approved: missing ready section, got %T", blocks[4])
 	}
 
-	// terminal rejection appends nothing and drops remaining buttons
+	// terminal rejection appends nothing and drops remaining buttons + labels
 	req.IsApproved = false
 	req.IsRejected = true
-	if blocks = rebuildReviewBlocks(m, req, reviewed); len(blocks) != 2 {
-		t.Errorf("rejected: got %d blocks, want 2", len(blocks))
+	if blocks = rebuildReviewBlocks(m, req, reviewed); len(blocks) != 3 {
+		t.Errorf("rejected: got %d blocks, want 3", len(blocks))
+	}
+
+	// synthetic reviewed group (admin/owner rejection, forced approval) matches
+	// no action block: its outcome must still be rendered, never a silent drop
+	synthetic := ReviewedGroup{Name: "owner-veto", Status: "REJECTED", ReviewerEmail: "b@b.com", ReviewedAt: reviewedAt}
+	sreq := &UpdateReviewMessageRequest{ReviewID: revID, IsRejected: true,
+		ReviewedGroups: []ReviewedGroup{synthetic}, TotalGroups: 2}
+	blocks = rebuildReviewBlocks(m, sreq, map[string]ReviewedGroup{synthetic.Name: synthetic})
+	var foundOutcome bool
+	for _, b := range blocks {
+		if _, ok := b.(*slack.ActionBlock); ok {
+			t.Errorf("synthetic rejection: buttons must be dropped")
+		}
+		if sec, ok := b.(*slack.SectionBlock); ok && strings.Contains(sec.Text.Text, "b@b.com") && strings.Contains(sec.Text.Text, "`rejected`") {
+			foundOutcome = true
+		}
+	}
+	if !foundOutcome {
+		t.Errorf("synthetic rejection: outcome section missing, blocks=%d", len(blocks))
 	}
 
 	// original blocks are shared across channels and must stay intact
-	if _, ok := original[1].(*slack.ActionBlock); !ok {
-		t.Errorf("original block set mutated: %T", original[1])
+	if _, ok := original[2].(*slack.ActionBlock); !ok {
+		t.Errorf("original block set mutated: %T", original[2])
 	}
 }
 

--- a/gateway/slack/service_test.go
+++ b/gateway/slack/service_test.go
@@ -1,9 +1,15 @@
 package slack
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
+
+	"github.com/slack-go/slack"
 )
 
 // The AI analysis text is model output derived from the user's script. Escaping
@@ -64,5 +70,131 @@ func TestTruncateRunesKeepsValidUTF8(t *testing.T) {
 	}
 	if got := truncateRunes("anything", -5); got != "" {
 		t.Errorf("negative max must yield empty, got %q", got)
+	}
+}
+
+// The block id format "<review-id>:<group-name>:<index>" is the only link
+// between a review group and its action block; group names may contain colons.
+func TestReviewGroupFromBlockID(t *testing.T) {
+	const revID = "8a4f4c5e-9f1d-4a89-b0f3-1c2d3e4f5a6b"
+	for _, tc := range []struct{ blockID, want string }{
+		{revID + ":admin:0", "admin"},
+		{revID + ":sre:eu:west:2", "sre:eu:west"},
+		{"other-review:admin:0", ""},
+		{revID + ":admin", "admin"},
+	} {
+		if got := reviewGroupFromBlockID(tc.blockID, revID); got != tc.want {
+			t.Errorf("reviewGroupFromBlockID(%q) = %q, want %q", tc.blockID, got, tc.want)
+		}
+	}
+}
+
+// A review resolved via API/webapp must rewrite only the reviewed groups'
+// action blocks, keep pending groups actionable, and never mutate the
+// originally posted block set shared across channels.
+func TestRebuildReviewBlocks(t *testing.T) {
+	const revID = "rev-1"
+	original := []slack.Block{
+		slack.NewHeaderBlock(&slack.TextBlockObject{Type: slack.PlainTextType, Text: "Hoop Review"}),
+		slack.NewActionBlock(revID + ":admin:0"),
+		slack.NewActionBlock(revID + ":sre:1"),
+	}
+	m := &sentReviewMessage{eventKind: EventKindOneTime, blocks: original}
+	reviewedAt := time.Date(2026, 8, 13, 10, 0, 0, 0, time.UTC)
+	reviewed := map[string]ReviewedGroup{
+		"admin": {Name: "admin", Status: "APPROVED", ReviewerEmail: "a@a.com", ReviewedAt: reviewedAt},
+	}
+
+	// partial approval: admin replaced, sre still actionable, progress context appended
+	req := &UpdateReviewMessageRequest{ReviewID: revID, ReviewedGroups: []ReviewedGroup{reviewed["admin"]}, TotalGroups: 2}
+	blocks := rebuildReviewBlocks(m, req, reviewed)
+	if len(blocks) != 4 {
+		t.Fatalf("partial: got %d blocks, want 4", len(blocks))
+	}
+	sec, ok := blocks[1].(*slack.SectionBlock)
+	if !ok {
+		t.Fatalf("partial: reviewed group block not replaced, got %T", blocks[1])
+	}
+	if !strings.Contains(sec.Text.Text, "a@a.com") || !strings.Contains(sec.Text.Text, "`approved`") {
+		t.Errorf("partial: unexpected outcome text: %s", sec.Text.Text)
+	}
+	if _, ok := blocks[2].(*slack.ActionBlock); !ok {
+		t.Errorf("partial: pending group must keep its buttons, got %T", blocks[2])
+	}
+	if _, ok := blocks[3].(*slack.ContextBlock); !ok {
+		t.Errorf("partial: missing progress context block, got %T", blocks[3])
+	}
+
+	// terminal approval (e.g. min_approvals reached): unreviewed sre buttons
+	// are dropped and the ready divider+section replaces the progress context
+	req.IsApproved = true
+	blocks = rebuildReviewBlocks(m, req, reviewed)
+	if len(blocks) != 4 {
+		t.Fatalf("approved: got %d blocks, want 4", len(blocks))
+	}
+	for _, b := range blocks {
+		if _, ok := b.(*slack.ActionBlock); ok {
+			t.Errorf("approved: terminal message must not keep buttons")
+		}
+	}
+	ready, ok := blocks[3].(*slack.SectionBlock)
+	if !ok || !strings.Contains(ready.Text.Text, "Session ready") {
+		t.Errorf("approved: missing ready section, got %T", blocks[3])
+	}
+
+	// terminal rejection appends nothing and drops remaining buttons
+	req.IsApproved = false
+	req.IsRejected = true
+	if blocks = rebuildReviewBlocks(m, req, reviewed); len(blocks) != 2 {
+		t.Errorf("rejected: got %d blocks, want 2", len(blocks))
+	}
+
+	// original blocks are shared across channels and must stay intact
+	if _, ok := original[1].(*slack.ActionBlock); !ok {
+		t.Errorf("original block set mutated: %T", original[1])
+	}
+}
+
+// Terminal updates must consume the tracked entry (no stale rewrites) and
+// untracked reviews must be a silent no-op even without an api client.
+func TestUpdateReviewMessageTracking(t *testing.T) {
+	s := &SlackService{sentReviewItems: make(map[string][]sentReviewMessage)}
+
+	// untracked review: no-op, no network
+	if err := s.UpdateReviewMessage(&UpdateReviewMessageRequest{ReviewID: "unknown", IsApproved: true}); err != nil {
+		t.Fatalf("untracked review must be a no-op, got %v", err)
+	}
+
+	// terminal update rewrites the message once and consumes the tracked entry
+	var updateCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		updateCalls++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"ok":true,"channel":"C1","ts":"1.0"}`)
+	}))
+	defer srv.Close()
+	s.apiClient = slack.New("xoxb-test", slack.OptionAPIURL(srv.URL+"/"))
+
+	s.sentReviewItems["rev-1"] = []sentReviewMessage{{channelID: "C1", timestamp: "1.0"}}
+	req := &UpdateReviewMessageRequest{ReviewID: "rev-1", IsApproved: true}
+	if err := s.UpdateReviewMessage(req); err != nil {
+		t.Fatalf("tracked terminal update failed: %v", err)
+	}
+	if updateCalls != 1 {
+		t.Fatalf("chat.update called %d times, want 1", updateCalls)
+	}
+	if err := s.UpdateReviewMessage(req); err != nil || updateCalls != 1 {
+		t.Fatalf("consumed entry must not be rewritten again, calls=%d err=%v", updateCalls, err)
+	}
+
+	// eviction drops entries older than the retention window on new sends
+	stale := time.Now().UTC().Add(-sentReviewRetention - time.Hour)
+	s.sentReviewItems["rev-old"] = []sentReviewMessage{{channelID: "C1", timestamp: "1.0", sentAt: stale}}
+	s.trackSentReviewMessages("rev-new", []sentReviewMessage{{channelID: "C2", timestamp: "2.0", sentAt: time.Now().UTC()}})
+	if _, ok := s.sentReviewItems["rev-old"]; ok {
+		t.Errorf("expired entry survived eviction")
+	}
+	if _, ok := s.sentReviewItems["rev-new"]; !ok {
+		t.Errorf("fresh entry was not tracked")
 	}
 }

--- a/gateway/transport/plugins/slack/events.go
+++ b/gateway/transport/plugins/slack/events.go
@@ -81,6 +81,13 @@ func (p *slackPlugin) processEventResponse(ev *event) {
 }
 
 func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status models.ReviewStatusType) {
+	// DoReview rewrites every tracked review message (all channels, all
+	// reviewed groups) via UpdateSlackMessage. Capture trackedness before it
+	// consumes the entry on terminal states; the callback-based update below
+	// is only a fallback for untracked messages (e.g. posted before a gateway
+	// restart), otherwise its click-time blocks would overwrite the rewrite
+	// with a stale version where only the clicked block changed.
+	tracked := ev.ss.HasTrackedReviewMessages(ev.msg.ID)
 	rev, err := reviewapi.DoReview(ctx, ev.msg.ID, status, nil, false, ev.msg.RejectionReason)
 	var msg string
 	switch err {
@@ -96,7 +103,11 @@ func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status mo
 		isApproved := rev.Status == models.ReviewStatusApproved
 		isStillPending := rev.Status == models.ReviewStatusPending
 
-		if isStillPending {
+		switch {
+		case tracked:
+			log.With("sid", ev.msg.SessionID).Infof("review id=%s, status=%v, skipping callback update, message rewrite delegated to DoReview",
+				ev.msg.ID, rev.Status)
+		case isStillPending:
 			// Count how many groups have approved
 			approvedCount := 0
 			for _, rg := range rev.ReviewGroups {
@@ -109,7 +120,7 @@ func (p *slackPlugin) performReview(ev *event, ctx *storagev2.Context, status mo
 			err = ev.ss.UpdateMessagePartialApproval(ev.msg, approvedCount, len(rev.ReviewGroups))
 			log.With("sid", ev.msg.SessionID).Infof("review id=%s, partial approval, approved=%d/%d, update-msg-err=%v",
 				ev.msg.ID, approvedCount, len(rev.ReviewGroups), err)
-		} else {
+		default:
 			// Full approval or rejection
 			err = ev.ss.UpdateMessage(ev.msg, isApproved)
 			log.With("sid", ev.msg.SessionID).Infof("review id=%s, isapproved=%v, status=%v, update-msg-err=%v",

--- a/gateway/transport/plugins/slack/slack.go
+++ b/gateway/transport/plugins/slack/slack.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"encoding/base64"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/hoophq/hoop/common/log"
@@ -30,30 +29,7 @@ type (
 	}
 )
 
-var instances map[string]*slack.SlackService
-var mu sync.RWMutex
-
-func GetSlackServiceInstance(orgID string) *slack.SlackService {
-	mu.Lock()
-	defer mu.Unlock()
-	return instances[orgID]
-}
-
-func removeSlackServiceInstance(orgID string) {
-	mu.Lock()
-	defer mu.Unlock()
-	delete(instances, orgID)
-}
-
-func addSlackServiceInstance(orgID string, slackSvc *slack.SlackService) {
-	mu.Lock()
-	defer mu.Unlock()
-	instances[orgID] = slackSvc
-}
-
 func New(releaseConnFn reviewapi.TransportReleaseConnectionFunc) *slackPlugin {
-	instances = map[string]*slack.SlackService{}
-	mu = sync.RWMutex{}
 	return &slackPlugin{
 		TransportReleaseConnection: releaseConnFn,
 		apiURL:                     appconfig.Get().ApiURL(),
@@ -74,7 +50,7 @@ func (p *slackPlugin) startSlackServiceInstance(orgID string, slackConfig *slack
 	if err != nil {
 		return fmt.Errorf("failed starting slack service, err=%v", err)
 	}
-	addSlackServiceInstance(orgID, ss)
+	slack.SetServiceInstance(orgID, ss)
 	reviewRespCh := make(chan *slack.MessageReviewResponse)
 	go func() {
 		defer close(reviewRespCh)
@@ -84,7 +60,7 @@ func (p *slackPlugin) startSlackServiceInstance(orgID string, slackConfig *slack
 		}
 		log.Infof("done processing events for org %v", orgID)
 		ss.Close()
-		removeSlackServiceInstance(orgID)
+		slack.RemoveServiceInstance(orgID)
 	}()
 
 	// response channel
@@ -130,7 +106,7 @@ func (p *slackPlugin) OnStartup(_ plugintypes.Context) error {
 }
 
 func (p *slackPlugin) OnUpdate(oldState, newState plugintypes.PluginResource) error {
-	slackInstance := GetSlackServiceInstance(newState.GetOrgID())
+	slackInstance := slack.GetServiceInstance(newState.GetOrgID())
 	if slackInstance == nil {
 		slackInstance = &slack.SlackService{}
 	}
@@ -171,7 +147,7 @@ func (p *slackPlugin) OnUpdate(oldState, newState plugintypes.PluginResource) er
 				if slackInstance != nil {
 					slackInstance.Close()
 				}
-				removeSlackServiceInstance(newState.GetOrgID())
+				slack.RemoveServiceInstance(newState.GetOrgID())
 				err := p.startSlackServiceInstance(newState.GetOrgID(), newSlackConfig)
 				if err == nil {
 					return nil
@@ -190,7 +166,7 @@ func (p *slackPlugin) OnUpdate(oldState, newState plugintypes.PluginResource) er
 
 // SendApprovedMessage sends a message informing the session is ready
 func SendApprovedMessage(orgID, slackID, sid, apiURL string) {
-	if slacksvc := GetSlackServiceInstance(orgID); slacksvc != nil {
+	if slacksvc := slack.GetServiceInstance(orgID); slacksvc != nil {
 		msg := fmt.Sprintf("Your session is ready.\nFollow this link to see the details: %s/sessions/%s",
 			apiURL, sid)
 		_ = slacksvc.PostMessage(slackID, msg)
@@ -202,7 +178,7 @@ func (p *slackPlugin) OnReceive(pctx plugintypes.Context, pkt *pb.Packet) (*plug
 	if pkt.Type != pbagent.SessionOpen {
 		return nil, nil
 	}
-	slackSvc := GetSlackServiceInstance(pctx.OrgID)
+	slackSvc := slack.GetServiceInstance(pctx.OrgID)
 	log.With("sid", pctx.SID).Infof("executing slack on-receive, hasinstance=%v", slackSvc != nil)
 	if slackSvc == nil {
 		return nil, nil


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
>
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

Slack review messages now stay in sync with the review state regardless of where the review is resolved.
Previously, messages were only updated through the Slack interaction callback: reviews approved/rejected via
the webapp, API, or MCP left stale Approve/Reject buttons in Slack, and clicking a button only replaced the
clicked group's block — other reviewed groups (e.g. when the reviewer belongs to multiple groups or
`min_approvals` finalized the review) kept live buttons.

`SendMessageReview` now tracks each posted review message in memory (channel, timestamp, original blocks, per
review ID, 48h retention). A new `SlackService.UpdateReviewMessage` rewrites all tracked messages via
`chat.update` whenever the review state changes, rebuilding the block set from the original send: reviewed
groups' action blocks become outcome sections ("user `approved` this session at ..."), terminal states drop
the remaining buttons and their labels, partial approvals append an "Approved by N of M" progress line.
`DoReview` invokes this through the implemented `UpdateSlackMessage`, making it the single renderer for every
review surface; the callback-based update in the Slack plugin remains only as a fallback for untracked
messages (e.g. posted before a gateway restart).

The per-org `SlackService` registry moved from `gateway/transport/plugins/slack` into `gateway/slack` to break
the import cycle (`plugins/slack` → `api/review` → `plugins/slack`).

## 🔗 Related Issue

N/A

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- Implemented `UpdateSlackMessage` in `gateway/api/review/review.go`: called from `DoReview` after persisting,
  it maps the review state (status, reviewed groups, reviewer email, reviewed-at) to a Slack message rewrite;
  errors are logged, never block the review.
- `gateway/slack/service.go`: track posted review messages per review ID (`sentReviewItems`, lazy 48h
  eviction, consumed on terminal states); added `UpdateReviewMessage`, `HasTrackedReviewMessages`, and
  `rebuildReviewBlocks` — replaces reviewed groups' action blocks with outcome sections, drops unreviewed
  buttons and their "Approver groups" labels on terminal states, renders synthetic review groups (admin/owner
  rejection, forced approval) so rejections are never rendered without attribution.
- `gateway/transport/plugins/slack/events.go`: `performReview` skips the callback-based
  `UpdateMessage`/`UpdateMessagePartialApproval` when the review's messages are tracked (checked before
  `DoReview` consumes the entry), preventing the click-time blocks from overwriting the full rewrite with a
  stale single-block version.
- Moved the per-org `SlackService` registry into `gateway/slack`
  (`GetServiceInstance`/`SetServiceInstance`/`RemoveServiceInstance` with proper `RWMutex`); migrated the plugin
  and `gateway/api/session/ai_review.go` to it and deleted the plugin-local map/wrappers.
- Added unit tests: block-ID parsing (colon-containing group names), block rebuild for
  partial/approved/rejected/synthetic-group states, immutability of the shared original block set, terminal
  consumption via a stub Slack API server, and retention eviction.

## 🧪 Testing

Approved and rejected reviews from the webapp and API with single- and multi-group approver setups, and via
the Slack Approve/Reject buttons; verified the Slack message rewrites all reviewed groups' blocks, removes
remaining buttons on terminal states, and shows the partial-approval progress line while pending. Unit tests
cover the block rebuild logic, tracked-message lifecycle, and eviction against a stub Slack API.

### Test Configuration:

- **Browser(s)**: 
- **OS**: macOS

### Tests performed:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes
