### PR TITLE
feat: add AQL filtering and object type reference attributes for Jira

### DIFF
--- a/gateway/api/integrations/issuetemplates.go
+++ b/gateway/api/integrations/issuetemplates.go
@@ -157,7 +157,7 @@ func GetIssueTemplatesByID(c *gin.Context) {
 //	@Param			name				query		string	false	"Specify a name to filter"
 //	@Param			aql					query		string	false	"Additional AQL expression to filter values with"
 //	@Success		200					{object}	openapi.JiraAssetObjects
-//	@Failure		400,404,500			{object}	openapi.HTTPError
+//	@Failure		400,404,422,500		{object}	openapi.HTTPError
 //	@Router			/integrations/jira/assets/objects [get]
 func GetAssetObjects(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
@@ -203,18 +203,13 @@ func GetAssetObjects(c *gin.Context) {
 //	@Produce		json
 //	@Param			object_type_ids	query		string	true	"Comma-separated list of object type ids"
 //	@Success		200				{object}	openapi.JiraAssetObjectTypeAttributes
-//	@Failure		400,404,500		{object}	openapi.HTTPError
+//	@Failure		400,404,422,500	{object}	openapi.HTTPError
 //	@Router			/integrations/jira/assets/objecttypes/attributes [get]
 func GetAssetObjectTypeAttributes(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
-	var objectTypeIDs []string
-	for _, id := range strings.Split(c.Query("object_type_ids"), ",") {
-		if id = strings.TrimSpace(id); id != "" {
-			objectTypeIDs = append(objectTypeIDs, id)
-		}
-	}
-	if len(objectTypeIDs) == 0 {
-		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "object_type_ids query string is required"})
+	objectTypeIDs, err := parseObjectTypeIDs(c.Query("object_type_ids"))
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
 		return
 	}
 	config, err := models.GetJiraIntegration(ctx.OrgID)
@@ -236,6 +231,23 @@ func GetAssetObjectTypeAttributes(c *gin.Context) {
 		})
 	}
 	c.JSON(http.StatusOK, openapi.JiraAssetObjectTypeAttributes{Items: items})
+}
+
+// parseObjectTypeIDs splits a comma-separated id list, trimming blanks and
+// dropping duplicates so repeated ids cannot multiply upstream requests.
+func parseObjectTypeIDs(raw string) ([]string, error) {
+	seen := map[string]bool{}
+	var ids []string
+	for _, id := range strings.Split(raw, ",") {
+		if id = strings.TrimSpace(id); id != "" && !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("object_type_ids query string is required")
+	}
+	return ids, nil
 }
 
 // buildAssetObjectsQuery composes the AQL expression used to list asset

--- a/gateway/api/integrations/issuetemplates.go
+++ b/gateway/api/integrations/issuetemplates.go
@@ -157,7 +157,7 @@ func GetIssueTemplatesByID(c *gin.Context) {
 //	@Param			name				query		string	false	"Specify a name to filter"
 //	@Param			aql					query		string	false	"AQL expression scoping the values; replaces the object_type_id filter when set"
 //	@Success		200					{object}	openapi.JiraAssetObjects
-//	@Failure		400,404,422,500		{object}	openapi.HTTPError
+//	@Failure		422,500				{object}	openapi.HTTPError
 //	@Router			/integrations/jira/assets/objects [get]
 func GetAssetObjects(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
@@ -203,7 +203,7 @@ func GetAssetObjects(c *gin.Context) {
 //	@Produce		json
 //	@Param			jira_fields	query		string	true	"Comma-separated list of Jira custom field ids (e.g. customfield_10092)"
 //	@Success		200			{object}	openapi.JiraAssetFieldConfigs
-//	@Failure		400,404,422,500	{object}	openapi.HTTPError
+//	@Failure		422,500		{object}	openapi.HTTPError
 //	@Router			/integrations/jira/assets/fieldconfigs [get]
 func GetAssetFieldConfigs(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)

--- a/gateway/api/integrations/issuetemplates.go
+++ b/gateway/api/integrations/issuetemplates.go
@@ -155,6 +155,7 @@ func GetIssueTemplatesByID(c *gin.Context) {
 //	@Param			object_type_id		query		string	true	"The Jira object type to filter values for"
 //	@Param			object_schema_id	query		string	false	"The Jira object schema id to fetch values for"
 //	@Param			name				query		string	false	"Specify a name to filter"
+//	@Param			aql					query		string	false	"Additional AQL expression to filter values with"
 //	@Success		200					{object}	openapi.JiraAssetObjects
 //	@Failure		400,404,500			{object}	openapi.HTTPError
 //	@Router			/integrations/jira/assets/objects [get]
@@ -170,11 +171,7 @@ func GetAssetObjects(c *gin.Context) {
 		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed obtaining jira integration configuration: %v", err)
 		return
 	}
-	query := fmt.Sprintf(`objectTypeId = %q AND name LIKE %q`, objectTypeID, c.Query("name"))
-	if objectSchemaID != "" {
-		query = fmt.Sprintf(`objectTypeId = %q AND objectSchemaId = %q AND name LIKE %q`,
-			objectTypeID, objectSchemaID, c.Query("name"))
-	}
+	query := buildAssetObjectsQuery(objectTypeID, objectSchemaID, c.Query("name"), c.Query("aql"))
 
 	resp, err := jira.FetchObjectsByAQL(config, limit, offset, query)
 	if err != nil {
@@ -196,6 +193,64 @@ func GetAssetObjects(c *gin.Context) {
 		HasNextPage: !resp.Last,
 		Values:      objectValues,
 	})
+}
+
+// GetAssetObjectTypeAttributes
+//
+//	@Summary		Get Asset Object Type Reference Attributes
+//	@Description	List the object-reference attributes of Jira Service Management (JSM) Assets object types. These schema edges drive the CMDB dropdown cascade filters.
+//	@Tags			Jira
+//	@Produce		json
+//	@Param			object_type_ids	query		string	true	"Comma-separated list of object type ids"
+//	@Success		200				{object}	openapi.JiraAssetObjectTypeAttributes
+//	@Failure		400,404,500		{object}	openapi.HTTPError
+//	@Router			/integrations/jira/assets/objecttypes/attributes [get]
+func GetAssetObjectTypeAttributes(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	var objectTypeIDs []string
+	for _, id := range strings.Split(c.Query("object_type_ids"), ",") {
+		if id = strings.TrimSpace(id); id != "" {
+			objectTypeIDs = append(objectTypeIDs, id)
+		}
+	}
+	if len(objectTypeIDs) == 0 {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "object_type_ids query string is required"})
+		return
+	}
+	config, err := models.GetJiraIntegration(ctx.OrgID)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed obtaining jira integration configuration: %v", err)
+		return
+	}
+	refs, err := jira.FetchObjectTypeReferenceAttributes(config, objectTypeIDs)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching object type attributes from Jira: %v", err)
+		return
+	}
+	items := []openapi.JiraAssetObjectTypeRefAttribute{}
+	for _, ref := range refs {
+		items = append(items, openapi.JiraAssetObjectTypeRefAttribute{
+			ObjectTypeID:          ref.ObjectTypeID,
+			AttributeName:         ref.Name,
+			ReferenceObjectTypeID: ref.ReferenceObjectTypeID,
+		})
+	}
+	c.JSON(http.StatusOK, openapi.JiraAssetObjectTypeAttributes{Items: items})
+}
+
+// buildAssetObjectsQuery composes the AQL expression used to list asset
+// objects. A template-defined aql expression is AND-composed (parenthesized)
+// with the base objectTypeId/objectSchemaId/name filters.
+func buildAssetObjectsQuery(objectTypeID, objectSchemaID, name, aql string) string {
+	query := fmt.Sprintf(`objectTypeId = %q AND name LIKE %q`, objectTypeID, name)
+	if objectSchemaID != "" {
+		query = fmt.Sprintf(`objectTypeId = %q AND objectSchemaId = %q AND name LIKE %q`,
+			objectTypeID, objectSchemaID, name)
+	}
+	if aql != "" {
+		query = fmt.Sprintf(`(%s) AND %s`, aql, query)
+	}
+	return query
 }
 
 func parseObjectValuesOptions(c *gin.Context) (objectTypeID, objectSchemaID string, limit, offset int, err error) {

--- a/gateway/api/integrations/issuetemplates.go
+++ b/gateway/api/integrations/issuetemplates.go
@@ -155,7 +155,7 @@ func GetIssueTemplatesByID(c *gin.Context) {
 //	@Param			object_type_id		query		string	true	"The Jira object type to filter values for"
 //	@Param			object_schema_id	query		string	false	"The Jira object schema id to fetch values for"
 //	@Param			name				query		string	false	"Specify a name to filter"
-//	@Param			aql					query		string	false	"Additional AQL expression to filter values with"
+//	@Param			aql					query		string	false	"AQL expression scoping the values; replaces the object_type_id filter when set"
 //	@Success		200					{object}	openapi.JiraAssetObjects
 //	@Failure		400,404,422,500		{object}	openapi.HTTPError
 //	@Router			/integrations/jira/assets/objects [get]
@@ -195,19 +195,19 @@ func GetAssetObjects(c *gin.Context) {
 	})
 }
 
-// GetAssetObjectTypeAttributes
+// GetAssetFieldConfigs
 //
-//	@Summary		Get Asset Object Type Reference Attributes
-//	@Description	List the object-reference attributes of Jira Service Management (JSM) Assets object types. These schema edges drive the CMDB dropdown cascade filters.
+//	@Summary		Get Asset Field Configurations
+//	@Description	Get the AQL configuration of Jira Service Management (JSM) Assets custom fields. These are the object scope and dependent-field (issue scope) filters Jira's own portal applies; they drive the CMDB dropdown cascade. Fields without any configured filter are omitted.
 //	@Tags			Jira
 //	@Produce		json
-//	@Param			object_type_ids	query		string	true	"Comma-separated list of object type ids"
-//	@Success		200				{object}	openapi.JiraAssetObjectTypeAttributes
+//	@Param			jira_fields	query		string	true	"Comma-separated list of Jira custom field ids (e.g. customfield_10092)"
+//	@Success		200			{object}	openapi.JiraAssetFieldConfigs
 //	@Failure		400,404,422,500	{object}	openapi.HTTPError
