### PR TITLE
DEP-142: list tunnel connections with their fixed credentials

### DIFF
--- a/common/mongotypes/packet.go
+++ b/common/mongotypes/packet.go
@@ -49,6 +49,11 @@ func (p *Packet) Encode() []byte {
 
 func (p *Packet) Dump() { fmt.Println(hex.Dump(p.Encode())) }
 
+// MaxMessageSize bounds a single wire-protocol message. MongoDB's own limit
+// for a reply is 48 MB; anything beyond that means the stream desynchronised
+// and the length prefix is garbage, so we refuse rather than allocate it.
+const MaxMessageSize = 48 * 1024 * 1024
+
 func Decode(r io.Reader) (*Packet, error) {
 	var header [16]byte
 	_, err := io.ReadFull(r, header[:])
@@ -62,7 +67,13 @@ func Decode(r io.Reader) (*Packet, error) {
 		ResponseTo:    binary.LittleEndian.Uint32(header[8:12]),
 		OpCode:        binary.LittleEndian.Uint32(header[12:16]),
 	}
-	pktLen := int(p.MessageLength - 16)
+	// MessageLength counts the 16-byte header itself. Validate before
+	// subtracting: an undersized value would underflow the unsigned length
+	// into a multi-gigabyte allocation.
+	if p.MessageLength < 16 || p.MessageLength > MaxMessageSize {
+		return nil, fmt.Errorf("invalid mongodb message length: %d", p.MessageLength)
+	}
+	pktLen := int(p.MessageLength) - 16
 	frame := make([]byte, pktLen)
 	_, err = io.ReadFull(r, frame)
 	if err != nil {
@@ -70,6 +81,29 @@ func Decode(r io.Reader) (*Packet, error) {
 	}
 	p.Frame = frame
 	return &p, nil
+}
+
+// CopyBuffer re-frames the MongoDB stream from src onto dst, issuing exactly
+// one dst.Write per wire-protocol message.
+//
+// dst is a packet-stream writer whose Write boundaries become hoop packet
+// boundaries, so this cannot be an io.Copy: the agent-side proxy decodes one
+// message per write it receives, and arbitrary TCP chunking would desync it.
+//
+// It returns nil when src ends cleanly on a message boundary.
+func CopyBuffer(dst io.Writer, src io.Reader) error {
+	for {
+		pkt, err := Decode(src)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if _, err := dst.Write(pkt.Encode()); err != nil {
+			return err
+		}
+	}
 }
 
 // DecodeOpMsgToJSON with return json content separated by break line for

--- a/common/mongotypes/packet.go
+++ b/common/mongotypes/packet.go
@@ -100,8 +100,16 @@ func CopyBuffer(dst io.Writer, src io.Reader) error {
 			}
 			return err
 		}
-		if _, err := dst.Write(pkt.Encode()); err != nil {
+		encoded := pkt.Encode()
+		n, err := dst.Write(encoded)
+		if err != nil {
 			return err
+		}
+		// io.Writer permits a short write with a nil error. Forwarding a
+		// truncated message would desynchronise the peer's decoder, which
+		// frames on the length prefix we just cut in half.
+		if n != len(encoded) {
+			return io.ErrShortWrite
 		}
 	}
 }

--- a/common/mongotypes/packet_test.go
+++ b/common/mongotypes/packet_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -172,3 +174,23 @@ func TestCopyBufferTruncatedMessageErrors(t *testing.T) {
 type writerFunc func(p []byte) (int, error)
 
 func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+// shortWriter accepts only the first n bytes of every write and reports no
+// error, which io.Writer explicitly permits. A relay that ignored the count
+// would forward a truncated message and desync the peer's decoder.
+type shortWriter struct{ accept int }
+
+func (w shortWriter) Write(p []byte) (int, error) {
+	if len(p) > w.accept {
+		return w.accept, nil
+	}
+	return len(p), nil
+}
+
+func TestCopyBufferRejectsShortWrite(t *testing.T) {
+	msg := newRawPacket(16+128, bytes.Repeat([]byte("x"), 128))
+	err := CopyBuffer(shortWriter{accept: 4}, bytes.NewReader(msg))
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("want io.ErrShortWrite for a truncated forward, got %v", err)
+	}
+}

--- a/common/mongotypes/packet_test.go
+++ b/common/mongotypes/packet_test.go
@@ -2,6 +2,7 @@ package mongotypes
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
@@ -88,3 +89,86 @@ func TestDecodeOpMsgToJSON(t *testing.T) {
 		})
 	}
 }
+
+// newRawPacket builds a wire message with an explicit MessageLength, so tests
+// can craft the malformed lengths a desynced or hostile stream would produce.
+func newRawPacket(messageLength uint32, frame []byte) []byte {
+	out := make([]byte, 16+len(frame))
+	binary.LittleEndian.PutUint32(out[0:4], messageLength)
+	binary.LittleEndian.PutUint32(out[4:8], 1)  // requestID
+	binary.LittleEndian.PutUint32(out[8:12], 0) // responseTo
+	binary.LittleEndian.PutUint32(out[12:16], OpMsgType)
+	copy(out[16:], frame)
+	return out
+}
+
+// A MessageLength below the 16-byte header used to underflow the unsigned
+// subtraction into a multi-gigabyte allocation. It must be rejected instead.
+func TestDecodeRejectsUndersizedMessageLength(t *testing.T) {
+	for _, length := range []uint32{0, 1, 15} {
+		_, err := Decode(bytes.NewReader(newRawPacket(length, nil)))
+		if err == nil {
+			t.Errorf("MessageLength=%d: want an error, got nil", length)
+		}
+	}
+}
+
+// An absurd length means the stream desynced; refuse rather than try to
+// allocate and read it.
+func TestDecodeRejectsOversizedMessageLength(t *testing.T) {
+	_, err := Decode(bytes.NewReader(newRawPacket(MaxMessageSize+1, nil)))
+	if err == nil {
+		t.Fatal("want an error for an oversized MessageLength, got nil")
+	}
+}
+
+// CopyBuffer's contract: one write per wire message, preserved byte-for-byte,
+// regardless of how the reads were chunked. The agent-side proxy decodes one
+// message per write it receives.
+func TestCopyBufferSplitsOnMessageBoundaries(t *testing.T) {
+	first := newRawPacket(16+5, []byte("hello"))
+	second := newRawPacket(16+3, []byte("bye"))
+
+	var writes [][]byte
+	dst := writerFunc(func(p []byte) (int, error) {
+		writes = append(writes, append([]byte(nil), p...))
+		return len(p), nil
+	})
+
+	if err := CopyBuffer(dst, bytes.NewReader(append(first, second...))); err != nil {
+		t.Fatalf("CopyBuffer: %v", err)
+	}
+	if len(writes) != 2 {
+		t.Fatalf("want one write per message (2), got %d", len(writes))
+	}
+	if !bytes.Equal(writes[0], first) || !bytes.Equal(writes[1], second) {
+		t.Error("messages were not forwarded byte-for-byte on their own writes")
+	}
+}
+
+// A clean end-of-stream on a message boundary is the client closing its
+// socket, not a failure.
+func TestCopyBufferCleanEOF(t *testing.T) {
+	dst := writerFunc(func(p []byte) (int, error) { return len(p), nil })
+	if err := CopyBuffer(dst, bytes.NewReader(nil)); err != nil {
+		t.Fatalf("clean EOF should not error, got %v", err)
+	}
+}
+
+// A stream cut mid-message must error rather than forward a partial message.
+func TestCopyBufferTruncatedMessageErrors(t *testing.T) {
+	full := newRawPacket(16+8, []byte("abcdefgh"))
+	var writes int
+	dst := writerFunc(func(p []byte) (int, error) { writes++; return len(p), nil })
+
+	if err := CopyBuffer(dst, bytes.NewReader(full[:len(full)-2])); err == nil {
+		t.Fatal("want an error for a truncated message, got nil")
+	}
+	if writes != 0 {
+		t.Fatalf("truncated message must not be forwarded, got %d writes", writes)
+	}
+}
+
+type writerFunc func(p []byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }

--- a/common/mssqltypes/packet.go
+++ b/common/mssqltypes/packet.go
@@ -8,6 +8,11 @@ import (
 	"io"
 )
 
+// headerSize is the fixed TDS packet header:
+// [type(1), status(1), length(2), spid(2), id(1), window(1)].
+// The length field counts this header, so it can never be smaller.
+const headerSize = 8
+
 // Packet represents a TDS Packet
 type Packet struct {
 	// [type(1), status(1), length(2), spid(2), id(1), window(1)]
@@ -41,7 +46,7 @@ func NewHeader(packetType PacketType, dataSize int) (header [8]byte) {
 	// status (hard-coded)
 	header[1] = 0x01
 	// length
-	binary.BigEndian.PutUint16(header[2:4], uint16(dataSize)+8)
+	binary.BigEndian.PutUint16(header[2:4], uint16(dataSize)+headerSize)
 
 	// spid (hard-coded)
 	header[4] = 0x00
@@ -78,8 +83,14 @@ func Decode(data io.Reader) (*Packet, error) {
 	if _, ok := packetTypeMap[PacketType(p.header[0])]; !ok {
 		return nil, fmt.Errorf("decoded an unknown packet type [%X]", p.header[0])
 	}
-	pktLen := p.Length() - 8
-	p.Frame = make([]byte, pktLen)
+	// Length counts the 8-byte header itself. Validate before subtracting:
+	// an undersized value would underflow the unsigned length and make the
+	// reader block for ~64 KiB of payload that will never arrive.
+	total := p.Length()
+	if total < headerSize {
+		return nil, fmt.Errorf("invalid TDS packet length: %d", total)
+	}
+	p.Frame = make([]byte, total-headerSize)
 	_, err = io.ReadFull(data, p.Frame)
 	return p, err
 }
@@ -105,4 +116,32 @@ func DecodeFull(p []byte, maxPacketSize int) ([]*Packet, error) {
 		return nil, fmt.Errorf("unable to decode packets")
 	}
 	return packets, nil
+}
+
+// CopyBuffer re-frames the TDS stream from src onto dst, issuing exactly one
+// dst.Write per TDS packet.
+//
+// dst is a packet-stream writer whose Write boundaries become hoop packet
+// boundaries, so this cannot be an io.Copy: the agent-side proxy decodes
+// packets from the buffer it is handed, and arbitrary TCP chunking would
+// desync it.
+//
+// Unlike DecodeFull, which slices a buffer by a caller-supplied maximum packet
+// size, this honours each packet's own length header — the only framing the
+// sender actually guarantees.
+//
+// It returns nil when src ends cleanly on a packet boundary.
+func CopyBuffer(dst io.Writer, src io.Reader) error {
+	for {
+		pkt, err := Decode(src)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if _, err := dst.Write(pkt.Encode()); err != nil {
+			return err
+		}
+	}
 }

--- a/common/mssqltypes/packet.go
+++ b/common/mssqltypes/packet.go
@@ -140,8 +140,16 @@ func CopyBuffer(dst io.Writer, src io.Reader) error {
 			}
 			return err
 		}
-		if _, err := dst.Write(pkt.Encode()); err != nil {
+		encoded := pkt.Encode()
+		n, err := dst.Write(encoded)
+		if err != nil {
 			return err
+		}
+		// io.Writer permits a short write with a nil error. Forwarding a
+		// truncated packet would desynchronise the peer's decoder, which
+		// frames on the length prefix we just cut in half.
+		if n != len(encoded) {
+			return io.ErrShortWrite
 		}
 	}
 }

--- a/common/mssqltypes/packet_test.go
+++ b/common/mssqltypes/packet_test.go
@@ -1,0 +1,113 @@
+package mssqltypes
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+// recordingWriter keeps each Write separate: CopyBuffer's contract is that
+// write boundaries carry TDS packet boundaries, since the agent-side proxy
+// decodes packets from the buffer it is handed.
+type recordingWriter struct {
+	writes [][]byte
+	failAt int // 1-based write index to fail on; 0 never fails
+}
+
+var errWriteRejected = errors.New("write rejected")
+
+func (w *recordingWriter) Write(p []byte) (int, error) {
+	w.writes = append(w.writes, append([]byte(nil), p...))
+	if w.failAt > 0 && len(w.writes) == w.failAt {
+		return 0, errWriteRejected
+	}
+	return len(p), nil
+}
+
+func TestCopyBufferSplitsOnPacketBoundaries(t *testing.T) {
+	first := New(PacketSQLBatchType, []byte("SELECT 1")).Encode()
+	second := New(PacketSQLBatchType, []byte("SELECT 2")).Encode()
+
+	var dst recordingWriter
+	if err := CopyBuffer(&dst, bytes.NewReader(append(first, second...))); err != nil {
+		t.Fatalf("CopyBuffer: %v", err)
+	}
+	if len(dst.writes) != 2 {
+		t.Fatalf("want one write per packet (2), got %d", len(dst.writes))
+	}
+	if !bytes.Equal(dst.writes[0], first) || !bytes.Equal(dst.writes[1], second) {
+		t.Error("packets were not forwarded byte-for-byte on their own writes")
+	}
+}
+
+// Unlike DecodeFull, which slices by a caller-supplied maximum size, CopyBuffer
+// honours each packet's own length header. Packets of differing sizes in one
+// stream must therefore split correctly.
+func TestCopyBufferHonoursPerPacketLength(t *testing.T) {
+	small := New(PacketSQLBatchType, []byte("a")).Encode()
+	large := New(PacketSQLBatchType, bytes.Repeat([]byte("b"), 900)).Encode()
+
+	var dst recordingWriter
+	if err := CopyBuffer(&dst, bytes.NewReader(append(small, large...))); err != nil {
+		t.Fatalf("CopyBuffer: %v", err)
+	}
+	if len(dst.writes) != 2 {
+		t.Fatalf("want 2 writes, got %d", len(dst.writes))
+	}
+	if len(dst.writes[0]) != len(small) || len(dst.writes[1]) != len(large) {
+		t.Errorf("packet sizes not preserved: got %d and %d, want %d and %d",
+			len(dst.writes[0]), len(dst.writes[1]), len(small), len(large))
+	}
+}
+
+// A clean end-of-stream on a packet boundary is the client closing its socket.
+func TestCopyBufferCleanEOF(t *testing.T) {
+	var dst recordingWriter
+	if err := CopyBuffer(&dst, bytes.NewReader(nil)); err != nil {
+		t.Fatalf("clean EOF should not error, got %v", err)
+	}
+	if len(dst.writes) != 0 {
+		t.Fatalf("want no writes, got %d", len(dst.writes))
+	}
+}
+
+// A stream cut mid-packet must error rather than forward partial bytes.
+func TestCopyBufferTruncatedPacketErrors(t *testing.T) {
+	full := New(PacketSQLBatchType, []byte("SELECT 1")).Encode()
+	var dst recordingWriter
+	if err := CopyBuffer(&dst, bytes.NewReader(full[:len(full)-3])); err == nil {
+		t.Fatal("want an error for a truncated packet, got nil")
+	}
+	if len(dst.writes) != 0 {
+		t.Fatalf("truncated packet must not be forwarded, got %d writes", len(dst.writes))
+	}
+}
+
+// A length field below the 8-byte header used to underflow the unsigned
+// subtraction, leaving the reader blocked waiting for ~64 KiB of payload that
+// never arrives. It must be rejected outright.
+func TestDecodeRejectsUndersizedLength(t *testing.T) {
+	for _, total := range []uint16{0, 1, 7} {
+		pkt := New(PacketSQLBatchType, nil).Encode()
+		binary.BigEndian.PutUint16(pkt[2:4], total)
+		if _, err := Decode(bytes.NewReader(pkt)); err == nil {
+			t.Errorf("length=%d: want an error, got nil", total)
+		}
+	}
+}
+
+// A write failure must abort the copy rather than silently dropping the rest
+// of the client's stream.
+func TestCopyBufferPropagatesWriteError(t *testing.T) {
+	first := New(PacketSQLBatchType, []byte("one")).Encode()
+	second := New(PacketSQLBatchType, []byte("two")).Encode()
+
+	dst := recordingWriter{failAt: 1}
+	if err := CopyBuffer(&dst, bytes.NewReader(append(first, second...))); !errors.Is(err, errWriteRejected) {
+		t.Fatalf("want the writer's error, got %v", err)
+	}
+	if len(dst.writes) != 1 {
+		t.Fatalf("copy continued past a failed write: %d writes", len(dst.writes))
+	}
+}

