### PR TITLE
Apply complete data masking rules to RDP

### DIFF
--- a/agentrs/src/piigate/analyze.rs
+++ b/agentrs/src/piigate/analyze.rs
@@ -558,6 +558,7 @@ mod tests {
             params: AnalysisParams {
                 score_threshold: 0.5,
                 entity_allowlist: vec!["US_SSN".into()],
+                ad_hoc_recognizers: Vec::new(),
                 entity_denylist: Vec::new(),
                 band_padding: 8,
                 max_ocr_concurrency: 4,

--- a/agentrs/src/piigate/config.rs
+++ b/agentrs/src/piigate/config.rs
@@ -1,19 +1,45 @@
 //! Resolving the agent-side PII guard configuration for a session.
 //!
-//! The enable decision, resource entity allowlist, score threshold, and band
-//! padding are sent by the gateway in SessionStarted metadata. Endpoints
+//! The enable decision, complete connection-scoped Data Masking rule payload,
+//! and band padding are sent by the gateway in SessionStarted metadata. Endpoints
 //! (Presidio analyzer, OCR sidecar) come from the agent's own environment —
 //! the sidecar and analyzer live in the customer network next to the agent,
 //! so their addresses are deliberately NOT carried on the wire or held in
 //! gateway state. This mirrors the Go agent's terminal-DLP precedent, where
 //! the agent reads MSPRESIDIO_ANALYZER_URL from its environment.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
+use serde::Deserialize;
 use tracing::warn;
 
-use super::presidio::AnalysisParams;
+use super::presidio::{AdHocRecognizer, AdHocRecognizerPattern, AnalysisParams};
 use super::GatePolicy;
+
+#[derive(Debug, Deserialize)]
+struct DataMaskingRule {
+    #[serde(default)]
+    supported_entity_types: Vec<SupportedEntityTypesEntry>,
+    #[serde(default)]
+    custom_entity_types: Vec<CustomEntityTypesEntry>,
+    score_threshold: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SupportedEntityTypesEntry {
+    name: String,
+    #[serde(default)]
+    entity_types: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CustomEntityTypesEntry {
+    name: String,
+    regex: Option<String>,
+    #[serde(default)]
+    deny_list: Vec<String>,
+    score: Option<f64>,
+}
 
 /// Env var for the Presidio analyzer base URL (shared with the Go agent's
 /// DLP override convention).
@@ -53,6 +79,96 @@ pub fn guard_requested(metadata: &HashMap<String, String>) -> bool {
 /// `resolve`.
 pub fn supports_pii_guard() -> bool {
     env_url(PRESIDIO_ANALYZER_URL_ENV).is_some() && env_url(OCR_SERVER_URL_ENV).is_some()
+}
+
+fn is_canonical_entity_type(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == b'_')
+}
+
+fn apply_data_masking_rules(
+    params: &mut AnalysisParams,
+    raw_rules: &str,
+) -> anyhow::Result<()> {
+    let rules: Vec<DataMaskingRule> =
+        serde_json::from_str(raw_rules).map_err(|e| anyhow::anyhow!("invalid JSON: {e}"))?;
+    if rules.is_empty() {
+        anyhow::bail!("rule list is empty");
+    }
+
+    let mut entity_allowlist = BTreeSet::new();
+    let mut ad_hoc_recognizers = Vec::new();
+    let mut score_threshold: Option<f64> = None;
+    for rule in rules {
+        let mut rule_has_entities = false;
+
+        for group in &rule.supported_entity_types {
+            if group.entity_types.is_empty() {
+                anyhow::bail!("supported entity group {:?} is empty", group.name);
+            }
+            for entity in &group.entity_types {
+                if !is_canonical_entity_type(entity) {
+                    anyhow::bail!("invalid entity type {entity:?}");
+                }
+                entity_allowlist.insert(entity.clone());
+                rule_has_entities = true;
+            }
+        }
+
+        for custom in rule.custom_entity_types {
+            if !is_canonical_entity_type(&custom.name) {
+                anyhow::bail!("invalid custom entity name {:?}", custom.name);
+            }
+            let regex = custom.regex.unwrap_or_default();
+            if regex.is_empty() && custom.deny_list.is_empty() {
+                anyhow::bail!(
+                    "custom entity {:?} requires regex or deny_list",
+                    custom.name
+                );
+            }
+            let score = custom.score.unwrap_or(0.0);
+            if !(0.0..=1.0).contains(&score) || !score.is_finite() {
+                anyhow::bail!("custom entity {:?} has invalid score {score}", custom.name);
+            }
+            entity_allowlist.insert(custom.name.clone());
+            rule_has_entities = true;
+            let patterns = if regex.is_empty() {
+                Vec::new()
+            } else {
+                vec![AdHocRecognizerPattern {
+                    name: custom.name.clone(),
+                    regex,
+                    score,
+                }]
+            };
+            ad_hoc_recognizers.push(AdHocRecognizer {
+                name: custom.name.clone(),
+                supported_language: "en".into(),
+                supported_entity: custom.name,
+                deny_list: custom.deny_list,
+                patterns,
+            });
+        }
+        if rule_has_entities {
+            let score = rule.score_threshold.unwrap_or(0.5);
+            if !(0.0..=1.0).contains(&score) || !score.is_finite() {
+                anyhow::bail!("invalid score threshold {score}");
+            }
+            score_threshold = Some(score_threshold.map_or(score, |current| current.min(score)));
+        }
+    }
+    if entity_allowlist.is_empty() {
+        anyhow::bail!("rules contain no entity types");
+    }
+
+    params.entity_allowlist = entity_allowlist.into_iter().collect();
+    params.ad_hoc_recognizers = ad_hoc_recognizers;
+    if let Some(score) = score_threshold {
+        params.score_threshold = score;
+    }
+    Ok(())
 }
 
 impl GuardConfig {
@@ -95,16 +211,19 @@ impl GuardConfig {
         if let Some(v) = metadata.get("pii_band_padding").and_then(|s| s.parse().ok()) {
             params.band_padding = v;
         }
-        if let Some(list) = metadata.get("pii_entity_allowlist") {
-            // JSON array: entity names use Presidio's external vocabulary and
-            // must not rely on being comma-free.
+        if let Some(rules) = metadata.get("data_masking_entity_data") {
+            apply_data_masking_rules(&mut params, rules)
+                .map_err(|e| anyhow::anyhow!("invalid data_masking_entity_data: {e}"))?;
+        } else if let Some(list) = metadata.get("pii_entity_allowlist") {
+            // Compatibility with gateways predating complete Data Masking
+            // policy metadata. The full rule payload takes precedence.
             match serde_json::from_str::<Vec<String>>(list) {
                 Ok(entities) => params.entity_allowlist = entities,
                 Err(e) => warn!(%sid, "piigate: ignoring malformed pii_entity_allowlist: {e}"),
             }
         } else if let Some(list) = metadata.get("pii_entity_denylist") {
             // Compatibility with gateways predating connection-scoped
-            // allowlists. The v2 allowlist takes precedence when both exist.
+            // allowlists.
             match serde_json::from_str::<Vec<String>>(list) {
                 Ok(entities) => params.entity_denylist = entities,
                 Err(e) => warn!(%sid, "piigate: ignoring malformed pii_entity_denylist: {e}"),
@@ -307,4 +426,120 @@ mod tests {
             });
         }
     }
+    #[test]
+    fn resolves_complete_data_masking_rules() {
+        with_endpoints(Some("http://p"), Some("http://o"), || {
+            let cfg = GuardConfig::resolve(
+                &md(&[
+                    ("pii_guard", "enabled"),
+                    ("pii_score_threshold", "0.9"),
+                    (
+                        "data_masking_entity_data",
+                        r#"[
+                            {
+                                "supported_entity_types": [
+                                    {"name": "CONTACT_INFORMATION", "entity_types": ["PERSON", "DATE_TIME"]}
+                                ],
+                                "custom_entity_types": [
+                                    {"name": "EMPLOYEE_ID", "regex": "EMP-[0-9]+", "score": 0.83},
+                                    {"name": "VIP_NAME", "deny_list": ["Alice Example"], "score": 0.7}
+                                ],
+                                "score_threshold": 0.4
+                            }
+                        ]"#,
+                    ),
+                ]),
+                "sid",
+            )
+            .unwrap()
+            .unwrap();
+
+            assert_eq!(cfg.params.score_threshold, 0.4);
+            assert_eq!(
+                cfg.params.entity_allowlist,
+                vec!["DATE_TIME", "EMPLOYEE_ID", "PERSON", "VIP_NAME"]
+            );
+            assert_eq!(cfg.params.ad_hoc_recognizers.len(), 2);
+            assert_eq!(
+                cfg.params.ad_hoc_recognizers[0].patterns,
+                vec![AdHocRecognizerPattern {
+                    name: "EMPLOYEE_ID".into(),
+                    regex: "EMP-[0-9]+".into(),
+                    score: 0.83,
+                }]
+            );
+            assert_eq!(
+                cfg.params.ad_hoc_recognizers[1].deny_list,
+                vec!["Alice Example"]
+            );
+        });
+    }
+
+    #[test]
+    fn complete_data_masking_rules_take_precedence_over_legacy_keys() {
+        with_endpoints(Some("http://p"), Some("http://o"), || {
+            let cfg = GuardConfig::resolve(
+                &md(&[
+                    ("pii_guard", "enabled"),
+                    ("pii_score_threshold", "0.9"),
+                    ("pii_entity_allowlist", r#"["US_SSN"]"#),
+                    (
+                        "data_masking_entity_data",
+                        r#"[{"supported_entity_types":[{"name":"TIME_DATA","entity_types":["DATE_TIME"]}],"score_threshold":0}]"#,
+                    ),
+                ]),
+                "sid",
+            )
+            .unwrap()
+            .unwrap();
+
+            assert_eq!(cfg.params.score_threshold, 0.0);
+            assert_eq!(cfg.params.entity_allowlist, vec!["DATE_TIME"]);
+        });
+    }
+
+    #[test]
+    fn invalid_complete_data_masking_rules_fail_closed() {
+        with_endpoints(Some("http://p"), Some("http://o"), || {
+            for rules in [
+                "not-json",
+                "[]",
+                r#"[{"supported_entity_types":[{"name":"UNKNOWN"}]}]"#,
+                r#"[{"custom_entity_types":[{"name":"EMPLOYEE_ID","score":0.8}]}]"#,
+                r#"[{"custom_entity_types":[{"name":"employee-id","regex":"EMP-[0-9]+","score":0.8}]}]"#,
+                r#"[{"custom_entity_types":[{"name":"EMPLOYEE_ID","regex":"EMP-[0-9]+","score":1.1}]}]"#,
+            ] {
+                let err = GuardConfig::resolve(
+                    &md(&[
+                        ("pii_guard", "enabled"),
+                        ("data_masking_entity_data", rules),
+                    ]),
+                    "sid",
+                )
+                .unwrap_err();
+                assert!(
+                    err.to_string().contains("invalid data_masking_entity_data"),
+                    "unexpected error for {rules}: {err}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn threshold_matches_gateway_rule_combination() {
+        let mut params = AnalysisParams::default();
+        apply_data_masking_rules(
+            &mut params,
+            r#"[
+                {"score_threshold":0.1},
+                {"supported_entity_types":[{"name":"TIME_DATA","entity_types":["DATE_TIME"]}]},
+                {"supported_entity_types":[{"name":"CONTACT_INFORMATION","entity_types":["PERSON"]}],"score_threshold":0.9}
+            ]"#,
+        )
+        .unwrap();
+
+        assert_eq!(params.score_threshold, 0.5);
+        assert_eq!(params.entity_allowlist, vec!["DATE_TIME", "PERSON"]);
+    }
+
 }

--- a/agentrs/src/piigate/config.rs
+++ b/agentrs/src/piigate/config.rs
@@ -38,7 +38,7 @@ struct CustomEntityTypesEntry {
     regex: Option<String>,
     #[serde(default)]
     deny_list: Vec<String>,
-    score: Option<f64>,
+    score: f64,
 }
 
 /// Env var for the Presidio analyzer base URL (shared with the Go agent's
@@ -128,7 +128,7 @@ fn apply_data_masking_rules(
                     custom.name
                 );
             }
-            let score = custom.score.unwrap_or(0.0);
+            let score = custom.score;
             if !(0.0..=1.0).contains(&score) || !score.is_finite() {
                 anyhow::bail!("custom entity {:?} has invalid score {score}", custom.name);
             }
@@ -441,7 +441,7 @@ mod tests {
                                     {"name": "CONTACT_INFORMATION", "entity_types": ["PERSON", "DATE_TIME"]}
                                 ],
                                 "custom_entity_types": [
-                                    {"name": "EMPLOYEE_ID", "regex": "EMP-[0-9]+", "score": 0.83},
+                                    {"name": "EMPLOYEE_ID", "regex": "EMP-[0-9]+", "score": 0.0},
                                     {"name": "VIP_NAME", "deny_list": ["Alice Example"], "score": 0.7}
                                 ],
                                 "score_threshold": 0.4
@@ -465,7 +465,7 @@ mod tests {
                 vec![AdHocRecognizerPattern {
                     name: "EMPLOYEE_ID".into(),
                     regex: "EMP-[0-9]+".into(),
-                    score: 0.83,
+                    score: 0.0,
                 }]
             );
             assert_eq!(
@@ -508,6 +508,8 @@ mod tests {
                 r#"[{"custom_entity_types":[{"name":"EMPLOYEE_ID","score":0.8}]}]"#,
                 r#"[{"custom_entity_types":[{"name":"employee-id","regex":"EMP-[0-9]+","score":0.8}]}]"#,
                 r#"[{"custom_entity_types":[{"name":"EMPLOYEE_ID","regex":"EMP-[0-9]+","score":1.1}]}]"#,
+                r#"[{"custom_entity_types":[{"name":"EMPLOYEE_ID","regex":"EMP-[0-9]+"}]}]"#,
+                r#"[{"custom_entity_types":[{"name":"EMPLOYEE_ID","regex":"EMP-[0-9]+","score":null}]}]"#,
             ] {
                 let err = GuardConfig::resolve(
                     &md(&[

--- a/agentrs/src/piigate/presidio.rs
+++ b/agentrs/src/piigate/presidio.rs
@@ -12,6 +12,25 @@ use serde::{Deserialize, Serialize};
 
 use super::ocr::Word;
 
+/// One request-scoped Presidio regex recognizer generated from a custom
+/// Data Masking entity type. It is carried inline so the analyzer does not
+/// need persistent recognizer registration.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct AdHocRecognizer {
+    pub name: String,
+    pub supported_language: String,
+    pub supported_entity: String,
+    pub deny_list: Vec<String>,
+    pub patterns: Vec<AdHocRecognizerPattern>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct AdHocRecognizerPattern {
+    pub name: String,
+    pub regex: String,
+    pub score: f64,
+}
+
 /// Request payload for Presidio's /analyze endpoint.
 #[derive(Debug, Serialize)]
 struct AnalyzerRequest<'a> {
@@ -20,6 +39,8 @@ struct AnalyzerRequest<'a> {
     score_threshold: f64,
     #[serde(skip_serializing_if = "<[String]>::is_empty")]
     entities: &'a [String],
+    #[serde(skip_serializing_if = "<[AdHocRecognizer]>::is_empty")]
+    ad_hoc_recognizers: &'a [AdHocRecognizer],
 }
 
 /// A single PII entity found by Presidio.
@@ -84,6 +105,7 @@ impl PresidioClient {
         text: &str,
         score_threshold: f64,
         entity_allowlist: &[String],
+        ad_hoc_recognizers: &[AdHocRecognizer],
     ) -> anyhow::Result<Vec<AnalyzerResult>> {
         if text.is_empty() {
             return Ok(Vec::new());
@@ -96,6 +118,7 @@ impl PresidioClient {
                 language: "en",
                 score_threshold,
                 entities: entity_allowlist,
+                ad_hoc_recognizers,
             })
             .send()
             .await
@@ -120,6 +143,9 @@ pub struct AnalysisParams {
     pub score_threshold: f64,
     /// Entity types selected by the resource's DataMaskingRules.
     pub entity_allowlist: Vec<String>,
+    /// Request-scoped Presidio recognizers built from custom Data Masking
+    /// entity types.
+    pub ad_hoc_recognizers: Vec<AdHocRecognizer>,
     /// Legacy entity exclusions sent by gateways predating resource allowlists.
     pub entity_denylist: Vec<String>,
     /// Vertical padding around dirty rects AND parallel-chunk overlap.
@@ -133,6 +159,7 @@ impl Default for AnalysisParams {
         Self {
             score_threshold: 0.5,
             entity_allowlist: Vec::new(),
+            ad_hoc_recognizers: Vec::new(),
             entity_denylist: Vec::new(),
             band_padding: super::bands::DEFAULT_BAND_PADDING,
             max_ocr_concurrency: 8,
@@ -206,7 +233,12 @@ pub async fn analyze_text(
     params: &AnalysisParams,
 ) -> anyhow::Result<SnapshotResult> {
     let mut results = presidio
-        .analyze(text, params.score_threshold, &params.entity_allowlist)
+        .analyze(
+            text,
+            params.score_threshold,
+            &params.entity_allowlist,
+            &params.ad_hoc_recognizers,
+        )
         .await?;
     results.retain(|result| entity_is_selected(&result.entity_type, params));
 
@@ -245,11 +277,43 @@ mod tests {
             language: "en",
             score_threshold: 0.0,
             entities: &entities,
+            ad_hoc_recognizers: &[
+                AdHocRecognizer {
+                    name: "EMPLOYEE_ID".into(),
+                    supported_language: "en".into(),
+                    supported_entity: "EMPLOYEE_ID".into(),
+                    deny_list: Vec::new(),
+                    patterns: vec![AdHocRecognizerPattern {
+                        name: "EMPLOYEE_ID".into(),
+                        regex: "EMP-[0-9]+".into(),
+                        score: 0.83,
+                    }],
+                },
+                AdHocRecognizer {
+                    name: "VIP_NAME".into(),
+                    supported_language: "en".into(),
+                    supported_entity: "VIP_NAME".into(),
+                    deny_list: vec!["Alice Example".into()],
+                    patterns: Vec::new(),
+                },
+            ],
         };
 
         let payload = serde_json::to_value(request).unwrap();
         assert_eq!(payload["score_threshold"], 0.0);
         assert_eq!(payload["entities"], serde_json::json!(["DATE_TIME", "PERSON"]));
+        assert_eq!(
+            payload["ad_hoc_recognizers"][0]["supported_entity"],
+            "EMPLOYEE_ID"
+        );
+        assert_eq!(
+            payload["ad_hoc_recognizers"][0]["patterns"][0]["regex"],
+            "EMP-[0-9]+"
+        );
+        assert_eq!(
+            payload["ad_hoc_recognizers"][1]["deny_list"][0],
+            "Alice Example"
+        );
     }
 
     #[test]

--- a/agentrs/src/ws/client.rs
+++ b/agentrs/src/ws/client.rs
@@ -189,17 +189,23 @@ impl WebSocket {
     }
 
     /// Sends the connection-scoped capability advertisement. Carries the
-    /// agent's PII guard endpoint readiness and entity-policy support. The
-    /// frame is addressed with the well-known control sentinel sid, not a
-    /// session id — the gateway dispatches it by message type at the
-    /// connection level.
+    /// agent's PII guard endpoint readiness and complete Data Masking rule
+    /// support. The frame is addressed with the well-known control sentinel
+    /// sid, not a session id — the gateway dispatches it by message type at
+    /// the connection level.
     async fn send_capabilities(ws_sender: &WsWriter) -> anyhow::Result<()> {
         let mut metadata = HashMap::new();
+        let supports_guard = crate::piigate::config::supports_pii_guard();
         metadata.insert(
             "supports_pii_guard".to_string(),
-            crate::piigate::config::supports_pii_guard().to_string(),
+            supports_guard.to_string(),
         );
+        // Retained for gateways predating complete rule metadata support.
         metadata.insert("supports_pii_entity_allowlist".to_string(), "true".to_string());
+        metadata.insert(
+            "supports_pii_data_masking_rules".to_string(),
+            "true".to_string(),
+        );
         let msg = WebSocketMessage::new(MessageType::Capabilities, metadata, Vec::new());
         let framed = msg
             .encode_with_header(CONTROL_SENTINEL_SID)
@@ -210,8 +216,8 @@ impl WebSocket {
             .await
             .context("sending capabilities frame")?;
         info!(
-            "> Advertised capabilities to gateway (supports_pii_guard={})",
-            crate::piigate::config::supports_pii_guard()
+            "> Advertised capabilities to gateway \
+             (supports_pii_guard={supports_guard}, supports_pii_data_masking_rules=true)"
         );
         Ok(())
     }

--- a/gateway/broker/agent_capabilities_test.go
+++ b/gateway/broker/agent_capabilities_test.go
@@ -25,12 +25,13 @@ func TestAgentCapability_UnknownWhenUnregistered(t *testing.T) {
 
 func TestAgentCapability_KnownIncapable(t *testing.T) {
 	const name = "agent-incapable"
-	if _, err := CreateAgent(name, nil); err != nil {
+	instanceID, err := CreateAgent(name, nil)
+	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
 	defer BrokerInstance.agents.Delete(name)
 
-	SetAgentCapabilities(name, map[string]string{CapabilitySupportsPIIGuard: "false"})
+	SetAgentCapabilities(name, instanceID, map[string]string{CapabilitySupportsPIIGuard: "false"})
 
 	value, known := AgentCapability(name, CapabilitySupportsPIIGuard)
 	if !known {
@@ -43,12 +44,13 @@ func TestAgentCapability_KnownIncapable(t *testing.T) {
 
 func TestAgentCapability_KnownCapable(t *testing.T) {
 	const name = "agent-capable"
-	if _, err := CreateAgent(name, nil); err != nil {
+	instanceID, err := CreateAgent(name, nil)
+	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
 	defer BrokerInstance.agents.Delete(name)
 
-	SetAgentCapabilities(name, map[string]string{CapabilitySupportsPIIGuard: "true"})
+	SetAgentCapabilities(name, instanceID, map[string]string{CapabilitySupportsPIIGuard: "true"})
 
 	value, known := AgentCapability(name, CapabilitySupportsPIIGuard)
 	if !known {
@@ -63,12 +65,13 @@ func TestAgentCapability_KnownCapable(t *testing.T) {
 // "unknown": the agent advertised, it just doesn't have this capability.
 func TestAgentCapability_KnownButKeyAbsent(t *testing.T) {
 	const name = "agent-other-caps"
-	if _, err := CreateAgent(name, nil); err != nil {
+	instanceID, err := CreateAgent(name, nil)
+	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
 	defer BrokerInstance.agents.Delete(name)
 
-	SetAgentCapabilities(name, map[string]string{"some_other_capability": "true"})
+	SetAgentCapabilities(name, instanceID, map[string]string{"some_other_capability": "true"})
 
 	value, known := AgentCapability(name, CapabilitySupportsPIIGuard)
 	if !known {
@@ -82,7 +85,7 @@ func TestAgentCapability_KnownButKeyAbsent(t *testing.T) {
 // SetAgentCapabilities on an unregistered agent must be a harmless no-op
 // (the agent may have disconnected between connect and frame handling).
 func TestSetAgentCapabilities_UnregisteredNoop(t *testing.T) {
-	SetAgentCapabilities("ghost-agent", map[string]string{CapabilitySupportsPIIGuard: "true"})
+	SetAgentCapabilities("ghost-agent", uuid.New(), map[string]string{CapabilitySupportsPIIGuard: "true"})
 	if _, known := AgentCapability("ghost-agent", CapabilitySupportsPIIGuard); known {
 		t.Fatalf("setting caps on an unregistered agent must not create state")
 	}
@@ -113,14 +116,15 @@ func TestAgentCapability_UnknownAfterWaitWhenNeverAdvertised(t *testing.T) {
 // starts waiting must still be observed (not raced into a false "unknown").
 func TestAgentCapability_ObservesLateAdvertisement(t *testing.T) {
 	const name = "agent-late"
-	if _, err := CreateAgent(name, nil); err != nil {
+	instanceID, err := CreateAgent(name, nil)
+	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
 	defer BrokerInstance.agents.Delete(name)
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		SetAgentCapabilities(name, map[string]string{CapabilitySupportsPIIGuard: "true"})
+		SetAgentCapabilities(name, instanceID, map[string]string{CapabilitySupportsPIIGuard: "true"})
 	}()
 
 	value, known := AgentCapability(name, CapabilitySupportsPIIGuard)
@@ -162,6 +166,30 @@ func TestRemoveAgent_OnlyRemovesMatchingInstance(t *testing.T) {
 	}
 }
 
+// A capability frame belongs to the WebSocket connection that delivered it.
+// A late frame from a replaced connection must not overwrite the live
+// connection's capabilities.
+func TestSetAgentCapabilities_IgnoresStaleInstance(t *testing.T) {
+	const name = "agent-stale-capabilities"
+	oldID, err := CreateAgent(name, nil)
+	if err != nil {
+		t.Fatalf("CreateAgent old: %v", err)
+	}
+	newID, err := CreateAgent(name, nil)
+	if err != nil {
+		t.Fatalf("CreateAgent new: %v", err)
+	}
+	defer BrokerInstance.agents.Delete(name)
+
+	SetAgentCapabilities(name, newID, map[string]string{CapabilitySupportsPIIGuard: "false"})
+	SetAgentCapabilities(name, oldID, map[string]string{CapabilitySupportsPIIGuard: "true"})
+
+	value, known := AgentCapability(name, CapabilitySupportsPIIGuard)
+	if !known || value {
+		t.Fatalf("stale advertisement changed live capabilities, got value=%v known=%v", value, known)
+	}
+}
+
 // Sentinel must stay byte-for-byte identical to the agent constant
 // (ws::control::CONTROL_SENTINEL_SID) and pass header validation.
 func TestControlSentinelSID_StableAndValid(t *testing.T) {
@@ -181,13 +209,14 @@ func TestControlSentinelSID_StableAndValid(t *testing.T) {
 // returns must not affect stored state.
 func TestSetAgentCapabilities_DefensiveCopy(t *testing.T) {
 	const name = "agent-mutate"
-	if _, err := CreateAgent(name, nil); err != nil {
+	instanceID, err := CreateAgent(name, nil)
+	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
 	defer BrokerInstance.agents.Delete(name)
 
 	m := map[string]string{CapabilitySupportsPIIGuard: "true"}
-	SetAgentCapabilities(name, m)
+	SetAgentCapabilities(name, instanceID, m)
 	m[CapabilitySupportsPIIGuard] = "false" // mutate after store
 
 	value, known := AgentCapability(name, CapabilitySupportsPIIGuard)

--- a/gateway/broker/headers.go
+++ b/gateway/broker/headers.go
@@ -43,9 +43,10 @@ const (
 // and OCR sidecar endpoints configured).
 const CapabilitySupportsPIIGuard = "supports_pii_guard"
 
-// CapabilitySupportsPIIEntityAllowlist distinguishes agents that understand
-// the connection-scoped entity-selection metadata from legacy guard agents.
-const CapabilitySupportsPIIEntityAllowlist = "supports_pii_entity_allowlist"
+// CapabilitySupportsPIIDataMaskingRules distinguishes agents that consume the
+// complete connection-scoped Data Masking rule payload, including custom
+// regex and deny-list entity types.
+const CapabilitySupportsPIIDataMaskingRules = "supports_pii_data_masking_rules"
 
 // ControlSentinelSID is the well-known sid used for connection-scoped control
 // frames (those that describe the agent connection, not a session). The wire

--- a/gateway/broker/protocol_rdp.go
+++ b/gateway/broker/protocol_rdp.go
@@ -34,12 +34,12 @@ func (h *RDPHandler) HandleData(session *Session, msg *WebSocketMessage) error {
 // gateway suppresses its own gate — single enforcement point). The endpoints
 // (Presidio, OCR sidecar) are NOT sent on the wire: the agent reads those
 // from its own environment, keeping customer-network infra out of gateway
-// state. Only the enable decision and analysis policy travel here.
+// state. The enable decision, complete Data Masking policy, and guard tuning
+// travel here.
 type RDPGuardConfig struct {
-	Enabled         bool
-	ScoreThreshold  float64
-	EntityAllowlist []string
-	BandPadding     int
+	Enabled               bool
+	DataMaskingEntityData json.RawMessage
+	BandPadding           int
 	// Policy is "kill", "redact", or "redact_and_kill" (agent default kill
 	// when empty/unrecognized).
 	Policy string
@@ -115,22 +115,17 @@ func CreateRDPSession(
 		"target_address": address,
 		"proxy_user":     extractedCreds, // Use the extracted credentials as proxy_user
 	}
-	// Agent-side PII guard: only signal "guard this session" plus analysis
-	// policy. The agent supplies Presidio/OCR endpoints from its own env.
-	// Absent keys mean "no guard" — an older agent simply ignores them.
+	// Agent-side PII guard: signal "guard this session" and pass the same raw
+	// Data Masking rule payload used by the other protocol redactors. The
+	// agent supplies Presidio/OCR endpoints from its own environment.
 	if guard.Enabled {
 		metadata["pii_guard"] = "enabled"
-		metadata["pii_score_threshold"] = strconv.FormatFloat(guard.ScoreThreshold, 'f', -1, 64)
 		metadata["pii_band_padding"] = strconv.Itoa(guard.BandPadding)
 		if guard.Policy != "" {
 			metadata["pii_policy"] = guard.Policy
 		}
-		if len(guard.EntityAllowlist) > 0 {
-			// JSON array, not a comma-join: entity names are an external
-			// (Presidio) vocabulary and must not rely on being comma-free.
-			if allowlist, err := json.Marshal(guard.EntityAllowlist); err == nil {
-				metadata["pii_entity_allowlist"] = string(allowlist)
-			}
+		if len(guard.DataMaskingEntityData) > 0 {
+			metadata["data_masking_entity_data"] = string(guard.DataMaskingEntityData)
 		}
 	}
 	msg := &WebSocketMessage{

--- a/gateway/broker/session.go
+++ b/gateway/broker/session.go
@@ -349,14 +349,13 @@ func GetAgent(agentID string) (ConnectionCommunicator, bool) {
 	return nil, false
 }
 
-// SetAgentCapabilities records the connection-scoped capabilities advertised
-// by an agent and unblocks anyone waiting on the advertisement. Called when a
-// Capabilities control frame is received. No-op if the agent is not currently
-// registered. The map is defensively copied so later mutation by the caller
-// cannot race readers of the stored state.
-func SetAgentCapabilities(agentID string, capabilities map[string]string) {
+// SetAgentCapabilities records capabilities advertised by a specific agent
+// connection and unblocks anyone waiting on the advertisement. It ignores a
+// stale connection whose instance ID no longer matches the live registration.
+// The map is defensively copied so later caller mutation cannot race readers.
+func SetAgentCapabilities(agentID string, instanceID uuid.UUID, capabilities map[string]string) {
 	e, ok := getAgentEntry(agentID)
-	if !ok {
+	if !ok || e.id != instanceID {
 		return
 	}
 	cp := make(map[string]string, len(capabilities))

--- a/gateway/rdp/irongw.go
+++ b/gateway/rdp/irongw.go
@@ -256,10 +256,9 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 	}
 
 	// When a connection-scoped rule applies, the agent runs the PII gate where
-	// the plaintext already flows. The gateway sends the resource policy while
-	// the agent supplies its local Presidio/OCR endpoints. Masked sessions fail
-	// closed unless the selected agent advertises both capabilities required to
-	// enforce that policy.
+	// the plaintext already flows. The gateway sends the complete resource
+	// policy while the agent supplies its local Presidio/OCR endpoints. Masked
+	// sessions fail closed unless the selected agent can enforce that policy.
 	agentGuard := broker.RDPGuardConfig{Enabled: maskingParams != nil}
 	if agentGuard.Enabled {
 		capable, known := broker.AgentCapability(connectionModel.AgentName, broker.CapabilitySupportsPIIGuard)
@@ -280,12 +279,12 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 			return
 		}
 
-		allowlistCapable, allowlistKnown := broker.AgentCapability(
+		rulesCapable, rulesKnown := broker.AgentCapability(
 			connectionModel.AgentName,
-			broker.CapabilitySupportsPIIEntityAllowlist,
+			broker.CapabilitySupportsPIIDataMaskingRules,
 		)
-		if !allowlistKnown || !allowlistCapable {
-			log.Errorf("refusing RDP session: agent %q does not support connection-scoped PII entity selection",
+		if !rulesKnown || !rulesCapable {
+			log.Errorf("refusing RDP session: agent %q does not support complete connection-scoped Data Masking rules",
 				connectionModel.AgentName)
 			writeRDPClientError(ws, cppVersion,
 				fmt.Sprintf("Connection refused: agent %q must be upgraded to apply this connection's Data Masking rule.",
@@ -295,8 +294,7 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 	}
 
 	if agentGuard.Enabled {
-		agentGuard.ScoreThreshold = maskingParams.ScoreThreshold
-		agentGuard.EntityAllowlist = maskingParams.EntityAllowlist
+		agentGuard.DataMaskingEntityData = maskingParams.DataMaskingEntityData
 		agentGuard.BandPadding = maskingParams.BandPadding
 		agentGuard.Policy = appconfig.Get().RDPPIIGuardPolicy()
 	}
@@ -430,29 +428,11 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 	// pipe all data between WebSocket and TLS connection
 	// We also record all traffic for session recording
 
-	// Realtime PII guard (hold-and-release): when enabled, server->client
-	// bytes are held until OCR+Presidio analysis clears them; on detection
-	// the held frames are dropped and the session is terminated.
-	//
-	// When the agent runs the guard (agentGuard.Enabled), the gateway does
-	// NOT also gate: the agent already cleared/redacted every frame before it
-	// reached the gateway, so a second gate here would only double OCR cost
-	// and latency. The gateway still records — now of clean frames.
-	var gate *PIIGate
-	switch {
-	case maskingParams == nil:
-		// No connection-scoped masking rule: normal passthrough.
-	case agentGuard.Enabled:
-		log.With("sid", sessionID).Infof("piigate: agent-side guard active, gateway gate suppressed")
-	default:
-		gate = newSessionPIIGate(recorderOrgID, sessionID, ws, session, func(err error) {
-			sessionErrMu.Lock()
-			sessionErr = err
-			sessionErrMu.Unlock()
-		})
-		if gate != nil {
-			defer gate.Close()
-		}
+	// Guarded bytes were already held, analyzed, and redacted by the agent
+	// before reaching the gateway. A second gateway-side gate would duplicate
+	// OCR/Presidio work and could diverge from the connection's rule policy.
+	if agentGuard.Enabled {
+		log.With("sid", sessionID).Infof("piigate: agent-side guard active")
 	}
 
 	// Use a done channel to signal when the websocket read goroutine exits
@@ -502,13 +482,6 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 
 		// Record server -> client traffic (bitmap updates, etc.)
 		recorder.RecordOutput(buffer[:n])
-
-		if gate != nil {
-			// Hold-and-release: the gate forwards to the websocket from its
-			// analysis goroutine once the frames are cleared.
-			gate.Ingest(buffer[:n])
-			continue
-		}
 
 		err = ws.WriteMessage(websocket.BinaryMessage, buffer[:n])
 		if err != nil {

--- a/gateway/rdp/piigate.go
+++ b/gateway/rdp/piigate.go
@@ -5,18 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"sort"
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
-	"github.com/hoophq/hoop/common/featureflag"
 	"github.com/hoophq/hoop/common/log"
-	"github.com/hoophq/hoop/gateway/appconfig"
-	"github.com/hoophq/hoop/gateway/broker"
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/hoophq/hoop/gateway/rdp/analyzer"
-	"github.com/hoophq/hoop/gateway/rdp/ocr"
 	"github.com/hoophq/hoop/gateway/rdp/parser"
 	"github.com/hoophq/hoop/gateway/rdp/rle"
 	"github.com/hoophq/hoop/gateway/services"
@@ -627,9 +621,8 @@ type rdpDataMaskingRule struct {
 }
 
 type rdpDataMaskingParams struct {
-	ScoreThreshold  float64
-	EntityAllowlist []string
-	BandPadding     int
+	DataMaskingEntityData json.RawMessage
+	BandPadding           int
 }
 
 func isCanonicalEntityType(entityType string) bool {
@@ -659,14 +652,9 @@ func parseRDPDataMaskingRules(data []byte) (*rdpDataMaskingParams, error) {
 		return nil, fmt.Errorf("decode data masking rules for RDP connection: %w", err)
 	}
 
-	entitySet := make(map[string]struct{})
-	scoreThreshold := 0.0
-	hasThreshold := false
+	hasEntities := false
 	for _, rule := range rules {
-		if len(rule.CustomEntityTypes) > 0 {
-			return nil, fmt.Errorf("RDP masking does not support custom entity types in rule %q", rule.Name)
-		}
-		hasEntities := false
+		ruleHasEntities := false
 		for _, group := range rule.SupportedEntityTypes {
 			if len(group.EntityTypes) == 0 {
 				return nil, fmt.Errorf("RDP masking rule %q has an empty supported entity group %q", rule.Name, group.Name)
@@ -675,13 +663,25 @@ func parseRDPDataMaskingRules(data []byte) (*rdpDataMaskingParams, error) {
 				if !isCanonicalEntityType(entity) {
 					return nil, fmt.Errorf("RDP masking rule %q has invalid entity type %q", rule.Name, entity)
 				}
-				entitySet[entity] = struct{}{}
-				hasEntities = true
+				ruleHasEntities = true
 			}
 		}
-		if !hasEntities {
+		for _, entity := range rule.CustomEntityTypes {
+			if !isCanonicalEntityType(entity.Name) {
+				return nil, fmt.Errorf("RDP masking rule %q has invalid custom entity type %q", rule.Name, entity.Name)
+			}
+			if entity.Regex == "" && len(entity.DenyList) == 0 {
+				return nil, fmt.Errorf("RDP masking rule %q custom entity type %q has no regex or deny list", rule.Name, entity.Name)
+			}
+			if math.IsNaN(entity.Score) || math.IsInf(entity.Score, 0) || entity.Score < 0 || entity.Score > 1 {
+				return nil, fmt.Errorf("RDP masking rule %q custom entity type %q has invalid score %v", rule.Name, entity.Name, entity.Score)
+			}
+			ruleHasEntities = true
+		}
+		if !ruleHasEntities {
 			continue
 		}
+		hasEntities = true
 
 		threshold := 0.5
 		if rule.ScoreThreshold != nil {
@@ -690,126 +690,15 @@ func parseRDPDataMaskingRules(data []byte) (*rdpDataMaskingParams, error) {
 		if math.IsNaN(threshold) || math.IsInf(threshold, 0) || threshold < 0 || threshold > 1 {
 			return nil, fmt.Errorf("RDP masking rule %q has invalid score threshold %v", rule.Name, threshold)
 		}
-		if !hasThreshold || threshold < scoreThreshold {
-			scoreThreshold = threshold
-			hasThreshold = true
-		}
 	}
-	if len(entitySet) == 0 {
+	if !hasEntities {
 		return nil, nil
 	}
 
-	params := &rdpDataMaskingParams{
-		ScoreThreshold:  scoreThreshold,
-		EntityAllowlist: make([]string, 0, len(entitySet)),
-		BandPadding:     analyzer.DefaultBandPadding,
-	}
-	for entity := range entitySet {
-		params.EntityAllowlist = append(params.EntityAllowlist, entity)
-	}
-	sort.Strings(params.EntityAllowlist)
-	return params, nil
-}
-
-// newSessionPIIGate builds a PIIGate wired to a live IronRDP session: it
-// forwards cleared bytes to the websocket and, on detection, persists the
-// violation and terminates the broker session. Returns nil when the guard is
-// not enabled for the org or its prerequisites (Presidio, an OCR engine) are
-// missing — callers fall back to direct forwarding.
-func newSessionPIIGate(
-	orgID, sessionID string,
-	ws *websocket.Conn,
-	session *broker.Session,
-	setSessionErr func(error),
-) *PIIGate {
-	if !featureflag.IsEnabled(orgID, PIIGateFlagName) {
-		return nil
-	}
-	// Unlike the async job pipeline (analyzer.IsEnabled), the gate does not
-	// depend on the worker pool: it only needs Presidio and an OCR engine.
-	analyzerURL := appconfig.Get().MSPresidioAnalyzerURL()
-	if analyzerURL == "" || !ocr.IsAvailable() {
-		log.With("sid", sessionID).Warnf("piigate: %s is on but presidio/OCR engine are unavailable, session runs UNGUARDED", PIIGateFlagName)
-		return nil
-	}
-
-	gate, err := NewPIIGate(context.Background(), PIIGateConfig{
-		SessionID: sessionID,
-		Presidio:  analyzer.NewPresidioClient(analyzerURL),
-		Params:    analyzer.DefaultAnalysisParams(),
-		Forward: func(data []byte) error {
-			return ws.WriteMessage(websocket.BinaryMessage, data)
-		},
-		OnDetection: func(res *analyzer.SnapshotResult) {
-			setSessionErr(fmt.Errorf("session terminated: PII detected on screen (%s)", formatEntityCounts(res.Counts)))
-			// Tear the session down first; persistence is best-effort and
-			// must not delay enforcement on a slow database. Closing the
-			// websocket too is required: session.Close() only unblocks the
-			// TLS side, and the handler would otherwise stay parked on the
-			// websocket reader until the (idle) browser acts.
-			session.Close()
-			_ = ws.Close()
-			go persistPIIViolation(orgID, sessionID, res)
-		},
-		OnOverload: func(droppedBytes int) {
-			setSessionErr(fmt.Errorf("session terminated: PII analysis backlog exceeded (%d bytes dropped)", droppedBytes))
-			session.Close()
-			_ = ws.Close()
-		},
-	})
-	if err != nil {
-		log.With("sid", sessionID).Warnf("piigate: failed to start, session runs UNGUARDED: %v", err)
-		return nil
-	}
-	log.With("sid", sessionID).Infof("piigate: realtime PII guard active (hold-and-release)")
-	return gate
-}
-
-// persistPIIViolation records the detection as guardrails info on the session
-// and stores the per-entity bounding boxes for the UI. The two writes are
-// deliberately best-effort and non-transactional: enforcement (session kill)
-// has already happened, and partial evidence is better than none.
-func persistPIIViolation(orgID, sessionID string, res *analyzer.SnapshotResult) {
-	info := []models.SessionGuardRailsInfo{{
-		RuleName:     "rdp_pii_guard",
-		Rule:         models.SessionGuardRailMatchedRule{Type: "pii_detection"},
-		Direction:    "server_to_client",
-		MatchedWords: entityTypes(res.Counts),
-	}}
-	if data, err := json.Marshal(info); err == nil {
-		if err := models.UpdateSessionGuardRailsInfo(orgID, sessionID, data); err != nil {
-			log.With("sid", sessionID).Warnf("piigate: failed to persist guardrails info: %v", err)
-		}
-	}
-	if len(res.Detections) > 0 {
-		if err := models.BulkInsertRDPEntityDetections(res.Detections); err != nil {
-			log.With("sid", sessionID).Warnf("piigate: failed to persist entity detections: %v", err)
-		}
-	}
-}
-
-func entityTypes(counts map[string]int64) []string {
-	types := make([]string, 0, len(counts))
-	for entity := range counts {
-		types = append(types, entity)
-	}
-	sort.Strings(types)
-	return types
-}
-
-func formatEntityCounts(counts map[string]int64) string {
-	parts := entityTypes(counts)
-	for i, entity := range parts {
-		parts[i] = fmt.Sprintf("%s x%d", entity, counts[entity])
-	}
-	out := ""
-	for i, p := range parts {
-		if i > 0 {
-			out += ", "
-		}
-		out += p
-	}
-	return out
+	return &rdpDataMaskingParams{
+		DataMaskingEntityData: append(json.RawMessage(nil), data...),
+		BandPadding:           analyzer.DefaultBandPadding,
+	}, nil
 }
 
 // Killed reports whether the gate terminated the session on a detection.

--- a/gateway/rdp/piigate.go
+++ b/gateway/rdp/piigate.go
@@ -616,8 +616,15 @@ func (c *shadowCanvas) grow(width, height int) {
 type rdpDataMaskingRule struct {
 	Name                 string                             `json:"name"`
 	SupportedEntityTypes []models.SupportedEntityTypesEntry `json:"supported_entity_types"`
-	CustomEntityTypes    []models.CustomEntityTypesEntry    `json:"custom_entity_types"`
+	CustomEntityTypes    []rdpCustomEntityType              `json:"custom_entity_types"`
 	ScoreThreshold       *float64                           `json:"score_threshold"`
+}
+
+type rdpCustomEntityType struct {
+	Name     string   `json:"name"`
+	Regex    string   `json:"regex"`
+	DenyList []string `json:"deny_list"`
+	Score    *float64 `json:"score"`
 }
 
 type rdpDataMaskingParams struct {
@@ -673,8 +680,11 @@ func parseRDPDataMaskingRules(data []byte) (*rdpDataMaskingParams, error) {
 			if entity.Regex == "" && len(entity.DenyList) == 0 {
 				return nil, fmt.Errorf("RDP masking rule %q custom entity type %q has no regex or deny list", rule.Name, entity.Name)
 			}
-			if math.IsNaN(entity.Score) || math.IsInf(entity.Score, 0) || entity.Score < 0 || entity.Score > 1 {
-				return nil, fmt.Errorf("RDP masking rule %q custom entity type %q has invalid score %v", rule.Name, entity.Name, entity.Score)
+			if entity.Score == nil {
+				return nil, fmt.Errorf("RDP masking rule %q custom entity type %q is missing score", rule.Name, entity.Name)
+			}
+			if math.IsNaN(*entity.Score) || math.IsInf(*entity.Score, 0) || *entity.Score < 0 || *entity.Score > 1 {
+				return nil, fmt.Errorf("RDP masking rule %q custom entity type %q has invalid score %v", rule.Name, entity.Name, *entity.Score)
 			}
 			ruleHasEntities = true
 		}

--- a/gateway/rdp/piigate_test.go
+++ b/gateway/rdp/piigate_test.go
@@ -1003,7 +1003,7 @@ func TestParseRDPDataMaskingRulesSupportsCustomEntities(t *testing.T) {
 			"name": "employee-data",
 			"supported_entity_types": [{"name": "CONTACT_INFORMATION", "entity_types": ["PERSON"]}],
 			"custom_entity_types": [
-				{"name": "EMPLOYEE_ID", "regex": "EMP-[0-9]+", "score": 0.8},
+				{"name": "EMPLOYEE_ID", "regex": "EMP-[0-9]+", "score": 0.0},
 				{"name": "VIP_NAME", "deny_list": ["Alice Example"], "score": 0.9}
 			],
 			"score_threshold": 0.4
@@ -1026,6 +1026,8 @@ func TestParseRDPDataMaskingRulesRejectsInvalidCustomEntities(t *testing.T) {
 		`[{"name":"missing-pattern","custom_entity_types":[{"name":"EMPLOYEE_ID","score":0.8}]}]`,
 		`[{"name":"invalid-name","custom_entity_types":[{"name":"employee-id","regex":"EMP-[0-9]+","score":0.8}]}]`,
 		`[{"name":"invalid-score","custom_entity_types":[{"name":"EMPLOYEE_ID","regex":"EMP-[0-9]+","score":1.1}]}]`,
+		`[{"name":"missing-score","custom_entity_types":[{"name":"EMPLOYEE_ID","regex":"EMP-[0-9]+"}]}]`,
+		`[{"name":"null-score","custom_entity_types":[{"name":"EMPLOYEE_ID","regex":"EMP-[0-9]+","score":null}]}]`,
 	}
 	for _, data := range tests {
 		if params, err := parseRDPDataMaskingRules([]byte(data)); err == nil {

--- a/gateway/rdp/piigate_test.go
+++ b/gateway/rdp/piigate_test.go
@@ -890,8 +890,8 @@ func TestPIIGate_FragmentedUpdateHeldUntilReassembly(t *testing.T) {
 	}
 }
 
-func TestParseRDPDataMaskingRulesUsesResourceEntitiesAndThreshold(t *testing.T) {
-	params, err := parseRDPDataMaskingRules([]byte(`[
+func TestParseRDPDataMaskingRulesPreservesCompleteResourcePolicy(t *testing.T) {
+	data := []byte(`[
 		{
 			"supported_entity_types": [
 				{"name": "CONTACT_INFORMATION", "entity_types": ["PERSON", "EMAIL_ADDRESS"]},
@@ -905,18 +905,16 @@ func TestParseRDPDataMaskingRulesUsesResourceEntitiesAndThreshold(t *testing.T) 
 			],
 			"score_threshold": 0.6
 		}
-	]`))
+	]`)
+	params, err := parseRDPDataMaskingRules(data)
 	if err != nil {
 		t.Fatalf("parse rules: %v", err)
 	}
 	if params == nil {
 		t.Fatal("rules with supported entities must enable masking")
 	}
-	if got, want := fmt.Sprint(params.EntityAllowlist), "[DATE_TIME EMAIL_ADDRESS PERSON US_SSN]"; got != want {
-		t.Fatalf("entity allowlist = %s, want %s", got, want)
-	}
-	if params.ScoreThreshold != 0.6 {
-		t.Fatalf("score threshold = %v, want 0.6", params.ScoreThreshold)
+	if !bytes.Equal(params.DataMaskingEntityData, data) {
+		t.Fatal("complete Data Masking rule payload was not preserved for the RDP agent")
 	}
 
 	none, err := parseRDPDataMaskingRules([]byte(`[]`))
@@ -965,7 +963,7 @@ func TestParseRDPDataMaskingRulesRejectsNonCanonicalEntities(t *testing.T) {
 	}
 }
 
-func TestParseRDPDataMaskingRulesPreservesZeroThreshold(t *testing.T) {
+func TestParseRDPDataMaskingRulesAcceptsZeroThreshold(t *testing.T) {
 	params, err := parseRDPDataMaskingRules([]byte(`[
 		{
 			"name": "all-confidence",
@@ -976,8 +974,8 @@ func TestParseRDPDataMaskingRulesPreservesZeroThreshold(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse rules: %v", err)
 	}
-	if params == nil || params.ScoreThreshold != 0 {
-		t.Fatalf("score threshold = %#v, want 0", params)
+	if params == nil {
+		t.Fatal("zero threshold must remain a valid guarded policy")
 	}
 }
 
@@ -999,15 +997,39 @@ func TestParseRDPDataMaskingRulesRejectsInvalidThresholds(t *testing.T) {
 	}
 }
 
-func TestParseRDPDataMaskingRulesRejectsCustomEntities(t *testing.T) {
-	params, err := parseRDPDataMaskingRules([]byte(`[
+func TestParseRDPDataMaskingRulesSupportsCustomEntities(t *testing.T) {
+	data := []byte(`[
 		{
-			"name": "employee-id",
+			"name": "employee-data",
 			"supported_entity_types": [{"name": "CONTACT_INFORMATION", "entity_types": ["PERSON"]}],
-			"custom_entity_types": [{"name": "EMPLOYEE_ID", "regex": "EMP-[0-9]+", "score": 1}]
+			"custom_entity_types": [
+				{"name": "EMPLOYEE_ID", "regex": "EMP-[0-9]+", "score": 0.8},
+				{"name": "VIP_NAME", "deny_list": ["Alice Example"], "score": 0.9}
+			],
+			"score_threshold": 0.4
 		}
-	]`))
-	if err == nil {
-		t.Fatalf("custom entity rule returned params %#v; want an unsupported-rule error", params)
+	]`)
+	params, err := parseRDPDataMaskingRules(data)
+	if err != nil {
+		t.Fatalf("parse custom entity rules: %v", err)
+	}
+	if params == nil {
+		t.Fatal("custom entity rules must enable masking")
+	}
+	if !bytes.Equal(params.DataMaskingEntityData, data) {
+		t.Fatal("complete Data Masking rule payload was not preserved for the RDP agent")
+	}
+}
+
+func TestParseRDPDataMaskingRulesRejectsInvalidCustomEntities(t *testing.T) {
+	tests := []string{
+		`[{"name":"missing-pattern","custom_entity_types":[{"name":"EMPLOYEE_ID","score":0.8}]}]`,
+		`[{"name":"invalid-name","custom_entity_types":[{"name":"employee-id","regex":"EMP-[0-9]+","score":0.8}]}]`,
+		`[{"name":"invalid-score","custom_entity_types":[{"name":"EMPLOYEE_ID","regex":"EMP-[0-9]+","score":1.1}]}]`,
+	}
+	for _, data := range tests {
+		if params, err := parseRDPDataMaskingRules([]byte(data)); err == nil {
+			t.Fatalf("invalid custom entity rule returned params %#v; want an error", params)
+		}
 	}
 }

--- a/gateway/transport/websocket.go
+++ b/gateway/transport/websocket.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/hoophq/hoop/common/dsnkeys"
 	"github.com/hoophq/hoop/common/log"
@@ -92,7 +93,7 @@ func HandleConnection(c *gin.Context) {
 		if messageType != websocket.BinaryMessage {
 			continue
 		}
-		handleWebSocketMessage(agent.Name, data)
+		handleWebSocketMessage(agent.Name, agentInstanceID, data)
 	}
 
 	// Cleanup: remove this connection's broker state (only if it is still the
@@ -189,7 +190,7 @@ func persistAgentGuardrailsViolation(s *broker.Session, payload []byte) {
 	log.With("sid", sessionID).Infof("piigate: agent-side PII guard violation persisted (kind=%s, entities=%v)", report.Kind, report.EntityTypes)
 }
 
-func handleWebSocketMessage(agentName string, data []byte) {
+func handleWebSocketMessage(agentName string, agentInstanceID uuid.UUID, data []byte) {
 	// 1) Try CONTROL frame first (JSON-like)
 	if sid, msg, err := broker.DecodeWebSocketMessage(data); err == nil {
 		// Connection-scoped control frames (sid == ControlSentinelSID) describe
@@ -198,7 +199,7 @@ func handleWebSocketMessage(agentName string, data []byte) {
 		if sid == broker.ControlSentinelSID {
 			switch msg.Type {
 			case broker.MessageTypeCapabilities:
-				broker.SetAgentCapabilities(agentName, msg.Metadata)
+				broker.SetAgentCapabilities(agentName, agentInstanceID, msg.Metadata)
 				log.Debugf("agent=%s advertised capabilities: %v", agentName, msg.Metadata)
 			default:
 				log.Infof("Unhandled connection-scoped control message type=%q for agent=%s", msg.Type, agentName)


### PR DESCRIPTION
## Description

Apply each RDP connection's complete Data Masking policy in the agent, including supported entities, custom regex/deny-list matchers, and per-rule score thresholds.

- Forward the raw connection-scoped policy through `SessionStarted`, negotiate complete-policy support explicitly, and fail closed for incompatible agents.
- Build request-scoped Presidio `ad_hoc_recognizers` for custom entities while preserving deterministic supported-entity and threshold semantics.
- Bind capability advertisements to the originating WebSocket instance so a stale reconnect cannot authorize guard delegation to a replacement agent.

## User-facing impact

RDP live masking now honors the supported and custom entities configured on the selected connection instead of using gateway-wide entity settings.

## How to test

### Automated

```bash
cd gateway
go test ./broker ./transport ./rdp

cd ../agentrs
cargo test piigate
```

Expected: all three Go packages pass; the Rust PII-gate suites pass, including complete-policy parsing, custom recognizer serialization, invalid-policy fail-closed behavior, and stale capability lifecycle coverage.

### Local RDP flow

1. Build and start the local stack:

   ```bash
   docker build --platform linux/arm64 -f Dockerfile.localbuild -t hoophq/hoop:local .
   docker build --platform linux/arm64 -f Dockerfile.agent-ocr --build-arg HOOP_IMAGE=hoophq/hoop:local -t hoophq/hoop-agent-ocr:local .
   scripts/dev/run-pii-demo.sh
   ```

2. Assign an active Live Data Masking rule to an RDP connection. Select `PERSON` and `DATE_TIME`, then add this regex-only custom entity:

   ```json
   {"name":"FIXTURE_REGEX","regex":"rdp-gold-fixture-[0-9]{4}","deny_list":[],"score":0.8}
   ```

3. Display `rdp-gold-fixture-2026`, a person name, and a date on the target desktop, then open the connection's RDP web client.

Expected: the gateway logs `piigate: agent-side guard active`; a detection includes `FIXTURE_REGEX`; the matching fixture and date/name regions are blacked out while the session remains usable under the default `redact` policy.

### Negative path

Connect through an older agent that does not advertise `supports_pii_data_masking_rules`, or pass malformed complete-policy metadata in the Rust resolver tests.

Expected: the gateway refuses delegation to the older agent, and malformed complete policy returns an error instead of falling back to partial entity metadata.

## Verification performed

Go and Rust focused suites passed locally. A rebuilt local gateway/agent stack detected `PERSON`, `DATE_TIME`, and regex-only `FIXTURE_REGEX`; the matching RDP regions were visibly redacted. Agent violation persistence still exposes the pre-existing broker-session/database-session ID mismatch and is not changed by this PR.

Automated by MisterMal