### PR TITLE
EVL-211: in-app TTFV survey (frontend)

### DIFF
--- a/webapp_v2/CLAUDE.md
+++ b/webapp_v2/CLAUDE.md
@@ -292,8 +292,12 @@ CSS Modules are allowed **only** for complex selectors that Mantine props cannot
 Available Mantine CSS variables (set by the theme in `src/theme.js`):
 
 ```css
-/* Spacing — xs=4px sm=8px md=16px lg=24px xl=32px xxl=48px xxxl=64px */
-var(--mantine-spacing-xs | sm | md | lg | xl | xxl | xxxl)
+/* Spacing — TWO scales live side by side, and the `*Alt` suffix is part of the
+   variable name. `theme.js` only overrides the *Alt keys; Mantine deep-merges
+   them with its own defaults, which stay untouched. There is NO
+   --mantine-spacing-xxl / -xxxl — those exist only with the Alt suffix. */
+var(--mantine-spacing-xs | sm | md | lg | xl)                     /* Mantine: 10 12 16 20 32px */
+var(--mantine-spacing-xsAlt | smAlt | mdAlt | lgAlt | xlAlt | xxlAlt | xxxlAlt)  /* ours: 4 8 16 24 32 48 64px */
 
 /* Font sizes — xs=12px sm=14px md=16px lg=18px xl=20px */
 var(--mantine-font-size-xs | sm | md | lg | xl)
@@ -318,6 +322,14 @@ var(--mantine-color-{name}-light-color)  /* light variant text */
 /* ✅ Correct — always reference the theme */
 .label { font-size: var(--mantine-font-size-xs); margin-bottom: var(--mantine-spacing-sm); color: var(--mantine-color-indigo-8); }
 ```
+
+**A misspelled variable fails silently — check the name against the list above.**
+An undefined custom property doesn't fall back to the default, it invalidates the
+whole declaration, so the property is simply dropped. Inside a `calc()` this is
+especially quiet: `max-height: calc(50vh - var(--mantine-spacing-xxl))` had no
+`max-height` at all in the shipped origin survey, and the card ran off the top of
+short viewports instead of scrolling. If a rule looks like it isn't applying,
+inspect it in DevTools — an invalid declaration shows struck through.
 
 ## Text color — use Mantine tokens, not raw names
 

--- a/webapp_v2/COMPONENTS.md
+++ b/webapp_v2/COMPONENTS.md
@@ -818,7 +818,7 @@ Non-obvious notes only:
 - `originSurvey.js` / `ttfvSurvey.js` — the in-app surveys. Both are write-only:
   there is no GET, because whether to ask is a boolean on `/userinfo`
   (`show_origin_survey`, `show_ttfv_survey`) and the whole policy — admin check,
-  feature flag, cooldown, already-answered — lives in the gateway. Both POST
+  org eligibility, cooldown, already-answered — lives in the gateway. Both POST
   return 204, and 409 on a repeat answer, so callers fire and forget rather than
   surfacing an error the user can't act on. On `ttfvSurvey.answer`, `activity` is
   only read when `reachedValue` is true and `activityOther` only when `activity`

--- a/webapp_v2/COMPONENTS.md
+++ b/webapp_v2/COMPONENTS.md
@@ -620,6 +620,39 @@ Props: `onAdd()`, `selectMode`, `onToggleSelectMode()`, `allSelected`, `onToggle
 
 ---
 
+### `SurveyWidget`
+The shell every in-app survey is rendered in: a floating launcher pinned to the right edge of the viewport that expands into a non-blocking card, plus the "Answer received" acknowledgement that replaces the question and retires the widget. It owns presentation and the collapsed/open/closed lifecycle only — the survey feature owns visibility (`due`) and submission (`answered`).
+```jsx
+import SurveyWidget from '@/components/SurveyWidget'
+import { EMPTY_CHOICE_ANSWER } from '@/components/SurveyWidget/constants'
+
+const due = useUserStore((state) => !!state.user?.show_origin_survey)
+const [answer, setAnswer] = useState(EMPTY_CHOICE_ANSWER)
+const [answered, setAnswered] = useState(false)
+
+<SurveyWidget label={QUESTION} due={due} answered={answered}>
+  <SurveyWidget.ChoiceQuestion
+    question={QUESTION}
+    options={OPTIONS}
+    answer={answer}
+    onAnswerChange={setAnswer}
+    otherValue="other"
+    otherMaxLength={255}
+    otherLabel="Specify how you heard about Hoop"
+    onSubmit={handleSubmit}
+  />
+</SurveyWidget>
+```
+Props: `label` (announced on both launcher and card — keep it stable across a multi-step survey), `due`, `answered`, `children`.
+
+`SurveyWidget.ChoiceQuestion` is a single-choice question with a free-text follow-up on one designated option plus its Submit button; Submit stays disabled until the free text is filled in for that option. It is **controlled** — the card unmounts when the user collapses it, so the `{ value, otherText }` answer must live in the feature, which stays mounted. Seed it with `EMPTY_CHOICE_ANSWER`.
+
+Two rules when adding a survey:
+- Mount it through `features/Surveys`, never in `App.jsx` directly — every survey anchors to the same spot, so only one may be on screen at a time and that coordinator is what picks.
+- Read visibility from a `/userinfo` boolean (`show_origin_survey`, `show_ttfv_survey`). A gateway that doesn't know the field yet leaves it undefined, which reads as "don't ask" — the widget fails closed.
+
+---
+
 ### `FullBleed` (`src/layout/FullBleed/`)
 Lets a page render edge-to-edge and exactly one viewport tall **inside** the padded `PageLayout` — cancels the page padding (single-sourced from `PageLayout`'s `PAGE_PADDING`) and fills the `AppShell.Main` height. Use for hero/promotion panels.
 ```jsx
@@ -782,6 +815,14 @@ Non-obvious notes only:
   page. Never use it as an existence probe.
 - `onboarding.js` — `GET /orgs/onboarding`, admin only. The gateway computes the
   whole setup checklist in one query; backs `useConfigStatusStore`.