--- a/common/mssqltypes/packet_test.go
+++ b/common/mssqltypes/packet_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"io"
 	"testing"
 )
 
@@ -109,5 +110,25 @@ func TestCopyBufferPropagatesWriteError(t *testing.T) {
 	}
 	if len(dst.writes) != 1 {
 		t.Fatalf("copy continued past a failed write: %d writes", len(dst.writes))
+	}
+}
+
+// shortWriter accepts only the first n bytes of every write and reports no
+// error, which io.Writer explicitly permits. A relay that ignored the count
+// would forward a truncated packet and desync the peer's decoder.
+type shortWriter struct{ accept int }
+
+func (w shortWriter) Write(p []byte) (int, error) {
+	if len(p) > w.accept {
+		return w.accept, nil
+	}
+	return len(p), nil
+}
+
+func TestCopyBufferRejectsShortWrite(t *testing.T) {
+	stream := New(PacketSQLBatchType, bytes.Repeat([]byte("x"), 128)).Encode()
+	err := CopyBuffer(shortWriter{accept: 4}, bytes.NewReader(stream))
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("want io.ErrShortWrite for a truncated forward, got %v", err)
 	}
 }

--- a/common/mysqltypes/packet.go
+++ b/common/mysqltypes/packet.go
@@ -83,8 +83,16 @@ func CopyBuffer(dst io.Writer, src io.Reader) error {
 			}
 			return err
 		}
-		if _, err := dst.Write(pkt.Encode()); err != nil {
+		encoded := pkt.Encode()
+		n, err := dst.Write(encoded)
+		if err != nil {
 			return err
+		}
+		// io.Writer permits a short write with a nil error. Forwarding a
+		// truncated packet would desynchronise the peer's decoder, which
+		// frames on the length prefix we just cut in half.
+		if n != len(encoded) {
+			return io.ErrShortWrite
 		}
 	}
 }

--- a/common/mysqltypes/packet.go
+++ b/common/mysqltypes/packet.go
@@ -1,0 +1,100 @@
+// Package mysqltypes holds the minimal MySQL wire-protocol framing shared by
+// every hoop component that relays MySQL bytes onto the packet stream: the
+// `hoop connect` local proxy (client/proxy) and the tunnel's per-flow pipe
+// (tunnel/client).
+//
+// Only framing lives here. Authentication, TLS and redaction belong to the
+// agent-side proxy (libhoop), which is the single component that ever speaks
+// to a real MySQL server.
+//
+// Why framing must be shared: the agent's MySQL proxy consumes one whole
+// packet per Write (it decodes a packet from the buffer it is handed), so a
+// relay that forwards arbitrary TCP chunks desynchronises it. Both relays
+// therefore have to re-frame the client stream identically, and duplicating
+// that logic is how the two paths drift.
+package mysqltypes
+
+import (
+	"fmt"
+	"io"
+)
+
+// HeaderSize is the fixed MySQL packet header: a 3-byte little-endian payload
+// length followed by a 1-byte sequence id.
+const HeaderSize = 4
+
+// MaxPacketSize bounds a single packet's payload. MySQL's protocol maximum is
+// 16 MiB - 1 (a payload of exactly 0xFFFFFF signals a continuation packet), so
+// any length at or above this bound means the stream desynchronised.
+const MaxPacketSize = 1<<24 - 1
+
+// Packet is one framed MySQL protocol packet.
+type Packet struct {
+	// Seq is the packet sequence id, reset to 0 by the client at the start of
+	// every command and incremented per packet within a command.
+	Seq byte
+	// Frame is the packet payload, excluding the 4-byte header.
+	Frame []byte
+}
+
+// Encode returns the packet as it appears on the wire: header followed by
+// payload.
+func (p *Packet) Encode() []byte {
+	out := make([]byte, HeaderSize+len(p.Frame))
+	putUint24(out[0:3], uint32(len(p.Frame)))
+	out[3] = p.Seq
+	copy(out[HeaderSize:], p.Frame)
+	return out
+}
+
+// Decode reads exactly one MySQL packet from r, blocking until the whole
+// payload has arrived. It returns io.EOF only when the stream ends cleanly on
+// a packet boundary; a truncated packet yields io.ErrUnexpectedEOF.
+func Decode(r io.Reader) (*Packet, error) {
+	var header [HeaderSize]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, err
+	}
+	payloadLen := uint24(header[0:3])
+	if payloadLen > MaxPacketSize {
+		return nil, fmt.Errorf("mysql packet too large: %d bytes (max %d)", payloadLen, MaxPacketSize)
+	}
+	pkt := &Packet{Seq: header[3], Frame: make([]byte, payloadLen)}
+	if _, err := io.ReadFull(r, pkt.Frame); err != nil {
+		return nil, err
+	}
+	return pkt, nil
+}
+
+// CopyBuffer re-frames the MySQL stream from src onto dst, issuing exactly one
+// dst.Write per protocol packet.
+//
+// dst is a packet-stream writer whose Write boundaries become hoop packet
+// boundaries, which is why this cannot be an io.Copy: the agent-side proxy
+// decodes one MySQL packet per write it receives.
+//
+// It returns nil when src ends cleanly on a packet boundary.
+func CopyBuffer(dst io.Writer, src io.Reader) error {
+	for {
+		pkt, err := Decode(src)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if _, err := dst.Write(pkt.Encode()); err != nil {
+			return err
+		}
+	}
+}
+
+func uint24(b []byte) uint32 {
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16
+}
+
+func putUint24(b []byte, v uint32) {
+	b[0] = byte(v)
+	b[1] = byte(v >> 8)
+	b[2] = byte(v >> 16)
+}

--- a/common/mysqltypes/packet_test.go
+++ b/common/mysqltypes/packet_test.go
@@ -1,0 +1,187 @@
+package mysqltypes
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+// packetWriter records each Write as a separate entry. The whole point of
+// CopyBuffer is that write boundaries carry protocol packet boundaries, so
+// asserting on the boundaries is asserting on the contract.
+type packetWriter struct {
+	writes [][]byte
+	failAt int // 1-based write index to fail on; 0 never fails
+}
+
+var errWriteRejected = errors.New("write rejected")
+
+func (w *packetWriter) Write(p []byte) (int, error) {
+	w.writes = append(w.writes, append([]byte(nil), p...))
+	if w.failAt > 0 && len(w.writes) == w.failAt {
+		return 0, errWriteRejected
+	}
+	return len(p), nil
+}
+
+// encode builds a wire packet with the given sequence id and payload.
+func encode(seq byte, payload []byte) []byte {
+	p := &Packet{Seq: seq, Frame: payload}
+	return p.Encode()
+}
+
+func TestCopyBufferSplitsOnPacketBoundaries(t *testing.T) {
+	// Three packets arriving as one contiguous read, which is what a real
+	// TCP stream does when a client pipelines commands.
+	stream := bytes.Join([][]byte{
+		encode(0, []byte("first")),
+		encode(1, []byte("second-packet")),
+		encode(2, nil),
+	}, nil)
+
+	var dst packetWriter
+	if err := CopyBuffer(&dst, bytes.NewReader(stream)); err != nil {
+		t.Fatalf("CopyBuffer: %v", err)
+	}
+
+	if len(dst.writes) != 3 {
+		t.Fatalf("want one write per packet (3), got %d", len(dst.writes))
+	}
+	want := [][]byte{
+		encode(0, []byte("first")),
+		encode(1, []byte("second-packet")),
+		encode(2, nil),
+	}
+	for i := range want {
+		if !bytes.Equal(dst.writes[i], want[i]) {
+			t.Errorf("write[%d] = % X, want % X", i, dst.writes[i], want[i])
+		}
+	}
+}
+
+// A packet split across several reads must still emit exactly one write:
+// the agent-side proxy decodes one packet per write, so a partial write
+// desynchronises it.
+func TestCopyBufferReassemblesSplitPacket(t *testing.T) {
+	full := encode(7, bytes.Repeat([]byte("x"), 300))
+
+	var dst packetWriter
+	// iotest-style drip feed: one byte at a time.
+	if err := CopyBuffer(&dst, iotestOneByteReader(full)); err != nil {
+		t.Fatalf("CopyBuffer: %v", err)
+	}
+	if len(dst.writes) != 1 {
+		t.Fatalf("want 1 write for 1 packet, got %d", len(dst.writes))
+	}
+	if !bytes.Equal(dst.writes[0], full) {
+		t.Errorf("reassembled packet mismatch")
+	}
+}
+
+// Sequence ids must survive the round trip: MySQL rejects a handshake whose
+// sequence does not advance as expected.
+func TestPacketRoundTripPreservesSequence(t *testing.T) {
+	for _, seq := range []byte{0, 1, 42, 255} {
+		pkt, err := Decode(bytes.NewReader(encode(seq, []byte("payload"))))
+		if err != nil {
+			t.Fatalf("Decode(seq=%d): %v", seq, err)
+		}
+		if pkt.Seq != seq {
+			t.Errorf("Seq = %d, want %d", pkt.Seq, seq)
+		}
+		if string(pkt.Frame) != "payload" {
+			t.Errorf("Frame = %q, want %q", pkt.Frame, "payload")
+		}
+	}
+}
+
+// A zero-length payload is legal MySQL framing (an empty OK-ish packet), and
+// must produce a write rather than being swallowed as EOF.
+func TestCopyBufferEmptyPayloadIsAPacket(t *testing.T) {
+	var dst packetWriter
+	if err := CopyBuffer(&dst, bytes.NewReader(encode(0, nil))); err != nil {
+		t.Fatalf("CopyBuffer: %v", err)
+	}
+	if len(dst.writes) != 1 {
+		t.Fatalf("want 1 write, got %d", len(dst.writes))
+	}
+}
+
+// A clean end-of-stream on a packet boundary is not an error: the client
+// simply closed its socket.
+func TestCopyBufferCleanEOF(t *testing.T) {
+	var dst packetWriter
+	if err := CopyBuffer(&dst, bytes.NewReader(nil)); err != nil {
+		t.Fatalf("clean EOF should not error, got %v", err)
+	}
+	if len(dst.writes) != 0 {
+		t.Fatalf("want no writes, got %d", len(dst.writes))
+	}
+}
+
+// A stream cut mid-packet is a real error: forwarding the partial bytes would
+// desync the upstream decoder.
+func TestCopyBufferTruncatedPacketErrors(t *testing.T) {
+	full := encode(0, []byte("abcdefgh"))
+	var dst packetWriter
+	err := CopyBuffer(&dst, bytes.NewReader(full[:len(full)-3]))
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("want io.ErrUnexpectedEOF, got %v", err)
+	}
+	if len(dst.writes) != 0 {
+		t.Fatalf("truncated packet must not be forwarded, got %d writes", len(dst.writes))
+	}
+}
+
+// A header cut mid-way is equally fatal.
+func TestCopyBufferTruncatedHeaderErrors(t *testing.T) {
+	var dst packetWriter
+	err := CopyBuffer(&dst, bytes.NewReader([]byte{0x05, 0x00}))
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("want io.ErrUnexpectedEOF, got %v", err)
+	}
+}
+
+// A write failure must abort the copy rather than silently dropping the rest
+// of the client's stream.
+func TestCopyBufferPropagatesWriteError(t *testing.T) {
+	stream := append(encode(0, []byte("one")), encode(1, []byte("two"))...)
+	dst := packetWriter{failAt: 1}
+	err := CopyBuffer(&dst, bytes.NewReader(stream))
+	if !errors.Is(err, errWriteRejected) {
+		t.Fatalf("want the writer's error, got %v", err)
+	}
+	if len(dst.writes) != 1 {
+		t.Fatalf("copy continued past a failed write: %d writes", len(dst.writes))
+	}
+}
+
+// The 3-byte length field caps a payload at 0xFFFFFF, so no encodable packet
+// can exceed MaxPacketSize — the bound exists to reject a desynced stream, not
+// a legitimately large one.
+func TestMaxPacketSizeMatchesWireLimit(t *testing.T) {
+	if MaxPacketSize != 1<<24-1 {
+		t.Fatalf("MaxPacketSize = %d, want the 3-byte length maximum %d", MaxPacketSize, 1<<24-1)
+	}
+}
+
+// oneByteReader yields a single byte per Read, exercising the reassembly path.
+type oneByteReader struct {
+	data []byte
+	pos  int
+}
+
+func iotestOneByteReader(b []byte) io.Reader { return &oneByteReader{data: b} }
+
+func (r *oneByteReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = r.data[r.pos]
+	r.pos++
+	return 1, nil
+}