-//	@Router			/integrations/jira/assets/objecttypes/attributes [get]
-func GetAssetObjectTypeAttributes(c *gin.Context) {
+//	@Router			/integrations/jira/assets/fieldconfigs [get]
+func GetAssetFieldConfigs(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
-	objectTypeIDs, err := parseObjectTypeIDs(c.Query("object_type_ids"))
+	fieldIDs, err := parseIDListParam(c.Query("jira_fields"), "jira_fields")
 	if err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
 		return
@@ -217,25 +217,26 @@ func GetAssetObjectTypeAttributes(c *gin.Context) {
 		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed obtaining jira integration configuration: %v", err)
 		return
 	}
-	refs, err := jira.FetchObjectTypeReferenceAttributes(config, objectTypeIDs)
+	fieldConfigs, err := jira.FetchAssetFieldConfigs(config, fieldIDs)
 	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching object type attributes from Jira: %v", err)
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching asset field configurations from Jira: %v", err)
 		return
 	}
-	items := []openapi.JiraAssetObjectTypeRefAttribute{}
-	for _, ref := range refs {
-		items = append(items, openapi.JiraAssetObjectTypeRefAttribute{
-			ObjectTypeID:          ref.ObjectTypeID,
-			AttributeName:         ref.Name,
-			ReferenceObjectTypeID: ref.ReferenceObjectTypeID,
+	items := []openapi.JiraAssetFieldConfig{}
+	for _, fc := range fieldConfigs {
+		items = append(items, openapi.JiraAssetFieldConfig{
+			JiraField:             fc.JiraField,
+			ObjectSchemaID:        fc.ObjectSchemaID,
+			ObjectFilterQuery:     fc.ObjectFilterQuery,
+			IssueScopeFilterQuery: fc.IssueScopeFilterQuery,
 		})
 	}
-	c.JSON(http.StatusOK, openapi.JiraAssetObjectTypeAttributes{Items: items})
+	c.JSON(http.StatusOK, openapi.JiraAssetFieldConfigs{Items: items})
 }
 
-// parseObjectTypeIDs splits a comma-separated id list, trimming blanks and
+// parseIDListParam splits a comma-separated id list, trimming blanks and
 // dropping duplicates so repeated ids cannot multiply upstream requests.
-func parseObjectTypeIDs(raw string) ([]string, error) {
+func parseIDListParam(raw, param string) ([]string, error) {
 	seen := map[string]bool{}
 	var ids []string
 	for _, id := range strings.Split(raw, ",") {
@@ -245,24 +246,29 @@ func parseObjectTypeIDs(raw string) ([]string, error) {
 		}
 	}
 	if len(ids) == 0 {
-		return nil, fmt.Errorf("object_type_ids query string is required")
+		return nil, fmt.Errorf("%s query string is required", param)
 	}
 	return ids, nil
 }
 
 // buildAssetObjectsQuery composes the AQL expression used to list asset
-// objects. A template-defined aql expression is AND-composed (parenthesized)
-// with the base objectTypeId/objectSchemaId/name filters.
+// objects.
+//
+// Without an aql expression the objects are scoped by the template's
+// objectTypeId. An aql expression comes from the Assets field configuration
+// in Jira, which already defines every object the field accepts, so it
+// replaces the objectTypeId scope instead of narrowing it — exactly what
+// Jira's own picker does. AND-ing both would return nothing whenever the
+// template's object type disagrees with the field configuration.
 func buildAssetObjectsQuery(objectTypeID, objectSchemaID, name, aql string) string {
-	query := fmt.Sprintf(`objectTypeId = %q AND name LIKE %q`, objectTypeID, name)
-	if objectSchemaID != "" {
-		query = fmt.Sprintf(`objectTypeId = %q AND objectSchemaId = %q AND name LIKE %q`,
-			objectTypeID, objectSchemaID, name)
-	}
+	scope := fmt.Sprintf(`objectTypeId = %q`, objectTypeID)
 	if aql != "" {
-		query = fmt.Sprintf(`(%s) AND %s`, aql, query)
+		scope = fmt.Sprintf(`(%s)`, aql)
 	}
-	return query
+	if objectSchemaID != "" {
+		scope = fmt.Sprintf(`%s AND objectSchemaId = %q`, scope, objectSchemaID)
+	}
+	return fmt.Sprintf(`%s AND name LIKE %q`, scope, name)
 }
 
 func parseObjectValuesOptions(c *gin.Context) (objectTypeID, objectSchemaID string, limit, offset int, err error) {

--- a/gateway/api/integrations/issuetemplates_test.go
+++ b/gateway/api/integrations/issuetemplates_test.go
@@ -1,0 +1,55 @@
+package apijiraintegration
+
+import "testing"
+
+func TestBuildAssetObjectsQuery(t *testing.T) {
+	for _, tt := range []struct {
+		msg            string
+		objectTypeID   string
+		objectSchemaID string
+		name           string
+		aql            string
+		want           string
+	}{
+		{
+			msg:          "no schema, no aql",
+			objectTypeID: "1",
+			name:         "srv",
+			want:         `objectTypeId = "1" AND name LIKE "srv"`,
+		},
+		{
+			msg:            "with schema",
+			objectTypeID:   "1",
+			objectSchemaID: "9",
+			name:           "srv",
+			want:           `objectTypeId = "1" AND objectSchemaId = "9" AND name LIKE "srv"`,
+		},
+		{
+			msg:          "with aql only",
+			objectTypeID: "1",
+			name:         "srv",
+			aql:          `"Status" = "Active"`,
+			want:         `("Status" = "Active") AND objectTypeId = "1" AND name LIKE "srv"`,
+		},
+		{
+			msg:            "with schema and aql",
+			objectTypeID:   "1",
+			objectSchemaID: "9",
+			name:           "srv",
+			aql:            `"Status" = "Active"`,
+			want:           `("Status" = "Active") AND objectTypeId = "1" AND objectSchemaId = "9" AND name LIKE "srv"`,
+		},
+		{
+			msg:          "empty name keeps LIKE filter",
+			objectTypeID: "1",
+			want:         `objectTypeId = "1" AND name LIKE ""`,
+		},
+	} {
+		t.Run(tt.msg, func(t *testing.T) {
+			got := buildAssetObjectsQuery(tt.objectTypeID, tt.objectSchemaID, tt.name, tt.aql)
+			if got != tt.want {
+				t.Errorf("got  %s\nwant %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/gateway/api/integrations/issuetemplates_test.go
+++ b/gateway/api/integrations/issuetemplates_test.go
@@ -1,6 +1,9 @@
 package apijiraintegration
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestBuildAssetObjectsQuery(t *testing.T) {
 	for _, tt := range []struct {
@@ -49,6 +52,37 @@ func TestBuildAssetObjectsQuery(t *testing.T) {
 			got := buildAssetObjectsQuery(tt.objectTypeID, tt.objectSchemaID, tt.name, tt.aql)
 			if got != tt.want {
 				t.Errorf("got  %s\nwant %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseObjectTypeIDs(t *testing.T) {
+	for _, tt := range []struct {
+		msg     string
+		raw     string
+		want    []string
+		wantErr string
+	}{
+		{msg: "single id", raw: "76", want: []string{"76"}},
+		{msg: "trims and drops blanks", raw: " 76 , ,77,", want: []string{"76", "77"}},
+		{msg: "dedupes repeated ids", raw: "77,77,76,77", want: []string{"77", "76"}},
+		{msg: "empty is rejected", raw: "", wantErr: "object_type_ids query string is required"},
+		{msg: "blanks only is rejected", raw: " , ,", wantErr: "object_type_ids query string is required"},
+	} {
+		t.Run(tt.msg, func(t *testing.T) {
+			got, err := parseObjectTypeIDs(tt.raw)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("got err %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if fmt.Sprint(got) != fmt.Sprint(tt.want) {
+				t.Errorf("got  %v\nwant %v", got, tt.want)
 			}
 		})
 	}

--- a/gateway/api/integrations/issuetemplates_test.go
+++ b/gateway/api/integrations/issuetemplates_test.go
@@ -28,19 +28,19 @@ func TestBuildAssetObjectsQuery(t *testing.T) {
 			want:           `objectTypeId = "1" AND objectSchemaId = "9" AND name LIKE "srv"`,
 		},
 		{
-			msg:          "with aql only",
+			msg:          "aql replaces the object type scope",
 			objectTypeID: "1",
 			name:         "srv",
-			aql:          `"Status" = "Active"`,
-			want:         `("Status" = "Active") AND objectTypeId = "1" AND name LIKE "srv"`,
+			aql:          `objectType = "Service"`,
+			want:         `(objectType = "Service") AND name LIKE "srv"`,
 		},
 		{
-			msg:            "with schema and aql",
+			msg:            "aql keeps the schema scope",
 			objectTypeID:   "1",
 			objectSchemaID: "9",
 			name:           "srv",
-			aql:            `"Status" = "Active"`,
-			want:           `("Status" = "Active") AND objectTypeId = "1" AND objectSchemaId = "9" AND name LIKE "srv"`,
+			aql:            `objectType = "Service" AND Product = "Git"`,
+			want:           `(objectType = "Service" AND Product = "Git") AND objectSchemaId = "9" AND name LIKE "srv"`,
 		},
 		{
 			msg:          "empty name keeps LIKE filter",
@@ -57,21 +57,21 @@ func TestBuildAssetObjectsQuery(t *testing.T) {
 	}
 }
 
-func TestParseObjectTypeIDs(t *testing.T) {
+func TestParseIDListParam(t *testing.T) {
 	for _, tt := range []struct {
 		msg     string
 		raw     string
 		want    []string
 		wantErr string
 	}{
-		{msg: "single id", raw: "76", want: []string{"76"}},
-		{msg: "trims and drops blanks", raw: " 76 , ,77,", want: []string{"76", "77"}},
-		{msg: "dedupes repeated ids", raw: "77,77,76,77", want: []string{"77", "76"}},
-		{msg: "empty is rejected", raw: "", wantErr: "object_type_ids query string is required"},
-		{msg: "blanks only is rejected", raw: " , ,", wantErr: "object_type_ids query string is required"},
+		{msg: "single id", raw: "customfield_10092", want: []string{"customfield_10092"}},
+		{msg: "trims and drops blanks", raw: " a , ,b,", want: []string{"a", "b"}},
+		{msg: "dedupes repeated ids", raw: "b,b,a,b", want: []string{"b", "a"}},
+		{msg: "empty is rejected", raw: "", wantErr: "jira_fields query string is required"},
+		{msg: "blanks only is rejected", raw: " , ,", wantErr: "jira_fields query string is required"},
 	} {
 		t.Run(tt.msg, func(t *testing.T) {
-			got, err := parseObjectTypeIDs(tt.raw)
+			got, err := parseIDListParam(tt.raw, "jira_fields")
 			if tt.wantErr != "" {
 				if err == nil || err.Error() != tt.wantErr {
 					t.Fatalf("got err %v, want %q", err, tt.wantErr)

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4211,6 +4211,59 @@ const docTemplate = `{
                 }
             }
         },
+        "/integrations/jira/assets/fieldconfigs": {
+            "get": {
+                "description": "Get the AQL configuration of Jira Service Management (JSM) Assets custom fields. These are the object scope and dependent-field (issue scope) filters Jira's own portal applies; they drive the CMDB dropdown cascade. Fields without any configured filter are omitted.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Jira"
+                ],
+                "summary": "Get Asset Field Configurations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma-separated list of Jira custom field ids (e.g. customfield_10092)",
+                        "name": "jira_fields",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.JiraAssetFieldConfigs"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/integrations/jira/assets/objects": {
             "get": {
                 "description": "Get objects from the Jira Service Management (JSM) Assets API",
@@ -4243,7 +4296,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Additional AQL expression to filter values with",
+                        "description": "AQL expression scoping the values; replaces the object_type_id filter when set",
                         "name": "aql",
                         "in": "query"
                     }
@@ -4253,59 +4306,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/openapi.JiraAssetObjects"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/integrations/jira/assets/objecttypes/attributes": {
-            "get": {
-                "description": "List the object-reference attributes of Jira Service Management (JSM) Assets object types. These schema edges drive the CMDB dropdown cascade filters.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Jira"
-                ],
-                "summary": "Get Asset Object Type Reference Attributes",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Comma-separated list of object type ids",
-                        "name": "object_type_ids",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.JiraAssetObjectTypeAttributes"
                         }
                     },
                     "400": {
@@ -14169,35 +14169,40 @@ const docTemplate = `{
                 "IdpProviderUnknown"
             ]
         },
-        "openapi.JiraAssetObjectTypeAttributes": {
+        "openapi.JiraAssetFieldConfig": {
             "type": "object",
             "properties": {
-                "items": {
-                    "description": "The object-reference attributes found",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/openapi.JiraAssetObjectTypeRefAttribute"
-                    }
+                "issue_scope_filter_query": {
+                    "description": "Dependent-field AQL; may reference sibling fields with ${customfield_x.label} placeholders",
+                    "type": "string",
+                    "example": "\"Product\" = ${customfield_10091.label}"
+                },
+                "jira_field": {
+                    "description": "The Jira custom field id",
+                    "type": "string",
+                    "example": "customfield_10092"
+                },
+                "object_filter_query": {
+                    "description": "AQL scoping every fetch of the field's options",
+                    "type": "string",
+                    "example": "objectType = \"Product\""
+                },
+                "object_schema_id": {
+                    "description": "The Assets object schema the field is bound to",
+                    "type": "string",
+                    "example": "2"
                 }
             }
         },
-        "openapi.JiraAssetObjectTypeRefAttribute": {
+        "openapi.JiraAssetFieldConfigs": {
             "type": "object",
             "properties": {
-                "attribute_name": {
-                    "description": "Name of the reference attribute, usable in AQL clauses",
-                    "type": "string",
-                    "example": "Product"
-                },
-                "object_type_id": {
-                    "description": "The object type owning the reference attribute",
-                    "type": "string",
-                    "example": "77"
-                },
-                "reference_object_type_id": {
-                    "description": "The object type the attribute points at",
-                    "type": "string",
-                    "example": "76"
+                "items": {
+                    "description": "The field configurations found; fields without any filter are omitted",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.JiraAssetFieldConfig"
+                    }
                 }
             }
         },

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4267,6 +4267,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/openapi.HTTPError"
                         }
                     },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4310,6 +4316,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "schema": {
                             "$ref": "#/definitions/openapi.HTTPError"
                         }

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4237,18 +4237,6 @@ const docTemplate = `{
                             "$ref": "#/definitions/openapi.JiraAssetFieldConfigs"
                         }
                     },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
@@ -4306,18 +4294,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/openapi.JiraAssetObjects"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/openapi.HTTPError"
                         }
                     },
                     "422": {

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -4240,6 +4240,12 @@ const docTemplate = `{
                         "description": "Specify a name to filter",
                         "name": "name",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Additional AQL expression to filter values with",
+                        "name": "aql",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -4247,6 +4253,53 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/openapi.JiraAssetObjects"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/integrations/jira/assets/objecttypes/attributes": {
+            "get": {
+                "description": "List the object-reference attributes of Jira Service Management (JSM) Assets object types. These schema edges drive the CMDB dropdown cascade filters.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Jira"
+                ],
+                "summary": "Get Asset Object Type Reference Attributes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma-separated list of object type ids",
+                        "name": "object_type_ids",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.JiraAssetObjectTypeAttributes"
                         }
                     },
                     "400": {
@@ -14103,6 +14156,38 @@ const docTemplate = `{
                 "IdpProviderJumpCloud",
                 "IdpProviderUnknown"
             ]
+        },
+        "openapi.JiraAssetObjectTypeAttributes": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "description": "The object-reference attributes found",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.JiraAssetObjectTypeRefAttribute"
+                    }
+                }
+            }
+        },
+        "openapi.JiraAssetObjectTypeRefAttribute": {
+            "type": "object",
+            "properties": {
+                "attribute_name": {
+                    "description": "Name of the reference attribute, usable in AQL clauses",
+                    "type": "string",
+                    "example": "Product"
+                },
+                "object_type_id": {
+                    "description": "The object type owning the reference attribute",
+                    "type": "string",
+                    "example": "77"
+                },
+                "reference_object_type_id": {
+                    "description": "The object type the attribute points at",
+                    "type": "string",
+                    "example": "76"
+                }
+            }
         },
         "openapi.JiraAssetObjectValue": {
             "type": "object",

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -13787,26 +13787,6 @@
             },
             "description": "OK"
           },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/openapi.HTTPError"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/openapi.HTTPError"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
           "422": {
             "content": {
               "application/json": {
@@ -13882,26 +13862,6 @@
               }
             },
             "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/openapi.HTTPError"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/openapi.HTTPError"
-                }
-              }
-            },
-            "description": "Not Found"
           },
           "422": {
             "content": {

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -3529,6 +3529,38 @@
           "IdpProviderUnknown"
         ]
       },
+      "openapi.JiraAssetObjectTypeAttributes": {
+        "properties": {
+          "items": {
+            "description": "The object-reference attributes found",
+            "items": {
+              "$ref": "#/components/schemas/openapi.JiraAssetObjectTypeRefAttribute"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "openapi.JiraAssetObjectTypeRefAttribute": {
+        "properties": {
+          "attribute_name": {
+            "description": "Name of the reference attribute, usable in AQL clauses",
+            "example": "Product",
+            "type": "string"
+          },
+          "object_type_id": {
+            "description": "The object type owning the reference attribute",
+            "example": "77",
+            "type": "string"
+          },
+          "reference_object_type_id": {
+            "description": "The object type the attribute points at",
+            "example": "76",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "openapi.JiraAssetObjectValue": {
         "properties": {
           "id": {
@@ -13753,6 +13785,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Additional AQL expression to filter values with",
+            "in": "query",
+            "name": "aql",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -13798,6 +13838,68 @@
           }
         },
         "summary": "Get Asset Objects",
+        "tags": [
+          "Jira"
+        ]
+      }
+    },
+    "/integrations/jira/assets/objecttypes/attributes": {
+      "get": {
+        "description": "List the object-reference attributes of Jira Service Management (JSM) Assets object types. These schema edges drive the CMDB dropdown cascade filters.",
+        "parameters": [
+          {
+            "description": "Comma-separated list of object type ids",
+            "in": "query",
+            "name": "object_type_ids",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.JiraAssetObjectTypeAttributes"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get Asset Object Type Reference Attributes",
         "tags": [
           "Jira"
         ]

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -13826,6 +13826,16 @@
             },
             "description": "Not Found"
           },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
           "500": {
             "content": {
               "application/json": {
@@ -13887,6 +13897,16 @@
               }
             },
             "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
           },
           "500": {
             "content": {

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -3529,34 +3529,39 @@
           "IdpProviderUnknown"
         ]
       },
-      "openapi.JiraAssetObjectTypeAttributes": {
+      "openapi.JiraAssetFieldConfig": {
         "properties": {
-          "items": {
-            "description": "The object-reference attributes found",
-            "items": {
-              "$ref": "#/components/schemas/openapi.JiraAssetObjectTypeRefAttribute"
-            },
-            "type": "array"
+          "issue_scope_filter_query": {
+            "description": "Dependent-field AQL; may reference sibling fields with ${customfield_x.label} placeholders",
+            "example": "\"Product\" = ${customfield_10091.label}",
+            "type": "string"
+          },
+          "jira_field": {
+            "description": "The Jira custom field id",
+            "example": "customfield_10092",
+            "type": "string"
+          },
+          "object_filter_query": {
+            "description": "AQL scoping every fetch of the field's options",
+            "example": "objectType = \"Product\"",
+            "type": "string"
+          },
+          "object_schema_id": {
+            "description": "The Assets object schema the field is bound to",
+            "example": "2",
+            "type": "string"
           }
         },
         "type": "object"
       },
-      "openapi.JiraAssetObjectTypeRefAttribute": {
+      "openapi.JiraAssetFieldConfigs": {
         "properties": {
-          "attribute_name": {
-            "description": "Name of the reference attribute, usable in AQL clauses",
-            "example": "Product",
-            "type": "string"
-          },
-          "object_type_id": {
-            "description": "The object type owning the reference attribute",
-            "example": "77",
-            "type": "string"
-          },
-          "reference_object_type_id": {
-            "description": "The object type the attribute points at",
-            "example": "76",
-            "type": "string"
+          "items": {
+            "description": "The field configurations found; fields without any filter are omitted",
+            "items": {
+              "$ref": "#/components/schemas/openapi.JiraAssetFieldConfig"
+            },
+            "type": "array"
           }
         },
         "type": "object"
@@ -13757,6 +13762,78 @@
         ]
       }
     },
+    "/integrations/jira/assets/fieldconfigs": {
+      "get": {
+        "description": "Get the AQL configuration of Jira Service Management (JSM) Assets custom fields. These are the object scope and dependent-field (issue scope) filters Jira's own portal applies; they drive the CMDB dropdown cascade. Fields without any configured filter are omitted.",
+        "parameters": [
+          {
+            "description": "Comma-separated list of Jira custom field ids (e.g. customfield_10092)",
+            "in": "query",
+            "name": "jira_fields",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.JiraAssetFieldConfigs"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get Asset Field Configurations",
+        "tags": [
+          "Jira"
+        ]
+      }
+    },
     "/integrations/jira/assets/objects": {
       "get": {
         "description": "Get objects from the Jira Service Management (JSM) Assets API",
@@ -13787,7 +13864,7 @@
             }
           },
           {
-            "description": "Additional AQL expression to filter values with",
+            "description": "AQL expression scoping the values; replaces the object_type_id filter when set",
             "in": "query",
             "name": "aql",
             "schema": {
@@ -13848,78 +13925,6 @@
           }
         },
         "summary": "Get Asset Objects",
-        "tags": [
-          "Jira"
-        ]
-      }
-    },
-    "/integrations/jira/assets/objecttypes/attributes": {
-      "get": {
-        "description": "List the object-reference attributes of Jira Service Management (JSM) Assets object types. These schema edges drive the CMDB dropdown cascade filters.",
-        "parameters": [
-          {
-            "description": "Comma-separated list of object type ids",
-            "in": "query",
-            "name": "object_type_ids",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/openapi.JiraAssetObjectTypeAttributes"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/openapi.HTTPError"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/openapi.HTTPError"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/openapi.HTTPError"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/openapi.HTTPError"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          }
-        },
-        "summary": "Get Asset Object Type Reference Attributes",
         "tags": [
           "Jira"
         ]

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1797,18 +1797,20 @@ type JiraAssetObjects struct {
 	HasNextPage bool `json:"has_next_page"`
 }
 
-type JiraAssetObjectTypeRefAttribute struct {
-	// The object type owning the reference attribute
-	ObjectTypeID string `json:"object_type_id" example:"77"`
-	// Name of the reference attribute, usable in AQL clauses
-	AttributeName string `json:"attribute_name" example:"Product"`
-	// The object type the attribute points at
-	ReferenceObjectTypeID string `json:"reference_object_type_id" example:"76"`
+type JiraAssetFieldConfig struct {
+	// The Jira custom field id
+	JiraField string `json:"jira_field" example:"customfield_10092"`
+	// The Assets object schema the field is bound to
+	ObjectSchemaID string `json:"object_schema_id" example:"2"`
+	// AQL scoping every fetch of the field's options
+	ObjectFilterQuery string `json:"object_filter_query" example:"objectType = \"Product\""`
+	// Dependent-field AQL; may reference sibling fields with ${customfield_x.label} placeholders
+	IssueScopeFilterQuery string `json:"issue_scope_filter_query" example:"\"Product\" = ${customfield_10091.label}"`
 }
 
-type JiraAssetObjectTypeAttributes struct {
-	// The object-reference attributes found
-	Items []JiraAssetObjectTypeRefAttribute `json:"items"`
+type JiraAssetFieldConfigs struct {
+	// The field configurations found; fields without any filter are omitted
+	Items []JiraAssetFieldConfig `json:"items"`
 }
 
 type GuardRailRuleRequest struct {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1797,6 +1797,20 @@ type JiraAssetObjects struct {
 	HasNextPage bool `json:"has_next_page"`
 }
 
+type JiraAssetObjectTypeRefAttribute struct {
+	// The object type owning the reference attribute
+	ObjectTypeID string `json:"object_type_id" example:"77"`
+	// Name of the reference attribute, usable in AQL clauses
+	AttributeName string `json:"attribute_name" example:"Product"`
+	// The object type the attribute points at
+	ReferenceObjectTypeID string `json:"reference_object_type_id" example:"76"`
+}
+
+type JiraAssetObjectTypeAttributes struct {
+	// The object-reference attributes found
+	Items []JiraAssetObjectTypeRefAttribute `json:"items"`
+}
+
 type GuardRailRuleRequest struct {
 	// Unique name for the rule
 	Name string `json:"name" binding:"required" example:"my-strict-rule"`

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -1054,6 +1054,11 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		apijiraintegration.GetAssetObjects)
 
+	r.GET("/integrations/jira/assets/objecttypes/attributes",
+		apiroutes.ReadOnlyAccessRole,
+		r.AuthMiddleware,
+		apijiraintegration.GetAssetObjectTypeAttributes)
+
 	// AWS routes
 	r.GET("/integrations/aws/iam/userinfo",
 		apiroutes.AdminAndAuditorAccessRole,

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -1054,10 +1054,10 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		apijiraintegration.GetAssetObjects)
 
-	r.GET("/integrations/jira/assets/objecttypes/attributes",
+	r.GET("/integrations/jira/assets/fieldconfigs",
 		apiroutes.ReadOnlyAccessRole,
 		r.AuthMiddleware,
-		apijiraintegration.GetAssetObjectTypeAttributes)
+		apijiraintegration.GetAssetFieldConfigs)
 
 	// AWS routes
 	r.GET("/integrations/aws/iam/userinfo",

--- a/gateway/jira/assetsapi.go
+++ b/gateway/jira/assetsapi.go
@@ -44,67 +44,87 @@ func FetchObjectsByAQL(config *models.JiraIntegration, limit, offset int, query 
 	return fetchObjectsByAQL(config, vals, query)
 }
 
-// FetchObjectTypeReferenceAttributes lists the object-reference attributes of
-// the given Assets object types. These edges of the schema drive the CMDB
-// dropdown cascade: an object type is filtered by the selection of any type
-// one of its reference attributes points at.
-// https://developer.atlassian.com/cloud/assets/rest/api-group-objecttype/#api-objecttype-id-attributes-get
-func FetchObjectTypeReferenceAttributes(config *models.JiraIntegration, objectTypeIDs []string) ([]ObjectTypeReferenceAttribute, error) {
+// FetchAssetFieldConfigs resolves the Assets configuration of each Jira
+// custom field: field -> context id -> JSM cmdb fieldconfig. The returned
+// AQL queries are the same ones Jira's portal applies to the field's own
+// dropdown; fields without any query (including non-Assets fields) are
+// omitted. The fieldconfig route is served by Jira Service Management but is
+// not part of the documented public API.
+func FetchAssetFieldConfigs(config *models.JiraIntegration, fieldIDs []string) ([]AssetFieldConfig, error) {
 	ctx, cancelFn := context.WithTimeoutCause(context.Background(), defaultRequestTimeout, &ErrTimeoutReached{})
 	defer cancelFn()
-	workspaceID, err := fetchWorkspaceID(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-	refs := []ObjectTypeReferenceAttribute{}
-	for _, objectTypeID := range objectTypeIDs {
-		attributes, err := fetchObjectTypeAttributes(ctx, config, workspaceID, objectTypeID)
+	configs := []AssetFieldConfig{}
+	for _, fieldID := range fieldIDs {
+		contextID, err := fetchFieldContextID(ctx, config, fieldID)
 		if err != nil {
 			return nil, err
 		}
-		for _, attr := range attributes {
-			// type 1 is an object reference attribute
-			if attr.Type != 1 || attr.ReferenceObjectTypeID == "" {
-				continue
-			}
-			refs = append(refs, ObjectTypeReferenceAttribute{
-				ObjectTypeID:          objectTypeID,
-				Name:                  attr.Name,
-				ReferenceObjectTypeID: attr.ReferenceObjectTypeID,
-			})
+		if contextID == "" {
+			continue
 		}
+		var fieldConfig assetFieldConfig
+		apiURL := fmt.Sprintf("%s/rest/servicedesk/cmdb/latest/fieldconfig/%s", config.URL, url.PathEscape(contextID))
+		if err := fetchAssetsJSON(ctx, config, apiURL, "cmdb-fieldconfig", &fieldConfig); err != nil {
+			return nil, err
+		}
+		if fieldConfig.ObjectFilterQuery == "" && fieldConfig.IssueScopeFilterQuery == "" {
+			continue
+		}
+		configs = append(configs, AssetFieldConfig{
+			JiraField:             fieldID,
+			ObjectSchemaID:        fieldConfig.ObjectSchemaID,
+			ObjectFilterQuery:     fieldConfig.ObjectFilterQuery,
+			IssueScopeFilterQuery: fieldConfig.IssueScopeFilterQuery,
+		})
 	}
-	return refs, nil
+	return configs, nil
 }
 
-func fetchObjectTypeAttributes(ctx context.Context, config *models.JiraIntegration, workspaceID, objectTypeID string) ([]objectTypeAttribute, error) {
-	apiURL := fmt.Sprintf("%s/%s/v1/objecttype/%s/attributes", baseAssetsAPI, workspaceID, url.PathEscape(objectTypeID))
+// fetchFieldContextID returns the field's global context id, falling back to
+// the first context. Fields without contexts resolve to "".
+func fetchFieldContextID(ctx context.Context, config *models.JiraIntegration, fieldID string) (string, error) {
+	var contexts fieldContexts
+	apiURL := fmt.Sprintf("%s/rest/api/2/field/%s/context", config.URL, url.PathEscape(fieldID))
+	if err := fetchAssetsJSON(ctx, config, apiURL, "field-contexts", &contexts); err != nil {
+		return "", err
+	}
+	if len(contexts.Values) == 0 {
+		return "", nil
+	}
+	for _, c := range contexts.Values {
+		if c.IsGlobalContext {
+			return c.ID, nil
+		}
+	}
+	return contexts.Values[0].ID, nil
+}
+
+func fetchAssetsJSON(ctx context.Context, config *models.JiraIntegration, apiURL, resource string, out any) error {
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating object type attributes request, reason=%v", err)
+		return fmt.Errorf("failed creating %s request, reason=%v", resource, err)
 	}
 	req.Header.Set("Accept", "application/json")
 	req.SetBasicAuth(config.User, config.APIToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		if errCtx, ok := context.Cause(ctx).(*ErrTimeoutReached); ok {
-			errCtx.apiResource = "objecttype-attributes"
-			errCtx.query = objectTypeID
-			return nil, errCtx
+			errCtx.apiResource = resource
+			errCtx.query = apiURL
+			return errCtx
 		}
-		return nil, fmt.Errorf("failed fetching object type attributes, object-type=%v, reason=%v", objectTypeID, err)
+		return fmt.Errorf("failed fetching %s, api-url=%v, reason=%v", resource, apiURL, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("unable to fetch object type attributes, api-url=%v, status=%v, body=%v",
-			apiURL, resp.StatusCode, string(body))
+		return fmt.Errorf("unable to fetch %s, api-url=%v, status=%v, body=%v",
+			resource, apiURL, resp.StatusCode, string(body))
 	}
-	var attributes []objectTypeAttribute
-	if err := json.NewDecoder(resp.Body).Decode(&attributes); err != nil {
-		return nil, fmt.Errorf("failed decoding object type attributes response, reason=%v", err)
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("failed decoding %s response, reason=%v", resource, err)
 	}
-	return attributes, nil
+	return nil
 }
 
 // https://developer.atlassian.com/cloud/assets/rest/api-group-object/#api-object-aql-post

--- a/gateway/jira/assetsapi.go
+++ b/gateway/jira/assetsapi.go
@@ -117,7 +117,11 @@ func fetchAssetsJSON(ctx context.Context, config *models.JiraIntegration, apiURL
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("unable to fetch %s, api-url=%v, status=%v (failed reading response body: %v)",
+				resource, apiURL, resp.StatusCode, readErr)
+		}
 		return fmt.Errorf("unable to fetch %s, api-url=%v, status=%v, body=%v",
 			resource, apiURL, resp.StatusCode, string(body))
 	}

--- a/gateway/jira/assetsapi.go
+++ b/gateway/jira/assetsapi.go
@@ -44,6 +44,69 @@ func FetchObjectsByAQL(config *models.JiraIntegration, limit, offset int, query 
 	return fetchObjectsByAQL(config, vals, query)
 }
 
+// FetchObjectTypeReferenceAttributes lists the object-reference attributes of
+// the given Assets object types. These edges of the schema drive the CMDB
+// dropdown cascade: an object type is filtered by the selection of any type
+// one of its reference attributes points at.
+// https://developer.atlassian.com/cloud/assets/rest/api-group-objecttype/#api-objecttype-id-attributes-get
+func FetchObjectTypeReferenceAttributes(config *models.JiraIntegration, objectTypeIDs []string) ([]ObjectTypeReferenceAttribute, error) {
+	ctx, cancelFn := context.WithTimeoutCause(context.Background(), defaultRequestTimeout, &ErrTimeoutReached{})
+	defer cancelFn()
+	workspaceID, err := fetchWorkspaceID(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	refs := []ObjectTypeReferenceAttribute{}
+	for _, objectTypeID := range objectTypeIDs {
+		attributes, err := fetchObjectTypeAttributes(ctx, config, workspaceID, objectTypeID)
+		if err != nil {
+			return nil, err
+		}
+		for _, attr := range attributes {
+			// type 1 is an object reference attribute
+			if attr.Type != 1 || attr.ReferenceObjectTypeID == "" {
+				continue
+			}
+			refs = append(refs, ObjectTypeReferenceAttribute{
+				ObjectTypeID:          objectTypeID,
+				Name:                  attr.Name,
+				ReferenceObjectTypeID: attr.ReferenceObjectTypeID,
+			})
+		}
+	}
+	return refs, nil
+}
+
+func fetchObjectTypeAttributes(ctx context.Context, config *models.JiraIntegration, workspaceID, objectTypeID string) ([]objectTypeAttribute, error) {
+	apiURL := fmt.Sprintf("%s/%s/v1/objecttype/%s/attributes", baseAssetsAPI, workspaceID, url.PathEscape(objectTypeID))
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating object type attributes request, reason=%v", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.SetBasicAuth(config.User, config.APIToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if errCtx, ok := context.Cause(ctx).(*ErrTimeoutReached); ok {
+			errCtx.apiResource = "objecttype-attributes"
+			errCtx.query = objectTypeID
+			return nil, errCtx
+		}
+		return nil, fmt.Errorf("failed fetching object type attributes, object-type=%v, reason=%v", objectTypeID, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unable to fetch object type attributes, api-url=%v, status=%v, body=%v",
+			apiURL, resp.StatusCode, string(body))
+	}
+	var attributes []objectTypeAttribute
+	if err := json.NewDecoder(resp.Body).Decode(&attributes); err != nil {
+		return nil, fmt.Errorf("failed decoding object type attributes response, reason=%v", err)
+	}
+	return attributes, nil
+}
+
 // https://developer.atlassian.com/cloud/assets/rest/api-group-object/#api-object-aql-post
 func fetchObjectsByAQL(config *models.JiraIntegration, queryVals url.Values, query string) (*AqlResponse, error) {
 	ctx, cancelFn := context.WithTimeoutCause(context.Background(), defaultRequestTimeout, &ErrTimeoutReached{})

--- a/gateway/jira/types.go
+++ b/gateway/jira/types.go
@@ -134,18 +134,31 @@ type ObjectType struct {
 	ObjectSchemaID string `json:"objectSchemaId"`
 }
 
-// objectTypeAttribute is the Assets API attribute payload; type 1 marks an
-// object reference attribute.
-type objectTypeAttribute struct {
-	Name                  string `json:"name"`
-	Type                  int    `json:"type"`
-	ReferenceObjectTypeID string `json:"referenceObjectTypeId"`
+// fieldContexts is the Jira field context page; the context id addresses the
+// Assets custom field configuration.
+type fieldContexts struct {
+	Values []struct {
+		ID              string `json:"id"`
+		IsGlobalContext bool   `json:"isGlobalContext"`
+	} `json:"values"`
 }
 
-// ObjectTypeReferenceAttribute is an edge of the Assets schema: the attribute
-// of ObjectTypeID whose values reference objects of ReferenceObjectTypeID.
-type ObjectTypeReferenceAttribute struct {
-	ObjectTypeID          string
-	Name                  string
-	ReferenceObjectTypeID string
+// assetFieldConfig is the JSM Assets custom field configuration payload.
+// Non-Assets fields return the payload with both queries empty.
+type assetFieldConfig struct {
+	ObjectSchemaID        string `json:"objectSchemaId"`
+	ObjectFilterQuery     string `json:"objectFilterQuery"`
+	IssueScopeFilterQuery string `json:"issueScopeFilterQuery"`
+}
+
+// AssetFieldConfig is the AQL configuration of an Assets custom field:
+// ObjectFilterQuery scopes every fetch, IssueScopeFilterQuery may reference
+// sibling fields with ${customfield_x.label} placeholders (Jira's native
+// dependent-field mechanism). ObjectSchemaID is the schema the field is
+// bound to.
+type AssetFieldConfig struct {
+	JiraField             string
+	ObjectSchemaID        string
+	ObjectFilterQuery     string
+	IssueScopeFilterQuery string
 }

--- a/gateway/jira/types.go
+++ b/gateway/jira/types.go
@@ -133,3 +133,19 @@ type ObjectType struct {
 	Description    string `json:"description"`
 	ObjectSchemaID string `json:"objectSchemaId"`
 }
+
+// objectTypeAttribute is the Assets API attribute payload; type 1 marks an
+// object reference attribute.
+type objectTypeAttribute struct {
+	Name                  string `json:"name"`
+	Type                  int    `json:"type"`
+	ReferenceObjectTypeID string `json:"referenceObjectTypeId"`
+}
+
+// ObjectTypeReferenceAttribute is an edge of the Assets schema: the attribute
+// of ObjectTypeID whose values reference objects of ReferenceObjectTypeID.
+type ObjectTypeReferenceAttribute struct {
+	ObjectTypeID          string
+	Name                  string
+	ReferenceObjectTypeID string
+}

--- a/webapp/src/webapp/events/jira_templates.cljs
+++ b/webapp/src/webapp/events/jira_templates.cljs
@@ -41,43 +41,44 @@
  (fn [db [_ object-type loading?]]
    (assoc-in db [:jira-templates :cmdb-loading object-type] loading?)))
 
-;; The Assets schema edges (object-reference attributes between the template's
-;; object types) that drive the dropdown cascade. Fetched once per prompt.
+;; The AQL configuration of each row's Assets custom field (the same filters
+;; Jira's portal applies) drives the dropdown cascade. Fetched once per prompt.
 (rf/reg-event-fx
- :jira-templates->get-cmdb-relations
+ :jira-templates->get-cmdb-fieldconfigs
  (fn [{:keys [db]} [_ cmdb-items]]
-   (let [type-ids (distinct (keep :jira_object_type cmdb-items))]
-     (if (< (count type-ids) 2)
-       {:db (assoc-in db [:jira-templates :cmdb-relations] [])}
-       {:db (assoc-in db [:jira-templates :cmdb-relations] [])
+   (let [fields (distinct (keep :jira_field cmdb-items))]
+     (if (empty? fields)
+       {:db (assoc-in db [:jira-templates :cmdb-fieldconfigs] {})}
+       {:db (assoc-in db [:jira-templates :cmdb-fieldconfigs] {})
         :fx [[:dispatch
               [:fetch {:method "GET"
-                       :uri (str "/integrations/jira/assets/objecttypes/attributes?object_type_ids="
-                                 (js/encodeURIComponent (cs/join "," type-ids)))
-                       :on-success #(rf/dispatch [:jira-templates->set-cmdb-relations (:items %)])
+                       :uri (str "/integrations/jira/assets/fieldconfigs?jira_fields="
+                                 (js/encodeURIComponent (cs/join "," fields)))
+                       :on-success #(rf/dispatch [:jira-templates->set-cmdb-fieldconfigs (:items %)])
                        ;; No cascade is better than a broken prompt: fall back
-                       ;; to unfiltered dropdowns when the schema lookup fails.
-                       :on-failure #(rf/dispatch [:jira-templates->set-cmdb-relations []])}]]]}))))
+                       ;; to unfiltered dropdowns when the config lookup fails.
+                       :on-failure #(rf/dispatch [:jira-templates->set-cmdb-fieldconfigs []])}]]]}))))
 
 (rf/reg-event-fx
- :jira-templates->set-cmdb-relations
- (fn [{:keys [db]} [_ relations]]
-   (let [relations (vec relations)
+ :jira-templates->set-cmdb-fieldconfigs
+ (fn [{:keys [db]} [_ config-items]]
+   (let [fieldconfigs (cascade/index-configs config-items)
          items (get-in db [:jira-templates->submit-template :data :cmdb_types :items])
          template-id (get-in db [:jira-templates->submit-template :data :id])
-         ;; Rows whose filter is already derivable (an upstream row prefilled
-         ;; by the template config, or selected before the schema lookup
-         ;; landed) are refetched now with the AQL applied. Nothing selected
-         ;; means no dispatches: the common path is unchanged.
-         needs-refetch (filter #(some? (cascade/aql-for % items relations)) items)]
-     {:db (assoc-in db [:jira-templates :cmdb-relations] relations)
-      :fx (vec (for [item needs-refetch]
+         ;; Every configured row is refreshed: the field configuration
+         ;; replaces the template's object type, so the fetch that already
+         ;; went out with the legacy scope must be redone (or emptied, when
+         ;; the row waits on an upstream selection). Unconfigured fields keep
+         ;; their in-flight fetch.
+         configured (filter #(some? (cascade/filter-for % items fieldconfigs)) items)]
+     {:db (assoc-in db [:jira-templates :cmdb-fieldconfigs] fieldconfigs)
+      :fx (vec (for [item configured]
                  [:dispatch [:jira-templates->get-cmdb-values template-id item 1 "" true]]))})))
 
 (rf/reg-sub
- :jira-templates->cmdb-relations
+ :jira-templates->cmdb-fieldconfigs
  (fn [db _]
-   (get-in db [:jira-templates :cmdb-relations] [])))
+   (get-in db [:jira-templates :cmdb-fieldconfigs] {})))
 
 (rf/reg-event-fx
  :jira-templates->update-cmdb-value
@@ -88,8 +89,8 @@
          ;; name so sibling rows can substitute it into their AQL filters.
          selected-name (:name (first (filter #(= (:id %) value)
                                              (:jira_values cmdb-item))))
-         relations (get-in db [:jira-templates :cmdb-relations] [])
-         dependents (cascade/all-dependents cmdb-item cmdb-items relations)
+         fieldconfigs (get-in db [:jira-templates :cmdb-fieldconfigs] {})
+         dependents (cascade/all-dependents cmdb-item cmdb-items fieldconfigs)
          dependent-fields (set (map :jira_field dependents))
          updated-cmdb-items (map (fn [item]
                                    (cond
@@ -127,32 +128,46 @@
          cmdb-items (get-in db [:jira-templates->submit-template :data :cmdb_types :items])
          current-item (or (first (filter #(= (:jira_field %) (:jira_field cmdb-item)) cmdb-items))
                           cmdb-item)
-         relations (get-in db [:jira-templates :cmdb-relations] [])
-         aql (cascade/aql-for current-item cmdb-items relations)
+         fieldconfigs (get-in db [:jira-templates :cmdb-fieldconfigs] {})
+         field-filter (cascade/filter-for current-item cmdb-items fieldconfigs)
+         ;; The field configuration owns the scope when present: its AQL
+         ;; replaces the template's object type and its schema wins too.
+         schema-id (or (:object-schema-id field-filter) (:jira_object_schema_id cmdb-item))
          ;; Monotonic id per object type: only the latest in-flight fetch may
          ;; update the dropdown, so a slower older response cannot overwrite
-         ;; AQL-filtered options with unfiltered ones.
-         request-id (inc (get-in db [:jira-templates :cmdb-request-id object-type] 0))]
-     {:db (assoc-in db [:jira-templates :cmdb-request-id object-type] request-id)
-      :fx [[:dispatch [:jira-templates->set-cmdb-loading object-type true]]
-           [:dispatch
-            [:fetch {:method "GET"
-                     :uri (str "/integrations/jira/assets/objects?"
-                               "object_type_id=" object-type
-                               "&object_schema_id=" (:jira_object_schema_id cmdb-item)
-                               "&offset=" (* (- page 1) (:per-page pagination))
-                               "&limit=" (:per-page pagination)
-                               (when-not (empty? search-term)
-                                 (str "&name=" (js/encodeURIComponent search-term)))
-                               (when-not (empty? aql)
-                                 (str "&aql=" (js/encodeURIComponent aql))))
-                     :on-success (fn [response]
-                                   (rf/dispatch [:jira-templates->cmdb-values-success cmdb-item request-id
-                                                 {:page page
-                                                  :per-page (:per-page pagination)
-                                                  :response response}]))
-                     :on-failure (fn [_error]
-                                   (rf/dispatch [:jira-templates->cmdb-values-failure cmdb-item request-id cascade?]))}]]]})))
+         ;; AQL-filtered options with unfiltered ones. Bumped for the pending
+         ;; case too, to invalidate anything already in flight.
+         request-id (inc (get-in db [:jira-templates :cmdb-request-id object-type] 0))
+         db (assoc-in db [:jira-templates :cmdb-request-id object-type] request-id)]
+     (if (= :pending field-filter)
+       ;; Configured, but the dependent-field filter has no upstream
+       ;; selection yet: the field accepts nothing, so offer nothing.
+       {:db db
+        :fx [[:dispatch [:jira-templates->set-cmdb-loading object-type false]]
+             [:dispatch [:jira-templates->set-cmdb-pagination
+                         cmdb-item
+                         {:page 1 :per-page (:per-page pagination) :total-items 0}]]
+             [:dispatch [:jira-templates->merge-cmdb-values cmdb-item []]]]}
+       {:db db
+        :fx [[:dispatch [:jira-templates->set-cmdb-loading object-type true]]
+             [:dispatch
+              [:fetch {:method "GET"
+                       :uri (str "/integrations/jira/assets/objects?"
+                                 "object_type_id=" object-type
+                                 "&object_schema_id=" schema-id
+                                 "&offset=" (* (- page 1) (:per-page pagination))
+                                 "&limit=" (:per-page pagination)
+                                 (when-not (empty? search-term)
+                                   (str "&name=" (js/encodeURIComponent search-term)))
+                                 (when-not (empty? (:aql field-filter))
+                                   (str "&aql=" (js/encodeURIComponent (:aql field-filter)))))
+                       :on-success (fn [response]
+                                     (rf/dispatch [:jira-templates->cmdb-values-success cmdb-item request-id
+                                                   {:page page
+                                                    :per-page (:per-page pagination)
+                                                    :response response}]))
+                       :on-failure (fn [_error]
+                                     (rf/dispatch [:jira-templates->cmdb-values-failure cmdb-item request-id cascade?]))}]]]}))))
 
 (rf/reg-event-fx
  :jira-templates->cmdb-values-success
@@ -304,7 +319,7 @@
                               :uri (str "/integrations/jira/issuetemplates/" id)
                               :on-success (fn [template]
                                             (rf/dispatch [:jira-templates->set-submit-template template])
-                                            (rf/dispatch [:jira-templates->get-cmdb-relations (get-in template [:cmdb_types :items])])
+                                            (rf/dispatch [:jira-templates->get-cmdb-fieldconfigs (get-in template [:cmdb_types :items])])
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
                                               (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) true])
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item 1 ""])))
@@ -321,7 +336,7 @@
                               :uri (str "/integrations/jira/issuetemplates/" id)
                               :on-success (fn [template]
                                             (rf/dispatch [:jira-templates->set-submit-template-re-run template])
-                                            (rf/dispatch [:jira-templates->get-cmdb-relations (get-in template [:cmdb_types :items])])
+                                            (rf/dispatch [:jira-templates->get-cmdb-fieldconfigs (get-in template [:cmdb_types :items])])
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
                                               (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) true])
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item 1 ""])))

--- a/webapp/src/webapp/events/jira_templates.cljs
+++ b/webapp/src/webapp/events/jira_templates.cljs
@@ -59,10 +59,20 @@
                        ;; to unfiltered dropdowns when the schema lookup fails.
                        :on-failure #(rf/dispatch [:jira-templates->set-cmdb-relations []])}]]]}))))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  :jira-templates->set-cmdb-relations
- (fn [db [_ relations]]
-   (assoc-in db [:jira-templates :cmdb-relations] (vec relations))))
+ (fn [{:keys [db]} [_ relations]]
+   (let [relations (vec relations)
+         items (get-in db [:jira-templates->submit-template :data :cmdb_types :items])
+         template-id (get-in db [:jira-templates->submit-template :data :id])
+         ;; Rows whose filter is already derivable (an upstream row prefilled
+         ;; by the template config, or selected before the schema lookup
+         ;; landed) are refetched now with the AQL applied. Nothing selected
+         ;; means no dispatches: the common path is unchanged.
+         needs-refetch (filter #(some? (cascade/aql-for % items relations)) items)]
+     {:db (assoc-in db [:jira-templates :cmdb-relations] relations)
+      :fx (vec (for [item needs-refetch]
+                 [:dispatch [:jira-templates->get-cmdb-values template-id item 1 "" true]]))})))
 
 (rf/reg-sub
  :jira-templates->cmdb-relations
@@ -79,7 +89,7 @@
          selected-name (:name (first (filter #(= (:id %) value)
                                              (:jira_values cmdb-item))))
          relations (get-in db [:jira-templates :cmdb-relations] [])
-         dependents (cascade/dependents-of cmdb-item cmdb-items relations)
+         dependents (cascade/all-dependents cmdb-item cmdb-items relations)
          dependent-fields (set (map :jira_field dependents))
          updated-cmdb-items (map (fn [item]
                                    (cond
@@ -96,15 +106,21 @@
          updated-template (assoc-in current-template [:cmdb_types :items] updated-cmdb-items)
          template-id (:id current-template)]
      {:db (assoc-in db [:jira-templates->submit-template :data] updated-template)
-      :fx (vec (for [dep dependents]
-                 [:dispatch [:jira-templates->get-cmdb-values template-id dep]]))})))
+      ;; Dependents refetch as cascade fetches (last arg): a failure keeps
+      ;; the options already loaded instead of opening the retry modal, and
+      ;; any stale search term is dropped alongside the stale pick.
+      :fx (vec (mapcat (fn [dep]
+                         [[:dispatch [:jira-templates->set-cmdb-search dep ""]]
+                          [:dispatch [:jira-templates->get-cmdb-values template-id dep 1 "" true]]])
+                       dependents))})))
 
 (rf/reg-event-fx
  :jira-templates->get-cmdb-values
- (fn [{:keys [db]} [_ template-id cmdb-item & [page search-term]]]
+ (fn [{:keys [db]} [_ template-id cmdb-item & [page search-term cascade?]]]
    (let [page (or page 1)
          search-term (or search-term "")
-         pagination (get-in db [:jira-templates :cmdb-pagination (:jira_object_type cmdb-item)]
+         object-type (:jira_object_type cmdb-item)
+         pagination (get-in db [:jira-templates :cmdb-pagination object-type]
                             {:page page :per-page 50})
          ;; Resolve against the freshest row state: the component may hand us
          ;; an item captured before the latest sibling selection.
@@ -112,12 +128,17 @@
          current-item (or (first (filter #(= (:jira_field %) (:jira_field cmdb-item)) cmdb-items))
                           cmdb-item)
          relations (get-in db [:jira-templates :cmdb-relations] [])
-         aql (cascade/aql-for current-item cmdb-items relations)]
-     {:fx [[:dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) true]]
+         aql (cascade/aql-for current-item cmdb-items relations)
+         ;; Monotonic id per object type: only the latest in-flight fetch may
+         ;; update the dropdown, so a slower older response cannot overwrite
+         ;; AQL-filtered options with unfiltered ones.
+         request-id (inc (get-in db [:jira-templates :cmdb-request-id object-type] 0))]
+     {:db (assoc-in db [:jira-templates :cmdb-request-id object-type] request-id)
+      :fx [[:dispatch [:jira-templates->set-cmdb-loading object-type true]]
            [:dispatch
             [:fetch {:method "GET"
                      :uri (str "/integrations/jira/assets/objects?"
-                               "object_type_id=" (:jira_object_type cmdb-item)
+                               "object_type_id=" object-type
                                "&object_schema_id=" (:jira_object_schema_id cmdb-item)
                                "&offset=" (* (- page 1) (:per-page pagination))
                                "&limit=" (:per-page pagination)
@@ -126,16 +147,44 @@
                                (when-not (empty? aql)
                                  (str "&aql=" (js/encodeURIComponent aql))))
                      :on-success (fn [response]
-                                   (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) false])
-                                   (rf/dispatch [:jira-templates->set-cmdb-pagination
-                                                 cmdb-item
+                                   (rf/dispatch [:jira-templates->cmdb-values-success cmdb-item request-id
                                                  {:page page
                                                   :per-page (:per-page pagination)
-                                                  :total-items (:total response)}])
-                                   (rf/dispatch [:jira-templates->merge-cmdb-values cmdb-item (:values response)]))
-                     :on-failure (fn [error]
-                                   (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) false])
-                                   (rf/dispatch [:jira-templates->merge-cmdb-values cmdb-item nil]))}]]]})))
+                                                  :response response}]))
+                     :on-failure (fn [_error]
+                                   (rf/dispatch [:jira-templates->cmdb-values-failure cmdb-item request-id cascade?]))}]]]})))
+
+(rf/reg-event-fx
+ :jira-templates->cmdb-values-success
+ (fn [{:keys [db]} [_ cmdb-item request-id {:keys [page per-page response]}]]
+   (let [object-type (:jira_object_type cmdb-item)]
+     (if (not= request-id (get-in db [:jira-templates :cmdb-request-id object-type]))
+       {} ;; stale: a newer fetch for this object type is in flight
+       {:fx [[:dispatch [:jira-templates->set-cmdb-loading object-type false]]
+             [:dispatch [:jira-templates->set-cmdb-pagination
+                         cmdb-item
+                         {:page page
+                          :per-page per-page
+                          :total-items (:total response)}]]
+             [:dispatch [:jira-templates->merge-cmdb-values cmdb-item (:values response)]]]}))))
+
+(rf/reg-event-fx
+ :jira-templates->cmdb-values-failure
+ (fn [{:keys [db]} [_ cmdb-item request-id cascade?]]
+   (let [object-type (:jira_object_type cmdb-item)]
+     (cond
+       (not= request-id (get-in db [:jira-templates :cmdb-request-id object-type]))
+       {} ;; stale: a newer fetch for this object type is in flight
+
+       ;; A failed cascade refetch degrades to the options already loaded
+       ;; instead of escalating to the retry modal, which would remount the
+       ;; form and discard everything the user already typed.
+       cascade?
+       {:fx [[:dispatch [:jira-templates->set-cmdb-loading object-type false]]]}
+
+       :else
+       {:fx [[:dispatch [:jira-templates->set-cmdb-loading object-type false]]
+             [:dispatch [:jira-templates->merge-cmdb-values cmdb-item nil]]]}))))
 
 (rf/reg-event-fx
  :jira-templates->merge-cmdb-values

--- a/webapp/src/webapp/events/jira_templates.cljs
+++ b/webapp/src/webapp/events/jira_templates.cljs
@@ -1,6 +1,8 @@
 (ns webapp.events.jira-templates
   (:require
+   [clojure.string :as cs]
    [re-frame.core :as rf]
+   [webapp.jira-templates.cascade :as cascade]
    [webapp.jira-templates.prompt-form :as prompt-form]
    [webapp.jira-templates.loading-jira-templates :as loading-jira-templates]
    [webapp.jira-templates.cmdb-error :as cmdb-error]))
@@ -39,18 +41,63 @@
  (fn [db [_ object-type loading?]]
    (assoc-in db [:jira-templates :cmdb-loading object-type] loading?)))
 
+;; The Assets schema edges (object-reference attributes between the template's
+;; object types) that drive the dropdown cascade. Fetched once per prompt.
+(rf/reg-event-fx
+ :jira-templates->get-cmdb-relations
+ (fn [{:keys [db]} [_ cmdb-items]]
+   (let [type-ids (distinct (keep :jira_object_type cmdb-items))]
+     (if (< (count type-ids) 2)
+       {:db (assoc-in db [:jira-templates :cmdb-relations] [])}
+       {:db (assoc-in db [:jira-templates :cmdb-relations] [])
+        :fx [[:dispatch
+              [:fetch {:method "GET"
+                       :uri (str "/integrations/jira/assets/objecttypes/attributes?object_type_ids="
+                                 (js/encodeURIComponent (cs/join "," type-ids)))
+                       :on-success #(rf/dispatch [:jira-templates->set-cmdb-relations (:items %)])
+                       ;; No cascade is better than a broken prompt: fall back
+                       ;; to unfiltered dropdowns when the schema lookup fails.
+                       :on-failure #(rf/dispatch [:jira-templates->set-cmdb-relations []])}]]]}))))
+
 (rf/reg-event-db
+ :jira-templates->set-cmdb-relations
+ (fn [db [_ relations]]
+   (assoc-in db [:jira-templates :cmdb-relations] (vec relations))))
+
+(rf/reg-sub
+ :jira-templates->cmdb-relations
+ (fn [db _]
+   (get-in db [:jira-templates :cmdb-relations] [])))
+
+(rf/reg-event-fx
  :jira-templates->update-cmdb-value
- (fn [db [_ cmdb-item value]]
+ (fn [{:keys [db]} [_ cmdb-item value]]
    (let [current-template (get-in db [:jira-templates->submit-template :data])
          cmdb-items (get-in current-template [:cmdb_types :items])
+         ;; The searchbox hands us the selected object id; keep the matching
+         ;; name so sibling rows can substitute it into their AQL filters.
+         selected-name (:name (first (filter #(= (:id %) value)
+                                             (:jira_values cmdb-item))))
+         relations (get-in db [:jira-templates :cmdb-relations] [])
+         dependents (cascade/dependents-of cmdb-item cmdb-items relations)
+         dependent-fields (set (map :jira_field dependents))
          updated-cmdb-items (map (fn [item]
-                                   (if (= (:jira_field item) (:jira_field cmdb-item))
-                                     (assoc item :value value)
-                                     item))
+                                   (cond
+                                     (= (:jira_field item) (:jira_field cmdb-item))
+                                     (assoc item :value value :selected-name selected-name)
+
+                                     ;; A row filtered by this selection loses its
+                                     ;; current pick and gets refetched below.
+                                     (contains? dependent-fields (:jira_field item))
+                                     (assoc item :value nil :selected-name nil)
+
+                                     :else item))
                                  cmdb-items)
-         updated-template (assoc-in current-template [:cmdb_types :items] updated-cmdb-items)]
-     (assoc-in db [:jira-templates->submit-template :data] updated-template))))
+         updated-template (assoc-in current-template [:cmdb_types :items] updated-cmdb-items)
+         template-id (:id current-template)]
+     {:db (assoc-in db [:jira-templates->submit-template :data] updated-template)
+      :fx (vec (for [dep dependents]
+                 [:dispatch [:jira-templates->get-cmdb-values template-id dep]]))})))
 
 (rf/reg-event-fx
  :jira-templates->get-cmdb-values
@@ -58,7 +105,14 @@
    (let [page (or page 1)
          search-term (or search-term "")
          pagination (get-in db [:jira-templates :cmdb-pagination (:jira_object_type cmdb-item)]
-                            {:page page :per-page 50})]
+                            {:page page :per-page 50})
+         ;; Resolve against the freshest row state: the component may hand us
+         ;; an item captured before the latest sibling selection.
+         cmdb-items (get-in db [:jira-templates->submit-template :data :cmdb_types :items])
+         current-item (or (first (filter #(= (:jira_field %) (:jira_field cmdb-item)) cmdb-items))
+                          cmdb-item)
+         relations (get-in db [:jira-templates :cmdb-relations] [])
+         aql (cascade/aql-for current-item cmdb-items relations)]
      {:fx [[:dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) true]]
            [:dispatch
             [:fetch {:method "GET"
@@ -68,7 +122,9 @@
                                "&offset=" (* (- page 1) (:per-page pagination))
                                "&limit=" (:per-page pagination)
                                (when-not (empty? search-term)
-                                 (str "&name=" (js/encodeURIComponent search-term))))
+                                 (str "&name=" (js/encodeURIComponent search-term)))
+                               (when-not (empty? aql)
+                                 (str "&aql=" (js/encodeURIComponent aql))))
                      :on-success (fn [response]
                                    (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) false])
                                    (rf/dispatch [:jira-templates->set-cmdb-pagination
@@ -199,6 +255,7 @@
                               :uri (str "/integrations/jira/issuetemplates/" id)
                               :on-success (fn [template]
                                             (rf/dispatch [:jira-templates->set-submit-template template])
+                                            (rf/dispatch [:jira-templates->get-cmdb-relations (get-in template [:cmdb_types :items])])
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
                                               (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) true])
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item 1 ""])))
@@ -215,6 +272,7 @@
                               :uri (str "/integrations/jira/issuetemplates/" id)
                               :on-success (fn [template]
                                             (rf/dispatch [:jira-templates->set-submit-template-re-run template])
+                                            (rf/dispatch [:jira-templates->get-cmdb-relations (get-in template [:cmdb_types :items])])
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
                                               (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) true])
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item 1 ""])))

--- a/webapp/src/webapp/events/jira_templates.cljs
+++ b/webapp/src/webapp/events/jira_templates.cljs
@@ -10,36 +10,39 @@
 ;; CMDB
 
 ;; Estado adicional para paginação e busca de CMDB
+;; All per-row CMDB state (pagination, search, loading, request ids) is keyed
+;; by the row's jira_field: object types are not unique across rows, and two
+;; rows sharing a type may carry different field-config AQL filters.
 (rf/reg-event-db
  :jira-templates->set-cmdb-pagination
  (fn [db [_ cmdb-item pagination]]
-   (assoc-in db [:jira-templates :cmdb-pagination (:jira_object_type cmdb-item)] pagination)))
+   (assoc-in db [:jira-templates :cmdb-pagination (:jira_field cmdb-item)] pagination)))
 
 (rf/reg-event-db
  :jira-templates->set-cmdb-search
  (fn [db [_ cmdb-item search-term]]
-   (assoc-in db [:jira-templates :cmdb-search (:jira_object_type cmdb-item)] search-term)))
+   (assoc-in db [:jira-templates :cmdb-search (:jira_field cmdb-item)] search-term)))
 
 (rf/reg-sub
  :jira-templates->cmdb-pagination
- (fn [db [_ object-type]]
-   (get-in db [:jira-templates :cmdb-pagination object-type]
+ (fn [db [_ jira-field]]
+   (get-in db [:jira-templates :cmdb-pagination jira-field]
            {:page 1 :per-page 50 :total-items 0})))
 
 (rf/reg-sub
  :jira-templates->cmdb-search
- (fn [db [_ object-type]]
-   (get-in db [:jira-templates :cmdb-search object-type] "")))
+ (fn [db [_ jira-field]]
+   (get-in db [:jira-templates :cmdb-search jira-field] "")))
 
 (rf/reg-sub
  :jira-templates->cmdb-loading?
- (fn [db [_ object-type]]
-   (get-in db [:jira-templates :cmdb-loading object-type] false)))
+ (fn [db [_ jira-field]]
+   (get-in db [:jira-templates :cmdb-loading jira-field] false)))
 
 (rf/reg-event-db
  :jira-templates->set-cmdb-loading
- (fn [db [_ object-type loading?]]
-   (assoc-in db [:jira-templates :cmdb-loading object-type] loading?)))
+ (fn [db [_ jira-field loading?]]
+   (assoc-in db [:jira-templates :cmdb-loading jira-field] loading?)))
 
 ;; The AQL configuration of each row's Assets custom field (the same filters
 ;; Jira's portal applies) drives the dropdown cascade. Fetched once per prompt.
@@ -97,10 +100,13 @@
                                      (= (:jira_field item) (:jira_field cmdb-item))
                                      (assoc item :value value :selected-name selected-name)
 
-                                     ;; A row filtered by this selection loses its
-                                     ;; current pick and gets refetched below.
+                                     ;; A row filtered by this selection loses
+                                     ;; its current pick AND its loaded options:
+                                     ;; they belong to the previous upstream
+                                     ;; selection, and must not stay selectable
+                                     ;; if the refetch below fails.
                                      (contains? dependent-fields (:jira_field item))
-                                     (assoc item :value nil :selected-name nil)
+                                     (assoc item :value nil :selected-name nil :jira_values [])
 
                                      :else item))
                                  cmdb-items)
@@ -121,7 +127,8 @@
    (let [page (or page 1)
          search-term (or search-term "")
          object-type (:jira_object_type cmdb-item)
-         pagination (get-in db [:jira-templates :cmdb-pagination object-type]
+         field (:jira_field cmdb-item)
+         pagination (get-in db [:jira-templates :cmdb-pagination field]
                             {:page page :per-page 50})
          ;; Resolve against the freshest row state: the component may hand us
          ;; an item captured before the latest sibling selection.
@@ -133,23 +140,23 @@
          ;; The field configuration owns the scope when present: its AQL
          ;; replaces the template's object type and its schema wins too.
          schema-id (or (:object-schema-id field-filter) (:jira_object_schema_id cmdb-item))
-         ;; Monotonic id per object type: only the latest in-flight fetch may
-         ;; update the dropdown, so a slower older response cannot overwrite
-         ;; AQL-filtered options with unfiltered ones. Bumped for the pending
-         ;; case too, to invalidate anything already in flight.
-         request-id (inc (get-in db [:jira-templates :cmdb-request-id object-type] 0))
-         db (assoc-in db [:jira-templates :cmdb-request-id object-type] request-id)]
+         ;; Monotonic id per row (jira_field): only the latest in-flight fetch
+         ;; may update the dropdown, so a slower older response cannot
+         ;; overwrite AQL-filtered options with unfiltered ones. Bumped for
+         ;; the pending case too, to invalidate anything already in flight.
+         request-id (inc (get-in db [:jira-templates :cmdb-request-id field] 0))
+         db (assoc-in db [:jira-templates :cmdb-request-id field] request-id)]
      (if (= :pending field-filter)
        ;; Configured, but the dependent-field filter has no upstream
        ;; selection yet: the field accepts nothing, so offer nothing.
        {:db db
-        :fx [[:dispatch [:jira-templates->set-cmdb-loading object-type false]]
+        :fx [[:dispatch [:jira-templates->set-cmdb-loading field false]]
              [:dispatch [:jira-templates->set-cmdb-pagination
                          cmdb-item
                          {:page 1 :per-page (:per-page pagination) :total-items 0}]]
              [:dispatch [:jira-templates->merge-cmdb-values cmdb-item []]]]}
        {:db db
-        :fx [[:dispatch [:jira-templates->set-cmdb-loading object-type true]]
+        :fx [[:dispatch [:jira-templates->set-cmdb-loading field true]]
              [:dispatch
               [:fetch {:method "GET"
                        :uri (str "/integrations/jira/assets/objects?"
@@ -172,10 +179,10 @@
 (rf/reg-event-fx
  :jira-templates->cmdb-values-success
  (fn [{:keys [db]} [_ cmdb-item request-id {:keys [page per-page response]}]]
-   (let [object-type (:jira_object_type cmdb-item)]
-     (if (not= request-id (get-in db [:jira-templates :cmdb-request-id object-type]))
-       {} ;; stale: a newer fetch for this object type is in flight
-       {:fx [[:dispatch [:jira-templates->set-cmdb-loading object-type false]]
+   (let [field (:jira_field cmdb-item)]
+     (if (not= request-id (get-in db [:jira-templates :cmdb-request-id field]))
+       {} ;; stale: a newer fetch for this row is in flight
+       {:fx [[:dispatch [:jira-templates->set-cmdb-loading field false]]
              [:dispatch [:jira-templates->set-cmdb-pagination
                          cmdb-item
                          {:page page
@@ -186,19 +193,20 @@
 (rf/reg-event-fx
  :jira-templates->cmdb-values-failure
  (fn [{:keys [db]} [_ cmdb-item request-id cascade?]]
-   (let [object-type (:jira_object_type cmdb-item)]
+   (let [field (:jira_field cmdb-item)]
      (cond
-       (not= request-id (get-in db [:jira-templates :cmdb-request-id object-type]))
-       {} ;; stale: a newer fetch for this object type is in flight
+       (not= request-id (get-in db [:jira-templates :cmdb-request-id field]))
+       {} ;; stale: a newer fetch for this row is in flight
 
-       ;; A failed cascade refetch degrades to the options already loaded
-       ;; instead of escalating to the retry modal, which would remount the
-       ;; form and discard everything the user already typed.
+       ;; A failed cascade refetch degrades to whatever the row currently
+       ;; offers (dependents were already emptied at invalidation) instead of
+       ;; escalating to the retry modal, which would remount the form and
+       ;; discard everything the user already typed.
        cascade?
-       {:fx [[:dispatch [:jira-templates->set-cmdb-loading object-type false]]]}
+       {:fx [[:dispatch [:jira-templates->set-cmdb-loading field false]]]}
 
        :else
-       {:fx [[:dispatch [:jira-templates->set-cmdb-loading object-type false]]
+       {:fx [[:dispatch [:jira-templates->set-cmdb-loading field false]]
              [:dispatch [:jira-templates->merge-cmdb-values cmdb-item nil]]]}))))
 
 (rf/reg-event-fx
@@ -210,7 +218,7 @@
          failed-request? (nil? value)
          ;; Update items
          updated-cmdb-items (map (fn [item]
-                                   (if (= (:jira_object_type item) (:jira_object_type cmdb-item))
+                                   (if (= (:jira_field item) (:jira_field cmdb-item))
                                      (-> item
                                          (assoc :request-failed failed-request?)
                                          (assoc :jira_values (merge value)))
@@ -321,7 +329,7 @@
                                             (rf/dispatch [:jira-templates->set-submit-template template])
                                             (rf/dispatch [:jira-templates->get-cmdb-fieldconfigs (get-in template [:cmdb_types :items])])
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
-                                              (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) true])
+                                              (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_field cmdb-item) true])
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item 1 ""])))
                               :on-failure #(rf/dispatch [:jira-templates->set-submit-template nil])}]}]]}))
 
@@ -338,7 +346,7 @@
                                             (rf/dispatch [:jira-templates->set-submit-template-re-run template])
                                             (rf/dispatch [:jira-templates->get-cmdb-fieldconfigs (get-in template [:cmdb_types :items])])
                                             (doseq [cmdb-item (get-in template [:cmdb_types :items])]
-                                              (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_object_type cmdb-item) true])
+                                              (rf/dispatch [:jira-templates->set-cmdb-loading (:jira_field cmdb-item) true])
                                               (rf/dispatch [:jira-templates->get-cmdb-values id cmdb-item 1 ""])))
                               :on-failure #(rf/dispatch [:jira-templates->set-submit-template-re-run nil])}]}]]}))
 

--- a/webapp/src/webapp/jira_templates/cascade.cljs
+++ b/webapp/src/webapp/jira_templates/cascade.cljs
@@ -1,12 +1,29 @@
 (ns webapp.jira-templates.cascade
-  "Schema-driven cascade for CMDB dropdowns in the runtime prompt.
+  "Field-config-driven cascade for CMDB dropdowns in the runtime prompt.
 
-   The Jira Assets schema defines the edges: relations are the
-   object-reference attributes fetched from the Assets API, each
-   {:object_type_id :attribute_name :reference_object_type_id}. A dropdown
-   whose object type carries a reference attribute is filtered by an AQL
-   clause per attribute whose target type has a selected sibling row."
+   Each Assets custom field carries its own AQL configuration in Jira (the
+   same one the JSM portal applies): an object scope filter plus an optional
+   issue scope filter that may reference sibling fields with
+   ${customfield_x.label} placeholders — Jira's native dependent-field
+   mechanism. fieldconfigs is a map of jira_field ->
+   {:object-filter \"...\" :issue-scope \"...\"}; fields absent from the map
+   (plain text fields, unconfigured Assets fields) never filter and never
+   cascade."
   (:require [clojure.string :as cs]))
+
+(def ^:private placeholder-re #"\$\{(customfield_\d+)(?:\.([A-Za-z]+))?\}")
+
+(defn index-configs
+  "API items [{:jira_field :object_schema_id :object_filter_query
+   :issue_scope_filter_query}] -> {jira_field {:object-schema-id ...
+   :object-filter ... :issue-scope ...}}."
+  [items]
+  (into {}
+        (map (juxt :jira_field
+                   #(hash-map :object-schema-id (:object_schema_id %)
+                              :object-filter (:object_filter_query %)
+                              :issue-scope (:issue_scope_filter_query %))))
+        items))
 
 (defn- selected-name
   "Selected object name for a row: prefer the name captured at selection
@@ -25,53 +42,91 @@
                 (cs/replace "\\" "\\\\")
                 (cs/replace "\"" "\\\"")) "\""))
 
+(defn- placeholder-value
+  "Quoted substitution for a ${customfield_x[.suffix]} placeholder: the
+   sibling row's selected object name (label/bare) or raw value (any other
+   suffix, e.g. .id). nil while the referenced row has no selection."
+  [items field suffix]
+  (when-let [row (first (filter #(= (:jira_field %) field) items))]
+    (let [raw (if (contains? #{nil "label"} suffix)
+                (selected-name row)
+                (:value row))]
+      (when-not (cs/blank? raw)
+        (quote-aql raw)))))
+
+(defn- substitute-placeholders
+  "Resolve every placeholder in aql against the sibling rows' selections.
+   Returns nil when any placeholder is unresolved: a partially substituted
+   filter would silently show wrong options."
+  [aql items]
+  (let [unresolved? (atom false)
+        resolved (cs/replace aql placeholder-re
+                             (fn [[_ field suffix]]
+                               (or (placeholder-value items field suffix)
+                                   (do (reset! unresolved? true) ""))))]
+    (when-not @unresolved? resolved)))
+
+(defn filter-for
+  "How to scope item's dropdown, from its Jira field configuration:
+
+     nil       - the field has no Assets configuration; the caller keeps its
+                 own object type scope (unchanged legacy behaviour).
+     :pending  - configured, but its dependent-field placeholders have no
+                 selection yet; the field accepts nothing until the upstream
+                 row is picked, so the caller must show no options rather
+                 than fall back to a scope Jira would reject.
+     {:aql ... :object-schema-id ...}
+               - the AQL Jira itself applies to this field: the object scope
+                 filter, AND-composed with the resolved issue scope filter.
+
+   The AQL replaces the template's object type: the field configuration
+   already defines every object the field accepts."
+  [item items fieldconfigs]
+  (when-let [{:keys [object-schema-id object-filter issue-scope]}
+             (get fieldconfigs (:jira_field item))]
+    (let [scope (when-not (cs/blank? issue-scope)
+                  (substitute-placeholders issue-scope items))
+          clauses (remove cs/blank? [object-filter scope])]
+      (cond
+        (seq clauses)
+        {:aql (if (= 1 (count clauses))
+                (first clauses)
+                (cs/join " AND " (map #(str "(" % ")") clauses)))
+         :object-schema-id object-schema-id}
+
+        ;; configured with an unresolved dependency only
+        (not (cs/blank? issue-scope)) :pending
+
+        ;; configured with nothing to filter by
+        :else nil))))
+
+(defn- references?
+  "Does item's issue scope filter reference changed-field via placeholder?"
+  [fieldconfigs item changed-field]
+  (let [issue-scope (get-in fieldconfigs [(:jira_field item) :issue-scope])]
+    (some #(= changed-field (second %))
+          (re-seq placeholder-re (str issue-scope)))))
+
 (defn dependents-of
-  "Rows whose object type has a reference attribute pointing at the
-   changed row's object type."
-  [changed-item items relations]
-  (let [changed-type (:jira_object_type changed-item)
-        dependent-types (into #{}
-                              (comp (filter #(= (:reference_object_type_id %) changed-type))
-                                    (map :object_type_id))
-                              relations)]
-    (filter #(and (not= (:jira_field %) (:jira_field changed-item))
-                  (contains? dependent-types (:jira_object_type %)))
-            items)))
+  "Rows whose issue scope filter references the changed row's field."
+  [changed-item items fieldconfigs]
+  (filter #(and (not= (:jira_field %) (:jira_field changed-item))
+                (references? fieldconfigs % (:jira_field changed-item)))
+          items))
 
 (defn all-dependents
   "Transitive closure of dependents-of, breadth-first: a cleared row clears
    its own dependents in turn (A -> B -> C), so a chain never keeps a pick
    that was filtered by a now-cleared upstream. The seen set makes cyclic
-   schema references terminate."
-  [changed-item items relations]
+   references terminate."
+  [changed-item items fieldconfigs]
   (loop [frontier [changed-item]
          seen #{(:jira_field changed-item)}
          acc []]
     (if-let [item (first frontier)]
       (let [deps (remove #(contains? seen (:jira_field %))
-                         (dependents-of item items relations))]
+                         (dependents-of item items fieldconfigs))]
         (recur (into (vec (rest frontier)) deps)
                (into seen (map :jira_field deps))
                (into acc deps)))
       acc)))
-
-(defn aql-for
-  "AQL filter for item derived from the Assets schema: one
-   \"Attribute\" = \"Selected name\" clause per reference attribute of the
-   item's object type whose target type has a selected sibling row. When
-   several rows share the referenced type, the first row with a selection
-   wins. Returns nil when nothing applies, so callers fall back to the
-   unfiltered fetch."
-  [item items relations]
-  (let [clauses (keep (fn [{:keys [attribute_name reference_object_type_id]}]
-                        (let [nm (->> items
-                                      (filter #(and (not= (:jira_field %) (:jira_field item))
-                                                    (= (:jira_object_type %) reference_object_type_id)))
-                                      (keep selected-name)
-                                      (remove cs/blank?)
-                                      first)]
-                          (when nm
-                            (str (quote-aql attribute_name) " = " (quote-aql nm)))))
-                      (filter #(= (:object_type_id %) (:jira_object_type item)) relations))]
-    (when (seq clauses)
-      (cs/join " AND " clauses))))

--- a/webapp/src/webapp/jira_templates/cascade.cljs
+++ b/webapp/src/webapp/jira_templates/cascade.cljs
@@ -88,14 +88,16 @@
                   (substitute-placeholders issue-scope items))
           clauses (remove cs/blank? [object-filter scope])]
       (cond
+        ;; An unresolved dependent filter wins over any static scope: Jira
+        ;; enforces BOTH filters on the field, so options matching only the
+        ;; object filter could be invalid for the final selection.
+        (and (not (cs/blank? issue-scope)) (nil? scope)) :pending
+
         (seq clauses)
         {:aql (if (= 1 (count clauses))
                 (first clauses)
                 (cs/join " AND " (map #(str "(" % ")") clauses)))
          :object-schema-id object-schema-id}
-
-        ;; configured with an unresolved dependency only
-        (not (cs/blank? issue-scope)) :pending
 
         ;; configured with nothing to filter by
         :else nil))))

--- a/webapp/src/webapp/jira_templates/cascade.cljs
+++ b/webapp/src/webapp/jira_templates/cascade.cljs
@@ -1,0 +1,51 @@
+(ns webapp.jira-templates.cascade
+  "Schema-driven cascade for CMDB dropdowns in the runtime prompt.
+
+   The Jira Assets schema defines the edges: relations are the
+   object-reference attributes fetched from the Assets API, each
+   {:object_type_id :attribute_name :reference_object_type_id}. A dropdown
+   whose object type carries a reference attribute is filtered by an AQL
+   clause per attribute whose target type has a selected sibling row."
+  (:require [clojure.string :as cs]))
+
+(defn- selected-name
+  "Selected object name for a row: prefer the name captured at selection
+   time, then a lookup of the selected id in the loaded values, then the
+   raw :value (a plain name when prefilled by the template config)."
+  [{:keys [value jira_values] :as item}]
+  (or (:selected-name item)
+      (:name (first (filter #(= (:id %) value) jira_values)))
+      (when-not (cs/blank? value) value)))
+
+(defn- quote-aql [s]
+  (str "\"" (cs/replace s "\"" "\\\"") "\""))
+
+(defn dependents-of
+  "Rows whose object type has a reference attribute pointing at the
+   changed row's object type."
+  [changed-item items relations]
+  (let [changed-type (:jira_object_type changed-item)
+        dependent-types (into #{}
+                              (comp (filter #(= (:reference_object_type_id %) changed-type))
+                                    (map :object_type_id))
+                              relations)]
+    (filter #(and (not= (:jira_field %) (:jira_field changed-item))
+                  (contains? dependent-types (:jira_object_type %)))
+            items)))
+
+(defn aql-for
+  "AQL filter for item derived from the Assets schema: one
+   \"Attribute\" = \"Selected name\" clause per reference attribute of the
+   item's object type whose target type has a selected sibling row. Returns
+   nil when nothing applies, so callers fall back to the unfiltered fetch."
+  [item items relations]
+  (let [clauses (keep (fn [{:keys [attribute_name reference_object_type_id]}]
+                        (let [upstream (first (filter #(and (not= (:jira_field %) (:jira_field item))
+                                                            (= (:jira_object_type %) reference_object_type_id))
+                                                      items))
+                              nm (some-> upstream selected-name)]
+                          (when-not (cs/blank? nm)
+                            (str (quote-aql attribute_name) " = " (quote-aql nm)))))
+                      (filter #(= (:object_type_id %) (:jira_object_type item)) relations))]
+    (when (seq clauses)
+      (cs/join " AND " clauses))))

--- a/webapp/src/webapp/jira_templates/cascade.cljs
+++ b/webapp/src/webapp/jira_templates/cascade.cljs
@@ -17,8 +17,13 @@
       (:name (first (filter #(= (:id %) value) jira_values)))
       (when-not (cs/blank? value) value)))
 
-(defn- quote-aql [s]
-  (str "\"" (cs/replace s "\"" "\\\"") "\""))
+(defn- quote-aql
+  "AQL string literal: backslashes escaped before quotes so a trailing
+   backslash cannot swallow the closing quote."
+  [s]
+  (str "\"" (-> s
+                (cs/replace "\\" "\\\\")
+                (cs/replace "\"" "\\\"")) "\""))
 
 (defn dependents-of
   "Rows whose object type has a reference attribute pointing at the
@@ -33,18 +38,39 @@
                   (contains? dependent-types (:jira_object_type %)))
             items)))
 
+(defn all-dependents
+  "Transitive closure of dependents-of, breadth-first: a cleared row clears
+   its own dependents in turn (A -> B -> C), so a chain never keeps a pick
+   that was filtered by a now-cleared upstream. The seen set makes cyclic
+   schema references terminate."
+  [changed-item items relations]
+  (loop [frontier [changed-item]
+         seen #{(:jira_field changed-item)}
+         acc []]
+    (if-let [item (first frontier)]
+      (let [deps (remove #(contains? seen (:jira_field %))
+                         (dependents-of item items relations))]
+        (recur (into (vec (rest frontier)) deps)
+               (into seen (map :jira_field deps))
+               (into acc deps)))
+      acc)))
+
 (defn aql-for
   "AQL filter for item derived from the Assets schema: one
    \"Attribute\" = \"Selected name\" clause per reference attribute of the
-   item's object type whose target type has a selected sibling row. Returns
-   nil when nothing applies, so callers fall back to the unfiltered fetch."
+   item's object type whose target type has a selected sibling row. When
+   several rows share the referenced type, the first row with a selection
+   wins. Returns nil when nothing applies, so callers fall back to the
+   unfiltered fetch."
   [item items relations]
   (let [clauses (keep (fn [{:keys [attribute_name reference_object_type_id]}]
-                        (let [upstream (first (filter #(and (not= (:jira_field %) (:jira_field item))
-                                                            (= (:jira_object_type %) reference_object_type_id))
-                                                      items))
-                              nm (some-> upstream selected-name)]
-                          (when-not (cs/blank? nm)
+                        (let [nm (->> items
+                                      (filter #(and (not= (:jira_field %) (:jira_field item))
+                                                    (= (:jira_object_type %) reference_object_type_id)))
+                                      (keep selected-name)
+                                      (remove cs/blank?)
+                                      first)]
+                          (when nm
                             (str (quote-aql attribute_name) " = " (quote-aql nm)))))
                       (filter #(= (:object_type_id %) (:jira_object_type item)) relations))]
     (when (seq clauses)

--- a/webapp/src/webapp/jira_templates/prompt_form.cljs
+++ b/webapp/src/webapp/jira_templates/prompt_form.cljs
@@ -4,6 +4,7 @@
    [re-frame.core :as rf]
    [reagent.core :as r]
    [webapp.components.forms :as forms]
+   [webapp.jira-templates.cascade :as cascade]
    [webapp.components.paginated-searchbox :as paginated-searchbox]))
 
 (defn- create-cmdb-select-options [jira-values]
@@ -55,7 +56,7 @@
                   :value (get-in @form-data [:jira_fields jira_field] "")
                   :on-change on-change}]))
 
-(defn- cmdb-field [cmdb-item template-id form-data]
+(defn- cmdb-field [cmdb-item all-items relations template-id form-data]
   (let [object-type (:jira_object_type cmdb-item)
         pagination (rf/subscribe [:jira-templates->cmdb-pagination object-type])
         search-term (rf/subscribe [:jira-templates->cmdb-search object-type])
@@ -85,10 +86,17 @@
                                        template-id cmdb-item page @search-term]))
        :on-select (fn [value]
                     (rf/dispatch [:jira-templates->update-cmdb-value cmdb-item value])
-                    (swap! form-data assoc-in [:jira_fields (:jira_field cmdb-item)] value))}]]))
+                    (swap! form-data assoc-in [:jira_fields (:jira_field cmdb-item)] value)
+                    ;; Rows the Assets schema filters by this selection are
+                    ;; cleared and refetched (db side handled by
+                    ;; update-cmdb-value); drop their stale picks from the
+                    ;; local form state too.
+                    (doseq [dep (cascade/dependents-of cmdb-item all-items relations)]
+                      (swap! form-data update :jira_fields dissoc (:jira_field dep))))}]]))
 
 (defn main [{:keys [prompts on-submit]}]
   (let [cmdb-items (rf/subscribe [:jira-templates->submit-template-cmdb-items])
+        relations (rf/subscribe [:jira-templates->cmdb-relations])
         template-id (rf/subscribe [:jira-templates->submit-template-id])
         form-data (r/atom (init-form-data @cmdb-items))]
     (fn []
@@ -130,7 +138,7 @@
            (doall
             (for [item @cmdb-items]
               ^{:key (:jira_field item)}
-              [cmdb-field item @template-id form-data])))]
+              [cmdb-field item @cmdb-items @relations @template-id form-data])))]
 
         [:> Flex {:justify "end" :gap "3" :mt "6"}
          [:> Button {:variant "soft"

--- a/webapp/src/webapp/jira_templates/prompt_form.cljs
+++ b/webapp/src/webapp/jira_templates/prompt_form.cljs
@@ -57,10 +57,10 @@
                   :on-change on-change}]))
 
 (defn- cmdb-field [cmdb-item all-items fieldconfigs template-id form-data]
-  (let [object-type (:jira_object_type cmdb-item)
-        pagination (rf/subscribe [:jira-templates->cmdb-pagination object-type])
-        search-term (rf/subscribe [:jira-templates->cmdb-search object-type])
-        loading? (rf/subscribe [:jira-templates->cmdb-loading? object-type])
+  (let [field (:jira_field cmdb-item)
+        pagination (rf/subscribe [:jira-templates->cmdb-pagination field])
+        search-term (rf/subscribe [:jira-templates->cmdb-search field])
+        loading? (rf/subscribe [:jira-templates->cmdb-loading? field])
         options (create-cmdb-select-options (:jira_values cmdb-item))]
 
     [:div.mb-4

--- a/webapp/src/webapp/jira_templates/prompt_form.cljs
+++ b/webapp/src/webapp/jira_templates/prompt_form.cljs
@@ -91,7 +91,7 @@
                     ;; cleared and refetched (db side handled by
                     ;; update-cmdb-value); drop their stale picks from the
                     ;; local form state too.
-                    (doseq [dep (cascade/dependents-of cmdb-item all-items relations)]
+                    (doseq [dep (cascade/all-dependents cmdb-item all-items relations)]
                       (swap! form-data update :jira_fields dissoc (:jira_field dep))))}]]))
 
 (defn main [{:keys [prompts on-submit]}]

--- a/webapp/src/webapp/jira_templates/prompt_form.cljs
+++ b/webapp/src/webapp/jira_templates/prompt_form.cljs
@@ -56,7 +56,7 @@
                   :value (get-in @form-data [:jira_fields jira_field] "")
                   :on-change on-change}]))
 
-(defn- cmdb-field [cmdb-item all-items relations template-id form-data]
+(defn- cmdb-field [cmdb-item all-items fieldconfigs template-id form-data]
   (let [object-type (:jira_object_type cmdb-item)
         pagination (rf/subscribe [:jira-templates->cmdb-pagination object-type])
         search-term (rf/subscribe [:jira-templates->cmdb-search object-type])
@@ -91,12 +91,12 @@
                     ;; cleared and refetched (db side handled by
                     ;; update-cmdb-value); drop their stale picks from the
                     ;; local form state too.
-                    (doseq [dep (cascade/all-dependents cmdb-item all-items relations)]
+                    (doseq [dep (cascade/all-dependents cmdb-item all-items fieldconfigs)]
                       (swap! form-data update :jira_fields dissoc (:jira_field dep))))}]]))
 
 (defn main [{:keys [prompts on-submit]}]
   (let [cmdb-items (rf/subscribe [:jira-templates->submit-template-cmdb-items])
-        relations (rf/subscribe [:jira-templates->cmdb-relations])
+        fieldconfigs (rf/subscribe [:jira-templates->cmdb-fieldconfigs])
         template-id (rf/subscribe [:jira-templates->submit-template-id])
         form-data (r/atom (init-form-data @cmdb-items))]
     (fn []
@@ -138,7 +138,7 @@
            (doall
             (for [item @cmdb-items]
               ^{:key (:jira_field item)}
-              [cmdb-field item @cmdb-items @relations @template-id form-data])))]
+              [cmdb-field item @cmdb-items @fieldconfigs @template-id form-data])))]
 
         [:> Flex {:justify "end" :gap "3" :mt "6"}
          [:> Button {:variant "soft"

--- a/webapp/test/webapp/jira_templates/cascade_test.cljs
+++ b/webapp/test/webapp/jira_templates/cascade_test.cljs
@@ -1,0 +1,138 @@
+(ns webapp.jira-templates.cascade-test
+  "Field-config-driven cascade for CMDB dropdowns in the runtime prompt.
+
+  Each Assets custom field carries its own AQL configuration in Jira: an
+  object scope filter plus an optional issue scope filter that references
+  sibling fields with ${customfield_x.label} placeholders. That configuration
+  replaces the template's object type — it already defines every object the
+  field accepts. Fields without a configuration (plain text fields) keep the
+  template scope and never cascade."
+  (:require
+   [cljs.test :refer-macros [deftest testing is]]
+   [webapp.jira-templates.cascade :as cascade]))
+
+(def ^:private product
+  {:jira_field "customfield_10091" :label "Produto" :jira_object_type "76"
+   :value "ws:103" :selected-name "Git"
+   :jira_values [{:id "ws:103" :name "Git"} {:id "ws:69" :name "Hoop"}]})
+
+(def ^:private service
+  {:jira_field "customfield_10092" :label "Serviço" :jira_object_type "77"})
+
+(def ^:private text-row
+  {:jira_field "customfield_10056" :label "second" :jira_object_type "77"})
+
+;; mirrors /rest/servicedesk/cmdb/latest/fieldconfig responses
+(def ^:private fieldconfigs
+  (cascade/index-configs
+   [{:jira_field "customfield_10091"
+     :object_schema_id "2"
+     :object_filter_query "objectType = \"Produto\""
+     :issue_scope_filter_query ""}
+    {:jira_field "customfield_10092"
+     :object_schema_id "2"
+     :object_filter_query ""
+     :issue_scope_filter_query
+     "objectType = \"Serviço\" AND Produto = ${customfield_10091.label}"}]))
+
+(deftest static-object-scope-applies-without-any-selection
+  (is (= {:aql "objectType = \"Produto\"" :object-schema-id "2"}
+         (cascade/filter-for product [product service] fieldconfigs))))
+
+(deftest issue-scope-resolves-placeholder-with-selected-name
+  (is (= {:aql "objectType = \"Serviço\" AND Produto = \"Git\"" :object-schema-id "2"}
+         (cascade/filter-for service [product service] fieldconfigs))))
+
+(deftest unresolved-placeholder-is-pending-not-unfiltered
+  (testing "a configured field must not fall back to the template scope"
+    (let [unselected (dissoc product :value :selected-name)]
+      (is (= :pending (cascade/filter-for service [unselected service] fieldconfigs))))))
+
+(deftest unconfigured-fields-keep-the-template-scope
+  (testing "plain text fields have no config entry"
+    (is (nil? (cascade/filter-for text-row [product text-row] fieldconfigs)))
+    (is (empty? (cascade/dependents-of product [product text-row] fieldconfigs)))))
+
+(deftest configured-without-any-filter-keeps-the-template-scope
+  (let [cfgs (cascade/index-configs
+              [{:jira_field "customfield_10092" :object_schema_id "2"
+                :object_filter_query "" :issue_scope_filter_query ""}])]
+    (is (nil? (cascade/filter-for service [product service] cfgs)))))
+
+(deftest object-and-issue-scopes-are-and-composed
+  (let [cfgs (cascade/index-configs
+              [{:jira_field "customfield_10092"
+                :object_schema_id "2"
+                :object_filter_query "objectType = \"Serviço\""
+                :issue_scope_filter_query "Produto = ${customfield_10091.label}"}])]
+    (is (= "(objectType = \"Serviço\") AND (Produto = \"Git\")"
+           (:aql (cascade/filter-for service [product service] cfgs))))))
+
+(deftest placeholder-suffixes
+  (testing "bare placeholder behaves like .label"
+    (let [cfgs (cascade/index-configs
+                [{:jira_field "customfield_10092"
+                  :issue_scope_filter_query "Produto = ${customfield_10091}"}])]
+      (is (= "Produto = \"Git\""
+             (:aql (cascade/filter-for service [product service] cfgs))))))
+  (testing "other suffixes substitute the raw row value"
+    (let [cfgs (cascade/index-configs
+                [{:jira_field "customfield_10092"
+                  :issue_scope_filter_query "Produto = ${customfield_10091.id}"}])]
+      (is (= "Produto = \"ws:103\""
+             (:aql (cascade/filter-for service [product service] cfgs)))))))
+
+(deftest selected-name-fallbacks
+  (testing "id looked up in loaded values when selection name wasn't captured"
+    (let [prod (dissoc product :selected-name)]
+      (is (= "objectType = \"Serviço\" AND Produto = \"Git\""
+             (:aql (cascade/filter-for service [prod service] fieldconfigs))))))
+  (testing "config-prefilled plain name is used as-is"
+    (let [prod (-> product (dissoc :selected-name :jira_values) (assoc :value "Hoop"))]
+      (is (= "objectType = \"Serviço\" AND Produto = \"Hoop\""
+             (:aql (cascade/filter-for service [prod service] fieldconfigs)))))))
+
+(deftest substituted-values-are-escaped
+  (testing "quotes"
+    (let [prod (assoc product :selected-name "Gi\"t")]
+      (is (= "objectType = \"Serviço\" AND Produto = \"Gi\\\"t\""
+             (:aql (cascade/filter-for service [prod service] fieldconfigs))))))
+  (testing "a trailing backslash cannot swallow the closing quote"
+    (let [prod (assoc product :selected-name "Git\\")]
+      (is (= "objectType = \"Serviço\" AND Produto = \"Git\\\\\""
+             (:aql (cascade/filter-for service [prod service] fieldconfigs)))))))
+
+(deftest dependents-follow-placeholder-references
+  (testing "only rows whose issue scope references the changed field react"
+    (is (= ["customfield_10092"]
+           (map :jira_field
+                (cascade/dependents-of product [product service text-row] fieldconfigs)))))
+  (testing "the dependent row itself has no dependents"
+    (is (empty? (cascade/dependents-of service [product service text-row] fieldconfigs)))))
+
+(deftest all-dependents-clears-chains-transitively
+  (let [component {:jira_field "customfield_10093" :label "Componente"}
+        cfgs (cascade/index-configs
+              [{:jira_field "customfield_10092"
+                :issue_scope_filter_query "Produto = ${customfield_10091.label}"}
+               {:jira_field "customfield_10093"
+                :issue_scope_filter_query "Serviço = ${customfield_10092.label}"}])]
+    (testing "A -> B -> C: selecting A clears B and C"
+      (is (= ["customfield_10092" "customfield_10093"]
+             (map :jira_field
+                  (cascade/all-dependents product [product service component text-row] cfgs)))))
+    (testing "selecting B clears only C"
+      (is (= ["customfield_10093"]
+             (map :jira_field
+                  (cascade/all-dependents service [product service component] cfgs)))))
+    (testing "cyclic references terminate"
+      (let [cyclic (cascade/index-configs
+                    [{:jira_field "customfield_10092"
+                      :issue_scope_filter_query "Produto = ${customfield_10091.label}"}
+                     {:jira_field "customfield_10093"
+                      :issue_scope_filter_query "Serviço = ${customfield_10092.label}"}
+                     {:jira_field "customfield_10091"
+                      :issue_scope_filter_query "Componente = ${customfield_10093.label}"}])]
+        (is (= ["customfield_10092" "customfield_10093"]
+               (map :jira_field
+                    (cascade/all-dependents product [product service component] cyclic))))))))

--- a/webapp/test/webapp/jira_templates/cascade_test.cljs
+++ b/webapp/test/webapp/jira_templates/cascade_test.cljs
@@ -46,7 +46,14 @@
 (deftest unresolved-placeholder-is-pending-not-unfiltered
   (testing "a configured field must not fall back to the template scope"
     (let [unselected (dissoc product :value :selected-name)]
-      (is (= :pending (cascade/filter-for service [unselected service] fieldconfigs))))))
+      (is (= :pending (cascade/filter-for service [unselected service] fieldconfigs)))))
+  (testing "an unresolved dependency wins over a static object filter"
+    (let [unselected (dissoc product :value :selected-name)
+          cfgs (cascade/index-configs
+                [{:jira_field "customfield_10092"
+                  :object_filter_query "objectType = \"Serviço\""
+                  :issue_scope_filter_query "Produto = ${customfield_10091.label}"}])]
+      (is (= :pending (cascade/filter-for service [unselected service] cfgs))))))
 
 (deftest unconfigured-fields-keep-the-template-scope
   (testing "plain text fields have no config entry"


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
>
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

CMDB dropdowns in the Jira template runtime prompt now cascade: selecting a value in one field automatically filters the dependent fields to the objects related to that selection (e.g. selecting a Product shows only that product's Services).

The cascade is derived entirely from the Jira Assets schema — no template configuration required. On prompt open, the gateway fetches the object-reference attributes of the template's object types from the JSM Assets API; these schema edges define which dropdowns react to which selections. When an upstream value is picked, dependent dropdowns are cleared and refetched with a derived AQL filter (e.g. `"Produto" = "Git"`), composed server-side with the existing `objectTypeId`/`objectSchemaId`/`name` query. Fields whose object type has no reference attribute (standalone ICs) are unaffected, and a failed schema lookup degrades gracefully to today's unfiltered behavior.

## 🔗 Related Issue

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- **Gateway**: new endpoint `GET /integrations/jira/assets/objecttypes/attributes` returning the object-reference attributes (schema edges) of the requested Assets object types, backed by `FetchObjectTypeReferenceAttributes` in `gateway/jira/assetsapi.go` (workspace resolved once, `objecttype/{id}/attributes` per type, reference attributes only).
- **Gateway**: `GET /integrations/jira/assets/objects` accepts a new optional `aql` query param; the expression is parenthesized and AND-composed with the existing base filters via the extracted `buildAssetObjectsQuery` (empty `aql` reproduces the previous query exactly).
- **webapp (runtime prompt)**: `webapp.jira-templates.cascade` rewritten from unused scaffolding into the live cascade engine — `dependents-of` (rows whose object type references the changed row's type) and `aql-for` (one `"Attribute" = "Selected name"` clause per selected upstream, AND-joined, quotes escaped).
- **webapp (events)**: schema relations fetched once per prompt open and stored in the app db; selecting a value stores the selected object name, clears dependent rows (db + local form state), and refetches them with the derived AQL. Search and pagination keep the active filter.
- **Tests**: `cascade_test.cljs` rewritten for the schema-driven engine (edge detection, AND-joined clauses, selected-name fallbacks, quote escaping, no-edge/no-selection fallbacks); new Go unit test for `buildAssetObjectsQuery` composition.

## 🧪 Testing

Verified end-to-end against a live Jira Assets workspace with two related object types (Products: `Hoop`/`Git`; Services:
`Execução`/`Merge`, linked by a `Produto` reference attribute) and one template with zero cascade configuration:

- Prompt open: relations fetched from the new endpoint; both dropdowns load unfiltered.
- Selecting `Git` → Services dropdown refetches with `aql="Produto" = "Git"` and shows only `Merge`.
- Switching to `Hoop` → dependent selection is cleared and the dropdown re-filters to only `Execução`.
- Selecting a Service never filters Products (edges are directional) and standalone types stay untouched.
- Failure path: schema lookup error falls back to unfiltered dropdowns (previous behavior).

### Test Configuration:

- **Browser(s)**: Brave
- **OS**: macOS

### Tests performed:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## 📸 Screenshots (if applicable)

N/A — behavior is best seen in the runtime prompt: Product selection narrows the Service dropdown to the related objects only.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- No database migration and no template config changes: the cascade is derived from the Jira Assets schema at prompt time, so existing templates get the behavior automatically.
- The `aql` param on `assets/objects` is purely the transport for the derived filter; clients that never send it are unaffected.
- Swagger autogen files (`openapiv3.json`, `autogen/docs.go`) were not regenerated for the new endpoint/param — regenerate if that's part of the release flow.

---
