### PR TITLE
feat(helm): add podLabels support to the agent and gateway charts

### DIFF
--- a/deploy/helm-chart/chart/agent/templates/deployment.yaml
+++ b/deploy/helm-chart/chart/agent/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       labels:
         app: hoopagent
-      {{- with .Values.podLabels }}
+      {{- with omit .Values.podLabels "app" }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/deploy/helm-chart/chart/agent/templates/deployment.yaml
+++ b/deploy/helm-chart/chart/agent/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       {{- end }}
       labels:
         app: hoopagent
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: hoopagent

--- a/deploy/helm-chart/chart/agent/values.yaml
+++ b/deploy/helm-chart/chart/agent/values.yaml
@@ -168,6 +168,10 @@ tolerations: []
 # -- Affinity settings for pod assignment
 affinity: {}
 
+## Set additional pod labels
+##
+podLabels: {}
+
 ## Set pod annotations
 ##
 podAnnotations: {}

--- a/deploy/helm-chart/chart/gateway/templates/deployment-postgres.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/deployment-postgres.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: hoopgateway-pg
-      {{- with .Values.postgres.podLabels }}
+      {{- with omit .Values.postgres.podLabels "app" }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/deploy/helm-chart/chart/gateway/templates/deployment-postgres.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/deployment-postgres.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         app: hoopgateway-pg
+      {{- with .Values.postgres.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - env:

--- a/deploy/helm-chart/chart/gateway/templates/deployment.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       labels:
         app: hoopgateway
-      {{- with .Values.podLabels }}
+      {{- with omit .Values.podLabels "app" }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/deploy/helm-chart/chart/gateway/templates/deployment.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       {{- end }}
       labels:
         app: hoopgateway
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: hoopgateway

--- a/deploy/helm-chart/chart/gateway/templates/presidio-deployment.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/presidio-deployment.yaml
@@ -25,6 +25,9 @@ spec:
     metadata:
       labels:
         app: presidio-analyzer
+      {{- with .Values.dataMasking.analyzer.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
         checksum/gunicorn-config: {{ .Values.dataMasking.analyzer.gunicornConfigFile | sha256sum }}
     spec:
@@ -92,6 +95,9 @@ spec:
     metadata:
       labels:
         app: presidio-anonymizer
+      {{- with .Values.dataMasking.anonymizer.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
         checksum/gunicorn-config: {{ .Values.dataMasking.anonymizer.gunicornConfigFile | sha256sum }}
     spec:

--- a/deploy/helm-chart/chart/gateway/templates/presidio-deployment.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/presidio-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       labels:
         app: presidio-analyzer
-      {{- with .Values.dataMasking.analyzer.podLabels }}
+      {{- with omit .Values.dataMasking.analyzer.podLabels "app" }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       annotations:
@@ -95,7 +95,7 @@ spec:
     metadata:
       labels:
         app: presidio-anonymizer
-      {{- with .Values.dataMasking.anonymizer.podLabels }}
+      {{- with omit .Values.dataMasking.anonymizer.podLabels "app" }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       annotations:

--- a/deploy/helm-chart/chart/gateway/values.yaml
+++ b/deploy/helm-chart/chart/gateway/values.yaml
@@ -35,6 +35,8 @@ postgres:
   # -- Size of PVC
   size: 10Gi
   # annotations: {}
+  # -- Additional labels to add to the postgres pod
+  podLabels: {}
 
 # -- Enable data masking with Presidio
 dataMasking:
@@ -70,6 +72,8 @@ dataMasking:
       requests:
         cpu: 1024m
         memory: 1024Mi
+    # -- Additional labels to add to the presidio-analyzer pod
+    podLabels: {}
 
   anonymizer:
     replicas: 1
@@ -87,6 +91,9 @@ dataMasking:
       preload_app = True
       loglevel = 'debug'
       worker_class = 'gthread'
+
+    # -- Additional labels to add to the presidio-anonymizer pod
+    podLabels: {}
 
     resources:
       limits:
@@ -109,6 +116,10 @@ dataMasking:
       requests:
         cpu: 100m
         memory: 64Mi
+
+## Set additional pod labels
+##
+podLabels: {}
 
 ## Set pod annotations
 ##


### PR DESCRIPTION
## What

Add a `podLabels` value (default `{}`) to every pod template in the **agent** and **gateway** charts, merged in alongside the hardcoded `app:` selector label. This mirrors the existing `podAnnotations` pattern.

## Why

Both charts hardcode only `app: hoop*` in their pod templates and expose no way to add pod labels, so labels applied out-of-band with `kubectl label pod …` are silently reverted on the next `helm upgrade` when pods cycle. Today the only workaround is forking the chart.

Common use-cases for pod labels:

- Team/ownership labels for observability and cost attribution
- Prometheus `podMonitor` / `serviceMonitor` selectors
- Kubernetes `NetworkPolicy` pod selectors

## Implementation

The selector label is deliberately protected. `spec.selector.matchLabels` is immutable and fixed to `app: hoop*`, so allowing a caller to set `podLabels.app` would emit a duplicate `app` key that shadows it and make Kubernetes reject the Deployment. `omit` drops that one reserved key:

```yaml
labels:
  app: hoopagent
{{- with omit .Values.podLabels "app" }}
  {{- toYaml . | nindent 8 }}
{{- end }}
```

## Changes

| File | Value | Pod |
|---|---|---|
| `chart/agent/values.yaml` + `templates/deployment.yaml` | `podLabels` | `hoopagent` |
| `chart/gateway/values.yaml` + `templates/deployment.yaml` | `podLabels` | `hoopgateway` |
| `chart/gateway/templates/deployment-postgres.yaml` | `postgres.podLabels` | `hoopgateway-pg` |
| `chart/gateway/templates/presidio-deployment.yaml` | `dataMasking.analyzer.podLabels` | `presidio-analyzer` |
| `chart/gateway/templates/presidio-deployment.yaml` | `dataMasking.anonymizer.podLabels` | `presidio-anonymizer` |

The per-component values are namespaced to match where each pod's other settings already live (`postgres.*`, `dataMasking.analyzer.*`), rather than having one global key leak into subcomponent pods.

## Example

```yaml
# gateway values.yaml
podLabels:
  team: platform
dataMasking:
  analyzer:
    podLabels:
      team: platform
```

## Compatibility

Non-breaking: every `podLabels` key defaults to `{}`, so rendered output is byte-identical for existing installs. Diff is +30/-0 across 6 files, no existing lines modified.