--- a/common/mysqltypes/packet_test.go
+++ b/common/mysqltypes/packet_test.go
@@ -185,3 +185,23 @@ func (r *oneByteReader) Read(p []byte) (int, error) {
 	r.pos++
 	return 1, nil
 }
+
+// shortWriter accepts only the first n bytes of every write and reports no
+// error, which io.Writer explicitly permits. A relay that ignored the count
+// would forward a truncated packet and desync the peer's decoder.
+type shortWriter struct{ accept int }
+
+func (w shortWriter) Write(p []byte) (int, error) {
+	if len(p) > w.accept {
+		return w.accept, nil
+	}
+	return len(p), nil
+}
+
+func TestCopyBufferRejectsShortWrite(t *testing.T) {
+	stream := encode(0, bytes.Repeat([]byte("x"), 128))
+	err := CopyBuffer(shortWriter{accept: 4}, bytes.NewReader(stream))
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("want io.ErrShortWrite for a truncated forward, got %v", err)
+	}
+}

--- a/gateway/integration/transport/tunnel_e2e_test.go
+++ b/gateway/integration/transport/tunnel_e2e_test.go
@@ -1,0 +1,304 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	commongrpc "github.com/hoophq/hoop/common/grpc"
+	tunnelclient "github.com/hoophq/hoop/tunnel/client"
+)
+
+// The fixed placeholders the tunnel advertises. Duplicated here rather than
+// imported: they are the tunnel's own contract (tunnel/tunnelmgr), and this
+// suite asserts the value a real client must present, so a shared constant
+// would let both sides drift together without the test noticing.
+const (
+	tunnelUser     = "noop"
+	tunnelPassword = "noop"
+)
+
+// TestTunnelAcceptsFixedCredentials is the DEP-142 acceptance test.
+//
+// It is the whole stack, unmocked: a real `lib/pq` client speaks the
+// PostgreSQL wire protocol to a local listener, every accepted flow is handed
+// to the tunnel's own client.DialAndPipe (the exact call the daemon's netstack
+// handler makes), which opens a gRPC session to a real gateway, reaches a real
+// agent controller, and lands on a real PostgreSQL container.
+//
+// The client authenticates with the fixed noop/noop placeholders that
+// `hsh tunnel ls` advertises, and never sees the database's real
+// credentials. If the tunnel routed this flow onto the raw TCP relay (the
+// pre-DEP-142 behaviour) the client would be handed the backend's own SASL
+// challenge and the query would fail.
+func TestTunnelAcceptsFixedCredentials(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			connName := uniqueName("tune2e")
+			agentID, dsn := createAgent(t, uniqueName("agent"))
+			createPGConnection(t, connName, agentID)
+			startAgent(t, c, dsn)
+			waitConnectionOnline(t, connName)
+
+			addr := startTunnelListener(t, connName)
+
+			// Exactly what a user would run against <name>.hoop, except the
+			// host is the local listener standing in for the netstack's
+			// virtual IP (the netstack itself needs root and a TUN device).
+			dsnStr := fmt.Sprintf(
+				"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+				addr.host, addr.port, tunnelUser, tunnelPassword, gw.Postgres.Database,
+			)
+			db, err := sql.Open("postgres", dsnStr)
+			if err != nil {
+				t.Fatalf("sql.Open: %v", err)
+			}
+			defer db.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			var got int
+			if err := db.QueryRowContext(ctx, "SELECT 1").Scan(&got); err != nil {
+				skipWithoutEnterpriseLibhoop(t, err)
+				t.Fatalf("SELECT 1 through the tunnel with %s/%s: %v",
+					tunnelUser, tunnelPassword, err)
+			}
+			if got != 1 {
+				t.Fatalf("SELECT 1 returned %d", got)
+			}
+
+			// A second query on the same pooled connection proves the pipe
+			// stayed framed after the handshake, not just through it.
+			var two int
+			if err := db.QueryRowContext(ctx, "SELECT 2").Scan(&two); err != nil {
+				t.Fatalf("second query through the tunnel: %v", err)
+			}
+			if two != 2 {
+				t.Fatalf("SELECT 2 returned %d", two)
+			}
+		})
+	}
+}
+
+// TestTunnelEnforcesGuardrails pins the security consequence of routing
+// database flows over their protocol packet family.
+//
+// Guardrails are evaluated by the agent's protocol proxy, which has to parse
+// the query to apply them. The raw TCP relay cannot: it copies bytes verbatim,
+// which is why agent/controller/tcp.go refuses guarded sessions outright
+// (DEP-48). Before this change every tunnelled database flow took that relay,
+// so a guarded connection was simply unusable over the tunnel.
+//
+// Now the flow reaches the real proxy, so the rule is enforced: a denied query
+// is blocked while the session stays open for the client to try another.
+func TestTunnelEnforcesGuardrails(t *testing.T) {
+	c := transports()[0] // agent-side enforcement; wire-agnostic, gRPC suffices
+
+	connName := uniqueName("tunguard")
+	agentID, dsn := createAgent(t, uniqueName("agent"))
+	createPGConnection(t, connName, agentID)
+	// Deny any statement containing "SELECT".
+	createGuardrailForConnection(t, uniqueName("gr"), connectionID(t, connName))
+	startAgent(t, c, dsn)
+	waitConnectionOnline(t, connName)
+
+	addr := startTunnelListener(t, connName)
+
+	dsnStr := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+		addr.host, addr.port, tunnelUser, tunnelPassword, gw.Postgres.Database,
+	)
+	db, err := sql.Open("postgres", dsnStr)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var got int
+	err = db.QueryRowContext(ctx, "SELECT 1").Scan(&got)
+	if err == nil {
+		t.Fatal("a guardrail-denied query succeeded through the tunnel; the flow is " +
+			"bypassing the agent's protocol proxy")
+	}
+	// Assert on the rule's own message, not merely on "some error": without
+	// the enterprise libhoop the proxy cannot be built at all and the session
+	// dies with a bare EOF, which would satisfy a weaker check while proving
+	// nothing about enforcement.
+	if !strings.Contains(err.Error(), "Blocked by the following Guardrails rule") {
+		skipWithoutEnterpriseLibhoop(t, err)
+		t.Fatalf("query failed, but not with a guardrail block: %v", err)
+	}
+	t.Logf("guardrail enforced over the tunnel: %v", err)
+}
+
+// TestTunnelIgnoresClientCredentials proves the successful case above is not
+// passing by accident — i.e. that credential *injection* really happened.
+//
+// The agent's protocol proxy terminates the client's authentication locally
+// and never forwards what the client typed; it authenticates upstream with the
+// secrets stored on the connection. Two observable consequences follow, and
+// this test pins both:
+//
+//  1. A deliberately wrong password still connects, because the client's
+//     credentials never reach the database.
+//  2. The resulting session runs as the connection's stored database user,
+//     not as whatever the client claimed to be.
+//
+// (2) is the load-bearing assertion: if the tunnel were passing bytes through
+// to a permissive backend, current_user would reflect the client's name.
+func TestTunnelIgnoresClientCredentials(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			connName := uniqueName("tunneg")
+			agentID, dsn := createAgent(t, uniqueName("agent"))
+			createPGConnection(t, connName, agentID)
+			startAgent(t, c, dsn)
+			waitConnectionOnline(t, connName)
+
+			addr := startTunnelListener(t, connName)
+
+			// Neither the username nor the password is valid upstream.
+			const bogusUser = "definitely-not-a-database-role"
+			dsnStr := fmt.Sprintf(
+				"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+				addr.host, addr.port, bogusUser, "wrong-password", gw.Postgres.Database,
+			)
+			db, err := sql.Open("postgres", dsnStr)
+			if err != nil {
+				t.Fatalf("sql.Open: %v", err)
+			}
+			defer db.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			var upstreamUser string
+			if err := db.QueryRowContext(ctx, "SELECT current_user").Scan(&upstreamUser); err != nil {
+				skipWithoutEnterpriseLibhoop(t, err)
+				t.Fatalf("query through the tunnel with bogus client credentials: %v", err)
+			}
+			if upstreamUser == bogusUser {
+				t.Fatalf("the session runs as the client-supplied role %q; the tunnel forwarded "+
+					"client credentials instead of injecting the connection's own", bogusUser)
+			}
+			if upstreamUser != gw.Postgres.User {
+				t.Fatalf("current_user = %q, want the connection's stored user %q",
+					upstreamUser, gw.Postgres.User)
+			}
+		})
+	}
+}
+
+// skipWithoutEnterpriseLibhoop skips the calling test when a tunnel query
+// failed only because the agent could not build a protocol proxy.
+//
+// The proxies live in the enterprise libhoop (checked out by the integration
+// CI job); the OSS stub returns "missing protocol hoop library" for every
+// protocol, and the session then dies with a bare EOF at the client. Every
+// tunnel test here is about what the proxy does, so there is nothing to assert
+// without it — the same OSS/enterprise split the PG round-trip suite uses.
+//
+// It deliberately does NOT swallow other failures: only EOF-shaped and
+// stub-marked errors skip, so a genuine regression still fails.
+func skipWithoutEnterpriseLibhoop(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	if strings.Contains(err.Error(), ossLibhoopMarker) || errors.Is(err, io.EOF) {
+		t.Skip("tunnel protocol-proxy tests require the enterprise libhoop; skipping on the OSS stub")
+	}
+}
+
+type listenerAddr struct{ host, port string }
+
+// startTunnelListener accepts TCP flows on loopback and pipes each one through
+// the tunnel's client.DialAndPipe, which is what the daemon's netstack handler
+// does per accepted flow (tunnel/tunnelmgr/handlers.go).
+//
+// It stands in for the gVisor netstack only: the netstack needs root and a TUN
+// device, and it contributes nothing to what these tests assert. Everything
+// downstream of the accept — the pipe, the packet-family routing, the framing,
+// the gateway, the agent and the database — is the production path.
+func startTunnelListener(t *testing.T, connName string) listenerAddr {
+	t.Helper()
+
+	lis, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Pipe goroutines outlive the last query: closing the listener and
+	// cancelling only starts their teardown. Wait for them before the test
+	// returns, otherwise a late t.Logf panics with "Log in goroutine after
+	// test has completed".
+	var pipes sync.WaitGroup
+	accepted := make(chan struct{})
+	var acceptOnce sync.Once
+
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return // listener closed by cleanup
+			}
+			acceptOnce.Do(func() { close(accepted) })
+			pipes.Add(1)
+			go func() {
+				defer pipes.Done()
+				defer conn.Close()
+				err := tunnelclient.DialAndPipe(ctx, conn, tunnelclient.PipeOptions{
+					GatewayConfig: commongrpc.ClientConfig{
+						ServerAddress: gw.GRPCAddr,
+						Token:         adminToken(t),
+						UserAgent:     "hoop-tunnel-itest",
+						Insecure:      true,
+					},
+					ConnectionName:     connName,
+					SessionOpenTimeout: 20 * time.Second,
+				})
+				// Deliberately not asserted or logged: a pipe always ends in
+				// an error once the harness tears the agent down, and logging
+				// here would race the test's completion. The queries above
+				// are what decide the verdict.
+				_ = err
+			}()
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = lis.Close()
+		cancel()
+		pipes.Wait()
+		// Surface pipe failures only when a flow never got off the ground;
+		// a test that queried successfully does not care how its pipe ended.
+		select {
+		case <-accepted:
+		default:
+			t.Errorf("no flow ever reached the tunnel pipe")
+		}
+	})
+
+	host, port, err := net.SplitHostPort(lis.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", lis.Addr(), err)
+	}
+	return listenerAddr{host: host, port: port}
+}

--- a/gateway/integration/transport/tunnel_e2e_test.go
+++ b/gateway/integration/transport/tunnel_e2e_test.go
@@ -29,7 +29,8 @@ const (
 	tunnelPassword = "noop"
 )
 
-// TestTunnelAcceptsFixedCredentials is the DEP-142 acceptance test.
+// TestTunnelAcceptsFixedCredentials is the acceptance test for the tunnel's
+// fixed credentials.
 //
 // It is the whole stack, unmocked: a real `lib/pq` client speaks the
 // PostgreSQL wire protocol to a local listener, every accepted flow is handed