+- `originSurvey.js` / `ttfvSurvey.js` — the in-app surveys. Both are write-only:
+  there is no GET, because whether to ask is a boolean on `/userinfo`
+  (`show_origin_survey`, `show_ttfv_survey`) and the whole policy — admin check,
+  feature flag, cooldown, already-answered — lives in the gateway. Both POST
+  return 204, and 409 on a repeat answer, so callers fire and forget rather than
+  surfacing an error the user can't act on. On `ttfvSurvey.answer`, `activity` is
+  only read when `reachedValue` is true and `activityOther` only when `activity`
+  is `'other'`.
 - `reports.js` — `/reports/sessions` takes `YYYY-MM-DD` dates only and `end_date`
   is **exclusive** (the gateway compares against midnight *starting* that day, so
   send tomorrow to include today). Never send `group_by`.

--- a/webapp_v2/src/App.jsx
+++ b/webapp_v2/src/App.jsx
@@ -1,7 +1,7 @@
 import { Toaster } from 'sonner'
 import { useEffect } from 'react'
 import Router from './Router'
-import OriginSurvey from '@/features/OriginSurvey'
+import Surveys from '@/features/Surveys'
 import { useConnectionsMetadataStore } from '@/stores/useConnectionsMetadataStore'
 
 // Clears the global header so toasts never cover the Native Connections button
@@ -23,8 +23,8 @@ function App() {
       <Router />
       {/* Mounted outside the Router so it also reaches the onboarding routes,
           which render without the app Layout. Renders nothing until /userinfo
-          reports the survey is still due. */}
-      <OriginSurvey />
+          reports one of the surveys is still due. */}
+      <Surveys />
       <Toaster position="top-right" offset={TOAST_OFFSET} mobileOffset={TOAST_OFFSET} />
     </>
   )

--- a/webapp_v2/src/components/SurveyWidget/ChoiceQuestion.jsx
+++ b/webapp_v2/src/components/SurveyWidget/ChoiceQuestion.jsx
@@ -1,0 +1,67 @@
+import { Group, Stack } from '@mantine/core'
+import Button from '@/components/Button'
+import Radio from '@/components/Radio'
+import TextInput from '@/components/TextInput'
+
+/**
+ * A single-choice survey question with a free-text follow-up on one designated
+ * option, plus the Submit button that closes it. Both surveys ask one of these,
+ * and the interlock between the two inputs — Submit stays disabled until the
+ * free text is filled in for the "other" option — is the part worth having in
+ * one place.
+ *
+ * Controlled rather than self-contained: SurveyWidget unmounts the card when
+ * the user collapses it with the X, so state kept in here would be wiped by a
+ * mis-click. Holding it in the survey feature, which stays mounted, is what
+ * makes collapsing free.
+ *
+ * Renders a fragment — the pieces are spaced by the card's own Stack.
+ */
+function ChoiceQuestion({
+  question,
+  options,
+  answer,
+  onAnswerChange,
+  otherValue,
+  otherMaxLength,
+  otherLabel,
+  onSubmit,
+}) {
+  const otherSelected = answer.value === otherValue
+  const canSubmit = answer.value !== null && (!otherSelected || answer.otherText.trim() !== '')
+
+  return (
+    <>
+      <Radio.Group
+        value={answer.value}
+        onChange={(value) => onAnswerChange({ ...answer, value })}
+        label={question}
+        labelProps={{ fw: 400 }}
+      >
+        <Stack gap="sm" mt="sm">
+          {options.map((option) => (
+            <Radio key={option.value} value={option.value} label={option.label} size="xs" />
+          ))}
+        </Stack>
+      </Radio.Group>
+
+      {otherSelected && (
+        <TextInput
+          placeholder="Specify"
+          value={answer.otherText}
+          onChange={(event) => onAnswerChange({ ...answer, otherText: event.currentTarget.value })}
+          maxLength={otherMaxLength}
+          aria-label={otherLabel}
+        />
+      )}
+
+      <Group justify="flex-end">
+        <Button size="xs" disabled={!canSubmit} onClick={onSubmit}>
+          Submit
+        </Button>
+      </Group>
+    </>
+  )
+}
+
+export default ChoiceQuestion

--- a/webapp_v2/src/components/SurveyWidget/SurveyWidget.module.css
+++ b/webapp_v2/src/components/SurveyWidget/SurveyWidget.module.css
@@ -39,11 +39,17 @@
 
 /* Grows upward from just above the launcher, sharing its right edge. The cap
    keeps the top of the card on screen on short viewports; the space above the
-   launcher is the anchor minus its own half-height and the gap. */
+   launcher is the anchor minus its own half-height and the gap.
+
+   xxlAlt, not xxl: theme.js adds the 4/8/16/24/32/48/64 scale under *Alt keys
+   and leaves Mantine's own xs–xl defaults in place, so there is no
+   --mantine-spacing-xxl. Referencing it made the whole calc() invalid, which
+   dropped max-height entirely and let the card run off the top of short
+   viewports instead of scrolling. */
 .card {
   position: absolute;
   right: 0;
   bottom: calc(100% + var(--mantine-spacing-sm));
-  max-height: calc(var(--survey-anchor) - var(--mantine-spacing-xxl));
+  max-height: calc(var(--survey-anchor) - var(--mantine-spacing-xxlAlt));
   overflow-y: auto;
 }

--- a/webapp_v2/src/components/SurveyWidget/constants.js
+++ b/webapp_v2/src/components/SurveyWidget/constants.js
@@ -1,0 +1,4 @@
+// Starting value for the `answer` a SurveyWidget.ChoiceQuestion is driven by.
+// Never mutated — ChoiceQuestion only ever hands back a new object — so the two
+// surveys can safely share the one literal.
+export const EMPTY_CHOICE_ANSWER = { value: null, otherText: '' }

