### PR TITLE
feat: warn admins before the license expires (EVL-120)

### DIFF
--- a/client/cmd/admin/license.go
+++ b/client/cmd/admin/license.go
@@ -10,11 +10,12 @@ import (
 )
 
 var (
-	licenseFileFlag             string
-	licenseSignAllowedHostsFlag []string
-	licenseSignDescFlag         string
-	licenseSignExpireAtFlag     string
-	licenseSignFeaturesFlag     []string
+	licenseFileFlag              string
+	licenseSignAllowedHostsFlag  []string
+	licenseSignDescFlag          string
+	licenseSignExpireAtFlag      string
+	licenseSignFeaturesFlag      []string
+	licenseSignCustomerEmailFlag string
 )
 
 const (
@@ -29,6 +30,7 @@ func init() {
 	licenseSignCmd.Flags().StringVar(&licenseSignDescFlag, "description", "", "A description why this license was issued")
 	licenseSignCmd.Flags().StringVar(&licenseSignExpireAtFlag, "expire-at", "8640h", "The license expiration time")
 	licenseSignCmd.Flags().StringSliceVar(&licenseSignFeaturesFlag, "features", nil, "The features enabled by this license. Empty enables all features")
+	licenseSignCmd.Flags().StringVar(&licenseSignCustomerEmailFlag, "customer-email", "", "The email of the customer this license is issued to. Recorded in analytics only, not in the license itself")
 
 	licenseCmd.AddCommand(licenseSignCmd)
 	licenseCmd.AddCommand(licenseInstallCmd)
@@ -56,11 +58,12 @@ var licenseSignCmd = &cobra.Command{
 
 		apir := parseResourceOrDie([]string{"orglicense"}, "POST", "json")
 		req := map[string]any{
-			"license_type":  args[0],
-			"allowed_hosts": licenseSignAllowedHostsFlag,
-			"description":   licenseSignDescFlag,
-			"expire_at":     licenseSignExpireAtFlag,
-			"features":      licenseSignFeaturesFlag,
+			"license_type":   args[0],
+			"allowed_hosts":  licenseSignAllowedHostsFlag,
+			"description":    licenseSignDescFlag,
+			"expire_at":      licenseSignExpireAtFlag,
+			"features":       licenseSignFeaturesFlag,
+			"customer_email": licenseSignCustomerEmailFlag,
 		}
 		resp, err := httpBodyRequest(apir, "POST", req)
 		if err != nil {

--- a/client/cmd/admin/license.go
+++ b/client/cmd/admin/license.go
@@ -10,12 +10,11 @@ import (
 )
 
 var (
-	licenseFileFlag              string
-	licenseSignAllowedHostsFlag  []string
-	licenseSignDescFlag          string
-	licenseSignExpireAtFlag      string
-	licenseSignFeaturesFlag      []string
-	licenseSignCustomerEmailFlag string
+	licenseFileFlag             string
+	licenseSignAllowedHostsFlag []string
+	licenseSignDescFlag         string
+	licenseSignExpireAtFlag     string
+	licenseSignFeaturesFlag     []string
 )
 
 const (
@@ -30,7 +29,6 @@ func init() {
 	licenseSignCmd.Flags().StringVar(&licenseSignDescFlag, "description", "", "A description why this license was issued")
 	licenseSignCmd.Flags().StringVar(&licenseSignExpireAtFlag, "expire-at", "8640h", "The license expiration time")
 	licenseSignCmd.Flags().StringSliceVar(&licenseSignFeaturesFlag, "features", nil, "The features enabled by this license. Empty enables all features")
-	licenseSignCmd.Flags().StringVar(&licenseSignCustomerEmailFlag, "customer-email", "", "The email of the customer this license is issued to. Recorded in analytics only, not in the license itself")
 
 	licenseCmd.AddCommand(licenseSignCmd)
 	licenseCmd.AddCommand(licenseInstallCmd)
@@ -58,12 +56,11 @@ var licenseSignCmd = &cobra.Command{
 
 		apir := parseResourceOrDie([]string{"orglicense"}, "POST", "json")
 		req := map[string]any{
-			"license_type":   args[0],
-			"allowed_hosts":  licenseSignAllowedHostsFlag,
-			"description":    licenseSignDescFlag,
-			"expire_at":      licenseSignExpireAtFlag,
-			"features":       licenseSignFeaturesFlag,
-			"customer_email": licenseSignCustomerEmailFlag,
+			"license_type":  args[0],
+			"allowed_hosts": licenseSignAllowedHostsFlag,
+			"description":   licenseSignDescFlag,
+			"expire_at":     licenseSignExpireAtFlag,
+			"features":      licenseSignFeaturesFlag,
 		}
 		resp, err := httpBodyRequest(apir, "POST", req)
 		if err != nil {

--- a/gateway/analytics/events.go
+++ b/gateway/analytics/events.go
@@ -71,6 +71,9 @@ const (
 	EventUpdateOrgAnalyticsMode    = "hoop-update-org-analytics-mode"
 	EventProtectionProfileSelected = "hoop-protection-profile-selected"
 
+	// license
+	EventLicenseSigned = "hoop-license-signed"
+
 	// onboarding
 	EventOnboardingOriginAnswered = "hoop-onboarding-origin-answered"
 

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -17657,6 +17657,16 @@ const docTemplate = `{
                     "type": "string",
                     "example": "f2fb0c3143822b08be26f8fc5b703e0a6689e675"
                 },
+                "status": {
+                    "description": "Why the license is not valid, decided against the gateway clock. Clients\nshould branch on this instead of comparing expire_at locally\n* valid - the license verified successfully\n* expired - the license is authentic but past its expiration date\n* invalid - the license could not be verified",
+                    "type": "string",
+                    "enum": [
+                        "valid",
+                        "expired",
+                        "invalid"
+                    ],
+                    "example": "valid"
+                },
                 "type": {
                     "description": "The type of license",
                     "type": "string",

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -7081,6 +7081,16 @@
             "example": "f2fb0c3143822b08be26f8fc5b703e0a6689e675",
             "type": "string"
           },
+          "status": {
+            "description": "Why the license is not valid, decided against the gateway clock. Clients\nshould branch on this instead of comparing expire_at locally\n* valid - the license verified successfully\n* expired - the license is authentic but past its expiration date\n* invalid - the license could not be verified",
+            "enum": [
+              "valid",
+              "expired",
+              "invalid"
+            ],
+            "example": "valid",
+            "type": "string"
+          },
           "type": {
             "description": "The type of license",
             "enum": [

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1495,8 +1495,7 @@ type WebhooksDashboardResponse struct {
 	URL string `json:"url" example:"https://app.svix.com/app_3ZT4NrDlps0Pjp6Af8L6pJMMh3/endpoints"`
 }
 
-// Values for the license_info.status field returned by /serverinfo; each state
-// is documented on ServerLicenseInfo.Status below.
+// Values for ServerLicenseInfo.Status.
 const (
 	LicenseStatusValid   = "valid"
 	LicenseStatusExpired = "expired"

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1495,6 +1495,18 @@ type WebhooksDashboardResponse struct {
 	URL string `json:"url" example:"https://app.svix.com/app_3ZT4NrDlps0Pjp6Af8L6pJMMh3/endpoints"`
 }
 
+// License states reported by the /serverinfo endpoint.
+const (
+	// LicenseStatusValid means the license verified against the embedded public
+	// key, is inside its validity window and is allowed on this host.
+	LicenseStatusValid = "valid"
+	// LicenseStatusExpired means the license is authentic but past expire_at.
+	LicenseStatusExpired = "expired"
+	// LicenseStatusInvalid covers every other verification failure: bad
+	// signature, host not allowed, malformed or missing attributes.
+	LicenseStatusInvalid = "invalid"
+)
+
 type ServerLicenseInfo struct {
 	// Public Key identifier of who signed the license
 	KeyID string `json:"key_id" example:"f2fb0c3143822b08be26f8fc5b703e0a6689e675"`
@@ -1508,6 +1520,12 @@ type ServerLicenseInfo struct {
 	ExpireAt int64 `json:"expire_at" example:"1722261422"`
 	// Report if the license is valid
 	IsValid bool `json:"is_valid"`
+	// Why the license is not valid, decided against the gateway clock. Clients
+	// should branch on this instead of comparing expire_at locally
+	// * valid - the license verified successfully
+	// * expired - the license is authentic but past its expiration date
+	// * invalid - the license could not be verified
+	Status string `json:"status" enums:"valid,expired,invalid" example:"valid"`
 	// The error returned when verifying the license
 	VerifyError string `json:"verify_error" example:"unable to verify license"`
 	// The verified host (API_URL env)

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1495,15 +1495,11 @@ type WebhooksDashboardResponse struct {
 	URL string `json:"url" example:"https://app.svix.com/app_3ZT4NrDlps0Pjp6Af8L6pJMMh3/endpoints"`
 }
 
-// License states reported by the /serverinfo endpoint.
+// Values for the license_info.status field returned by /serverinfo; each state
+// is documented on ServerLicenseInfo.Status below.
 const (
-	// LicenseStatusValid means the license verified against the embedded public
-	// key, is inside its validity window and is allowed on this host.
-	LicenseStatusValid = "valid"
-	// LicenseStatusExpired means the license is authentic but past expire_at.
+	LicenseStatusValid   = "valid"
 	LicenseStatusExpired = "expired"
-	// LicenseStatusInvalid covers every other verification failure: bad
-	// signature, host not allowed, malformed or missing attributes.
 	LicenseStatusInvalid = "invalid"
 )
 

--- a/gateway/api/orgs/orglicense.go
+++ b/gateway/api/orgs/orglicense.go
@@ -113,20 +113,24 @@ func SignLicense(c *gin.Context) {
 	if features == nil {
 		features = []string{}
 	}
+	properties := map[string]any{
+		"org-id":        ctx.OrgID,
+		"license-type":  l.Payload.Type,
+		"description":   l.Payload.Description,
+		"allowed-hosts": l.Payload.AllowedHosts,
+		"features":      features,
+		"key-id":        l.KeyID,
+		"issued-at":     time.Unix(l.Payload.IssuedAt, 0).UTC().Format(time.RFC3339),
+		"expire-at":     time.Unix(l.Payload.ExpireAt, 0).UTC().Format(time.RFC3339),
+		"valid-for":     req.ExpireAt,
+	}
+	// Omitted rather than empty, so "customer-email is set" filters stay honest.
+	if req.CustomerEmail != "" {
+		properties["customer-email"] = req.CustomerEmail
+	}
 	trackClient := analytics.New()
 	defer trackClient.Close()
-	trackClient.Track(ctx.UserID, analytics.EventLicenseSigned, map[string]any{
-		"org-id":         ctx.OrgID,
-		"customer-email": req.CustomerEmail,
-		"license-type":   l.Payload.Type,
-		"description":    l.Payload.Description,
-		"allowed-hosts":  l.Payload.AllowedHosts,
-		"features":       features,
-		"key-id":         l.KeyID,
-		"issued-at":      time.Unix(l.Payload.IssuedAt, 0).UTC().Format(time.RFC3339),
-		"expire-at":      time.Unix(l.Payload.ExpireAt, 0).UTC().Format(time.RFC3339),
-		"valid-for":      req.ExpireAt,
-	})
+	trackClient.Track(ctx.UserID, analytics.EventLicenseSigned, properties)
 
 	c.JSON(http.StatusOK, l)
 }

--- a/gateway/api/orgs/orglicense.go
+++ b/gateway/api/orgs/orglicense.go
@@ -56,8 +56,6 @@ type SignRequest struct {
 	ExpireAt     string   `json:"expire_at"`
 	// Features enabled by the license. Empty means all features are enabled.
 	Features []string `json:"features"`
-	// Optional, not part of the signed payload: it only feeds the analytics event.
-	CustomerEmail string `json:"customer_email" binding:"omitempty,email"`
 }
 
 // SignLicense
@@ -107,14 +105,24 @@ func SignLicense(c *gin.Context) {
 		return
 	}
 
-	// Signed licenses are never stored here, so this event is the only record of
-	// what was issued and to whom. Route is restricted to the signing org.
+	// Signed licenses are never stored, so this event and the log line above are
+	// the only record of what was issued. Route is restricted to the signing org.
+	trackClient := analytics.New()
+	defer trackClient.Close()
+	trackClient.Track(ctx.UserID, analytics.EventLicenseSigned, signedLicenseProperties(ctx.OrgID, req, l))
+
+	c.JSON(http.StatusOK, l)
+}
+
+// signedLicenseProperties builds the analytics payload for a signed license. It
+// carries no PII: `description` is what identifies the customer we issued to.
+func signedLicenseProperties(orgID string, req SignRequest, l *license.License) map[string]any {
 	features := l.Payload.Features
 	if features == nil {
 		features = []string{}
 	}
-	properties := map[string]any{
-		"org-id":        ctx.OrgID,
+	return map[string]any{
+		"org-id":        orgID,
 		"license-type":  l.Payload.Type,
 		"description":   l.Payload.Description,
 		"allowed-hosts": l.Payload.AllowedHosts,
@@ -124,13 +132,4 @@ func SignLicense(c *gin.Context) {
 		"expire-at":     time.Unix(l.Payload.ExpireAt, 0).UTC().Format(time.RFC3339),
 		"valid-for":     req.ExpireAt,
 	}
-	// Omitted rather than empty, so "customer-email is set" filters stay honest.
-	if req.CustomerEmail != "" {
-		properties["customer-email"] = req.CustomerEmail
-	}
-	trackClient := analytics.New()
-	defer trackClient.Close()
-	trackClient.Track(ctx.UserID, analytics.EventLicenseSigned, properties)
-
-	c.JSON(http.StatusOK, l)
 }

--- a/gateway/api/orgs/orglicense.go
+++ b/gateway/api/orgs/orglicense.go
@@ -105,8 +105,7 @@ func SignLicense(c *gin.Context) {
 		return
 	}
 
-	// Signed licenses are never stored, so this event and the log line above are
-	// the only record of what was issued. Route is restricted to the signing org.
+	// Signed licenses are never stored, so this is the record of what was issued.
 	trackClient := analytics.New()
 	defer trackClient.Close()
 	trackClient.Track(ctx.UserID, analytics.EventLicenseSigned, signedLicenseProperties(ctx.OrgID, req, l))
@@ -114,8 +113,6 @@ func SignLicense(c *gin.Context) {
 	c.JSON(http.StatusOK, l)
 }
 
-// signedLicenseProperties builds the analytics payload for a signed license. It
-// carries no PII: `description` is what identifies the customer we issued to.
 func signedLicenseProperties(orgID string, req SignRequest, l *license.License) map[string]any {
 	features := l.Payload.Features
 	if features == nil {

--- a/gateway/api/orgs/orglicense.go
+++ b/gateway/api/orgs/orglicense.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/hoophq/hoop/common/license"
 	"github.com/hoophq/hoop/common/log"
+	"github.com/hoophq/hoop/gateway/analytics"
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/models"
@@ -55,6 +56,8 @@ type SignRequest struct {
 	ExpireAt     string   `json:"expire_at"`
 	// Features enabled by the license. Empty means all features are enabled.
 	Features []string `json:"features"`
+	// Optional, not part of the signed payload: it only feeds the analytics event.
+	CustomerEmail string `json:"customer_email" binding:"omitempty,email"`
 }
 
 // SignLicense
@@ -103,5 +106,27 @@ func SignLicense(c *gin.Context) {
 		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed verifying license: %v", err)
 		return
 	}
+
+	// Signed licenses are never stored here, so this event is the only record of
+	// what was issued and to whom. Route is restricted to the signing org.
+	features := l.Payload.Features
+	if features == nil {
+		features = []string{}
+	}
+	trackClient := analytics.New()
+	defer trackClient.Close()
+	trackClient.Track(ctx.UserID, analytics.EventLicenseSigned, map[string]any{
+		"org-id":         ctx.OrgID,
+		"customer-email": req.CustomerEmail,
+		"license-type":   l.Payload.Type,
+		"description":    l.Payload.Description,
+		"allowed-hosts":  l.Payload.AllowedHosts,
+		"features":       features,
+		"key-id":         l.KeyID,
+		"issued-at":      time.Unix(l.Payload.IssuedAt, 0).UTC().Format(time.RFC3339),
+		"expire-at":      time.Unix(l.Payload.ExpireAt, 0).UTC().Format(time.RFC3339),
+		"valid-for":      req.ExpireAt,
+	})
+
 	c.JSON(http.StatusOK, l)
 }

--- a/gateway/api/orgs/orglicense_test.go
+++ b/gateway/api/orgs/orglicense_test.go
@@ -7,8 +7,7 @@ import (
 	"github.com/hoophq/hoop/common/license"
 )
 
-// The event is the only durable record of what we issued, so a dropped or
-// renamed property silently breaks the dashboards built on it.
+// A dropped or renamed property breaks the dashboards without failing a build.
 func TestSignedLicenseProperties(t *testing.T) {
 	l := &license.License{
 		Payload: license.Payload{
@@ -49,11 +48,5 @@ func TestSignedLicenseProperties(t *testing.T) {
 		if got != wantValue {
 			t.Errorf("property %q = %v, want %v", key, got, wantValue)
 		}
-	}
-
-	// The signing org is ours, but the licensee is a third party: nothing that
-	// identifies a person belongs in this event.
-	if _, ok := props["customer-email"]; ok {
-		t.Error("customer-email must not be sent")
 	}
 }

--- a/gateway/api/orgs/orglicense_test.go
+++ b/gateway/api/orgs/orglicense_test.go
@@ -1,37 +1,59 @@
 package apiorgs
 
 import (
-	"net/http/httptest"
-	"strings"
+	"slices"
 	"testing"
 
-	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/common/license"
 )
 
-// customer_email is optional: the CLI always sends the key, empty when the flag
-// is not set, and older clients omit it entirely. Both must bind.
-func TestSignRequestCustomerEmailIsOptional(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	for _, tt := range []struct {
-		name    string
-		body    string
-		wantErr bool
-	}{
-		{"field absent", `{"license_type":"enterprise"}`, false},
-		{"field empty", `{"license_type":"enterprise","customer_email":""}`, false},
-		{"valid address", `{"license_type":"enterprise","customer_email":"user@hoop.dev"}`, false},
-		{"malformed address", `{"license_type":"enterprise","customer_email":"not-an-email"}`, true},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			c, _ := gin.CreateTestContext(httptest.NewRecorder())
-			c.Request = httptest.NewRequest("POST", "/", strings.NewReader(tt.body))
-			c.Request.Header.Set("Content-Type", "application/json")
+// The event is the only durable record of what we issued, so a dropped or
+// renamed property silently breaks the dashboards built on it.
+func TestSignedLicenseProperties(t *testing.T) {
+	l := &license.License{
+		Payload: license.Payload{
+			Type:         license.EnterpriseType,
+			Description:  "acme corp",
+			AllowedHosts: []string{"*"},
+			IssuedAt:     1755561600,
+			ExpireAt:     1758153600,
+		},
+		KeyID: "key-id",
+	}
 
-			var req SignRequest
-			err := c.ShouldBindJSON(&req)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("ShouldBindJSON() error = %v, wantErr %v", err, tt.wantErr)
+	props := signedLicenseProperties("org-1", SignRequest{ExpireAt: "720h"}, l)
+
+	want := map[string]any{
+		"org-id":        "org-1",
+		"license-type":  license.EnterpriseType,
+		"description":   "acme corp",
+		"allowed-hosts": []string{"*"},
+		"features":      []string{},
+		"key-id":        "key-id",
+		"issued-at":     "2025-08-19T00:00:00Z",
+		"expire-at":     "2025-09-18T00:00:00Z",
+		"valid-for":     "720h",
+	}
+	for key, wantValue := range want {
+		got, ok := props[key]
+		if !ok {
+			t.Errorf("missing property %q", key)
+			continue
+		}
+		if gotSlice, isSlice := got.([]string); isSlice {
+			if !slices.Equal(gotSlice, wantValue.([]string)) {
+				t.Errorf("property %q = %v, want %v", key, got, wantValue)
 			}
-		})
+			continue
+		}
+		if got != wantValue {
+			t.Errorf("property %q = %v, want %v", key, got, wantValue)
+		}
+	}
+
+	// The signing org is ours, but the licensee is a third party: nothing that
+	// identifies a person belongs in this event.
+	if _, ok := props["customer-email"]; ok {
+		t.Error("customer-email must not be sent")
 	}
 }

--- a/gateway/api/orgs/orglicense_test.go
+++ b/gateway/api/orgs/orglicense_test.go
@@ -1,0 +1,37 @@
+package apiorgs
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// customer_email is optional: the CLI always sends the key, empty when the flag
+// is not set, and older clients omit it entirely. Both must bind.
+func TestSignRequestCustomerEmailIsOptional(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, tt := range []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{"field absent", `{"license_type":"enterprise"}`, false},
+		{"field empty", `{"license_type":"enterprise","customer_email":""}`, false},
+		{"valid address", `{"license_type":"enterprise","customer_email":"user@hoop.dev"}`, false},
+		{"malformed address", `{"license_type":"enterprise","customer_email":"not-an-email"}`, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest("POST", "/", strings.NewReader(tt.body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			var req SignRequest
+			err := c.ShouldBindJSON(&req)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ShouldBindJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/gateway/api/serverinfo/serverinfo.go
+++ b/gateway/api/serverinfo/serverinfo.go
@@ -1,6 +1,7 @@
 package apiserverinfo
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
 	"os"
@@ -22,7 +23,9 @@ import (
 var (
 	isOrgMultiTenant = os.Getenv("ORG_MULTI_TENANT") == "true"
 	vinfo            = version.Get()
-	serverInfoData   = openapi.ServerInfo{
+	// Process-wide attributes only. Requests copy it before adding org fields;
+	// mutating in place raced and leaked licenses across tenants.
+	baseServerInfo = openapi.ServerInfo{
 		Version:                 vinfo.Version,
 		Commit:                  vinfo.GitCommit,
 		LogLevel:                os.Getenv("LOG_LEVEL"),
@@ -67,18 +70,19 @@ func Get(c *gin.Context) {
 
 	appc := appconfig.Get()
 	apiHostname := appc.ApiHostname()
-	l, licenseVerifyErr := defaultOSSLicense(), ""
+	// Separate from err, which still carries the tolerated models.ErrNotFound
+	// above; reusing it reported a perfectly good license as invalid.
+	l, licenseErr := defaultOSSLicense(), error(nil)
 	if org.LicenseData != nil {
-		l, err = license.Parse(org.LicenseData, apiHostname)
-		if err != nil {
-			licenseVerifyErr = err.Error()
-		}
+		l, licenseErr = license.Parse(org.LicenseData, apiHostname)
 	}
 
 	analyticsMode := org.AnalyticsMode
 	if !models.IsValidAnalyticsMode(analyticsMode) {
 		analyticsMode = models.AnalyticsModeAnonymous
 	}
+
+	serverInfoData := baseServerInfo
 	serverInfoData.AnalyticsMode = openapi.AnalyticsModeType(analyticsMode)
 	if analyticsMode == models.AnalyticsModeDisabled {
 		serverInfoData.AnalyticsTracking = string(openapi.AnalyticsTrackingDisabled)
@@ -104,10 +108,15 @@ func Get(c *gin.Context) {
 		miscConf.PostgresServerConfig.ListenAddress != ""
 	serverInfoData.FeatureFlags = featureflag.SnapshotForOrg(ctx.OrgID)
 	serverInfoData.LicenseInfo = &openapi.ServerLicenseInfo{
-		IsValid:      err == nil,
-		VerifyError:  licenseVerifyErr,
+		Status:       licenseStatus(licenseErr),
+		IsValid:      licenseErr == nil,
 		VerifiedHost: apiHostname,
 	}
+	if licenseErr != nil {
+		serverInfoData.LicenseInfo.VerifyError = licenseErr.Error()
+	}
+	// Parse returns the payload even when verification fails, so an expired
+	// license still reports expire_at. nil means it could not be decoded.
 	if l != nil {
 		serverInfoData.LicenseInfo.KeyID = l.KeyID
 		serverInfoData.LicenseInfo.AllowedHosts = l.Payload.AllowedHosts
@@ -123,6 +132,19 @@ func Get(c *gin.Context) {
 		}
 	}
 	c.JSON(http.StatusOK, serverInfoData)
+}
+
+// licenseStatus maps a verification error to the state the webapp renders. Expiry
+// is decided here, on the same clock the gRPC connect gate uses, not in the browser.
+func licenseStatus(err error) string {
+	switch {
+	case err == nil:
+		return openapi.LicenseStatusValid
+	case errors.Is(err, license.ErrExpired):
+		return openapi.LicenseStatusExpired
+	default:
+		return openapi.LicenseStatusInvalid
+	}
 }
 
 func defaultOSSLicense() *license.License {

--- a/gateway/api/serverinfo/serverinfo.go
+++ b/gateway/api/serverinfo/serverinfo.go
@@ -23,8 +23,7 @@ import (
 var (
 	isOrgMultiTenant = os.Getenv("ORG_MULTI_TENANT") == "true"
 	vinfo            = version.Get()
-	// Process-wide attributes only. Requests copy it before adding org fields;
-	// mutating in place raced and leaked licenses across tenants.
+	// Process-wide attributes only — requests copy it before adding org fields.
 	baseServerInfo = openapi.ServerInfo{
 		Version:                 vinfo.Version,
 		Commit:                  vinfo.GitCommit,
@@ -70,8 +69,7 @@ func Get(c *gin.Context) {
 
 	appc := appconfig.Get()
 	apiHostname := appc.ApiHostname()
-	// Separate from err, which still carries the tolerated models.ErrNotFound
-	// above; reusing it reported a perfectly good license as invalid.
+	// Separate from err, which still carries the tolerated models.ErrNotFound above.
 	l, licenseErr := defaultOSSLicense(), error(nil)
 	if org.LicenseData != nil {
 		l, licenseErr = license.Parse(org.LicenseData, apiHostname)
@@ -116,7 +114,7 @@ func Get(c *gin.Context) {
 		serverInfoData.LicenseInfo.VerifyError = licenseErr.Error()
 	}
 	// Parse returns the payload even when verification fails, so an expired
-	// license still reports expire_at. nil means it could not be decoded.
+	// license still reports expire_at.
 	if l != nil {
 		serverInfoData.LicenseInfo.KeyID = l.KeyID
 		serverInfoData.LicenseInfo.AllowedHosts = l.Payload.AllowedHosts
@@ -134,8 +132,7 @@ func Get(c *gin.Context) {
 	c.JSON(http.StatusOK, serverInfoData)
 }
 
-// licenseStatus maps a verification error to the state the webapp renders. Expiry
-// is decided here, on the same clock the gRPC connect gate uses, not in the browser.
+// Expiry is decided on the same clock the gRPC connect gate uses, not in the browser.
 func licenseStatus(err error) string {
 	switch {
 	case err == nil:

--- a/gateway/api/serverinfo/serverinfo_test.go
+++ b/gateway/api/serverinfo/serverinfo_test.go
@@ -1,0 +1,34 @@
+package apiserverinfo
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hoophq/hoop/common/license"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+)
+
+func TestLicenseStatus(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"verified license is valid", nil, openapi.LicenseStatusValid},
+		{"expired sentinel maps to expired", license.ErrExpired, openapi.LicenseStatusExpired},
+		{
+			"expired sentinel is matched through a wrap",
+			fmt.Errorf("failed parsing license: %w", license.ErrExpired),
+			openapi.LicenseStatusExpired,
+		},
+		{"host mismatch is invalid", errors.New(`host "acme.org" is not allowed`), openapi.LicenseStatusInvalid},
+		{"used before issued is invalid", license.ErrUsedBeforeIssued, openapi.LicenseStatusInvalid},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := licenseStatus(tt.err); got != tt.want {
+				t.Errorf("licenseStatus(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/webapp_v2/COMPONENTS.md
+++ b/webapp_v2/COMPONENTS.md
@@ -847,12 +847,13 @@ Opens the same destination as "Contact support" in the header user menu.
 ```js
 import { openSupport, GITHUB_DISCUSSIONS_URL } from '@/utils/support'
 
-openSupport(analyticsTracking, 'I want to renew my hoop license')
+openSupport('I want to renew my hoop license')
 ```
-Intercom is only booted when analytics is on, so `openSupport` falls back to the
-public GitHub discussions board otherwise. Use it for any support entry point
-outside the user menu — that one already has Intercom's launcher listener bound
-to its `#intercom-support-trigger` id and only needs the fallback.
+Delegates to `useUserStore.showIntercomMessage`, which boots Intercom when the
+app-boot init was skipped or shut down, and falls back to the public GitHub
+discussions board when it is unavailable (analytics off, widget blocked). Use it
+for any support entry point outside the user menu — that one already has
+Intercom's launcher listener bound to its `#intercom-support-trigger` id.
 
 ---
 

--- a/webapp_v2/COMPONENTS.md
+++ b/webapp_v2/COMPONENTS.md
@@ -828,6 +828,32 @@ isFreeFormCustomSubtype(subtype) // free-form credentials editor
   `GET /connection-credentials`, which is secret-less; `get()` is the only call
   that returns a plaintext secret, so it runs on demand when a row is expanded.
 
+### `license.js`
+Shared by the shell's `LicenseBanner` and the license settings page.
+```js
+import { LICENSE_STATUS, formatLicenseDate, daysUntilExpiration } from '@/utils/license'
+
+LICENSE_STATUS.VALID | .EXPIRED | .INVALID  // /serverinfo license_info.status
+formatLicenseDate(1785333321)               // "Jul 29, 2026"
+daysUntilExpiration(1785333321)             // whole days left, negative once past
+```
+Branch on `license_info.status`, never on a local `expire_at` comparison — the
+gateway decides expiry against its own clock, which is the clock that actually
+blocks sessions. `daysUntilExpiration` is only for the "expires in N days"
+countdown while the status is still `valid`.
+
+### `support.js`
+Opens the same destination as "Contact support" in the header user menu.
+```js
+import { openSupport, GITHUB_DISCUSSIONS_URL } from '@/utils/support'
+
+openSupport(analyticsTracking, 'I want to renew my hoop license')
+```
+Intercom is only booted when analytics is on, so `openSupport` falls back to the
+public GitHub discussions board otherwise. Use it for any support entry point
+outside the user menu — that one already has Intercom's launcher listener bound
+to its `#intercom-support-trigger` id and only needs the fallback.
+
 ---
 
 ## Notifications — `showSnackbar`

--- a/webapp_v2/src/layout/Header/UserMenu.jsx
+++ b/webapp_v2/src/layout/Header/UserMenu.jsx
@@ -5,10 +5,9 @@ import ActionMenu from '@/components/ActionMenu'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { getUserDisplayName } from '@/utils/user'
+import { GITHUB_DISCUSSIONS_URL } from '@/utils/support'
 import { UserAvatar } from './UserAvatar'
 import classes from './Header.module.css'
-
-const GITHUB_DISCUSSIONS_URL = 'https://github.com/hoophq/hoop/discussions'
 
 export function UserMenu() {
   const navigate = useNavigate()

--- a/webapp_v2/src/layout/Layout.jsx
+++ b/webapp_v2/src/layout/Layout.jsx
@@ -92,8 +92,6 @@ function Layout({ children }) {
         </AppShell.Navbar>
 
         <AppShell.Main id="main-content" tabIndex={-1}>
-          {/* Above the page body and outside PageLayout's padding, so the
-              warning spans the content area on React and CLJS routes alike. */}
           <LicenseBanner />
           {children}
         </AppShell.Main>

--- a/webapp_v2/src/layout/Layout.jsx
+++ b/webapp_v2/src/layout/Layout.jsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useUIStore } from '@/stores/useUIStore';
 import Sidebar from './Sidebar';
 import AppHeader from './Header';
+import LicenseBanner from './LicenseBanner';
 import { SkipLink } from './SkipLink';
 import NativeConnectionsDrawer from '@/features/NativeConnections';
 
@@ -91,6 +92,9 @@ function Layout({ children }) {
         </AppShell.Navbar>
 
         <AppShell.Main id="main-content" tabIndex={-1}>
+          {/* Above the page body and outside PageLayout's padding, so the
+              warning spans the content area on React and CLJS routes alike. */}
+          <LicenseBanner />
           {children}
         </AppShell.Main>
       </AppShell>

--- a/webapp_v2/src/layout/LicenseBanner/index.jsx
+++ b/webapp_v2/src/layout/LicenseBanner/index.jsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import { Anchor, Group, Text } from '@mantine/core'
+import { Link, useLocation } from 'react-router-dom'
+import { TriangleAlert } from 'lucide-react'
+import Alert from '@/components/Alert'
+import { useUserStore } from '@/stores/useUserStore'
+import { LICENSE_STATUS, daysUntilExpiration, formatLicenseDate } from '@/utils/license'
+import { openSupport } from '@/utils/support'
+
+const LICENSE_PAGE = '/settings/license'
+const SUPPORT_MESSAGE = 'I want to renew my hoop license'
+const WARN_DAYS = 30
+// Dismissing silences one step only, so ignoring it at 30 days does not stay
+// silent at 14. Inside the last week there is no close button at all.
+const DISMISS_STEPS = [30, 14]
+const LOCKED_DAYS = 7
+const DISMISS_KEY = 'license-expiration-dismissed-for'
+
+// Admin-only: renewing is their task. Non-admins get license.ErrNotValid on the
+// blocked session instead.
+function licenseNotice({ licenseInfo, isAdmin, dismissedFor }) {
+  if (!isAdmin || !licenseInfo) return null
+  const { status, type, expire_at: expireAt, verify_error: verifyError } = licenseInfo
+
+  if (status === LICENSE_STATUS.EXPIRED) {
+    return {
+      color: 'red',
+      message: `Your hoop license expired on ${formatLicenseDate(expireAt)}. New sessions are blocked until a valid license is installed.`,
+      action: 'update',
+    }
+  }
+
+  if (status === LICENSE_STATUS.INVALID) {
+    const reason = verifyError ? `: ${verifyError}` : ''
+    return {
+      color: 'red',
+      message: `Your hoop license could not be verified${reason}. New sessions are blocked until a valid license is installed.`,
+      action: 'update',
+    }
+  }
+
+  if (type !== 'enterprise') return null
+
+  const daysLeft = daysUntilExpiration(expireAt)
+  if (daysLeft === null || daysLeft > WARN_DAYS) return null
+
+  // findLast picks the tightest step, and the key carries the expiration so
+  // renewing re-arms the warning.
+  const step = daysLeft > LOCKED_DAYS ? DISMISS_STEPS.findLast((d) => daysLeft <= d) : null
+  const dismissKey = step ? `${expireAt}:${step}` : null
+  if (dismissKey && dismissedFor === dismissKey) return null
+
+  const when = daysLeft <= 0 ? 'today' : daysLeft === 1 ? 'tomorrow' : `in ${daysLeft} days`
+  return {
+    color: 'amber',
+    message: `Your hoop license expires ${when}, on ${formatLicenseDate(expireAt)}. Renew it to keep sessions running.`,
+    action: 'support',
+    dismissKey,
+  }
+}
+
+// Sits at the top of the shell content, so it reaches CLJS routes too.
+export default function LicenseBanner() {
+  const licenseInfo = useUserStore((state) => state.licenseInfo)
+  const isAdmin = useUserStore((state) => state.isAdmin)
+  const analyticsTracking = useUserStore((state) => state.analyticsTracking)
+  const { pathname } = useLocation()
+  const [dismissedFor, setDismissedFor] = useState(() => localStorage.getItem(DISMISS_KEY))
+
+  const notice = licenseNotice({ licenseInfo, isAdmin, dismissedFor })
+  // The license page states the same thing next to the field that fixes it.
+  if (!notice || pathname === LICENSE_PAGE) return null
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISS_KEY, notice.dismissKey)
+    setDismissedFor(notice.dismissKey)
+  }
+
+  return (
+    <Alert
+      color={notice.color}
+      variant="light"
+      radius={0}
+      py="sm"
+      icon={<TriangleAlert size={18} />}
+      withCloseButton={!!notice.dismissKey}
+      onClose={dismiss}
+      closeButtonLabel="Dismiss license warning"
+    >
+      <Group gap="xs" align="center" wrap="wrap">
+        <Text size="sm" component="span">
+          {notice.message}
+        </Text>
+        {notice.action === 'update' && (
+          <Anchor component={Link} to={LICENSE_PAGE} c={notice.color} fw={500} size="sm">
+            Update license
+          </Anchor>
+        )}
+        {notice.action === 'support' && (
+          <Anchor
+            component="button"
+            type="button"
+            onClick={() => openSupport(analyticsTracking, SUPPORT_MESSAGE)}
+            c={notice.color}
+            fw={500}
+            size="sm"
+          >
+            {'Contact support ↗'}
+          </Anchor>
+        )}
+      </Group>
+    </Alert>
+  )
+}

--- a/webapp_v2/src/layout/LicenseBanner/index.jsx
+++ b/webapp_v2/src/layout/LicenseBanner/index.jsx
@@ -10,14 +10,12 @@ import { openSupport } from '@/utils/support'
 const LICENSE_PAGE = '/settings/license'
 const SUPPORT_MESSAGE = 'I want to renew my hoop license'
 const WARN_DAYS = 30
-// Dismissing silences one step only, so ignoring it at 30 days does not stay
-// silent at 14. Inside the last week there is no close button at all.
+// Dismissing silences one step only; inside LOCKED_DAYS there is no close button.
 const DISMISS_STEPS = [30, 14]
 const LOCKED_DAYS = 7
 const DISMISS_KEY = 'license-expiration-dismissed-for'
 
-// Admin-only: renewing is their task. Non-admins get license.ErrNotValid on the
-// blocked session instead.
+// Admin-only: renewing is their task.
 function licenseNotice({ licenseInfo, isAdmin, userId, dismissedFor }) {
   if (!isAdmin || !licenseInfo) return null
   const { status, type, expire_at: expireAt, verify_error: verifyError } = licenseInfo
@@ -44,8 +42,8 @@ function licenseNotice({ licenseInfo, isAdmin, userId, dismissedFor }) {
   const daysLeft = daysUntilExpiration(expireAt)
   if (daysLeft === null || daysLeft > WARN_DAYS) return null
 
-  // findLast picks the tightest step. The key carries the expiration so renewing
-  // re-arms the warning, and the user so one admin cannot silence another.
+  // Keyed by expiration so renewing re-arms it, and by user so one admin cannot
+  // silence another.
   const step = daysLeft > LOCKED_DAYS ? DISMISS_STEPS.findLast((d) => daysLeft <= d) : null
   const dismissKey = step ? `${userId}:${expireAt}:${step}` : null
   if (dismissKey && dismissedFor === dismissKey) return null

--- a/webapp_v2/src/layout/LicenseBanner/index.jsx
+++ b/webapp_v2/src/layout/LicenseBanner/index.jsx
@@ -18,7 +18,7 @@ const DISMISS_KEY = 'license-expiration-dismissed-for'
 
 // Admin-only: renewing is their task. Non-admins get license.ErrNotValid on the
 // blocked session instead.
-function licenseNotice({ licenseInfo, isAdmin, dismissedFor }) {
+function licenseNotice({ licenseInfo, isAdmin, userId, dismissedFor }) {
   if (!isAdmin || !licenseInfo) return null
   const { status, type, expire_at: expireAt, verify_error: verifyError } = licenseInfo
 
@@ -44,10 +44,10 @@ function licenseNotice({ licenseInfo, isAdmin, dismissedFor }) {
   const daysLeft = daysUntilExpiration(expireAt)
   if (daysLeft === null || daysLeft > WARN_DAYS) return null
 
-  // findLast picks the tightest step, and the key carries the expiration so
-  // renewing re-arms the warning.
+  // findLast picks the tightest step. The key carries the expiration so renewing
+  // re-arms the warning, and the user so one admin cannot silence another.
   const step = daysLeft > LOCKED_DAYS ? DISMISS_STEPS.findLast((d) => daysLeft <= d) : null
-  const dismissKey = step ? `${expireAt}:${step}` : null
+  const dismissKey = step ? `${userId}:${expireAt}:${step}` : null
   if (dismissKey && dismissedFor === dismissKey) return null
 
   const when = daysLeft <= 0 ? 'today' : daysLeft === 1 ? 'tomorrow' : `in ${daysLeft} days`
@@ -63,11 +63,11 @@ function licenseNotice({ licenseInfo, isAdmin, dismissedFor }) {
 export default function LicenseBanner() {
   const licenseInfo = useUserStore((state) => state.licenseInfo)
   const isAdmin = useUserStore((state) => state.isAdmin)
-  const analyticsTracking = useUserStore((state) => state.analyticsTracking)
+  const userId = useUserStore((state) => state.user?.id)
   const { pathname } = useLocation()
   const [dismissedFor, setDismissedFor] = useState(() => localStorage.getItem(DISMISS_KEY))
 
-  const notice = licenseNotice({ licenseInfo, isAdmin, dismissedFor })
+  const notice = licenseNotice({ licenseInfo, isAdmin, userId, dismissedFor })
   // The license page states the same thing next to the field that fixes it.
   if (!notice || pathname === LICENSE_PAGE) return null
 
@@ -100,7 +100,7 @@ export default function LicenseBanner() {
           <Anchor
             component="button"
             type="button"
-            onClick={() => openSupport(analyticsTracking, SUPPORT_MESSAGE)}
+            onClick={() => openSupport(SUPPORT_MESSAGE)}
             c={notice.color}
             fw={500}
             size="sm"

--- a/webapp_v2/src/pages/Settings/License/index.jsx
+++ b/webapp_v2/src/pages/Settings/License/index.jsx
@@ -22,8 +22,7 @@ import { LICENSE_STATUS, daysUntilExpiration, formatLicenseDate } from '@/utils/
 import { showSnackbar } from '@/utils/snackbar'
 import { openSupport } from '@/utils/support'
 
-// Wider than the global banner's 30 days: this page is where renewal happens,
-// so a heads-up here is useful long before it is worth interrupting the app.
+// Wider than the global banner's 30 days: renewal happens here.
 const EXPIRATION_WARNING_DAYS = 90
 const SUPPORT_MESSAGE = 'I want to renew my hoop license'
 
@@ -33,8 +32,7 @@ function licenseTypeLabel(type) {
   return '—'
 }
 
-// Alert to render above the license table, or null. Also covers an already
-// expired license, which is exactly when the admin needs to be told.
+// Covers an already expired license too, which the old check suppressed.
 function expirationNotice(licenseInfo, isAdmin) {
   if (!isAdmin || !licenseInfo) return null
   const { status, type, expire_at: expireAt, verify_error: verifyError } = licenseInfo

--- a/webapp_v2/src/pages/Settings/License/index.jsx
+++ b/webapp_v2/src/pages/Settings/License/index.jsx
@@ -18,16 +18,12 @@ import Table from '@/components/Table'
 import licenseService from '@/services/license'
 import authService from '@/services/auth'
 import { docsUrl } from '@/utils/docsUrl'
+import { LICENSE_STATUS, daysUntilExpiration, formatLicenseDate } from '@/utils/license'
 import { showSnackbar } from '@/utils/snackbar'
 
-const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-
-function formatDate(timestamp) {
-  if (!timestamp) return '—'
-  const date = new Date(timestamp * 1000)
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${date.getFullYear()}/${MONTHS[date.getMonth()]}/${day}`
-}
+// Wider than the global banner's 30 days: this page is where renewal happens,
+// so a heads-up here is useful long before it is worth interrupting the app.
+const EXPIRATION_WARNING_DAYS = 90
 
 function licenseTypeLabel(type) {
   if (type === 'enterprise') return 'Enterprise License'
@@ -35,15 +31,33 @@ function licenseTypeLabel(type) {
   return '—'
 }
 
-function shouldShowExpirationWarning(licenseInfo, isAdmin) {
-  if (!isAdmin) return false
-  if (licenseInfo?.type !== 'enterprise') return false
-  if (!licenseInfo?.is_valid) return false
-  if (!licenseInfo?.expire_at) return false
-  const now = Date.now()
-  const expireMs = licenseInfo.expire_at * 1000
-  const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000
-  return now >= expireMs - ninetyDaysMs
+// Alert to render above the license table, or null. Also covers an already
+// expired license, which is exactly when the admin needs to be told.
+function expirationNotice(licenseInfo, isAdmin) {
+  if (!isAdmin || !licenseInfo) return null
+  const { status, type, expire_at: expireAt, verify_error: verifyError } = licenseInfo
+
+  if (status === LICENSE_STATUS.EXPIRED) {
+    return {
+      color: 'red',
+      message: `Your organization's license expired on ${formatLicenseDate(expireAt)}. New sessions are blocked until a valid license is installed — paste a new license key below, or contact us.`,
+    }
+  }
+  if (status === LICENSE_STATUS.INVALID) {
+    const reason = verifyError ? `: ${verifyError}` : ''
+    return {
+      color: 'red',
+      message: `Your organization's license could not be verified${reason}. New sessions are blocked until a valid license is installed.`,
+    }
+  }
+
+  if (type !== 'enterprise') return null
+  const daysLeft = daysUntilExpiration(expireAt)
+  if (daysLeft === null || daysLeft > EXPIRATION_WARNING_DAYS) return null
+  return {
+    color: 'amber',
+    message: `Your organization's license expires on ${formatLicenseDate(expireAt)}. Please contact us to avoid interruption.`,
+  }
 }
 
 function SettingsLicense() {
@@ -57,6 +71,7 @@ function SettingsLicense() {
 
   const disableInput = licenseInfo?.is_valid && licenseInfo?.type === 'enterprise'
   const disableSave = disableInput || !licenseKey.trim()
+  const notice = expirationNotice(licenseInfo, isAdmin)
 
   useEffect(() => {
     licenseService
@@ -120,9 +135,9 @@ function SettingsLicense() {
         </Group>
       </Group>
 
-      {shouldShowExpirationWarning(licenseInfo, isAdmin) && (
-        <Alert icon={<AlertCircle size={16} />} color="yellow" mb="xl">
-          Your organization's license is expiring soon. Please contact us to avoid interruption.
+      {notice && (
+        <Alert icon={<AlertCircle size={16} />} color={notice.color} mb="xl">
+          {notice.message}
         </Alert>
       )}
 
@@ -138,12 +153,12 @@ function SettingsLicense() {
           <Table.Tbody>
             <Table.Tr>
               <Table.Td>{licenseTypeLabel(licenseInfo?.type)}</Table.Td>
-              <Table.Td>{formatDate(licenseInfo?.issued_at)}</Table.Td>
+              <Table.Td>{formatLicenseDate(licenseInfo?.issued_at)}</Table.Td>
               <Table.Td>
                 {licenseInfo?.type === 'oss' ? (
                   <Text size="xs" c="dimmed">N/A</Text>
                 ) : (
-                  formatDate(licenseInfo?.expire_at)
+                  formatLicenseDate(licenseInfo?.expire_at)
                 )}
               </Table.Td>
             </Table.Tr>

--- a/webapp_v2/src/pages/Settings/License/index.jsx
+++ b/webapp_v2/src/pages/Settings/License/index.jsx
@@ -63,7 +63,7 @@ function expirationNotice(licenseInfo, isAdmin) {
 }
 
 function SettingsLicense() {
-  const { isAdmin, setServerInfo, analyticsTracking } = useUserStore()
+  const { isAdmin, setServerInfo } = useUserStore()
   const [licenseInfo, setLicenseInfo] = useState(null)
   const [licenseKey, setLicenseKey] = useState('')
   const [loading, setLoading] = useState(true)
@@ -146,7 +146,7 @@ function SettingsLicense() {
             <Anchor
               component="button"
               type="button"
-              onClick={() => openSupport(analyticsTracking, SUPPORT_MESSAGE)}
+              onClick={() => openSupport(SUPPORT_MESSAGE)}
               c={notice.color}
               fw={500}
               size="sm"

--- a/webapp_v2/src/pages/Settings/License/index.jsx
+++ b/webapp_v2/src/pages/Settings/License/index.jsx
@@ -20,10 +20,12 @@ import authService from '@/services/auth'
 import { docsUrl } from '@/utils/docsUrl'
 import { LICENSE_STATUS, daysUntilExpiration, formatLicenseDate } from '@/utils/license'
 import { showSnackbar } from '@/utils/snackbar'
+import { openSupport } from '@/utils/support'
 
 // Wider than the global banner's 30 days: this page is where renewal happens,
 // so a heads-up here is useful long before it is worth interrupting the app.
 const EXPIRATION_WARNING_DAYS = 90
+const SUPPORT_MESSAGE = 'I want to renew my hoop license'
 
 function licenseTypeLabel(type) {
   if (type === 'enterprise') return 'Enterprise License'
@@ -40,14 +42,14 @@ function expirationNotice(licenseInfo, isAdmin) {
   if (status === LICENSE_STATUS.EXPIRED) {
     return {
       color: 'red',
-      message: `Your organization's license expired on ${formatLicenseDate(expireAt)}. New sessions are blocked until a valid license is installed — paste a new license key below, or contact us.`,
+      message: `Your license expired on ${formatLicenseDate(expireAt)}. New sessions are blocked.`,
     }
   }
   if (status === LICENSE_STATUS.INVALID) {
     const reason = verifyError ? `: ${verifyError}` : ''
     return {
       color: 'red',
-      message: `Your organization's license could not be verified${reason}. New sessions are blocked until a valid license is installed.`,
+      message: `Your license could not be verified${reason}. New sessions are blocked.`,
     }
   }
 
@@ -56,12 +58,12 @@ function expirationNotice(licenseInfo, isAdmin) {
   if (daysLeft === null || daysLeft > EXPIRATION_WARNING_DAYS) return null
   return {
     color: 'amber',
-    message: `Your organization's license expires on ${formatLicenseDate(expireAt)}. Please contact us to avoid interruption.`,
+    message: `Your license expires on ${formatLicenseDate(expireAt)}. Renew it to avoid interruption.`,
   }
 }
 
 function SettingsLicense() {
-  const { isAdmin, setServerInfo } = useUserStore()
+  const { isAdmin, setServerInfo, analyticsTracking } = useUserStore()
   const [licenseInfo, setLicenseInfo] = useState(null)
   const [licenseKey, setLicenseKey] = useState('')
   const [loading, setLoading] = useState(true)
@@ -137,7 +139,21 @@ function SettingsLicense() {
 
       {notice && (
         <Alert icon={<AlertCircle size={16} />} color={notice.color} mb="xl">
-          {notice.message}
+          <Group gap="xs" align="center" wrap="wrap">
+            <Text size="sm" component="span">
+              {notice.message}
+            </Text>
+            <Anchor
+              component="button"
+              type="button"
+              onClick={() => openSupport(analyticsTracking, SUPPORT_MESSAGE)}
+              c={notice.color}
+              fw={500}
+              size="sm"
+            >
+              {'Contact support ↗'}
+            </Anchor>
+          </Group>
         </Alert>
       )}
 

--- a/webapp_v2/src/stores/useUserStore.js
+++ b/webapp_v2/src/stores/useUserStore.js
@@ -31,6 +31,9 @@ export const useUserStore = create((set, get) => ({
   // Only meaningful once serverInfoLoaded is true — gating fails closed
   // while /serverinfo hasn't been fetched successfully.
   licenseFeatures: null,
+  // Raw /serverinfo license_info. Null until serverinfo resolves, which is why
+  // LicenseBanner renders nothing rather than guessing a state.
+  licenseInfo: null,
   serverInfoLoaded: false,
   apiUrl: null,
   hasRedactCredentials: false,
@@ -60,6 +63,7 @@ export const useUserStore = create((set, get) => ({
       redactProvider, 
       apiUrl,
       licenseFeatures,
+      licenseInfo: license || null,
       serverInfoLoaded: true,
       hasRedactCredentials: !!serverInfo?.has_redact_credentials,
       postgresProxyEnabled: !!serverInfo?.postgres_proxy_enabled
@@ -86,8 +90,9 @@ export const useUserStore = create((set, get) => ({
       analyticsMode: 'anonymous', 
       disableClipboard: false, 
       gatewayVersion: null, 
-      featureFlags: {}, 
+      featureFlags: {},
       licenseFeatures: null,
+      licenseInfo: null,
       serverInfoLoaded: false,
       redactProvider: null, 
       apiUrl: null,

--- a/webapp_v2/src/stores/useUserStore.js
+++ b/webapp_v2/src/stores/useUserStore.js
@@ -31,8 +31,7 @@ export const useUserStore = create((set, get) => ({
   // Only meaningful once serverInfoLoaded is true — gating fails closed
   // while /serverinfo hasn't been fetched successfully.
   licenseFeatures: null,
-  // Raw /serverinfo license_info. Null until serverinfo resolves, which is why
-  // LicenseBanner renders nothing rather than guessing a state.
+  // Null until /serverinfo resolves, so consumers must not guess a state.
   licenseInfo: null,
   serverInfoLoaded: false,
   apiUrl: null,

--- a/webapp_v2/src/utils/license.js
+++ b/webapp_v2/src/utils/license.js
@@ -1,5 +1,4 @@
-// `license_info.status` from /serverinfo. Decided by the gateway clock, so
-// never re-derive "expired" from expire_at here.
+// Set by the gateway clock — never re-derive "expired" from expire_at here.
 export const LICENSE_STATUS = {
   VALID: 'valid',
   EXPIRED: 'expired',

--- a/webapp_v2/src/utils/license.js
+++ b/webapp_v2/src/utils/license.js
@@ -1,0 +1,25 @@
+// `license_info.status` from /serverinfo. Decided by the gateway clock, so
+// never re-derive "expired" from expire_at here.
+export const LICENSE_STATUS = {
+  VALID: 'valid',
+  EXPIRED: 'expired',
+  INVALID: 'invalid',
+}
+
+// Unix seconds -> "Sep 18, 2026", same format as the other Settings tables.
+export function formatLicenseDate(timestamp) {
+  if (!timestamp) return '—'
+  return new Date(timestamp * 1000).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  })
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+// Whole days left, rounded up so an expiry later today reads as 1, not 0.
+export function daysUntilExpiration(expireAt) {
+  if (!expireAt) return null
+  return Math.ceil((expireAt * 1000 - Date.now()) / DAY_MS)
+}

--- a/webapp_v2/src/utils/support.js
+++ b/webapp_v2/src/utils/support.js
@@ -1,0 +1,12 @@
+// Fallback for when analytics is off: Intercom is never booted in that case.
+export const GITHUB_DISCUSSIONS_URL = 'https://github.com/hoophq/hoop/discussions'
+
+// Opens the Intercom messenger with a prefilled message, same destination as
+// "Contact support" in the header user menu.
+export function openSupport(analyticsTracking, message) {
+  if (analyticsTracking && window.Intercom) {
+    window.Intercom('showNewMessage', message)
+    return
+  }
+  window.open(GITHUB_DISCUSSIONS_URL, '_blank', 'noopener,noreferrer')
+}

--- a/webapp_v2/src/utils/support.js
+++ b/webapp_v2/src/utils/support.js
@@ -1,12 +1,12 @@
-// Fallback for when analytics is off: Intercom is never booted in that case.
+import { useUserStore } from '@/stores/useUserStore'
+
+// Fallback for when Intercom is unavailable: analytics off, or the widget
+// failed to load.
 export const GITHUB_DISCUSSIONS_URL = 'https://github.com/hoophq/hoop/discussions'
 
 // Opens the Intercom messenger with a prefilled message, same destination as
-// "Contact support" in the header user menu.
-export function openSupport(analyticsTracking, message) {
-  if (analyticsTracking && window.Intercom) {
-    window.Intercom('showNewMessage', message)
-    return
-  }
+// "Contact support" in the header user menu. The store boots it when needed.
+export function openSupport(message) {
+  if (useUserStore.getState().showIntercomMessage(message)) return
   window.open(GITHUB_DISCUSSIONS_URL, '_blank', 'noopener,noreferrer')
 }

--- a/webapp_v2/src/utils/support.js
+++ b/webapp_v2/src/utils/support.js
@@ -1,11 +1,8 @@
 import { useUserStore } from '@/stores/useUserStore'
 
-// Fallback for when Intercom is unavailable: analytics off, or the widget
-// failed to load.
 export const GITHUB_DISCUSSIONS_URL = 'https://github.com/hoophq/hoop/discussions'
 
-// Opens the Intercom messenger with a prefilled message, same destination as
-// "Contact support" in the header user menu. The store boots it when needed.
+// Same destination as "Contact support" in the header user menu.
 export function openSupport(message) {
   if (useUserStore.getState().showIntercomMessage(message)) return
   window.open(GITHUB_DISCUSSIONS_URL, '_blank', 'noopener,noreferrer')


### PR DESCRIPTION
## 📝 Description

An expired license blocks every new session at the gRPC connect gate (`gateway/transport/server.go:134-141`), but the webapp never warned before it happened: the expiration notice lived only on `/settings/license` and was suppressed once the license went invalid (both the React predicate and the CLJS `gateway_info` check required `is_valid === true`). An org went from no warning at all straight to every session refused.

This PR surfaces the license state across the whole app, and adds the analytics event requested in the issue comment so we have a record of what we issued and to whom.

## 📣 User-facing impact

Admins see a banner when their license is close to expiring, and a persistent one once it has expired or cannot be verified, instead of discovering the problem when sessions start failing.

## 🔗 Related Issue

EVL-120 — https://linear.app/hoophq/issue/EVL-120/expired-license-causes-outage-without-webapp-warning

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

**Gateway**

- `/serverinfo` now reports `license_info.status` (`valid` | `expired` | `invalid`), decided on the gateway clock — the same one the connect gate enforces — so the browser can never disagree with what actually blocks sessions.
- Fixed `is_valid`: it reused the `err` variable still holding the tolerated `ErrNotFound` from the misc-config lookup above, so a valid license could be reported invalid.
- Fixed a data race: `serverInfoData` was a package-level struct mutated on every request, which could leak one org's license info into another org's response. Requests now copy the base.
- New `hoop-license-signed` analytics event on `POST /orgs/license/sign` with license type, description, allowed hosts, key id, features and expiration. Signed licenses are never stored gateway-side, so this event and the existing log line are the only record of what we issued. The route is restricted to the signing org, so customer deployments never reach it.
- The event carries no PII. `description` is the attribution — it is the field the internal signing runbook already prompts for, so no change is needed outside this repo.

**Webapp v2**

- New `LicenseBanner` in the shell, rendered above `AppShell.Main` so it covers CLJS routes too.
- Escalation: silent → dismissible at 30 days → dismissible again at 14 → locked inside the last 7 days → red and locked once expired or unverifiable.
- Dismissal is keyed by user + `expire_at` + step, so ignoring it at 30 days does not stay silent at 14, renewing re-arms the warning, and one admin cannot silence it for another on the same browser.
- Admin-only, and suppressed on `/settings/license`, which says the same thing next to the field that fixes it.
- The settings page reuses the shared helpers and no longer requires the license to be valid before warning.
- "Contact support" opens the same Intercom messenger as the header user menu, extracted to `utils/support.js`. It goes through `useUserStore.showIntercomMessage`, which boots Intercom when the app-boot init was skipped, and falls back to GitHub Discussions when it is unavailable.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

**Automated**

- `go test ./gateway/api/serverinfo/... ./gateway/api/orgs/... ./common/license/...` — `TestLicenseStatus` covers valid, expired, expired-through-a-wrap, host mismatch and used-before-issued; `TestSignedLicenseProperties` pins the analytics event's property contract.
- `npm run lint` (touched files clean) and `npm run build`.

**Manual — how to test**

The public key is embedded in the binary, so a locally-signed license cannot be verified by a stock build. Temporarily swap `licensePubKeyPem` in `common/license/license.go` for a disposable keypair, set `LICENSE_SIGNING_KEY=<org-id>,<base64 PKCS#8 key>` in `.env`, and rebuild.

1. Sign an enterprise license 30 days out: `hoop admin license sign enterprise --allowed-hosts '*' --description 'test' --expire-at 720h`, then `hoop admin license install --file <file>`.
2. Reload the webapp as an admin → amber banner, "expires in 30 days", with a close button. Dismiss it → gone; it returns at 14 days.
3. Re-sign with `--expire-at 120h` (5 days) and install → amber banner with no close button.
4. Install an already-expired license (`license.Sign` accepts a negative duration, but `PUT /orgs/license` verifies before storing, so write it straight into `private.orgs.license_data`) → red banner, no close button, "Update license" link, and `hoop connect` fails with `FailedPrecondition: license is not valid`.
5. Log in as a non-admin in any of these states → no banner.
6. Visit `/settings/license` in any state → page alert instead of the banner, never both.

## 📸 Screenshots

<img width="3024" height="1804" alt="CleanShot 2026-08-19 at 11 48 06@2x" src="https://github.com/user-attachments/assets/b48aa931-1720-4168-9121-1d227e46ab13" />

<img width="3024" height="1804" alt="CleanShot 2026-08-19 at 11 38 35@2x" src="https://github.com/user-attachments/assets/aed52e6b-c0de-40be-9a7b-e99289bf8fab" />

<img width="3024" height="1804" alt="CleanShot 2026-08-19 at 11 59 48@2x" src="https://github.com/user-attachments/assets/204302e4-81f7-4eed-84e8-53e8b807d41e" />

<img width="3024" height="1804" alt="CleanShot 2026-08-19 at 11 59 38@2x" src="https://github.com/user-attachments/assets/a26a681f-4cfa-4022-8d32-7eb539625e2f" />

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