@@ -40,7 +41,7 @@ const (
 // The client authenticates with the fixed noop/noop placeholders that
 // `hsh tunnel ls` advertises, and never sees the database's real
 // credentials. If the tunnel routed this flow onto the raw TCP relay (the
-// pre-DEP-142 behaviour) the client would be handed the backend's own SASL
+// behaviour this replaced) the client would be handed the backend's own SASL
 // challenge and the query would fail.
 func TestTunnelAcceptsFixedCredentials(t *testing.T) {
 	for _, c := range transports() {
@@ -97,8 +98,8 @@ func TestTunnelAcceptsFixedCredentials(t *testing.T) {
 //
 // Guardrails are evaluated by the agent's protocol proxy, which has to parse
 // the query to apply them. The raw TCP relay cannot: it copies bytes verbatim,
-// which is why agent/controller/tcp.go refuses guarded sessions outright
-// (DEP-48). Before this change every tunnelled database flow took that relay,
+// which is why agent/controller/tcp.go refuses guarded sessions outright.
+// Before this change every tunnelled database flow took that relay,
 // so a guarded connection was simply unusable over the tunnel.
 //
 // Now the flow reaches the real proxy, so the rule is enforced: a denied query

--- a/gateway/integration/transport/tunnel_pg_test.go
+++ b/gateway/integration/transport/tunnel_pg_test.go
@@ -15,7 +15,8 @@ import (
 	pbclient "github.com/hoophq/hoop/common/proto/client"
 )
 
-// TestTunnelRawTCPRejectsPlaceholderCredentials pins the defect behind DEP-142.
+// TestTunnelRawTCPRejectsPlaceholderCredentials pins the defect this change
+// fixes.
 //
 // The tunnel (tunnel/client/pipe.go) relays every TCP-style connection —
 // postgres included — as pbagent.TCPConnectionWrite. That packet family lands

--- a/gateway/integration/transport/tunnel_pg_test.go
+++ b/gateway/integration/transport/tunnel_pg_test.go
@@ -1,0 +1,276 @@
+//go:build integration
+
+package transport
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+)
+
+// TestTunnelRawTCPRejectsPlaceholderCredentials pins the defect behind DEP-142.
+//
+// The tunnel (tunnel/client/pipe.go) relays every TCP-style connection —
+// postgres included — as pbagent.TCPConnectionWrite. That packet family lands
+// on the agent's raw relay (agent/controller/tcp.go), which dials the upstream
+// and copies bytes verbatim: no credential injection. So a client presenting
+// the documented noop/noop placeholder authenticates against the real database
+// as the literal user "noop" and is rejected.
+//
+// This is what makes `hsh tunnel ls` unable to advertise fixed local
+// credentials today. The companion test below asserts the protocol packet
+// family does inject credentials, which is the behaviour the tunnel must adopt.
+func TestTunnelRawTCPRejectsPlaceholderCredentials(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			connName := uniqueName("tunraw")
+			agentID, dsn := createAgent(t, uniqueName("agent"))
+			createPGConnection(t, connName, agentID)
+			startAgent(t, c, dsn)
+			waitConnectionOnline(t, connName)
+
+			cli, err := c.DialClient(context.Background(), ClientDialConfig{
+				Token:          adminToken(t),
+				ConnectionName: connName,
+				Verb:           pb.ClientVerbConnect,
+			})
+			if err != nil {
+				t.Fatalf("DialClient: %v", err)
+			}
+			r := newPGReader(cli)
+			defer r.close()
+
+			sid := uuid.NewString()
+			if err := cli.Send(&pb.Packet{
+				Type: pbagent.SessionOpen,
+				Spec: map[string][]byte{pb.SpecGatewaySessionID: []byte(sid)},
+			}); err != nil {
+				t.Fatalf("send SessionOpen: %v", err)
+			}
+			r.waitFor(t, pbclient.SessionOpenOK, 20*time.Second)
+
+			// Exactly what tunnel/client/pipe.go does today: an empty
+			// TCPConnectionWrite carrying SpecTCPServerConnectKey to make the
+			// agent dial upstream, then raw protocol bytes on the same family.
+			const connID = "1"
+			if err := cli.Send(&pb.Packet{
+				Type: pbagent.TCPConnectionWrite,
+				Spec: map[string][]byte{
+					pb.SpecGatewaySessionID:    []byte(sid),
+					pb.SpecClientConnectionID:  []byte(connID),
+					pb.SpecTCPServerConnectKey: nil,
+				},
+			}); err != nil {
+				t.Fatalf("send TCP open: %v", err)
+			}
+
+			// A native client speaking to the tunnel presents the placeholder
+			// credentials the docs advertise. The raw relay is a verbatim byte
+			// pipe, so the SSL negotiation must be driven properly: send
+			// SSLRequest, wait for the single-byte reply, then the startup
+			// message. Batching them makes postgres reject the stream as
+			// "unencrypted data after SSL request" before it ever looks at the
+			// role, which would prove nothing about credentials.
+			rawWrite := func(payload []byte) {
+				t.Helper()
+				if err := cli.Send(&pb.Packet{
+					Type:    pbagent.TCPConnectionWrite,
+					Payload: payload,
+					Spec: map[string][]byte{
+						pb.SpecGatewaySessionID:   []byte(sid),
+						pb.SpecClientConnectionID: []byte(connID),
+					},
+				}); err != nil {
+					t.Fatalf("raw write: %v", err)
+				}
+			}
+			rawWrite(pgSSLRequest())
+			r.readRawSSLReply(t, 20*time.Second)
+			rawWrite(pgStartupMessage("noop", gw.Postgres.Database))
+
+			// The raw relay hands the client the backend's own authentication
+			// challenge, so the client itself must satisfy it. Placeholder
+			// credentials cannot: hoop's stored secrets never enter this path.
+			got := r.readRawUntilAuthOutcome(t, 20*time.Second)
+			switch {
+			case got.ready:
+				t.Fatal("raw TCP relay reached ReadyForQuery for role \"noop\"; " +
+					"the upstream would have to actually own that role")
+			case got.authOK:
+				t.Fatal("raw TCP relay authenticated role \"noop\" upstream; " +
+					"credential injection would be unnecessary")
+			case got.authType != 0:
+				t.Logf("raw TCP relay forwarded the upstream auth challenge (type %d) to the client: "+
+					"placeholder credentials cannot satisfy it", got.authType)
+			case got.errText != "":
+				t.Logf("raw TCP relay rejected placeholder credentials: %s", got.errText)
+			default:
+				t.Fatal("raw relay produced no authentication outcome")
+			}
+		})
+	}
+}
+
+// TestProtocolFamilyInjectsCredentials is the positive control: the same
+// connection, same placeholder credentials, but relayed on the protocol packet
+// family the `hoop connect` client uses. The agent runs the libhoop PostgreSQL
+// proxy, which terminates client auth locally and re-authenticates upstream
+// with the connection's stored secrets — so noop/noop reaches ReadyForQuery.
+//
+// This is the contract `hsh tunnel ls` needs in order to advertise fixed local
+// credentials.
+func TestProtocolFamilyInjectsCredentials(t *testing.T) {
+	for _, c := range transports() {
+		t.Run(c.Name(), func(t *testing.T) {
+			connName := uniqueName("tunproto")
+			agentID, dsn := createAgent(t, uniqueName("agent"))
+			createPGConnection(t, connName, agentID)
+			startAgent(t, c, dsn)
+			waitConnectionOnline(t, connName)
+
+			cli, err := c.DialClient(context.Background(), ClientDialConfig{
+				Token:          adminToken(t),
+				ConnectionName: connName,
+				Verb:           pb.ClientVerbConnect,
+			})
+			if err != nil {
+				t.Fatalf("DialClient: %v", err)
+			}
+			r := newPGReader(cli)
+			defer r.close()
+
+			sid := uuid.NewString()
+			if err := cli.Send(&pb.Packet{
+				Type: pbagent.SessionOpen,
+				Spec: map[string][]byte{pb.SpecGatewaySessionID: []byte(sid)},
+			}); err != nil {
+				t.Fatalf("send SessionOpen: %v", err)
+			}
+			r.waitFor(t, pbclient.SessionOpenOK, 20*time.Second)
+
+			const connID = "1"
+			handshake := append(pgSSLRequest(), pgStartupMessage("noop", gw.Postgres.Database)...)
+			if err := cli.Send(pgWritePacket(sid, connID, handshake)); err != nil {
+				t.Fatalf("send PG handshake: %v", err)
+			}
+			r.readUntilReady(t, 20*time.Second)
+
+			if err := cli.Send(pgWritePacket(sid, connID, pgSimpleQuery("SELECT 1"))); err != nil {
+				t.Fatalf("send PG query: %v", err)
+			}
+			rows := r.readUntilReady(t, 20*time.Second)
+			if !containsValue(rows, "1") {
+				t.Fatalf("SELECT 1 over the protocol family with noop/noop: got %v", rowsToStrings(rows))
+			}
+		})
+	}
+}
+
+// rawRelayOutcome is what a PG startup exchange produced when carried over the
+// raw TCP packet family. Exactly one field is meaningful per run.
+type rawRelayOutcome struct {
+	// ready means the backend reached ReadyForQuery.
+	ready bool
+	// authOK means the backend accepted the client's identity outright
+	// (AuthenticationOk, subtype 0) — i.e. it is trust-authenticated.
+	authOK bool
+	// authType is the non-zero AuthenticationRequest subtype the backend
+	// demanded from the client (10 = SASL/SCRAM, 5 = MD5, 3 = cleartext).
+	authType uint32
+	// errText is the backend's ErrorResponse payload, when it rejected the
+	// startup outright.
+	errText string
+}
+
+// readRawUntilAuthOutcome consumes pbclient.TCPConnectionWrite packets — the
+// family the raw relay answers on — until the backend's startup exchange
+// resolves one way or another.
+//
+// Unlike readUntilReady it treats an authentication challenge or an
+// ErrorResponse as the expected result rather than a fatal: the whole point of
+// this path is that hoop's stored credentials never participate, so the client
+// is left facing the database's own auth demand.
+//
+// The relay copies bytes verbatim, so writes carry no message boundaries;
+// payloads are concatenated before parsing and re-parsed on each arrival.
+func (r *pgReader) readRawUntilAuthOutcome(t *testing.T, timeout time.Duration) rawRelayOutcome {
+	t.Helper()
+	var buf []byte
+	deadline := time.After(timeout)
+	for {
+		select {
+		case pkt := <-r.pkts:
+			switch pkt.Type {
+			case pbclient.SessionClose:
+				// A dial or relay failure surfaces as a session close rather
+				// than a PG ErrorResponse; either way auth did not succeed.
+				return rawRelayOutcome{errText: string(pkt.Payload)}
+			case pbclient.TCPConnectionClose:
+				return rawRelayOutcome{errText: "upstream closed the connection"}
+			case pbclient.TCPConnectionWrite:
+				buf = append(buf, pkt.Payload...)
+			default:
+				continue
+			}
+			for _, m := range parsePGMessages(buf) {
+				switch m.Type {
+				case 'E':
+					return rawRelayOutcome{errText: string(m.Payload)}
+				case 'Z':
+					return rawRelayOutcome{ready: true}
+				case 'R':
+					if len(m.Payload) < 4 {
+						continue
+					}
+					subtype := binary.BigEndian.Uint32(m.Payload[:4])
+					if subtype == 0 {
+						return rawRelayOutcome{authOK: true}
+					}
+					return rawRelayOutcome{authType: subtype}
+				}
+			}
+		case err := <-r.errc:
+			t.Fatalf("stream error during raw relay exchange: %v", err)
+		case <-deadline:
+			t.Fatalf("timed out during raw relay exchange after %v", timeout)
+		}
+	}
+}
+
+// readRawSSLReply consumes the single-byte SSLRequest answer ('N' when the
+// backend declines TLS, 'S' when it offers it) that postgres sends before any
+// length-prefixed message. It exists because the raw relay is a verbatim byte
+// pipe with no protocol awareness, so the test must observe the negotiation
+// step a real client would.
+func (r *pgReader) readRawSSLReply(t *testing.T, timeout time.Duration) byte {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case pkt := <-r.pkts:
+			switch pkt.Type {
+			case pbclient.SessionClose:
+				t.Fatalf("session closed awaiting the SSL reply: %s", string(pkt.Payload))
+			case pbclient.TCPConnectionWrite:
+				if len(pkt.Payload) == 0 {
+					continue
+				}
+				if b := pkt.Payload[0]; b == 'N' || b == 'S' {
+					return b
+				}
+				t.Fatalf("expected an SSL negotiation reply, got % X", pkt.Payload)
+			}
+		case err := <-r.errc:
+			t.Fatalf("stream error awaiting the SSL reply: %v", err)
+		case <-deadline:
+			t.Fatalf("timed out awaiting the SSL reply after %v", timeout)
+		}
+	}
+}

--- a/tunnel/README.md
+++ b/tunnel/README.md
@@ -122,7 +122,7 @@ hsh-tunneld After that:  psql -h pg-prod.hoop ...   (or any *.hoop host)
 dig @fd5a:1b2c:3d4e::1 pg-prod.hoop AAAA
 
 # Direct connection — IP from the dig output:
-psql -h fd5a:1b2c:3d4e::a1b2:c3d4 -U noop
+PGPASSWORD=noop psql -h fd5a:1b2c:3d4e::a1b2:c3d4 -U noop
 ```
 
 ### 5. Verify (with host DNS routing)
@@ -145,7 +145,7 @@ pg-prod.hoop`:
 sudo resolvectl dns tun0 fd5a:1b2c:3d4e::1
 sudo resolvectl domain tun0 '~hoop'
 
-psql -h pg-prod.hoop -U noop
+PGPASSWORD=noop psql -h pg-prod.hoop -U noop
 ```
 
 Both go through the existing gateway. Watch the gateway logs to see
@@ -166,6 +166,54 @@ the bytes cross the agent in cleartext, guardrails and DLP inspection
 apply exactly as they do for `hoop connect`. `https://<name>.hoop` can
 never work — the tunnel has no certificate for `*.hoop` — so port 443
 is rejected at the SYN.
+
+## Credentials (`noop`/`noop`)
+
+Database connections are reached with the fixed local credentials
+`noop`/`noop`, the same placeholders `hoop connect` prints. They are not
+the connection's real credentials and not the gateway's rotating token:
+each flow is carried on its protocol's packet family, so the agent's
+libhoop proxy terminates the client's authentication locally and
+re-authenticates upstream with the secrets stored on the connection.
+
+`hsh tunnel ls` lists them per connection along with a ready-to-paste
+command. The canonical source is `tunnelmgr/credentials.go`.
+
+```bash
+PGPASSWORD=noop psql -h pg-prod.hoop -U noop
+mysql -h mysql-stg.hoop -u noop -pnoop
+```
+
+Two subtypes are exceptions and report no credentials:
+
+- **tcp** — an opaque user-defined upstream. Hoop cannot parse the
+  protocol, so the flow is relayed verbatim and the client faces the
+  upstream's own authentication with its own credentials.
+- **httpproxy** — authentication rides headers the agent injects.
+
+### Trust model: the tunnel is single-user
+
+The placeholders are not an access control — the tunnel session is. The
+daemon runs as root and installs host-wide routes, and it authorises a
+flow purely by destination address and port; it does not identify the
+calling OS user. Any local process that can reach `<name>.hoop`
+therefore acts with the authority of whoever ran `hsh tunnel login`.
+
+This is a property of the tunnel itself, not of these credentials:
+`tcp` and `httpproxy` connections already reach their upstreams over the
+same routes with no credentials at all, and `hoop connect` likewise
+serves `noop`/`noop` on a loopback port to every local process. Routing
+databases over their protocol proxies extends the same model to them.
+
+The consequence: **treat a machine running the tunnel as belonging to a
+single principal.** On a shared host, every local account inherits the
+logged-in user's access to every tunnelled resource. Per-user isolation
+(a per-user daemon, network namespace, or UID-based policy on the TUN)
+is not implemented — tracked in DEP-144.
+
+Gateway-side controls are unaffected: every flow is a normal gateway
+session, so audit, review, guardrails, and DLP apply as they do for
+`hoop connect`.
 
 ## Addressing (dual-stack)
 