--- a/webapp_v2/src/components/SurveyWidget/index.jsx
+++ b/webapp_v2/src/components/SurveyWidget/index.jsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react'
+import { Box, Group, Indicator, Paper, Stack, Text } from '@mantine/core'
+import { X } from 'lucide-react'
+import ActionIcon from '@/components/ActionIcon'
+import ChoiceQuestion from './ChoiceQuestion'
+import classes from './SurveyWidget.module.css'
+
+const CARD_WIDTH = 340
+
+// Large enough to read as a call to action on the launcher rather than as a
+// decorative dot.
+const PENDING_DOT_SIZE = 12
+
+// How long the acknowledgement stays on screen before the widget removes
+// itself. Long enough to read a two-word message without lingering.
+const ACK_DURATION_MS = 3000
+
+// Card chrome rather than survey content: every survey wears the same header
+// and the same acknowledgement, so the widget stays recognisable whichever one
+// happens to be due. Only the question inside changes.
+const CARD_TITLE = 'Help us out'
+const ACK_MESSAGE = 'Answer received'
+
+/**
+ * The shell every in-app survey is rendered in: a floating launcher on the
+ * right edge of the viewport that expands into a non-blocking card, plus the
+ * acknowledgement that replaces the question once it is answered.
+ *
+ * It owns the presentation and the open/collapsed/acknowledged lifecycle. It
+ * does not own visibility or submission — the survey feature passes `due` (the
+ * gateway's verdict on whether to ask at all) and flips `answered` once it has
+ * fired the write.
+ *
+ * Only one survey may be on screen at a time, since they all anchor to the same
+ * spot; `features/Surveys` is what enforces that.
+ *
+ * @param {string} label   Describes the survey to assistive tech. Used on both
+ *                         the launcher and the card, so it must stay stable
+ *                         across a multi-step survey rather than tracking the
+ *                         current step.
+ * @param {boolean} due    Whether the gateway still wants this survey asked.
+ * @param {boolean} answered Set by the feature once the answer is on its way.
+ */
+function SurveyWidget({ label, due, answered, children }) {
+  // 'collapsed' → launcher only, 'open' → showing the question, 'closed' →
+  // gone for this page load. The acknowledgement is not a phase of its own: it
+  // is driven by `answered`, which the feature owns.
+  const [phase, setPhase] = useState('collapsed')
+
+  useEffect(() => {
+    if (!answered) return
+    const timer = setTimeout(() => setPhase('closed'), ACK_DURATION_MS)
+    return () => clearTimeout(timer)
+  }, [answered])
+
+  // Once answered there is nothing left to come back to, so the X retires the
+  // widget instead of collapsing it — it only reappears if the gateway still
+  // reports the survey on the next load.
+  function handleDismiss() {
+    setPhase(answered ? 'closed' : 'collapsed')
+  }
+
+  function handleToggle() {
+    // Inert while acknowledging: the answer is already on its way, reopening
+    // the form would only invite a second submission.
+    if (answered) return
+    setPhase(phase === 'open' ? 'collapsed' : 'open')
+  }
+
+  if (phase === 'closed') return null
+  // Only checked while collapsed: a card the user already opened stays open
+  // even if the flag were to change underneath it.
+  if (phase === 'collapsed' && !due) return null
+
+  const expanded = phase === 'open' || answered
+
+  return (
+    <Box className={classes.widget} data-open={expanded || undefined}>
+      {expanded && (
+        <Paper
+          shadow="md"
+          radius="md"
+          p="md"
+          w={CARD_WIDTH}
+          className={classes.card}
+          role="dialog"
+          aria-label={label}
+        >
+          <Stack gap="lg">
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+              <Text fw={500}>{CARD_TITLE}</Text>
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                onClick={handleDismiss}
+                aria-label={answered ? 'Dismiss survey' : 'Collapse survey'}
+              >
+                <X size={16} />
+              </ActionIcon>
+            </Group>
+
+            {answered ? (
+              // The message replaces the question asynchronously, so it is
+              // announced rather than silently swapped in.
+              <Text size="sm" role="status">
+                {ACK_MESSAGE}
+              </Text>
+            ) : (
+              children
+            )}
+          </Stack>
+        </Paper>
+      )}
+
+      {/* The dot marks the survey as still pending, so it goes out as soon as
+          the answer is in — the launcher itself lingers only for the
+          acknowledgement. */}
+      <Indicator color="red" size={PENDING_DOT_SIZE} offset={4} withBorder disabled={answered}>
+        <ActionIcon
+          variant="default"
+          radius="xl"
+          size="lg"
+          className={classes.launcher}
+          onClick={handleToggle}
+          aria-expanded={expanded}
+          aria-label={label}
+        >
+          {/* The symbol SVG carries a viewBox but no width/height, so both axes
+              are given here — with only a height it has no layout width to fall
+              back on if the asset fails to load. viewBox is square. */}
+          <img src="/images/hoop-branding/SVG/hoop-symbol_black.svg" alt="" width={18} height={18} />
+        </ActionIcon>
+      </Indicator>
+    </Box>
+  )
+}
+
+SurveyWidget.ChoiceQuestion = ChoiceQuestion
+
+export default SurveyWidget

--- a/webapp_v2/src/features/OriginSurvey/constants.js
+++ b/webapp_v2/src/features/OriginSurvey/constants.js
@@ -1,3 +1,5 @@
+export const ORIGIN_QUESTION = 'How did you hear about Hoop?'
+
 // Answers of the onboarding "How did you hear about Hoop?" survey. The `value`
 // of each entry is the analytics contract shared with the gateway
 // (validSignupOrigins in gateway/api/user/originsurvey.go) — keep both lists in

--- a/webapp_v2/src/features/OriginSurvey/index.jsx
+++ b/webapp_v2/src/features/OriginSurvey/index.jsx
@@ -1,51 +1,24 @@
-import { useEffect, useState } from 'react'
-import { Box, Group, Indicator, Paper, Stack, Text } from '@mantine/core'
-import { X } from 'lucide-react'
-import ActionIcon from '@/components/ActionIcon'
-import Button from '@/components/Button'
-import Radio from '@/components/Radio'
-import TextInput from '@/components/TextInput'
+import { useState } from 'react'
+import SurveyWidget from '@/components/SurveyWidget'
+import { EMPTY_CHOICE_ANSWER } from '@/components/SurveyWidget/constants'
 import { useUserStore } from '@/stores/useUserStore'
 import { originSurveyService } from '@/services/originSurvey'