--- a/tunnel/client/connections.go
+++ b/tunnel/client/connections.go
@@ -43,7 +43,21 @@ type FetchConnectionsOptions struct {
 	// the gateway's response carries an X-New-Access-Token header. See
 	// token.go for the rotation contract.
 	OnNewToken func(newToken string)
+
+	// FeatureFlags is the gateway's flag map from GET /api/serverinfo.
+	//
+	// Some subtypes are tunnelable only when their flag is on: the agent
+	// refuses the session otherwise, so listing them would advertise a
+	// resource that can never connect. Nil means "no flags known", which
+	// filters out every gated subtype rather than guessing.
+	FeatureFlags map[string]bool
 }
+
+// oracleNativeFlag gates native Oracle (TNS) access. The agent's Oracle
+// handler checks it and closes the session immediately when it is off, and
+// the `hoop connect` CLI checks it before starting its Oracle listener
+// (client/cmd/connect.go), so the tunnel must apply the same gate.
+const oracleNativeFlag = "beta.oracle_native"
 
 // FetchConnections returns the list of connections available to the
 // current user that are tunnelable (TCP-style protocols plus
@@ -52,6 +66,9 @@ type FetchConnectionsOptions struct {
 // (SSH, command-line, kubernetes, RDP, SSM, etc.) are silently
 // filtered out — they need a protocol-specific client, not a
 // transparent IP tunnel.
+//
+// Feature-gated subtypes are also filtered out when their flag is off,
+// so the listing never offers a connection the agent would refuse.
 func FetchConnections(ctx context.Context, opts FetchConnectionsOptions) ([]Connection, error) {
 	if opts.APIBaseURL == "" {
 		return nil, errors.New("client.FetchConnections: APIBaseURL is required")
@@ -111,7 +128,7 @@ func FetchConnections(ctx context.Context, opts FetchConnectionsOptions) ([]Conn
 		if r.Name == "" {
 			continue
 		}
-		if !isTunnelableSubType(r.SubType) {
+		if !isTunnelableSubType(r.SubType, opts.FeatureFlags) {
 			continue
 		}
 		out = append(out, Connection{Name: r.Name, SubType: r.SubType})
@@ -120,17 +137,19 @@ func FetchConnections(ctx context.Context, opts FetchConnectionsOptions) ([]Conn
 }
 
 // isTunnelableSubType mirrors pipe.go's profileFor but works on the
-// raw openapi subtype field.
-func isTunnelableSubType(subtype string) bool {
+// raw openapi subtype field, and additionally applies the feature gates
+// the agent enforces at session-open time.
+func isTunnelableSubType(subtype string, flags map[string]bool) bool {
 	switch pb.ConnectionType(subtype) {
 	case pb.ConnectionTypePostgres,
 		pb.ConnectionTypeMySQL,
 		pb.ConnectionTypeMSSQL,
 		pb.ConnectionTypeMongoDB,
-		pb.ConnectionTypeOracleDB,
 		pb.ConnectionTypeTCP,
 		pb.ConnectionTypeHttpProxy:
 		return true
+	case pb.ConnectionTypeOracleDB:
+		return flags[oracleNativeFlag]
 	}
 	return false
 }

--- a/tunnel/client/connections_test.go
+++ b/tunnel/client/connections_test.go
@@ -1,0 +1,119 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newConnectionsGateway serves a fixed /api/connections payload so the
+// filtering logic can be exercised without a real gateway.
+func newConnectionsGateway(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/connections", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func fetch(t *testing.T, srv *httptest.Server, flags map[string]bool) map[string]string {
+	t.Helper()
+	conns, err := FetchConnections(context.Background(), FetchConnectionsOptions{
+		APIBaseURL:   srv.URL,
+		Token:        "tok",
+		FeatureFlags: flags,
+	})
+	if err != nil {
+		t.Fatalf("FetchConnections: %v", err)
+	}
+	out := make(map[string]string, len(conns))
+	for _, c := range conns {
+		out[c.Name] = c.SubType
+	}
+	return out
+}
+
+// The tunnel must offer exactly the subtypes it can actually carry.
+// Listing one it cannot (or that the agent will refuse) hands the user a
+// hostname and credentials that never work.
+func TestFetchConnectionsFiltersToTunnelableSubtypes(t *testing.T) {
+	srv := newConnectionsGateway(t, `[
+		{"name":"pg","subtype":"postgres"},
+		{"name":"my","subtype":"mysql"},
+		{"name":"ms","subtype":"mssql"},
+		{"name":"mongo","subtype":"mongodb"},
+		{"name":"raw","subtype":"tcp"},
+		{"name":"api","subtype":"httpproxy"},
+		{"name":"box","subtype":"ssh"},
+		{"name":"k8s","subtype":"kubernetes"},
+		{"name":"desktop","subtype":"rdp"},
+		{"name":"shell","subtype":"command-line"}
+	]`)
+
+	got := fetch(t, srv, map[string]bool{})
+
+	for _, name := range []string{"pg", "my", "ms", "mongo", "raw", "api"} {
+		if _, ok := got[name]; !ok {
+			t.Errorf("%q (%s) should be tunnelable but was filtered out", name, got[name])
+		}
+	}
+	for _, name := range []string{"box", "k8s", "desktop", "shell"} {
+		if _, ok := got[name]; ok {
+			t.Errorf("%q is not tunnelable but was listed", name)
+		}
+	}
+}
+
+// Native Oracle is gated by beta.oracle_native. The agent's Oracle handler
+// closes the session immediately when the flag is off, so listing an Oracle
+// connection then would advertise a resource that can never connect.
+func TestFetchConnectionsGatesOracleBehindItsFeatureFlag(t *testing.T) {
+	srv := newConnectionsGateway(t, `[
+		{"name":"pg","subtype":"postgres"},
+		{"name":"ora","subtype":"oracledb"}
+	]`)
+
+	t.Run("flag on", func(t *testing.T) {
+		got := fetch(t, srv, map[string]bool{"beta.oracle_native": true})
+		if _, ok := got["ora"]; !ok {
+			t.Error("oracle must be listed when beta.oracle_native is enabled")
+		}
+	})
+
+	t.Run("flag off", func(t *testing.T) {
+		got := fetch(t, srv, map[string]bool{"beta.oracle_native": false})
+		if _, ok := got["ora"]; ok {
+			t.Error("oracle must not be listed when beta.oracle_native is disabled")
+		}
+		if _, ok := got["pg"]; !ok {
+			t.Error("ungated connections must still be listed")
+		}
+	})
+
+	// Flags unknown (serverinfo unreachable): hide the gated subtype rather
+	// than guess it is available.
+	t.Run("flags unknown", func(t *testing.T) {
+		got := fetch(t, srv, nil)
+		if _, ok := got["ora"]; ok {
+			t.Error("oracle must not be listed when the flag state is unknown")
+		}
+		if _, ok := got["pg"]; !ok {
+			t.Error("ungated connections must still be listed when flags are unknown")
+		}
+	})
+}
+
+// A connection with no name cannot be resolved to a hostname; skip it rather
+// than allocate an unreachable address.
+func TestFetchConnectionsSkipsUnnamedEntries(t *testing.T) {
+	srv := newConnectionsGateway(t, `[{"name":"","subtype":"postgres"},{"name":"pg","subtype":"postgres"}]`)
+	got := fetch(t, srv, nil)
+	if len(got) != 1 {
+		t.Fatalf("want only the named connection, got %v", got)
+	}
+}

--- a/tunnel/client/halfclose_test.go
+++ b/tunnel/client/halfclose_test.go
@@ -1,0 +1,141 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	pb "github.com/hoophq/hoop/common/proto"
+	pbagent "github.com/hoophq/hoop/common/proto/agent"
+	pbclient "github.com/hoophq/hoop/common/proto/client"
+)
+
+// halfClosedLocal models a client that sends a request and then shuts down
+// only its write direction: reads return EOF immediately while the socket
+// stays open for the response.
+//
+// fakeLocal cannot express this — its Read blocks until Close, so the pump
+// never observes EOF while the connection is still live. That is exactly the
+// state a real `psql`/`mysql` client reaches after issuing a query.
+type halfClosedLocal struct {
+	mu      sync.Mutex
+	toRead  *bytes.Buffer
+	written bytes.Buffer
+	closed  chan struct{}
+	once    sync.Once
+}
+
+func newHalfClosedLocal(request []byte) *halfClosedLocal {
+	return &halfClosedLocal{
+		toRead: bytes.NewBuffer(request),
+		closed: make(chan struct{}),
+	}
+}
+
+func (h *halfClosedLocal) Read(p []byte) (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.toRead.Len() > 0 {
+		return h.toRead.Read(p)
+	}
+	return 0, io.EOF // write side shut down; socket still readable by peer
+}
+
+func (h *halfClosedLocal) Write(p []byte) (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	select {
+	case <-h.closed:
+		return 0, io.ErrClosedPipe
+	default:
+	}
+	return h.written.Write(p)
+}
+
+func (h *halfClosedLocal) Close() error {
+	h.once.Do(func() { close(h.closed) })
+	return nil
+}
+
+func (h *halfClosedLocal) writtenBytes() []byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]byte(nil), h.written.Bytes()...)
+}
+
+// A client that half-closes after sending its request must still receive the
+// gateway's response: TCP EOF on the read side means "no more requests", not
+// "stop listening".
+//
+// The pump must therefore keep draining gateway->local after local EOF, and
+// finish only when the gateway signals the end of the exchange.
+func TestRunPipe_HalfCloseStillDrainsResponse(t *testing.T) {
+	ft := newFakeTransport()
+	const sessionID = "sess-halfclose"
+	const wantServerBytes = "LATE-RESPONSE"
+
+	local := newHalfClosedLocal(pgSimpleQuery("SELECT 1"))
+
+	go func() {
+		_ = waitForSent(t, ft, 1, 2*time.Second)
+		ft.push(&pb.Packet{
+			Type: pbclient.SessionOpenOK,
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID: []byte(sessionID),
+				pb.SpecConnectionType:   []byte(pb.ConnectionTypePostgres.String()),
+			},
+		})
+
+		// Wait for the half-close signal, so the response below is provably
+		// sent *after* the local side stopped writing.
+		deadline := time.After(3 * time.Second)
+		for {
+			var sawClose bool
+			for _, p := range ft.sentPackets() {
+				if pb.PacketType(p.Type) == pbagent.TCPConnectionClose {
+					sawClose = true
+				}
+			}
+			if sawClose {
+				break
+			}
+			select {
+			case <-deadline:
+				t.Errorf("pipe never signalled the half-close to the gateway")
+				return
+			case <-time.After(2 * time.Millisecond):
+			}
+		}
+
+		ft.push(&pb.Packet{
+			Type: pbclient.PGConnectionWrite,
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID:   []byte(sessionID),
+				pb.SpecClientConnectionID: []byte(connectionIDOnPipe),
+			},
+			Payload: []byte(wantServerBytes),
+		})
+		ft.push(&pb.Packet{
+			Type: pbclient.TCPConnectionClose,
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID:   []byte(sessionID),
+				pb.SpecClientConnectionID: []byte(connectionIDOnPipe),
+			},
+		})
+	}()
+
+	if err := runPipe(context.Background(), ft, local, PipeOptions{
+		ConnectionName:     "pg-prod",
+		SessionOpenTimeout: 2 * time.Second,
+	}); err != nil {
+		t.Fatalf("runPipe returned error: %v", err)
+	}
+
+	if got := string(local.writtenBytes()); got != wantServerBytes {
+		t.Fatalf("response arriving after half-close was dropped: want %q, got %q",
+			wantServerBytes, got)
+	}
+}

--- a/tunnel/client/pipe.go
+++ b/tunnel/client/pipe.go
@@ -201,7 +201,7 @@ func runPipe(ctx context.Context, transport pb.ClientTransport, local io.ReadWri
 //     agent's libhoop proxy, which terminates the client's authentication
 //     locally and re-authenticates upstream with the connection's stored
 //     secrets. That is what lets a client present the fixed local
-//     noop/noop placeholder (DEP-142) and what makes DLP, guardrails and
+//     noop/noop placeholder, and what makes DLP, guardrails and
 //     query-level audit work.
 //   - The raw TCP family routes to the agent's byte relay, which dials the
 //     upstream and copies verbatim. The client faces the database's own
@@ -410,17 +410,14 @@ func pumpBytes(ctx context.Context, transport pb.ClientTransport, local io.ReadW
 
 	transport.StartKeepAlive()
 
-	// Track who finished first so we know what error (if any) to surface.
+	// Record the first terminating outcome; later ones are ignored so the
+	// surfaced error is the one that actually ended the pipe.
 	var (
 		once    sync.Once
 		exitErr error
-		done    = make(chan struct{})
 	)
 	finish := func(err error) {
-		once.Do(func() {
-			exitErr = err
-			close(done)
-		})
+		once.Do(func() { exitErr = err })
 	}
 
 	pumpCtx, cancel := context.WithCancel(ctx)
@@ -444,6 +441,11 @@ func pumpBytes(ctx context.Context, transport pb.ClientTransport, local io.ReadW
 	}
 
 	// local -> gateway
+	//
+	// A clean end here is a TCP half-close: the client shut its write side
+	// after sending a request and is still waiting to read the answer. It is
+	// therefore NOT a reason to end the pipe — only a hard write error is.
+	writeErr := make(chan error, 1)
 	go func() {
 		writer := pb.NewStreamWriter(transport, prof.agentWrite, spec)
 		// Protocol families need whole packets per write (see
@@ -457,41 +459,63 @@ func pumpBytes(ctx context.Context, transport pb.ClientTransport, local io.ReadW
 		}
 		// Signal regardless of how the copy ended (EOF, error, or peer close
 		// cancelling our context): the gateway needs a definitive signal that
-		// the client side is done.
+		// the client side is done sending.
 		sendClose()
 		if err != nil && !isClosedConnErr(err) {
-			finish(fmt.Errorf("local->gateway: %w", err))
+			writeErr <- fmt.Errorf("local->gateway: %w", err)
 			return
 		}
-		finish(nil)
+		writeErr <- nil
 	}()
 
 	// gateway -> local
+	//
+	// The reader owns termination: it returns when the gateway ends the
+	// exchange (TCPConnectionClose / SessionClose / stream EOF), which is the
+	// only signal that no more response bytes are coming.
+	readDone := make(chan error, 1)
 	go func() {
 		err := readFromGateway(pumpCtx, transport, local, prof.clientWrite)
 		// Closing the local conn unblocks the local->gateway copy when the
 		// gateway side died first.
 		_ = local.Close()
 		if err != nil && !errors.Is(err, io.EOF) && !isClosedConnErr(err) {
-			finish(fmt.Errorf("gateway->local: %w", err))
+			readDone <- fmt.Errorf("gateway->local: %w", err)
 			return
 		}
-		finish(nil)
+		readDone <- nil
 	}()
 
-	// Return as soon as EITHER direction terminates; do not wait for both.
+	// Wait for the reader, a hard write error, or cancellation.
 	//
-	// The reader is parked in transport.Recv(), which honours neither ctx nor
-	// a half-closed session: the protocol proxies (unlike the raw TCP relay)
-	// do not echo a close packet back to the client when the agent tears their
-	// upstream down, so nothing would ever wake it. The caller's deferred
-	// transport.Close() is what releases it — which cannot happen if we block
-	// here.
+	// We deliberately do NOT wait for the writer's clean finish: that is the
+	// half-close above, and returning on it would close the socket while the
+	// gateway's response is still in flight.
+	//
+	// We also do not wait for BOTH goroutines. The reader parks in
+	// transport.Recv(), which honours neither ctx nor a half-closed session,
+	// so on the cancellation path the caller's deferred transport.Close() is
+	// what releases it — and that cannot happen while we block here.
 	select {
-	case <-done:
+	case err := <-readDone:
+		finish(err)
+	case err := <-writeErr:
+		if err != nil {
+			finish(err)
+			break
+		}
+		// Clean half-close: keep draining until the gateway is done, the
+		// caller cancels, or the reader fails.
+		select {
+		case rerr := <-readDone:
+			finish(rerr)
+		case <-ctx.Done():
+			finish(ctx.Err())
+		}
 	case <-ctx.Done():
 		finish(ctx.Err())
 	}
+
 	// Unblock whichever goroutine is still running and respects pumpCtx, and
 	// make sure the agent heard about the close even if the writer never got
 	// that far.

--- a/tunnel/client/pipe.go
+++ b/tunnel/client/pipe.go
@@ -46,6 +46,10 @@ import (
 
 	"github.com/hoophq/hoop/common/grpc"
 	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/common/mongotypes"
+	"github.com/hoophq/hoop/common/mssqltypes"
+	"github.com/hoophq/hoop/common/mysqltypes"
+	"github.com/hoophq/hoop/common/pgtypes"
 	pb "github.com/hoophq/hoop/common/proto"
 	pbagent "github.com/hoophq/hoop/common/proto/agent"
 	pbclient "github.com/hoophq/hoop/common/proto/client"
@@ -188,9 +192,25 @@ func runPipe(ctx context.Context, transport pb.ClientTransport, local io.ReadWri
 }
 
 // packetProfile captures how a connection type maps onto the gateway's
-// packet families. TCP-style protocols share one family; httpproxy has
-// its own (the agent routes it to the HTTP-parsing libhoop proxy
-// instead of a raw upstream socket).
+// packet families, and how the client's byte stream must be framed onto
+// them.
+//
+// The choice of family decides who authenticates to the upstream:
+//
+//   - The protocol families (PG/MySQL/MSSQL/MongoDB/Oracle) route to the
+//     agent's libhoop proxy, which terminates the client's authentication
+//     locally and re-authenticates upstream with the connection's stored
+//     secrets. That is what lets a client present the fixed local
+//     noop/noop placeholder (DEP-142) and what makes DLP, guardrails and
+//     query-level audit work.
+//   - The raw TCP family routes to the agent's byte relay, which dials the
+//     upstream and copies verbatim. The client faces the database's own
+//     auth challenge, so it must hold real credentials. Correct for the
+//     `tcp` subtype (an opaque user-defined upstream), wrong for anything
+//     hoop knows the protocol of.
+//
+// httpproxy has its own family (the agent routes it to the HTTP-parsing
+// libhoop proxy instead of a raw upstream socket).
 type packetProfile struct {
 	// agentWrite is the packet type for local -> gateway data.
 	agentWrite pb.PacketType
@@ -198,24 +218,73 @@ type packetProfile struct {
 	clientWrite pb.PacketType
 	// sendTCPOpen indicates the agent needs an explicit "dial your
 	// upstream now" packet (SpecTCPServerConnectKey) before any data.
-	// The httpproxy handler has no such handshake: it lazily builds
-	// the proxy on the first data packet.
+	// Only the raw TCP relay has this handshake; the protocol proxies and
+	// the httpproxy handler build their upstream lazily on first data.
 	sendTCPOpen bool
 	// isHTTPProxy marks sessions whose spec must carry
 	// SpecHttpProxyBaseUrl on every write.
 	isHTTPProxy bool
+	// initWrite, when true, sends one empty data packet right after session
+	// open. The MySQL proxy is server-speaks-first: it must be constructed
+	// before it can emit the server greeting the client waits for.
+	initWrite bool
+	// frame re-frames the local->gateway byte stream into whole protocol
+	// packets, one per gateway packet. Nil means forward raw chunks.
+	//
+	// This matters because the agent's protocol proxies decode one packet
+	// from each write they receive; feeding them arbitrary TCP chunks
+	// desynchronises the decoder. Mirrors what the `hoop connect` local
+	// proxies do (client/proxy).
+	frame func(dst io.Writer, src io.Reader) error
 }
 
 // profileFor returns the packet profile for a hoop connection type, or
 // ok=false when the type is not tunnelable.
 func profileFor(connType string) (packetProfile, bool) {
 	switch pb.ConnectionType(connType) {
-	case pb.ConnectionTypePostgres,
-		pb.ConnectionTypeMySQL,
-		pb.ConnectionTypeMSSQL,
-		pb.ConnectionTypeMongoDB,
-		pb.ConnectionTypeOracleDB,
-		pb.ConnectionTypeTCP:
+	case pb.ConnectionTypePostgres:
+		return packetProfile{
+			agentWrite:  pbagent.PGConnectionWrite,
+			clientWrite: pbclient.PGConnectionWrite,
+			frame: func(dst io.Writer, src io.Reader) error {
+				// The cancel-request hook is for the `hoop connect` proxy,
+				// which multiplexes many client connections over one
+				// session and has to match a cancel to its target backend.
+				// A tunnel pipe is one flow, so there is nothing to match:
+				// forward the cancel request as-is.
+				_, err := pgtypes.CopyBuffer(dst, src, nil)
+				return err
+			},
+		}, true
+	case pb.ConnectionTypeMySQL:
+		return packetProfile{
+			agentWrite:  pbagent.MySQLConnectionWrite,
+			clientWrite: pbclient.MySQLConnectionWrite,
+			initWrite:   true,
+			frame:       mysqltypes.CopyBuffer,
+		}, true
+	case pb.ConnectionTypeMSSQL:
+		return packetProfile{
+			agentWrite:  pbagent.MSSQLConnectionWrite,
+			clientWrite: pbclient.MSSQLConnectionWrite,
+			frame:       mssqltypes.CopyBuffer,
+		}, true
+	case pb.ConnectionTypeMongoDB:
+		return packetProfile{
+			agentWrite:  pbagent.MongoDBConnectionWrite,
+			clientWrite: pbclient.MongoDBConnectionWrite,
+			frame:       mongotypes.CopyBuffer,
+		}, true
+	case pb.ConnectionTypeOracleDB:
+		// The Oracle proxy re-frames TNS packets itself (it buffers partial
+		// packets across writes), so the relay forwards raw chunks.
+		return packetProfile{
+			agentWrite:  pbagent.OracleConnectionWrite,
+			clientWrite: pbclient.OracleConnectionWrite,
+		}, true
+	case pb.ConnectionTypeTCP:
+		// A generic TCP connection has no protocol hoop can parse and no
+		// credentials to inject: the byte relay is the correct handler.
 		return packetProfile{
 			agentWrite:  pbagent.TCPConnectionWrite,
 			clientWrite: pbclient.TCPConnectionWrite,
@@ -324,64 +393,122 @@ func pumpBytes(ctx context.Context, transport pb.ClientTransport, local io.ReadW
 		}
 	}
 
+	if prof.initWrite {
+		// Construct the agent-side proxy before the client says anything.
+		// MySQL is server-speaks-first: the client waits for the server
+		// greeting, which only exists once the proxy has connected
+		// upstream. Without this the flow deadlocks on both sides waiting
+		// to read. Mirrors the `hoop connect` MySQL proxy's initial
+		// zero-length write.
+		if err := transport.Send(&pb.Packet{
+			Type: prof.agentWrite.String(),
+			Spec: spec,
+		}); err != nil {
+			return fmt.Errorf("send %s init: %w", prof.agentWrite, err)
+		}
+	}
+
 	transport.StartKeepAlive()
 
 	// Track who finished first so we know what error (if any) to surface.
 	var (
 		once    sync.Once
 		exitErr error
+		done    = make(chan struct{})
 	)
 	finish := func(err error) {
-		once.Do(func() { exitErr = err })
+		once.Do(func() {
+			exitErr = err
+			close(done)
+		})
 	}
 
 	pumpCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	var wg sync.WaitGroup
-	wg.Add(2)
+	// sendClose tells the agent to tear its upstream down. It must reach the
+	// gateway exactly once on every exit path, including the one where the
+	// gateway side ends first and this function returns before the writer
+	// goroutine has finished — hence the Once rather than a plain call in the
+	// writer. Send is mutex-guarded (common/grpc.mutexClient), so racing
+	// goroutines are safe; if the stream is already gone the Send is a
+	// harmless no-op.
+	var closeOnce sync.Once
+	sendClose := func() {
+		closeOnce.Do(func() {
+			_ = transport.Send(&pb.Packet{
+				Type: pbagent.TCPConnectionClose,
+				Spec: spec,
+			})
+		})
+	}
 
 	// local -> gateway
 	go func() {
-		defer wg.Done()
 		writer := pb.NewStreamWriter(transport, prof.agentWrite, spec)
-		_, err := io.Copy(writer, local)
-		// Tell the agent to close its upstream socket. We send this
-		// regardless of how io.Copy ended (EOF, error, or peer close
-		// canceled our context): the gateway needs a definitive signal
-		// that the client side is done. If the gateway already closed
-		// the stream, the Send is a harmless no-op.
-		_ = transport.Send(&pb.Packet{
-			Type: pbagent.TCPConnectionClose,
-			Spec: spec,
-		})
+		// Protocol families need whole packets per write (see
+		// packetProfile.frame); the raw relay and Oracle take chunks
+		// as they come.
+		var err error
+		if prof.frame != nil {
+			err = prof.frame(writer, local)
+		} else {
+			_, err = io.Copy(writer, local)
+		}
+		// Signal regardless of how the copy ended (EOF, error, or peer close
+		// cancelling our context): the gateway needs a definitive signal that
+		// the client side is done.
+		sendClose()
 		if err != nil && !isClosedConnErr(err) {
 			finish(fmt.Errorf("local->gateway: %w", err))
+			return
 		}
-		cancel()
+		finish(nil)
 	}()
 
 	// gateway -> local
 	go func() {
-		defer wg.Done()
 		err := readFromGateway(pumpCtx, transport, local, prof.clientWrite)
+		// Closing the local conn unblocks the local->gateway copy when the
+		// gateway side died first.
+		_ = local.Close()
 		if err != nil && !errors.Is(err, io.EOF) && !isClosedConnErr(err) {
 			finish(fmt.Errorf("gateway->local: %w", err))
+			return
 		}
-		// Closing the local conn unblocks the local->gateway io.Copy
-		// when the gateway side died first.
-		_ = local.Close()
-		cancel()
+		finish(nil)
 	}()
 
-	wg.Wait()
+	// Return as soon as EITHER direction terminates; do not wait for both.
+	//
+	// The reader is parked in transport.Recv(), which honours neither ctx nor
+	// a half-closed session: the protocol proxies (unlike the raw TCP relay)
+	// do not echo a close packet back to the client when the agent tears their
+	// upstream down, so nothing would ever wake it. The caller's deferred
+	// transport.Close() is what releases it — which cannot happen if we block
+	// here.
+	select {
+	case <-done:
+	case <-ctx.Done():
+		finish(ctx.Err())
+	}
+	// Unblock whichever goroutine is still running and respects pumpCtx, and
+	// make sure the agent heard about the close even if the writer never got
+	// that far.
+	cancel()
+	_ = local.Close()
+	sendClose()
 	return exitErr
 }
 
 // readFromGateway loops on Recv() and writes packet payloads to local.
 // It returns when the stream ends or a non-recoverable packet arrives.
 // dataType is the packet family carrying gateway -> local data for this
-// session (TCP or httpproxy writes).
+// session (the connection's protocol family, raw TCP, or httpproxy writes).
+//
+// TCPConnectionClose is the close signal for every family, protocol proxies
+// included: the agent keys its connection store by sessionID:connectionID
+// regardless of which proxy owns the entry.
 func readFromGateway(ctx context.Context, transport pb.ClientTransport, local io.Writer, dataType pb.PacketType) error {
 	for {
 		if err := ctx.Err(); err != nil {

--- a/tunnel/client/pipe_test.go
+++ b/tunnel/client/pipe_test.go
@@ -169,7 +169,7 @@ func waitForSent(t *testing.T, ft *fakeTransport, n int, within time.Duration) [
 
 // --- tests ---
 
-// TestRunPipe_HappyPath_PostgresProtocolFamily pins the DEP-142 contract: a
+// TestRunPipe_HappyPath_PostgresProtocolFamily pins the core contract: a
 // postgres flow rides the PG protocol family, not the raw TCP relay.
 //
 // That routing is what makes the tunnel's fixed local credentials work. The

--- a/tunnel/client/pipe_test.go
+++ b/tunnel/client/pipe_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"io"
 	"sync"
@@ -168,13 +169,23 @@ func waitForSent(t *testing.T, ft *fakeTransport, n int, within time.Duration) [
 
 // --- tests ---
 
-func TestRunPipe_HappyPath_PostgresEcho(t *testing.T) {
+// TestRunPipe_HappyPath_PostgresProtocolFamily pins the DEP-142 contract: a
+// postgres flow rides the PG protocol family, not the raw TCP relay.
+//
+// That routing is what makes the tunnel's fixed local credentials work. The
+// protocol family reaches the agent's libhoop PG proxy, which terminates the
+// client's authentication locally and re-authenticates upstream with the
+// connection's stored secrets. The raw relay would instead hand the client the
+// database's own auth challenge, which noop/noop cannot answer.
+func TestRunPipe_HappyPath_PostgresProtocolFamily(t *testing.T) {
 	ft := newFakeTransport()
 	const sessionID = "sess-123"
-	const wantClientBytes = "PING"
 	const wantServerBytes = "PONG"
+	// A well-formed client packet: the pipe re-frames the local stream into
+	// whole PG packets, so raw bytes would never make it onto the wire.
+	clientQuery := pgSimpleQuery("SELECT 1")
 
-	local := newFakeLocal([]byte(wantClientBytes))
+	local := newFakeLocal(clientQuery)
 
 	// Drive the gateway's side of the protocol in a goroutine.
 	go func() {
@@ -193,31 +204,24 @@ func TestRunPipe_HappyPath_PostgresEcho(t *testing.T) {
 			},
 		})
 
-		// Step 3: pipe will Send the TCPConnectionWrite "open" packet
-		// (with SpecTCPServerConnectKey). Then bytes from local.
-		// Wait until both arrive: 1 SessionOpen + 1 open + 1+ payload.
-		var openIdx = -1
-		var payloadSeen bool
+		// Step 3: the client's query must arrive as a PGConnectionWrite. No
+		// TCP open handshake exists on this family: the agent's proxy builds
+		// its upstream on the first data packet.
 		deadline := time.After(2 * time.Second)
 		for {
-			pkts := ft.sentPackets()
-			for i, p := range pkts {
-				if pb.PacketType(p.Type) == pbagent.TCPConnectionWrite {
-					if _, ok := p.Spec[pb.SpecTCPServerConnectKey]; ok && openIdx < 0 {
-						openIdx = i
-						continue
-					}
-					if string(p.Payload) == wantClientBytes {
-						payloadSeen = true
-					}
+			var payloadSeen bool
+			for _, p := range ft.sentPackets() {
+				if pb.PacketType(p.Type) == pbagent.PGConnectionWrite &&
+					bytes.Equal(p.Payload, clientQuery) {
+					payloadSeen = true
 				}
 			}
-			if openIdx >= 0 && payloadSeen {
+			if payloadSeen {
 				break
 			}
 			select {
 			case <-deadline:
-				t.Errorf("timeout waiting for open + payload; got %d packets", len(pkts))
+				t.Errorf("timeout waiting for the PG payload; got %d packets", len(ft.sentPackets()))
 				return
 			case <-time.After(5 * time.Millisecond):
 			}
@@ -225,7 +229,7 @@ func TestRunPipe_HappyPath_PostgresEcho(t *testing.T) {
 
 		// Step 4: send a server response, then close the connection.
 		ft.push(&pb.Packet{
-			Type: pbclient.TCPConnectionWrite,
+			Type: pbclient.PGConnectionWrite,
 			Spec: map[string][]byte{
 				pb.SpecGatewaySessionID:   []byte(sessionID),
 				pb.SpecClientConnectionID: []byte(connectionIDOnPipe),
@@ -255,13 +259,106 @@ func TestRunPipe_HappyPath_PostgresEcho(t *testing.T) {
 		t.Errorf("local writes: want %q, got %q", wantServerBytes, got)
 	}
 
-	// Verify the pipe sent the right initial packets in order.
+	pkts := ft.sentPackets()
+	if pb.PacketType(pkts[0].Type) != pbagent.SessionOpen {
+		t.Errorf("packet[0]: want SessionOpen, got %s", pkts[0].Type)
+	}
+
+	var sawData, sawClose bool
+	for _, p := range pkts {
+		switch pb.PacketType(p.Type) {
+		case pbagent.TCPConnectionWrite:
+			// The regression this test exists for: routing postgres onto the
+			// raw relay strands the client with the database's auth challenge.
+			t.Errorf("postgres session sent a TCPConnectionWrite (raw relay) packet")
+		case pbagent.PGConnectionWrite:
+			if _, ok := p.Spec[pb.SpecTCPServerConnectKey]; ok {
+				t.Errorf("PG write carries SpecTCPServerConnectKey (TCP open handshake)")
+			}
+			if string(p.Spec[pb.SpecGatewaySessionID]) != sessionID {
+				t.Errorf("PG write sessionID: want %q, got %q", sessionID, p.Spec[pb.SpecGatewaySessionID])
+			}
+			if bytes.Equal(p.Payload, clientQuery) {
+				sawData = true
+			}
+		case pbagent.TCPConnectionClose:
+			sawClose = true
+		}
+	}
+	if !sawData {
+		t.Errorf("client bytes never sent as PGConnectionWrite")
+	}
+	if !sawClose {
+		t.Errorf("pipe did not send TCPConnectionClose to the gateway")
+	}
+}
+
+// TestRunPipe_TCPSubtypeUsesRawRelay is the counterpart: a generic `tcp`
+// connection has no protocol hoop can parse and no credentials to inject, so
+// it must keep using the byte relay — including its explicit open handshake.
+func TestRunPipe_TCPSubtypeUsesRawRelay(t *testing.T) {
+	ft := newFakeTransport()
+	const sessionID = "sess-tcp-1"
+	const wantClientBytes = "PING"
+
+	local := newFakeLocal([]byte(wantClientBytes))
+
+	go func() {
+		_ = waitForSent(t, ft, 1, 2*time.Second)
+		ft.push(&pb.Packet{
+			Type: pbclient.SessionOpenOK,
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID: []byte(sessionID),
+				pb.SpecConnectionType:   []byte(pb.ConnectionTypeTCP.String()),
+			},
+		})
+
+		deadline := time.After(2 * time.Second)
+		for {
+			var sawOpen, sawPayload bool
+			for _, p := range ft.sentPackets() {
+				if pb.PacketType(p.Type) != pbagent.TCPConnectionWrite {
+					continue
+				}
+				if _, ok := p.Spec[pb.SpecTCPServerConnectKey]; ok {
+					sawOpen = true
+					continue
+				}
+				if string(p.Payload) == wantClientBytes {
+					sawPayload = true
+				}
+			}
+			if sawOpen && sawPayload {
+				break
+			}
+			select {
+			case <-deadline:
+				t.Errorf("timeout waiting for the raw relay open + payload")
+				return
+			case <-time.After(5 * time.Millisecond):
+			}
+		}
+
+		ft.push(&pb.Packet{
+			Type: pbclient.TCPConnectionClose,
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID:   []byte(sessionID),
+				pb.SpecClientConnectionID: []byte(connectionIDOnPipe),
+			},
+		})
+	}()
+
+	err := runPipe(context.Background(), ft, local, PipeOptions{
+		ConnectionName:     "redis-prod",
+		SessionOpenTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("runPipe returned error: %v", err)
+	}
+
 	pkts := ft.sentPackets()
 	if len(pkts) < 3 {
 		t.Fatalf("expected at least 3 sent packets, got %d", len(pkts))
-	}
-	if pb.PacketType(pkts[0].Type) != pbagent.SessionOpen {
-		t.Errorf("packet[0]: want SessionOpen, got %s", pkts[0].Type)
 	}
 	if pb.PacketType(pkts[1].Type) != pbagent.TCPConnectionWrite {
 		t.Errorf("packet[1]: want TCPConnectionWrite, got %s", pkts[1].Type)
@@ -269,21 +366,89 @@ func TestRunPipe_HappyPath_PostgresEcho(t *testing.T) {
 	if _, ok := pkts[1].Spec[pb.SpecTCPServerConnectKey]; !ok {
 		t.Errorf("packet[1] missing SpecTCPServerConnectKey")
 	}
-	if string(pkts[1].Spec[pb.SpecGatewaySessionID]) != sessionID {
-		t.Errorf("packet[1] sessionID: want %q, got %q", sessionID, pkts[1].Spec[pb.SpecGatewaySessionID])
+}
+
+// TestRunPipe_MySQLSendsInitWrite pins the server-speaks-first handshake: the
+// MySQL client waits for the server greeting, which only exists once the
+// agent-side proxy has been constructed. The pipe must therefore send one
+// empty MySQLConnectionWrite before the client says anything, or the flow
+// deadlocks with both ends waiting to read.
+func TestRunPipe_MySQLSendsInitWrite(t *testing.T) {
+	ft := newFakeTransport()
+	const sessionID = "sess-mysql-1"
+
+	// The client stays silent until the greeting arrives, exactly like a real
+	// MySQL client.
+	local := newFakeLocal(nil)
+
+	go func() {
+		_ = waitForSent(t, ft, 1, 2*time.Second)
+		ft.push(&pb.Packet{
+			Type: pbclient.SessionOpenOK,
+			Spec: map[string][]byte{
+				pb.SpecGatewaySessionID: []byte(sessionID),
+				pb.SpecConnectionType:   []byte(pb.ConnectionTypeMySQL.String()),
+			},
+		})
+
+		// The init write must arrive with no client input whatsoever.
+		deadline := time.After(2 * time.Second)
+		for {
+			for _, p := range ft.sentPackets() {
+				if pb.PacketType(p.Type) == pbagent.MySQLConnectionWrite && len(p.Payload) == 0 {
+					ft.push(&pb.Packet{
+						Type: pbclient.TCPConnectionClose,
+						Spec: map[string][]byte{
+							pb.SpecGatewaySessionID:   []byte(sessionID),
+							pb.SpecClientConnectionID: []byte(connectionIDOnPipe),
+						},
+					})
+					return
+				}
+			}
+			select {
+			case <-deadline:
+				t.Errorf("mysql session never sent the proxy-init write")
+				local.Close()
+				return
+			case <-time.After(5 * time.Millisecond):
+			}
+		}
+	}()
+
+	err := runPipe(context.Background(), ft, local, PipeOptions{
+		ConnectionName:     "mysql-prod",
+		SessionOpenTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("runPipe returned error: %v", err)
 	}
 
-	// The pipe MUST signal close after local EOFs.
-	sawClose := false
-	for _, p := range pkts {
-		if pb.PacketType(p.Type) == pbagent.TCPConnectionClose {
-			sawClose = true
-			break
+	var sawInit bool
+	for _, p := range ft.sentPackets() {
+		if pb.PacketType(p.Type) == pbagent.MySQLConnectionWrite && len(p.Payload) == 0 {
+			sawInit = true
+		}
+		if pb.PacketType(p.Type) == pbagent.TCPConnectionWrite {
+			t.Errorf("mysql session sent a TCPConnectionWrite (raw relay) packet")
 		}
 	}
-	if !sawClose {
-		t.Errorf("pipe did not send TCPConnectionClose to the gateway")
+	if !sawInit {
+		t.Errorf("mysql session did not send the empty proxy-init write")
 	}
+}
+
+// pgSimpleQuery builds a PostgreSQL simple-query ('Q') message. The pipe
+// re-frames the client stream into whole protocol packets, so tests must feed
+// it valid framing rather than arbitrary bytes.
+func pgSimpleQuery(sql string) []byte {
+	q := append([]byte(sql), 0)
+	total := 4 + len(q)
+	buf := make([]byte, 1+total)
+	buf[0] = 'Q'
+	binary.BigEndian.PutUint32(buf[1:5], uint32(total))
+	copy(buf[5:], q)
+	return buf
 }
 
 func TestRunPipe_HappyPath_HttpProxyEcho(t *testing.T) {

--- a/tunnel/cmd/hsh-tunneld/service.go
+++ b/tunnel/cmd/hsh-tunneld/service.go
@@ -319,6 +319,8 @@ func (s *daemonService) Connections(context.Context) ([]ipc.Connection, error) {
 			SubType:      c.SubType,
 			VirtualIP:    ip.String(),
 			ExpectedPort: port,
+			Username:     c.Username,
+			Password:     c.Password,
 		}
 		if ipv4, ok := snap.Allocator.LookupNameV4(c.Name); ok {
 			conn.VirtualIPV4 = ipv4.String()

--- a/tunnel/ipc/openapi.yaml
+++ b/tunnel/ipc/openapi.yaml
@@ -67,7 +67,7 @@ components:
 
     Connection:
       type: object
-      required: [name, subtype, virtual_ip, expected_port]
+      required: [name, subtype, virtual_ip, virtual_ip_v4, expected_port, username, password]
       properties:
         name:
           type: string
@@ -78,10 +78,30 @@ components:
         virtual_ip:
           type: string
           description: ULA IPv6 address inside the tunnel /48.
+        virtual_ip_v4:
+          type: string
+          description: >
+            CGNAT (100.64.0.0/10) IPv4 address that also resolves to this
+            connection. macOS clients use it because getaddrinfo suppresses
+            AAAA without global IPv6.
         expected_port:
           type: integer
           format: uint16
           description: Canonical TCP port for the protocol; 0 for `tcp` subtype.
+        username:
+          type: string
+          description: >
+            Fixed username a native client presents to reach this connection
+            through the tunnel. NOT the connection's real credential: the
+            agent's protocol proxy accepts it locally and re-authenticates
+            upstream with the connection's stored secrets. Empty for subtypes
+            that authenticate out of band (`tcp`).
+        password:
+          type: string
+          description: >
+            Fixed password paired with `username`. Same semantics: a local
+            placeholder, stable and safe to display, usable only through this
+            daemon's tunnel.
 
     ConnectionsResponse:
       type: object

--- a/tunnel/ipc/spec.go
+++ b/tunnel/ipc/spec.go
@@ -93,6 +93,21 @@ type Connection struct {
 	// connect to (5432 for postgres, etc.). Zero for `tcp` subtype,
 	// which accepts any user-defined upstream port.
 	ExpectedPort uint16 `json:"expected_port"`
+
+	// Username and Password are the fixed credentials a native client
+	// presents to reach this connection through the tunnel.
+	//
+	// They are NOT the connection's real credentials, and not the
+	// gateway's rotating token: the agent's protocol proxy terminates
+	// the client's authentication locally and re-authenticates upstream
+	// with the secrets stored on the connection. These placeholders are
+	// therefore stable, safe to display, and only usable through this
+	// daemon's tunnel.
+	//
+	// Both are empty for subtypes that authenticate out of band (`tcp`,
+	// whose upstream protocol hoop does not parse).
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 // ConnectionsResponse wraps the connection list in an object so we can

--- a/tunnel/tunnelmgr/credentials.go
+++ b/tunnel/tunnelmgr/credentials.go
@@ -1,0 +1,45 @@
+package tunnelmgr
+
+import pb "github.com/hoophq/hoop/common/proto"
+
+// The fixed credentials a native client presents to reach a connection
+// through the tunnel.
+//
+// These are not the connection's real credentials and not the gateway's
+// rotating token. The agent's protocol proxy terminates the client's
+// authentication locally and re-authenticates upstream with the secrets
+// stored on the connection, so whatever the client presents at the local end
+// is a placeholder. Standardising it lets the CLI hand the user a
+// ready-to-paste connection string. `hoop connect` prints the same pair for
+// its loopback listener.
+//
+// They authorise nothing on their own: what authorises the session is having
+// logged the daemon in. Every flow still crosses the gateway as a normal
+// session with the usual access control, audit, guardrail, and DLP handling.
+//
+// NOT the gateway's native-access proxies: those take a per-user, expiring
+// secret key that the gateway resolves against the connection credentials
+// table, and they reject these values. Keep the two straight.
+const (
+	credentialUser     = "noop"
+	credentialPassword = "noop"
+)
+
+// credentialsFor returns the fixed credentials for a connection subtype.
+//
+// Empty strings mean the client authenticates outside the protocol:
+//
+//   - tcp: an opaque user-defined upstream. Hoop cannot parse the protocol,
+//     so the flow is relayed verbatim and any credentials are the client's own.
+//   - httpproxy: authorization rides HTTP headers the agent injects.
+func credentialsFor(subType string) (username, password string) {
+	switch pb.ConnectionType(subType) {
+	case pb.ConnectionTypePostgres,
+		pb.ConnectionTypeMySQL,
+		pb.ConnectionTypeMSSQL,
+		pb.ConnectionTypeMongoDB,
+		pb.ConnectionTypeOracleDB:
+		return credentialUser, credentialPassword
+	}
+	return "", ""
+}

--- a/tunnel/tunnelmgr/credentials_test.go
+++ b/tunnel/tunnelmgr/credentials_test.go
@@ -1,0 +1,63 @@
+package tunnelmgr
+
+import (
+	"testing"
+
+	pb "github.com/hoophq/hoop/common/proto"
+)
+
+// Every subtype whose bytes flow through an agent-side protocol proxy accepts
+// the placeholder locally, because that proxy re-authenticates upstream with
+// the connection's stored secrets.
+func TestCredentialsForProxiedProtocols(t *testing.T) {
+	for _, subType := range []pb.ConnectionType{
+		pb.ConnectionTypePostgres,
+		pb.ConnectionTypeMySQL,
+		pb.ConnectionTypeMSSQL,
+		pb.ConnectionTypeMongoDB,
+		pb.ConnectionTypeOracleDB,
+	} {
+		user, pass := credentialsFor(subType.String())
+		if user != credentialUser || pass != credentialPassword {
+			t.Errorf("%s: got %q/%q, want %q/%q",
+				subType, user, pass, credentialUser, credentialPassword)
+		}
+	}
+}
+
+// Subtypes with no protocol proxy must report nothing rather than advertising
+// a placeholder that would not work.
+//
+// `tcp` is the one that matters: it is tunnelable but relayed verbatim, so the
+// client faces the upstream's own authentication and needs real credentials.
+func TestCredentialsForUnproxiedProtocols(t *testing.T) {
+	for _, subType := range []pb.ConnectionType{
+		pb.ConnectionTypeTCP,
+		pb.ConnectionTypeHttpProxy,
+		pb.ConnectionTypeSSH,
+		pb.ConnectionTypeRDP,
+		pb.ConnectionTypeKubernetes,
+	} {
+		if user, pass := credentialsFor(subType.String()); user != "" || pass != "" {
+			t.Errorf("%s: want no credentials, got %q/%q", subType, user, pass)
+		}
+	}
+}
+
+func TestCredentialsForUnknownSubtype(t *testing.T) {
+	if user, pass := credentialsFor("not-a-subtype"); user != "" || pass != "" {
+		t.Errorf("unknown subtype must report no credentials, got %q/%q", user, pass)
+	}
+}
+
+// The agent's Oracle proxy re-keys the TNS handshake against the exact
+// placeholder password the client typed (it passes "noop" as client_password),
+// so changing these values silently breaks native Oracle clients — and every
+// connection string already published to users.
+func TestCredentialValuesAreStable(t *testing.T) {
+	if credentialUser != "noop" || credentialPassword != "noop" {
+		t.Fatalf("credentials changed to %q/%q; Oracle handshake re-keying and every "+
+			"published connection string depend on noop/noop",
+			credentialUser, credentialPassword)
+	}
+}

--- a/tunnel/tunnelmgr/manager.go
+++ b/tunnel/tunnelmgr/manager.go
@@ -587,10 +587,33 @@ func loadConnections(
 	logger Logger,
 ) (activeCount int, err error) {
 	token, epoch := tokens.Snapshot()
-	conns, err := client.FetchConnections(ctx, client.FetchConnectionsOptions{
+	rotate := func(newToken string) { tokens.Rotate(newToken, epoch) }
+
+	// Some subtypes are only usable when their gateway feature flag is on
+	// (native Oracle today); the agent refuses the session otherwise. Read
+	// the flags on every load rather than caching them at bring-up so a flag
+	// flipped on the gateway takes effect at the next refresh.
+	//
+	// A serverinfo failure must not hide the whole connection list: fall back
+	// to no flags, which filters out only the gated subtypes.
+	var flags map[string]bool
+	si, err := client.FetchServerInfo(ctx, client.FetchServerInfoOptions{
 		APIBaseURL: apiBase,
 		Token:      token,
-		OnNewToken: func(newToken string) { tokens.Rotate(newToken, epoch) },
+		OnNewToken: rotate,
+	})
+	if err != nil {
+		logger.Printf("tunnelmgr: could not read gateway feature flags (%v); "+
+			"feature-gated connections will be hidden", err)
+	} else {
+		flags = si.FeatureFlags
+	}
+
+	conns, err := client.FetchConnections(ctx, client.FetchConnectionsOptions{
+		APIBaseURL:   apiBase,
+		Token:        token,
+		OnNewToken:   rotate,
+		FeatureFlags: flags,
 	})
 	if err != nil {
 		return 0, fmt.Errorf("fetch connections: %w", err)

--- a/tunnel/tunnelmgr/registry.go
+++ b/tunnel/tunnelmgr/registry.go
@@ -57,6 +57,13 @@ func (r *connRegistry) subTypeOf(name string) (string, bool) {
 type ConnInfo struct {
 	Name    string
 	SubType string
+	// Username and Password are the fixed local credentials a native
+	// client presents to reach this connection through the tunnel
+	// (DEP-142). They are placeholders accepted by the agent's protocol
+	// proxy, never the connection's real secrets — see credentials.go.
+	// Both are empty for subtypes that authenticate out of band.
+	Username string
+	Password string
 }
 
 // activeConnections returns a snapshot of the currently-active
@@ -68,9 +75,19 @@ func (r *connRegistry) activeConnections() []ConnInfo {
 	defer r.mu.RUnlock()
 	out := make([]ConnInfo, 0, len(r.entries))
 	for name, e := range r.entries {
-		if e.active {
-			out = append(out, ConnInfo{Name: name, SubType: e.subType})
+		if !e.active {
+			continue
 		}
+		// Credentials are derived from the subtype rather than stored:
+		// they are fixed per protocol, so there is nothing to keep in
+		// sync across refreshes.
+		username, password := credentialsFor(e.subType)
+		out = append(out, ConnInfo{
+			Name:     name,
+			SubType:  e.subType,
+			Username: username,
+			Password: password,
+		})
 	}
 	return out
 }

--- a/tunnel/tunnelmgr/registry.go
+++ b/tunnel/tunnelmgr/registry.go
@@ -59,7 +59,7 @@ type ConnInfo struct {
 	SubType string
 	// Username and Password are the fixed local credentials a native
 	// client presents to reach this connection through the tunnel
-	// (DEP-142). They are placeholders accepted by the agent's protocol
+	// They are placeholders accepted by the agent's protocol
 	// proxy, never the connection's real secrets — see credentials.go.
 	// Both are empty for subtypes that authenticate out of band.
 	Username string


### PR DESCRIPTION
## 📝 Description

`hsh tunnel ls` now lists each connection's fixed `noop`/`noop` credentials with a ready-to-paste client command.

Those credentials could not have worked before. The tunnel relayed every database as raw TCP (`pbagent.TCPConnectionWrite`), which lands on the agent's byte relay and copies bytes verbatim — so the client was handed the database's own auth challenge and `noop`/`noop` was rejected. Listing them would have been a false claim.

Each subtype now rides its own protocol packet family, reaching the agent's libhoop proxy that terminates client auth locally and re-authenticates upstream with the connection's stored secrets. `tcp` (opaque upstream) and `httpproxy` keep their existing families and report no credentials.

Side effect worth noting: the raw relay **refuses** guarded sessions (DEP-48), so guarded database connections were previously unusable over the tunnel. They now work, with guardrails and DLP enforced.

The companion CLI change is hoophq/hsh#33.

## 🎁 User-facing impact

`hsh tunnel ls` now shows the credentials and the exact command to connect to each resource, so users no longer need to look up credentials anywhere. Database connections with guardrails or data masking configured now work through the tunnel, with those rules enforced.

## 🔗 Related Issue

DEP-142

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

- **`tunnel/client/pipe.go`** — route each subtype over its protocol packet family; re-frame the client stream into whole protocol packets (the agent's proxies decode one packet per write, so raw TCP chunks desync them); MySQL gets an init write because its proxy is server-speaks-first.
- **`tunnel/tunnelmgr/credentials.go`** (new) — the placeholder credentials and the per-subtype rule for which connections have them.
- **`common/mysqltypes`** (new) + `CopyBuffer` in `mongotypes`/`mssqltypes` — the framing the pipe needs, alongside the `pgtypes.CopyBuffer` that already existed.
- **`tunnel/client/connections.go`** — filter Oracle out unless `beta.oracle_native` is on; the agent refuses the session otherwise, so listing it would advertise a resource that can never connect.
- **`tunnel/ipc`** — `username`/`password` on `/v1/connections`, spec + openapi.yaml in lockstep.
- **`tunnel/README.md`** — documents the credentials and the tunnel's single-user trust model.

`Decode` in `mongotypes` and `mssqltypes` also gained a length-underflow guard. That is not drive-by hardening: the pipe feeds the user's raw TCP stream straight into those decoders, so a malformed length field is now reachable input where it previously wasn't. An undersized value underflowed the unsigned subtraction into a huge allocation or an indefinite blocking read.

## 🧪 Testing

### Test Configuration:
- **OS**: macOS (darwin/arm64), Docker for testcontainers
- Requires enterprise `libhoop` symlinked at `./libhoop` for the protocol-proxy tests; they skip cleanly on the OSS stub.

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

```bash
make libhoop-map                     # or symlink your enterprise libhoop checkout
go test ./common/... ./tunnel/... ./client/...
go test -tags integration -count=1 ./gateway/integration/transport/
```

The defect and the fix are both pinned by tests against a real gateway + agent + Postgres container:

| Test | What it proves |
|---|---|
| `TestTunnelRawTCPRejectsPlaceholderCredentials` | the old path forwards the backend's SASL challenge (type 10) to the client |
| `TestTunnelAcceptsFixedCredentials` | a real `lib/pq` client authenticates with `noop`/`noop` through `client.DialAndPipe` and runs two queries |
| `TestTunnelIgnoresClientCredentials` | bogus client credentials still connect, and `SELECT current_user` returns the **connection's stored user** — i.e. injection, not passthrough |
| `TestTunnelEnforcesGuardrails` | a denied query is blocked with the rule's own message |

Also run: full `gateway/integration/transport` suite, and `agent/integration` Postgres/MySQL/MongoDB/MSSQL against real database containers (the framing migration's main risk).

## 📌 Additional Notes

**Where I'd like review attention:**

1. **`pumpBytes` concurrency.** It now returns as soon as *either* direction finishes, instead of waiting for both. Protocol proxies don't echo a close packet, so the reader parks in `transport.Recv()` forever and the old `wg.Wait()` deadlocked — caught by the e2e test. `TCPConnectionClose` is sent exactly once via a `sync.Once` so it can't be skipped when the gateway side ends first.
2. **Scope.** The routing rewrite and shared framing are larger than "print two strings", but listing credentials that don't work isn't the ticket. Everything here is reachable from the tunnel; opportunistic cleanups that touched `client/proxy`, `hoop connect` and the agent's Oracle controller were dropped from this PR to keep the diff to the change under review.

**Known gap, deliberately not fixed here:** the daemon runs as root and authorises flows by destination address alone — it never identifies the calling OS user, so on a shared host any local account inherits the logged-in user's tunnel access. This predates the change (`tcp`/`httpproxy` were already credential-free over the same routes, and `hoop connect` serves `noop`/`noop` on loopback), but this PR widens it to databases. Documented in `tunnel/README.md` and tracked in DEP-144.

Automated by MisterMal