-import { ORIGIN_OPTIONS, ORIGIN_OTHER, ORIGIN_OTHER_MAX_LENGTH } from './constants'
-import classes from './OriginSurvey.module.css'
-
-const CARD_WIDTH = 340
-
-// Large enough to read as a call to action on the launcher rather than as a
-// decorative dot.
-const PENDING_DOT_SIZE = 12
-
-// How long the acknowledgement stays on screen before the widget removes
-// itself. Long enough to read a two-word message without lingering.
-const ACK_DURATION_MS = 3000
+import { ORIGIN_OPTIONS, ORIGIN_OTHER, ORIGIN_OTHER_MAX_LENGTH, ORIGIN_QUESTION } from './constants'
 
 /**
- * Onboarding "How did you hear about Hoop?" survey — a floating launcher on the
- * right edge of the viewport that expands into a non-blocking card. Mounted
- * globally so it also reaches the chrome-less onboarding routes that render
- * outside the app Layout.
+ * Onboarding "How did you hear about Hoop?" survey.
  *
  * Visibility is owned by the gateway: /userinfo returns show_origin_survey,
  * which is true only while the user has not answered and is within 7 days of
- * their user record being created. The X collapses the card back to the
- * launcher, so a mis-click never costs us the answer.
+ * their user record being created.
+ *
+ * Rendered through `features/Surveys`, never mounted directly — see the note
+ * there about two surveys sharing one anchor.
  */
 function OriginSurvey() {
-  const user = useUserStore((state) => state.user)
-
-  // 'collapsed' → launcher only, 'open' → collecting the answer, 'ack' →
-  // acknowledging it, 'closed' → gone for this page load. The local phase
-  // outranks the server flag, which is only re-read on the next load.
-  const [phase, setPhase] = useState('collapsed')
-  const [origin, setOrigin] = useState(null)
-  const [otherText, setOtherText] = useState('')
-
-  useEffect(() => {
-    if (phase !== 'ack') return
-    const timer = setTimeout(() => setPhase('closed'), ACK_DURATION_MS)
-    return () => clearTimeout(timer)
-  }, [phase])
+  const due = useUserStore((state) => !!state.user?.show_origin_survey)
+  const [answer, setAnswer] = useState(EMPTY_CHOICE_ANSWER)
+  const [answered, setAnswered] = useState(false)
 
   function handleSubmit() {
     // Fire and forget: the acknowledgement shows on the click without waiting
@@ -55,126 +28,25 @@ function OriginSurvey() {
     // to act on in the meantime, so a failure toast would be pure noise. It
     // still reaches the console for anyone debugging the flow.
     originSurveyService
-      .answer({ origin, originOther: otherText.trim() })
+      .answer({ origin: answer.value, originOther: answer.otherText.trim() })
       .catch((err) => console.warn('[origin-survey] failed recording the answer:', err))
 
-    setPhase('ack')
+    setAnswered(true)
   }
-
-  // Once answered there is nothing left to come back to, so the X retires the
-  // widget instead of collapsing it — it only reappears if the gateway still
-  // reports the survey on the next load.
-  function handleDismiss() {
-    setPhase(phase === 'ack' ? 'closed' : 'collapsed')
-  }
-
-  function handleToggle() {
-    // Inert while acknowledging: the answer is already on its way, reopening
-    // the form would only invite a second submission.
-    if (phase === 'ack') return
-    setPhase(phase === 'open' ? 'collapsed' : 'open')
-  }
-
-  if (phase === 'closed') return null
-  if (phase === 'collapsed' && !user?.show_origin_survey) return null
-
-  const answered = phase === 'ack'
-  const expanded = phase === 'open' || answered
-  const otherSelected = origin === ORIGIN_OTHER
-  const canSubmit = origin !== null && (!otherSelected || otherText.trim() !== '')
 
   return (
-    <Box className={classes.widget} data-open={expanded || undefined}>
-      {expanded && (
-        <Paper
-          shadow="md"
-          radius="md"
-          p="md"
-          w={CARD_WIDTH}
-          className={classes.card}
-          role="dialog"
-          aria-label="How did you hear about Hoop?"
-        >
-          <Stack gap="lg">
-            <Group justify="space-between" align="flex-start" wrap="nowrap">
-              <Text fw={500}>Help us out</Text>
-              <ActionIcon
-                variant="subtle"
-                color="gray"
-                onClick={handleDismiss}
-                aria-label={answered ? 'Dismiss survey' : 'Collapse survey'}
-              >
-                <X size={16} />
-              </ActionIcon>
-            </Group>
-
-            {answered ? (
-              // The message replaces the form asynchronously, so it is
-              // announced rather than silently swapped in.
-              <Text size="sm" role="status">
-                Answer received
-              </Text>
-            ) : (
-              <>
-                <Radio.Group
-                  value={origin}
-                  onChange={setOrigin}
-                  label="How did you hear about Hoop?"
-                  labelProps={{ fw: 400 }}
-                >
-                  <Stack gap="sm" mt="sm">
-                    {ORIGIN_OPTIONS.map((option) => (
-                      <Radio key={option.value} value={option.value} label={option.label} size="xs" />
-                    ))}
-                  </Stack>
-                </Radio.Group>
-
-                {otherSelected && (
-                  <TextInput
-                    placeholder="Specify"
-                    value={otherText}
-                    onChange={(event) => setOtherText(event.currentTarget.value)}
-                    maxLength={ORIGIN_OTHER_MAX_LENGTH}
-                    aria-label="Specify how you heard about Hoop"
-                  />
-                )}
-
-                <Group justify="flex-end">
-                  <Button size="xs" disabled={!canSubmit} onClick={handleSubmit}>
-                    Submit
-                  </Button>
-                </Group>
-              </>
-            )}
-          </Stack>
-        </Paper>
-      )}
-
-      {/* The dot marks the survey as still pending, so it goes out as soon as
-          the answer is in — the launcher itself lingers only for the
-          acknowledgement. */}
-      <Indicator color="red" size={PENDING_DOT_SIZE} offset={4} withBorder disabled={answered}>
-        <ActionIcon
-          variant="default"
-          radius="xl"
-          size="lg"
-          className={classes.launcher}
-          onClick={handleToggle}
-          aria-expanded={expanded}
-          aria-label="How did you hear about Hoop?"
-        >
-          {/* The symbol SVG carries a viewBox but no width/height, so both axes
-              are given here — with only a height it has no layout width to fall
-              back on if the asset fails to load. viewBox is square. */}
-          <img
-            src="/images/hoop-branding/SVG/hoop-symbol_black.svg"
-            alt=""
-            width={18}
-            height={18}
-          />
-        </ActionIcon>
-      </Indicator>
-    </Box>
+    <SurveyWidget label={ORIGIN_QUESTION} due={due} answered={answered}>
+      <SurveyWidget.ChoiceQuestion
+        question={ORIGIN_QUESTION}
+        options={ORIGIN_OPTIONS}
+        answer={answer}
+        onAnswerChange={setAnswer}
+        otherValue={ORIGIN_OTHER}
+        otherMaxLength={ORIGIN_OTHER_MAX_LENGTH}
+        otherLabel="Specify how you heard about Hoop"
+        onSubmit={handleSubmit}
+      />
+    </SurveyWidget>
   )
 }
 

--- a/webapp_v2/src/features/Surveys/index.jsx
+++ b/webapp_v2/src/features/Surveys/index.jsx
@@ -1,0 +1,35 @@
+import OriginSurvey from '@/features/OriginSurvey'
+import TtfvSurvey from '@/features/TtfvSurvey'
+import { useUserStore } from '@/stores/useUserStore'
+
+/**
+ * Picks the one in-app survey to offer, if any.
+ *
+ * Every survey renders through SurveyWidget, which anchors to a fixed spot on
+ * the right edge of the viewport. Two of them at once would stack two launchers
+ * on the same pixels, and the admin of a freshly created org qualifies for both
+ * — so the choice is made here rather than by each survey independently.
+ *
+ * Priority goes to the origin survey because its window is the one that closes:
+ * it can only be answered in the first 7 days of a user's life and only once.
+ * TTFV survives being deferred — the gateway re-offers it after a cooldown for
+ * as long as the org has not confirmed value.
+ *
+ * The pick is deliberately not frozen. /userinfo is fetched once per app boot
+ * (see ProtectedRoute), so answering the origin survey does not flip its flag
+ * mid-session: this keeps returning OriginSurvey, which has retired itself and
+ * renders nothing. TTFV therefore waits for the next page load instead of
+ * popping up seconds after the survey the user just finished.
+ */
+function Surveys() {
+  const showOrigin = useUserStore((state) => !!state.user?.show_origin_survey)
+  const showTtfv = useUserStore((state) => !!state.user?.show_ttfv_survey)
+
+  // Each survey re-reads its own flag to drive SurveyWidget's `due`, so that it
+  // stays self-contained rather than trusting a caller to have checked.
+  if (showOrigin) return <OriginSurvey />
+  if (showTtfv) return <TtfvSurvey />
+  return null
+}
+
+export default Surveys

--- a/webapp_v2/src/features/TtfvSurvey/constants.js
+++ b/webapp_v2/src/features/TtfvSurvey/constants.js
@@ -1,0 +1,27 @@
+// Step 1. A "No" here is a valid, recorded answer — TTFV is the moment an admin
+// first says yes, so the gateway asks again after a cooldown.
+export const REACHED_VALUE_QUESTION = 'Did you get done what you came here to do?'
+
+// Step 2, asked only after a "Yes".
+export const ACTIVITY_QUESTION = 'What did you get done today?'
+
+// The `value` of each entry is the analytics contract shared with the gateway
+// (the valid-activity slice in the POST /orgs/ttfv-survey handler) — keep both
+// lists in sync and never repurpose an existing value, it would corrupt the
+// historical time-to-first-value reports.
+export const ACTIVITY_OPTIONS = [
+  { value: 'connected-infra-resource', label: 'Connected an infra resource' },
+  { value: 'approved-or-denied-access-request', label: 'Approved or denied an access request' },
+  { value: 'reviewed-recorded-session', label: 'Reviewed a recorded session' },
+  { value: 'created-or-activated-policy', label: 'Created or activated a policy (Guardrails)' },
+  { value: 'opened-ai-analyzed-session-report', label: 'Opened an AI-analyzed session report' },
+  { value: 'set-up-data-masking-rule', label: 'Set up a data masking rule' },
+  { value: 'other', label: 'Other (please specify)' },
+]
+
+// The only option that also asks for free text.
+export const ACTIVITY_OTHER = 'other'
+
+// Matches the ttfv_survey_responses.activity_other cap the API enforces; longer
+// values are rejected with a 400.
+export const ACTIVITY_OTHER_MAX_LENGTH = 255

--- a/webapp_v2/src/features/TtfvSurvey/constants.js
+++ b/webapp_v2/src/features/TtfvSurvey/constants.js
@@ -1,21 +1,36 @@
 // Step 1. A "No" here is a valid, recorded answer — TTFV is the moment an admin
 // first says yes, so the gateway asks again after a cooldown.
-export const REACHED_VALUE_QUESTION = 'Did you get done what you came here to do?'
+//
+// "yet" is load-bearing and should survive any rewording: the metric is the
+// first time value was ever reached, not whether it was reached in this visit.
+// Scoping the question to the session or the day would collect a truthful "No"
+// from someone whose first value happened last week — and a "No" costs a
+// cooldown, so it delays the very measurement this asks for. The product is
+// deliberately not named: naming it invites a verdict on the product, where
+// what we need to know is whether the admin accomplished their own goal.
+export const REACHED_VALUE_QUESTION = 'Have you gotten what you needed yet?'
 
-// Step 2, asked only after a "Yes".
-export const ACTIVITY_QUESTION = 'What did you get done today?'
+// Step 2, asked only after a "Yes". "so far" is cumulative for the same reason.
+export const ACTIVITY_QUESTION = 'What have you gotten done so far?'
 
+// Every option is a moment the product did something *for* the admin, never one
+// where they configured it. Connecting a resource, writing a policy and defining
+// a masking rule are all setup — costs the admin pays up front — so counting
+// them as value would measure "finished configuring", which is the thing TTFV
+// exists to be distinguished from. The guardrail and masking entries are
+// deliberately phrased as the rule being seen to apply, not as the rule being
+// created. Anything new here has to clear the same bar.
+//
 // The `value` of each entry is the analytics contract shared with the gateway
 // (the valid-activity slice in the POST /orgs/ttfv-survey handler) — keep both
 // lists in sync and never repurpose an existing value, it would corrupt the
 // historical time-to-first-value reports.
 export const ACTIVITY_OPTIONS = [
-  { value: 'connected-infra-resource', label: 'Connected an infra resource' },
+  { value: 'saw-guardrail-applied', label: 'Saw a guardrail apply to a live session' },
+  { value: 'saw-data-masked', label: 'Saw sensitive data masked in a session' },
   { value: 'approved-or-denied-access-request', label: 'Approved or denied an access request' },
   { value: 'reviewed-recorded-session', label: 'Reviewed a recorded session' },
-  { value: 'created-or-activated-policy', label: 'Created or activated a policy (Guardrails)' },
   { value: 'opened-ai-analyzed-session-report', label: 'Opened an AI-analyzed session report' },
-  { value: 'set-up-data-masking-rule', label: 'Set up a data masking rule' },
   { value: 'other', label: 'Other (please specify)' },
 ]
 

--- a/webapp_v2/src/features/TtfvSurvey/index.jsx
+++ b/webapp_v2/src/features/TtfvSurvey/index.jsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { Group, Text } from '@mantine/core'
+import Button from '@/components/Button'
+import SurveyWidget from '@/components/SurveyWidget'
+import { EMPTY_CHOICE_ANSWER } from '@/components/SurveyWidget/constants'
+import { useUserStore } from '@/stores/useUserStore'
+import { ttfvSurveyService } from '@/services/ttfvSurvey'
+import {
+  ACTIVITY_OPTIONS,
+  ACTIVITY_OTHER,
+  ACTIVITY_OTHER_MAX_LENGTH,
+  ACTIVITY_QUESTION,
+  REACHED_VALUE_QUESTION,
+} from './constants'
+
+/**
+ * Time-to-first-value survey. TTFV is the gap between an organization being
+ * created and the first moment an admin confirms they got value out of hoop;
+ * the product is self-hosted, so the only way to observe that moment is to ask.
+ *
+ * Two steps: a Yes/No, and — only after a Yes — what it was they got done. A No
+ * is an answer too, recorded on the spot, and the gateway asks again once its
+ * cooldown has passed.
+ *
+ * Visibility is owned entirely by the gateway: /userinfo returns
+ * show_ttfv_survey, which already accounts for the caller being an admin, the
+ * feature flag, the terminal Yes and the cooldown. Nothing about that policy is
+ * re-implemented here, so it can be re-tuned without a frontend deploy — and a
+ * gateway that does not know the field yet leaves it undefined, which reads as
+ * "do not ask".
+ *
+ * Rendered through `features/Surveys`, never mounted directly — see the note
+ * there about two surveys sharing one anchor.
+ */
+function TtfvSurvey() {
+  const due = useUserStore((state) => !!state.user?.show_ttfv_survey)
+  const [showActivity, setShowActivity] = useState(false)
+  const [answer, setAnswer] = useState(EMPTY_CHOICE_ANSWER)
+  const [answered, setAnswered] = useState(false)
+
+  // Fire and forget, like the origin survey: the acknowledgement shows on the
+  // click without waiting for the gateway. If the write does not land,
+  // /userinfo keeps reporting show_ttfv_survey and the admin is asked again —
+  // there is nothing for them to act on in the meantime, so a failure toast
+  // would be pure noise. It still reaches the console for anyone debugging.
+  function record(payload) {
+    ttfvSurveyService
+      .answer(payload)
+      .catch((err) => console.warn('[ttfv-survey] failed recording the answer:', err))
+
+    setAnswered(true)
+  }
+
+  return (
+    <SurveyWidget label={REACHED_VALUE_QUESTION} due={due} answered={answered}>
+      {showActivity ? (
+        <SurveyWidget.ChoiceQuestion
+          question={ACTIVITY_QUESTION}
+          options={ACTIVITY_OPTIONS}
+          answer={answer}
+          onAnswerChange={setAnswer}
+          otherValue={ACTIVITY_OTHER}
+          otherMaxLength={ACTIVITY_OTHER_MAX_LENGTH}
+          otherLabel="Specify what you got done"
+          onSubmit={() =>
+            record({
+              reachedValue: true,
+              activity: answer.value,
+              activityOther: answer.otherText.trim(),
+            })
+          }
+        />
+      ) : (
+        <>
+          <Text size="sm">{REACHED_VALUE_QUESTION}</Text>
+          {/* Yes advances to the follow-up rather than answering: a bare
+              "reached value" with no activity is not worth a row, and the
+              gateway treats the first Yes as terminal. */}
+          <Group justify="flex-end" gap="md">
+            <Button size="xs" onClick={() => setShowActivity(true)}>
+              Yes
+            </Button>
+            <Button size="xs" variant="default" onClick={() => record({ reachedValue: false })}>
+              No
+            </Button>
+          </Group>
+        </>
+      )}
+    </SurveyWidget>
+  )
+}
+
+export default TtfvSurvey

--- a/webapp_v2/src/features/TtfvSurvey/index.jsx
+++ b/webapp_v2/src/features/TtfvSurvey/index.jsx
@@ -23,9 +23,10 @@ import {
  * cooldown has passed.
  *
  * Visibility is owned entirely by the gateway: /userinfo returns
- * show_ttfv_survey, which already accounts for the caller being an admin, the
- * feature flag, the terminal Yes and the cooldown. Nothing about that policy is
- * re-implemented here, so it can be re-tuned without a frontend deploy — and a
+ * show_ttfv_survey, which already accounts for the caller being an admin,
+ * whether the organization is eligible to be asked at all, the terminal Yes and
+ * the cooldown. Nothing about that policy is re-implemented here — not even the
+ * names of its clauses — so it can be re-tuned without a frontend deploy, and a
  * gateway that does not know the field yet leaves it undefined, which reads as
  * "do not ask".
  *

--- a/webapp_v2/src/services/ttfvSurvey.js
+++ b/webapp_v2/src/services/ttfvSurvey.js
@@ -1,0 +1,15 @@
+import api from './api'
+
+export const ttfvSurveyService = {
+  // POST /orgs/ttfv-survey → 204 No Content. Admin-only.
+  // activity is only read by the API when reached_value is true, and
+  // activity_other only when activity is 'other'.
+  // Answering again after a "Yes" returns 409 — the first Yes stamps TTFV and
+  // is terminal. A "No" is recorded and the survey comes back after a cooldown.
+  answer: ({ reachedValue, activity, activityOther }) =>
+    api.post('/orgs/ttfv-survey', {
+      reached_value: reachedValue,
+      activity: activity ?? '',
+      activity_other: activityOther ?? '',
+    }),
+}


### PR DESCRIPTION
## 📝 Description

Frontend half of TTFV (time-to-first-value) measurement: the in-app survey that asks an admin whether they've gotten what they needed out of hoop, and what it was.

TTFV is the gap between an org being created and the first moment an admin confirms value. The product is self-hosted, so there is no way to observe that moment — we have to ask. This is the asking; **#1730** ([EVL-212](https://linear.app/hoophq/issue/EVL-212/ttfv-measurement-backend)) is the gateway side that decides *when* to ask, records the answer, and emits the analytics event server-side.

**Ships together with #1730.** This side fails closed, so it is technically safe alone — visibility comes entirely from `show_ttfv_survey` on `GET /userinfo`, and a gateway that doesn't know the field leaves it undefined, which reads as "don't ask". But #1730 alone would make the gateway report `show_ttfv_survey: true` with no widget to render it, so the metric would read zero and look like "shipped, nobody answers". If they ever do land separately, **this one goes first.**

## 📣 User-facing impact

Admins may see a small, dismissable survey in the corner of the app asking whether hoop has done what they needed. Answering it once positively retires it for the whole organization; declining it quiets it for a few days. Organizations with analytics disabled are never asked.

## 🔗 Related Issue

Linear: [EVL-211 — TTFV Measurement Frontend](https://linear.app/hoophq/issue/EVL-211/ttfv-measurement-frontend)
Backend counterpart: #1730 — [EVL-212](https://linear.app/hoophq/issue/EVL-212/ttfv-measurement-backend)

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [x] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

Four commits, in the order they're best reviewed:

- **`a87d0e81` — extract `components/SurveyWidget`.** The origin survey (#1701, EVL-185) had the launcher, card, acknowledgement and lifecycle all inline. TTFV needs every one of those, so the shell moved out and `OriginSurvey` now renders through it — **−180 lines, no behaviour change**. `SurveyWidget` owns presentation and the collapsed → open → closed lifecycle; the feature owns visibility (`due`) and submission (`answered`). `SurveyWidget.ChoiceQuestion` is the single-choice question with a free-text follow-up on one designated option, and it's *controlled* — the card unmounts when collapsed, so the answer has to live in the feature or it's lost on every collapse.
- **`380c4820` — the survey itself.** `features/TtfvSurvey`, `services/ttfvSurvey.js` (`POST /orgs/ttfv-survey`), and `features/Surveys`, a coordinator that picks the one survey to show. `App.jsx` now mounts the coordinator instead of a survey.
- **`6d01c7d5` — stop naming the gateway's eligibility clauses in frontend prose.** Comments used to enumerate them (feature flag, cooldown, terminal Yes…). The frontend re-implements none of that policy, so naming it just creates a second place to update.
- **`439c1fc9` — rewrite the survey copy and the activity options.** See below.

### Bug fixed on the way through

The **already-shipped** origin survey card had:

```css
max-height: calc(50vh - var(--mantine-spacing-xxl));
```

There is no `--mantine-spacing-xxl`. `theme.js` adds the 4/8/16/24/32/48/64 scale under `*Alt` keys and leaves Mantine's own `xs`–`xl` defaults in place. An undefined custom property doesn't fall back — it invalidates the whole declaration — so the card had **no `max-height` at all** and ran off the top of short viewports instead of scrolling. Now `xxlAlt`.

`webapp_v2/CLAUDE.md` had the same wrong table, which is how the bug got written in the first place; it's corrected, with a warning about this specific silent-failure mode.

### Copy: asking about value received, not setup completed

The original wording asked *"Did you get done what you came here to do?"* and *"What did you get done **today**?"*. Both scope the answer to the current visit — but TTFV is the first time value was **ever** reached. An admin whose first value happened last week answers "No" truthfully, and a "No" costs a cooldown before we may ask again. The copy was delaying the measurement it exists to take.

```
Step 1  Have you gotten what you needed yet?
Step 2  What have you gotten done so far?      (only after a Yes)
```

"yet" and "so far" are load-bearing — there's a comment in `constants.js` saying so. The product is deliberately not named: naming it invites a verdict on the product, where what we need is whether the admin accomplished their own goal.

### Activity options — shared enum with the gateway

| `value` | Label |
| -- | -- |
| `saw-guardrail-applied` | Saw a guardrail apply to a live session |
| `saw-data-masked` | Saw sensitive data masked in a session |
| `approved-or-denied-access-request` | Approved or denied an access request |
| `reviewed-recorded-session` | Reviewed a recorded session |
| `opened-ai-analyzed-session-report` | Opened an AI-analyzed session report |
| `other` | Other (please specify) |

**Every option is a moment the product did something *for* the admin, never one where they configured it** — that's the bar for anything added later. Connecting a resource, creating a policy and setting up a masking rule are setup, costs paid up front, so a "Yes" backed by one of them would stamp TTFV at the moment configuration finished, which is the exact thing this metric exists to be distinguished from. Hence no resource option, and the guardrail/masking entries describe the rule being *seen to apply* rather than created.

These `value`s are the analytics contract, duplicated in `validTTFVActivities` on the gateway. **Never repurpose one** — it silently reinterprets historical rows and reports.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome, macOS
- **OS**: macOS 15 (darwin 25.4.0)
- **Gateway**: local `hoopdev` built from `felipe/evl-212-ttfv-measurement-backend` at tip (OIDC auth); `POST /api/orgs/ttfv-survey` returns 401 unauthenticated, confirming the route is present

### Tests performed:
- [ ] Unit tests pass — *`webapp_v2` has no test runner (no vitest/jest/testing-library in `package.json`), so there is nothing to run*
- [ ] Integration tests pass — *none exist for this surface*
- [x] Manual testing completed — **partial; scope recorded below**

**Verified in the browser against a live EVL-212 gateway:**

| Scenario | Result |
| -- | -- |
| Widget appears for an admin of an eligible org (1 session, `analytics_mode = identified`) | ✅ |
| Non-admins see nothing | ✅ |
| "Other" keeps Submit disabled until the free text is non-blank; input caps at 255 | ✅ |
| The X collapses to the launcher and POSTs nothing; widget returns on reload | ✅ |
| Short viewport (~500px tall) — card caps its height and scrolls instead of running off the top | ✅ **this is the `max-height` regression fixed here** |

**Not yet exercised**, and honestly flagged rather than assumed:

- The **write path end to end** — no answer has been submitted, so no row has been written and the analytics event has never been observed. `private.ttfv_survey_responses` is empty.
- **Terminal Yes / 409** and the **decline + cooldown** path.
- **Origin-vs-TTFV priority** when both surveys are due (only TTFV was present).
- **Fail-closed against a gateway without EVL-212** — reasoned, not tested: the field is simply absent from `/userinfo` and deserialises to falsy.
- **`analytics_mode = 'disabled'` suppression.**

**`npm run lint`** — no new problems. 15 errors remain, all pre-existing in four files this branch never touches (`vite.config.js`, `CommandPaletteRoot.jsx`, `pages/Auth/Login/index.jsx`, `pages/EventRouting/Form/index.jsx`), verified against `git diff --stat`.

**`npm run build`** — green.

### Contract cross-checks against #1730

The POST is fire-and-forget (see below), so a 400 the client fails to prevent is invisible — no row, no event, no error, just a quietly low response rate. These were therefore verified statically rather than left to runtime:

1. **`ACTIVITY_OPTIONS` matches `validTTFVActivities` element for element, order included.** Compared programmatically by parsing both lists, not by eye. `ACTIVITY_OTHER === 'other'` and it is the last element on both sides.
2. **`reached_value` is never `undefined` or `null`** — the Yes path sends a literal `true`, the decline path a literal `false`. The gateway 400s on a missing value, and this is the path that would have hit it.
3. **`activity` is sent as `''` on a decline**, which the gateway ignores and stores as NULL.
4. **`activity_other` can never exceed the server's 255-*rune* cap.** The DOM's `maxLength` counts UTF-16 code units and an astral character is 2 units but 1 rune, so the browser is strictly stricter — never looser. Non-blank is enforced client-side before Submit enables.
5. **`POST /orgs/ttfv-survey`'s role (`AdminOnlyAccessRole`) agrees with the role gating `show_ttfv_survey` on `/userinfo`** — a mismatch would offer the survey to someone the POST then rejects.
6. **409 already behaves as the gateway wants it to.** It is swallowed like any other rejection: the acknowledgement shows, the widget closes, nothing is retried, no error is surfaced, and `/userinfo` won't offer it again on the next boot — which is exactly "treat it like a successful terminal Yes, another admin answered first".

`TestTTFVActivityContract` on #1730 pins the server side, but it cannot see the JS file — cross-repo-file drift is caught by review only.

### How to test

Requires the #1730 gateway. Against `main`'s gateway the widget simply never appears, which is itself the fail-closed case worth confirming first.

```bash
make run-dev-postgres                       # container hoopdevpg, host port 5449
HOOP_RS_BUILD=0 make run-dev                # run from the EVL-212 worktree, not this branch —
                                            # the image snapshots source at build time, and a
                                            # frontend-only build makes the endpoints 404
cd webapp_v2 && npm run dev:full            # Vite :5173 + shadow-cljs :8280
```

Open **http://localhost:5173** (not :8009 — only Vite proxies both `/api` and the CLJS assets). Sanity check the gateway first: `curl -o /dev/null -w '%{http_code}\n' -X POST localhost:8009/api/orgs/ttfv-survey` → **401** means the backend is there, **404** means it was rebuilt over.

1. **Fail-closed.** Point at a gateway without #1730. No launcher appears. `GET /api/userinfo` has no `show_ttfv_survey` field.
2. **It appears.** Admin of an org that has run at least one session — a round hoop-symbol launcher with a red dot on the right edge, vertically centred. Non-admins see nothing.
3. **Only one survey at a time.** An admin of a brand-new org qualifies for both. Only the **origin** survey shows — its window is the one that closes (7 days, once per user). After answering it, TTFV should *not* pop up until the next page load, because `/userinfo` is fetched once per boot.
4. **The No path.** Open → "Have you gotten what you needed yet?" → **No**. "Answer received" for 3s, then the widget disappears. One row with `reached_value = false`. Reload: gone, for the 3-day cooldown.
5. **The Yes path.** **Yes** advances to "What have you gotten done so far?" rather than submitting — a bare "reached value" with no activity isn't worth a row, and the first Yes is terminal. Pick an option → Submit → row with `reached_value = true` and the `activity`.
6. **Other requires text.** Submit stays disabled until non-blank; the input stops accepting at 255 characters.
7. **Terminal Yes.** Reload after a Yes — no launcher, ever again for that org. A hand-rolled POST returns **409**.
8. **X is not an answer.** Open, click X. Collapses to the launcher, nothing POSTed. Reload — it's back.
9. **Short viewport.** ~500px tall, open the card — it caps and scrolls rather than running off the top. Worth checking the origin survey too.
10. **Analytics off.** `analytics_mode = 'disabled'` → never appears.

Order matters for 4/5/7: a Yes is terminal and a No starts a 3-day cooldown, so reset between runs with `DELETE FROM private.ttfv_survey_responses;` and reload.

## 📸 Screenshots (if applicable)

To be added before this leaves draft.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes — *no test runner in `webapp_v2`*
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Draft until the write path has been exercised end to end and screenshots are attached. Neither is a code concern — the remaining risk is entirely "has anyone watched a row get written", and the answer is currently no.

### What reviewers should push back on

- **Fire and forget.** The POST is not awaited and its rejection is swallowed to a `console.warn`; the acknowledgement shows on the click. This matches the origin survey, and the reasoning is that a failed write leaves `/userinfo` still reporting the survey, so the admin is asked again and has nothing to act on meanwhile — a failure toast would be pure noise. It also gives the 409 semantics the gateway wants for free. **The cost is that a 400 is indistinguishable from a 204 in the UI**, which is what the six static cross-checks above are compensating for. If you think that trade is wrong, this is the place to say so.
- **No policy on the client.** Not the admin check, not org eligibility, not the terminal Yes, not the cooldown — and `6d01c7d5` removed even the *enumeration* of those clauses from comments. This already paid off: #1730 subsequently added a one-session precondition and cut the cooldown from 7 days to 3, and this branch needed zero edits. **If a duration, threshold or eligibility rule ever appears in `webapp_v2`, treat it as a bug.**
- **`due` is only checked while collapsed** — a card the user already opened stays open even if the flag changed underneath it.
- **The extraction touches shipped code.** `OriginSurvey` is live; worth a look on its own to confirm nothing regressed beyond the `max-height` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
