### PR TITLE
EVL-212: measure time to first value with an in-app survey

### DIFF
--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -117,13 +117,6 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentGateway, ComponentAgent},
 	},
-	"experimental.ttfv_survey": {
-		Name:        "experimental.ttfv_survey",
-		Description: "Offer the in-app TTFV survey (\"Did you get done what you came here to do?\") to admins, so the time between the organization being created and the first confirmed value can be measured. Answers are stored server-side and the event is emitted from the gateway, not the browser. When off, /userinfo reports show_ttfv_survey false and no widget renders anywhere.",
-		Default:     false,
-		Stability:   StabilityExperimental,
-		Components:  []Component{ComponentGateway},
-	},
 	"experimental.mcp_gateway": {
 		Name:        "experimental.mcp_gateway",
 		Description: "Offer the MCP Gateway (mcpproxy) resource type in the webapp catalog, so admins can create protocol-aware MCP connections: tool-level allow/deny, per-tool approval, rug-pull detection and structured tool-call audit, over remote (streamable-http/sse) or stdio backends run either on the agent or on each user's own machine. When off, the card is hidden and no new MCP Gateway connection can be created; connections that already exist keep working end to end, and their role form, edit view and Connect modal stay reachable.",

--- a/common/featureflag/featureflag.go
+++ b/common/featureflag/featureflag.go
@@ -117,6 +117,13 @@ var catalog = map[string]Flag{
 		Stability:   StabilityExperimental,
 		Components:  []Component{ComponentGateway, ComponentAgent},
 	},
+	"experimental.ttfv_survey": {
+		Name:        "experimental.ttfv_survey",
+		Description: "Offer the in-app TTFV survey (\"Did you get done what you came here to do?\") to admins, so the time between the organization being created and the first confirmed value can be measured. Answers are stored server-side and the event is emitted from the gateway, not the browser. When off, /userinfo reports show_ttfv_survey false and no widget renders anywhere.",
+		Default:     false,
+		Stability:   StabilityExperimental,
+		Components:  []Component{ComponentGateway},
+	},
 	"experimental.mcp_gateway": {
 		Name:        "experimental.mcp_gateway",
 		Description: "Offer the MCP Gateway (mcpproxy) resource type in the webapp catalog, so admins can create protocol-aware MCP connections: tool-level allow/deny, per-tool approval, rug-pull detection and structured tool-call audit, over remote (streamable-http/sse) or stdio backends run either on the agent or on each user's own machine. When off, the card is hidden and no new MCP Gateway connection can be created; connections that already exist keep working end to end, and their role form, edit view and Connect modal stay reachable.",

--- a/gateway/analytics/events.go
+++ b/gateway/analytics/events.go
@@ -74,6 +74,11 @@ const (
 	// onboarding
 	EventOnboardingOriginAnswered = "hoop-onboarding-origin-answered"
 
+	// ttfv
+	// Emitted server-side only: a browser-side call would be blocked by the
+	// same ad blockers that ruled out measuring this through Intercom.
+	EventTTFVSurveyAnswered = "hoop-ttfv-survey-answered"
+
 	// search api
 	EventSearch = "hoop-search"
 

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -5873,6 +5873,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/orgs/ttfv-survey": {
+            "post": {
+                "description": "Record whether an administrator got done what they came to do, and measure the time since the organization was created. A confirmed value is terminal — the organization is never asked again and a second attempt returns 409 — while a decline is recorded and followed by another ask after a cooldown. Dismissing the widget is not an answer and must not be submitted.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Server Management"
+                ],
+                "summary": "Answer TTFV Survey",
+                "parameters": [
+                    {
+                        "description": "The request body resource",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/openapi.TTFVSurveyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Answer recorded"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/plugins": {
             "get": {
                 "description": "List all Plugin resources",
@@ -18581,6 +18642,38 @@ const docTemplate = `{
                 }
             }
         },
+        "openapi.TTFVSurveyRequest": {
+            "type": "object",
+            "required": [
+                "reached_value"
+            ],
+            "properties": {
+                "activity": {
+                    "description": "The activity that delivered the value. Required when reached_value is\ntrue, ignored and stored as null otherwise",
+                    "type": "string",
+                    "enum": [
+                        "connected-infra-resource",
+                        "approved-or-denied-access-request",
+                        "reviewed-recorded-session",
+                        "created-or-activated-policy",
+                        "opened-ai-analyzed-session-report",
+                        "set-up-data-masking-rule",
+                        "other"
+                    ],
+                    "example": "connected-infra-resource"
+                },
+                "activity_other": {
+                    "description": "Free text detail, at most 255 characters. Required when activity is\n\"other\", ignored and stored as null otherwise",
+                    "type": "string",
+                    "example": "Configured SSO"
+                },
+                "reached_value": {
+                    "description": "Whether the user got done what they came to do. Required; a pointer so\nthat an explicit false is told apart from an omitted field",
+                    "type": "boolean",
+                    "example": true
+                }
+            }
+        },
         "openapi.TablesResponse": {
             "type": "object",
             "properties": {
@@ -18794,6 +18887,10 @@ const docTemplate = `{
                 },
                 "show_setup_checklist": {
                     "description": "Whether the sidebar setup checklist should still be offered. True only for\nadministrators of an organization that has not completed onboarding, and\npermanently false once it has.",
+                    "type": "boolean"
+                },
+                "show_ttfv_survey": {
+                    "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. True only for administrators of an organization that\nnever confirmed value and has not declined within the last 7 days, and\nonly while the experimental.ttfv_survey feature flag is on. Always false\nfor anonymous users.",
                     "type": "boolean"
                 },
                 "slack_id": {

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -5875,7 +5875,7 @@ const docTemplate = `{
         },
         "/orgs/ttfv-survey": {
             "post": {
-                "description": "Record whether an administrator got done what they came to do, and measure the time since the organization was created. A confirmed value is terminal — the organization is never asked again and a second attempt returns 409 — while a decline is recorded and followed by another ask after a cooldown. Dismissing the widget is not an answer and must not be submitted.",
+                "description": "Record whether an administrator has gotten what they needed yet, and measure the time since the organization was created. The question is cumulative rather than scoped to the current visit. A confirmed value is terminal — the organization is never asked again and a second attempt returns 409 — while a decline is recorded and followed by another ask after a cooldown. Dismissing the widget is not an answer and must not be submitted.",
                 "consumes": [
                     "application/json"
                 ],
@@ -18649,26 +18649,25 @@ const docTemplate = `{
             ],
             "properties": {
                 "activity": {
-                    "description": "The activity that delivered the value. Required when reached_value is\ntrue, ignored and stored as null otherwise",
+                    "description": "The activity that delivered the value. Required when reached_value is\ntrue, ignored and stored as null otherwise. Every option names something\nthe administrator perceived, never something they configured",
                     "type": "string",
                     "enum": [
-                        "connected-infra-resource",
+                        "saw-guardrail-applied",
+                        "saw-data-masked",
                         "approved-or-denied-access-request",
                         "reviewed-recorded-session",
-                        "created-or-activated-policy",
                         "opened-ai-analyzed-session-report",
-                        "set-up-data-masking-rule",
                         "other"
                     ],
-                    "example": "connected-infra-resource"
+                    "example": "saw-guardrail-applied"
                 },
                 "activity_other": {
                     "description": "Free text detail, at most 255 characters. Required when activity is\n\"other\", ignored and stored as null otherwise",
                     "type": "string",
-                    "example": "Configured SSO"
+                    "example": "Watched a query get masked in a live session"
                 },
                 "reached_value": {
-                    "description": "Whether the user got done what they came to do. Required; a pointer so\nthat an explicit false is told apart from an omitted field",
+                    "description": "Whether the user has gotten what they needed yet. Required; a pointer so\nthat an explicit false is told apart from an omitted field",
                     "type": "boolean",
                     "example": true
                 }
@@ -18890,7 +18889,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "show_ttfv_survey": {
-                    "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 3 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
+                    "description": "Whether the \"Have you gotten what you needed yet?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 3 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
                     "type": "boolean"
                 },
                 "slack_id": {

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -18890,7 +18890,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "show_ttfv_survey": {
-                    "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. True only for administrators of an organization that\nnever confirmed value and has not declined within the last 7 days, and\nonly while the experimental.ttfv_survey feature flag is on. Always false\nfor anonymous users.",
+                    "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, never confirmed\nvalue, and has not declined within the last 7 days. Permanently false once\nvalue is confirmed, and always false for anonymous users and for an\norganization whose analytics mode is disabled.",
                     "type": "boolean"
                 },
                 "slack_id": {

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -18890,7 +18890,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "show_ttfv_survey": {
-                    "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, never confirmed\nvalue, and has not declined within the last 7 days. Permanently false once\nvalue is confirmed, and always false for anonymous users and for an\norganization whose analytics mode is disabled.",
+                    "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 7 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
                     "type": "boolean"
                 },
                 "slack_id": {

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -18890,7 +18890,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "show_ttfv_survey": {
-                    "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 7 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
+                    "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 3 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
                     "type": "boolean"
                 },
                 "slack_id": {

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -8250,7 +8250,7 @@
             "type": "boolean"
           },
           "show_ttfv_survey": {
-            "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 7 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
+            "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 3 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
             "type": "boolean"
           },
           "slack_id": {

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -8006,6 +8006,38 @@
         },
         "type": "object"
       },
+      "openapi.TTFVSurveyRequest": {
+        "properties": {
+          "activity": {
+            "description": "The activity that delivered the value. Required when reached_value is\ntrue, ignored and stored as null otherwise",
+            "enum": [
+              "connected-infra-resource",
+              "approved-or-denied-access-request",
+              "reviewed-recorded-session",
+              "created-or-activated-policy",
+              "opened-ai-analyzed-session-report",
+              "set-up-data-masking-rule",
+              "other"
+            ],
+            "example": "connected-infra-resource",
+            "type": "string"
+          },
+          "activity_other": {
+            "description": "Free text detail, at most 255 characters. Required when activity is\n\"other\", ignored and stored as null otherwise",
+            "example": "Configured SSO",
+            "type": "string"
+          },
+          "reached_value": {
+            "description": "Whether the user got done what they came to do. Required; a pointer so\nthat an explicit false is told apart from an omitted field",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "reached_value"
+        ],
+        "type": "object"
+      },
       "openapi.TablesResponse": {
         "properties": {
           "schemas": {
@@ -8215,6 +8247,10 @@
           },
           "show_setup_checklist": {
             "description": "Whether the sidebar setup checklist should still be offered. True only for\nadministrators of an organization that has not completed onboarding, and\npermanently false once it has.",
+            "type": "boolean"
+          },
+          "show_ttfv_survey": {
+            "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. True only for administrators of an organization that\nnever confirmed value and has not declined within the last 7 days, and\nonly while the experimental.ttfv_survey feature flag is on. Always false\nfor anonymous users.",
             "type": "boolean"
           },
           "slack_id": {
@@ -15812,6 +15848,82 @@
           }
         },
         "summary": "Update Organization Protection Profile",
+        "tags": [
+          "Server Management"
+        ]
+      }
+    },
+    "/orgs/ttfv-survey": {
+      "post": {
+        "description": "Record whether an administrator got done what they came to do, and measure the time since the organization was created. A confirmed value is terminal — the organization is never asked again and a second attempt returns 409 — while a decline is recorded and followed by another ask after a cooldown. Dismissing the widget is not an answer and must not be submitted.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi.TTFVSurveyRequest"
+              }
+            }
+          },
+          "description": "The request body resource",
+          "required": true,
+          "x-originalParamName": "request"
+        },
+        "responses": {
+          "204": {
+            "description": "Answer recorded"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Answer TTFV Survey",
         "tags": [
           "Server Management"
         ]

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -8009,26 +8009,25 @@
       "openapi.TTFVSurveyRequest": {
         "properties": {
           "activity": {
-            "description": "The activity that delivered the value. Required when reached_value is\ntrue, ignored and stored as null otherwise",
+            "description": "The activity that delivered the value. Required when reached_value is\ntrue, ignored and stored as null otherwise. Every option names something\nthe administrator perceived, never something they configured",
             "enum": [
-              "connected-infra-resource",
+              "saw-guardrail-applied",
+              "saw-data-masked",
               "approved-or-denied-access-request",
               "reviewed-recorded-session",
-              "created-or-activated-policy",
               "opened-ai-analyzed-session-report",
-              "set-up-data-masking-rule",
               "other"
             ],
-            "example": "connected-infra-resource",
+            "example": "saw-guardrail-applied",
             "type": "string"
           },
           "activity_other": {
             "description": "Free text detail, at most 255 characters. Required when activity is\n\"other\", ignored and stored as null otherwise",
-            "example": "Configured SSO",
+            "example": "Watched a query get masked in a live session",
             "type": "string"
           },
           "reached_value": {
-            "description": "Whether the user got done what they came to do. Required; a pointer so\nthat an explicit false is told apart from an omitted field",
+            "description": "Whether the user has gotten what they needed yet. Required; a pointer so\nthat an explicit false is told apart from an omitted field",
             "example": true,
             "type": "boolean"
           }
@@ -8250,7 +8249,7 @@
             "type": "boolean"
           },
           "show_ttfv_survey": {
-            "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 3 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
+            "description": "Whether the \"Have you gotten what you needed yet?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 3 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
             "type": "boolean"
           },
           "slack_id": {
@@ -15855,7 +15854,7 @@
     },
     "/orgs/ttfv-survey": {
       "post": {
-        "description": "Record whether an administrator got done what they came to do, and measure the time since the organization was created. A confirmed value is terminal — the organization is never asked again and a second attempt returns 409 — while a decline is recorded and followed by another ask after a cooldown. Dismissing the widget is not an answer and must not be submitted.",
+        "description": "Record whether an administrator has gotten what they needed yet, and measure the time since the organization was created. The question is cumulative rather than scoped to the current visit. A confirmed value is terminal — the organization is never asked again and a second attempt returns 409 — while a decline is recorded and followed by another ask after a cooldown. Dismissing the widget is not an answer and must not be submitted.",
         "requestBody": {
           "content": {
             "application/json": {

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -8250,7 +8250,7 @@
             "type": "boolean"
           },
           "show_ttfv_survey": {
-            "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. True only for administrators of an organization that\nnever confirmed value and has not declined within the last 7 days, and\nonly while the experimental.ttfv_survey feature flag is on. Always false\nfor anonymous users.",
+            "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, never confirmed\nvalue, and has not declined within the last 7 days. Permanently false once\nvalue is confirmed, and always false for anonymous users and for an\norganization whose analytics mode is disabled.",
             "type": "boolean"
           },
           "slack_id": {

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -8250,7 +8250,7 @@
             "type": "boolean"
           },
           "show_ttfv_survey": {
-            "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, never confirmed\nvalue, and has not declined within the last 7 days. Permanently false once\nvalue is confirmed, and always false for anonymous users and for an\norganization whose analytics mode is disabled.",
+            "description": "Whether the \"Did you get done what you came here to do?\" survey should\nstill be offered. On by default for every organization, so it is true for\nadministrators of an organization that collects analytics, has run at\nleast one session, never confirmed value, and has not declined within the\nlast 7 days. Permanently false once value is confirmed, and always false\nfor anonymous users, for an organization whose analytics mode is disabled,\nand for one that has never used the product.",
             "type": "boolean"
           },
           "slack_id": {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -153,10 +153,11 @@ type UserInfo struct {
 	ShowSetupChecklist bool `json:"show_setup_checklist"`
 	// Whether the "Did you get done what you came here to do?" survey should
 	// still be offered. On by default for every organization, so it is true for
-	// administrators of an organization that collects analytics, never confirmed
-	// value, and has not declined within the last 7 days. Permanently false once
-	// value is confirmed, and always false for anonymous users and for an
-	// organization whose analytics mode is disabled.
+	// administrators of an organization that collects analytics, has run at
+	// least one session, never confirmed value, and has not declined within the
+	// last 7 days. Permanently false once value is confirmed, and always false
+	// for anonymous users, for an organization whose analytics mode is disabled,
+	// and for one that has never used the product.
 	ShowTtfvSurvey bool `json:"show_ttfv_survey"`
 }
 

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -155,7 +155,7 @@ type UserInfo struct {
 	// still be offered. On by default for every organization, so it is true for
 	// administrators of an organization that collects analytics, has run at
 	// least one session, never confirmed value, and has not declined within the
-	// last 7 days. Permanently false once value is confirmed, and always false
+	// last 3 days. Permanently false once value is confirmed, and always false
 	// for anonymous users, for an organization whose analytics mode is disabled,
 	// and for one that has never used the product.
 	ShowTtfvSurvey bool `json:"show_ttfv_survey"`

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -152,10 +152,11 @@ type UserInfo struct {
 	// permanently false once it has.
 	ShowSetupChecklist bool `json:"show_setup_checklist"`
 	// Whether the "Did you get done what you came here to do?" survey should
-	// still be offered. True only for administrators of an organization that
-	// never confirmed value and has not declined within the last 7 days, and
-	// only while the experimental.ttfv_survey feature flag is on. Always false
-	// for anonymous users.
+	// still be offered. On by default for every organization, so it is true for
+	// administrators of an organization that collects analytics, never confirmed
+	// value, and has not declined within the last 7 days. Permanently false once
+	// value is confirmed, and always false for anonymous users and for an
+	// organization whose analytics mode is disabled.
 	ShowTtfvSurvey bool `json:"show_ttfv_survey"`
 }
 

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -151,7 +151,7 @@ type UserInfo struct {
 	// administrators of an organization that has not completed onboarding, and
 	// permanently false once it has.
 	ShowSetupChecklist bool `json:"show_setup_checklist"`
-	// Whether the "Did you get done what you came here to do?" survey should
+	// Whether the "Have you gotten what you needed yet?" survey should
 	// still be offered. On by default for every organization, so it is true for
 	// administrators of an organization that collects analytics, has run at
 	// least one session, never confirmed value, and has not declined within the
@@ -1491,15 +1491,16 @@ type OrgOnboardingResponse struct {
 // not an answer and must not be submitted. Whether the survey should be offered
 // at all is read from show_ttfv_survey on the /userinfo payload.
 type TTFVSurveyRequest struct {
-	// Whether the user got done what they came to do. Required; a pointer so
+	// Whether the user has gotten what they needed yet. Required; a pointer so
 	// that an explicit false is told apart from an omitted field
 	ReachedValue *bool `json:"reached_value" binding:"required" example:"true"`
 	// The activity that delivered the value. Required when reached_value is
-	// true, ignored and stored as null otherwise
-	Activity string `json:"activity" enums:"connected-infra-resource,approved-or-denied-access-request,reviewed-recorded-session,created-or-activated-policy,opened-ai-analyzed-session-report,set-up-data-masking-rule,other" example:"connected-infra-resource"`
+	// true, ignored and stored as null otherwise. Every option names something
+	// the administrator perceived, never something they configured
+	Activity string `json:"activity" enums:"saw-guardrail-applied,saw-data-masked,approved-or-denied-access-request,reviewed-recorded-session,opened-ai-analyzed-session-report,other" example:"saw-guardrail-applied"`
 	// Free text detail, at most 255 characters. Required when activity is
 	// "other", ignored and stored as null otherwise
-	ActivityOther string `json:"activity_other" example:"Configured SSO"`
+	ActivityOther string `json:"activity_other" example:"Watched a query get masked in a live session"`
 }
 
 var FeatureList = []string{"ask-ai"}

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -151,6 +151,12 @@ type UserInfo struct {
 	// administrators of an organization that has not completed onboarding, and
 	// permanently false once it has.
 	ShowSetupChecklist bool `json:"show_setup_checklist"`
+	// Whether the "Did you get done what you came here to do?" survey should
+	// still be offered. True only for administrators of an organization that
+	// never confirmed value and has not declined within the last 7 days, and
+	// only while the experimental.ttfv_survey feature flag is on. Always false
+	// for anonymous users.
+	ShowTtfvSurvey bool `json:"show_ttfv_survey"`
 }
 
 type ServiceAccountStatusType string
@@ -1477,6 +1483,21 @@ type OrgOnboardingResponse struct {
 	// First connection of any kind, the native-access fallback for the same
 	// shortcut; null when the organization has no connections
 	FirstConnectionName *string `json:"first_connection_name" example:"pgdemo"`
+}
+
+// TTFVSurveyRequest is one answer to the TTFV survey. Dismissing the widget is
+// not an answer and must not be submitted. Whether the survey should be offered
+// at all is read from show_ttfv_survey on the /userinfo payload.
+type TTFVSurveyRequest struct {
+	// Whether the user got done what they came to do. Required; a pointer so
+	// that an explicit false is told apart from an omitted field
+	ReachedValue *bool `json:"reached_value" binding:"required" example:"true"`
+	// The activity that delivered the value. Required when reached_value is
+	// true, ignored and stored as null otherwise
+	Activity string `json:"activity" enums:"connected-infra-resource,approved-or-denied-access-request,reviewed-recorded-session,created-or-activated-policy,opened-ai-analyzed-session-report,set-up-data-masking-rule,other" example:"connected-infra-resource"`
+	// Free text detail, at most 255 characters. Required when activity is
+	// "other", ignored and stored as null otherwise
+	ActivityOther string `json:"activity_other" example:"Configured SSO"`
 }
 
 var FeatureList = []string{"ask-ai"}

--- a/gateway/api/orgs/orgttfvsurvey.go
+++ b/gateway/api/orgs/orgttfvsurvey.go
@@ -1,0 +1,183 @@
+package apiorgs
+
+import (
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/gateway/analytics"
+	"github.com/hoophq/hoop/gateway/api/httputils"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/services"
+	"github.com/hoophq/hoop/gateway/storagev2"
+	"gorm.io/gorm"
+)
+
+// ttfvActivityOther is the single option that also carries free text.
+const ttfvActivityOther = "other"
+
+// validTTFVActivities are the accepted answers to "what did you get done?".
+// These identifiers are the analytics contract and are duplicated in
+// webapp_v2/src/features/TtfvSurvey/constants.js: renaming one breaks the TTFV
+// reports and the widget at the same time, so add new options instead of
+// repurposing existing ones. The user-facing labels live in the webapp.
+var validTTFVActivities = []string{
+	"connected-infra-resource",
+	"approved-or-denied-access-request",
+	"reviewed-recorded-session",
+	"created-or-activated-policy",
+	"opened-ai-analyzed-session-report",
+	"set-up-data-masking-rule",
+	ttfvActivityOther,
+}
+
+// maxTTFVActivityOtherLength bounds the free text. The column is a TEXT, so
+// this is a contract limit rather than a storage one: it keeps a pasted
+// document out of the response history.
+const maxTTFVActivityOtherLength = 255
+
+// validateTTFVAnswer turns a request body into the answer to store, rejecting
+// the combinations the contract does not allow.
+//
+// Fields that do not belong to the chosen answer are dropped rather than
+// rejected, so the stored row is always unambiguous about which answer it is
+// regardless of what the client kept in its state.
+func validateTTFVAnswer(req openapi.TTFVSurveyRequest) (services.TTFVSurveyAnswer, error) {
+	// Non-nil is guaranteed by binding:"required" on the pointer, which is
+	// what lets an explicit false through where a plain bool could not — and a
+	// "no" that cannot be submitted would make the survey terminal on the
+	// first decline, the opposite of the policy.
+	if !*req.ReachedValue {
+		return services.TTFVSurveyAnswer{ReachedValue: false}, nil
+	}
+
+	activity := strings.TrimSpace(req.Activity)
+	if !slices.Contains(validTTFVActivities, activity) {
+		return services.TTFVSurveyAnswer{}, errors.New(
+			"invalid activity, accepted values are " + strings.Join(validTTFVActivities, ", "))
+	}
+
+	answer := services.TTFVSurveyAnswer{ReachedValue: true, Activity: &activity}
+	if activity != ttfvActivityOther {
+		return answer, nil
+	}
+
+	detail := strings.TrimSpace(req.ActivityOther)
+	switch {
+	case detail == "":
+		return services.TTFVSurveyAnswer{}, errors.New(`activity_other is required when activity is "other"`)
+	// Counted in characters, not bytes, so a perfectly storable non-ASCII
+	// answer is not turned into a 400 by its UTF-8 width.
+	case utf8.RuneCountInString(detail) > maxTTFVActivityOtherLength:
+		return services.TTFVSurveyAnswer{}, errors.New("activity_other must not exceed 255 characters")
+	}
+	answer.ActivityOther = &detail
+	return answer, nil
+}
+
+// PostOrgTTFVSurvey
+//
+//	@Summary		Answer TTFV Survey
+//	@Description	Record whether an administrator got done what they came to do, and measure the time since the organization was created. A confirmed value is terminal — the organization is never asked again and a second attempt returns 409 — while a decline is recorded and followed by another ask after a cooldown. Dismissing the widget is not an answer and must not be submitted.
+//	@Tags			Server Management
+//	@Accept			json
+//	@Produce		json
+//	@Param			request				body	openapi.TTFVSurveyRequest	true	"The request body resource"
+//	@Success		204					"Answer recorded"
+//	@Failure		400,403,404,409,500	{object}	openapi.HTTPError
+//	@Router			/orgs/ttfv-survey [post]
+func PostOrgTTFVSurvey(c *gin.Context) {
+	// experimental.ttfv_survey is deliberately not re-checked here. It gates
+	// visibility, and an answer only exists because the widget was rendered, so
+	// refusing it would discard a real data point rather than prevent one. It
+	// would also lose answers routinely: the flag cache is warmed once per
+	// process at startup and updated only on the node that served the admin's
+	// write, so a gateway serving this POST can still believe the flag is off
+	// while the one that served /userinfo knows it is on.
+	ctx := storagev2.ParseContext(c)
+	// Anonymous users are not the administrator whose confirmation defines
+	// TTFV, and have no record to attribute the answer to.
+	if ctx.IsAnonymous() {
+		c.JSON(http.StatusForbidden, gin.H{"message": "the signup must be completed before answering the survey"})
+		return
+	}
+
+	var req openapi.TTFVSurveyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+	answer, err := validateTTFVAnswer(req)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	measurement, err := services.RecordTTFVSurveyAnswer(models.DB, ctx.OrgID, ctx.UserID, answer)
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"message": "organization not found"})
+		return
+	case errors.Is(err, models.ErrAlreadyExists):
+		c.JSON(http.StatusConflict, gin.H{"message": "the ttfv survey was already answered for this organization"})
+		return
+	case err != nil:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed recording the ttfv survey answer")
+		return
+	}
+
+	// Emitted from the gateway rather than the browser: a client-side call is
+	// blocked by the same ad blockers that ruled out measuring this through
+	// Intercom, which would bias the metric towards the users least likely to
+	// run one.
+	//
+	// The row written above is the system of record; this event is the copy the
+	// product dashboards read. It is deliberately best effort — Track drops it
+	// when no Segment key is configured or when the organization set its
+	// analytics mode to disabled — which is why the duration is recomputable
+	// from private.ttfv_survey_responses and does not exist only here.
+	trackClient := analytics.New()
+	defer trackClient.Close()
+	trackClient.Track(ctx.UserID, analytics.EventTTFVSurveyAnswered,
+		ttfvEventProperties(ctx.OrgID, answer, measurement))
+
+	c.Status(http.StatusNoContent)
+}
+
+// ttfvEventProperties builds the analytics payload for one recorded answer.
+//
+// Pure and separate from the handler, like identifyTraits in gateway/analytics,
+// so a test can hold the event to its contract: a property that quietly stops
+// being sent breaks no build and fails no other test, it just makes the metric
+// downstream go to zero.
+//
+// The free text is intentionally absent. It is user supplied and may contain
+// personal data, which would bypass the organization's analytics mode. Read it
+// from private.ttfv_survey_responses when the answers are reviewed.
+func ttfvEventProperties(orgID string, answer services.TTFVSurveyAnswer, measurement *models.TTFVMeasurement) map[string]any {
+	// Kebab-case throughout, matching every other event this gateway emits
+	// (org-id, session-id, auth-method, client-version). "org-id" in particular
+	// is load-bearing rather than stylistic: Segment.Track reads that exact key
+	// to resolve the organization's analytics mode and to set $groups.
+	properties := map[string]any{
+		"org-id":        orgID,
+		"reached-value": answer.ReachedValue,
+	}
+	if answer.Activity != nil {
+		properties["activity"] = *answer.Activity
+	}
+	// Both are absent for an organization with no recorded creation time, which
+	// has no duration to report rather than a duration of zero.
+	if measurement.OrgCreatedAt != nil {
+		properties["org-created-at"] = measurement.OrgCreatedAt.Format(time.RFC3339)
+	}
+	if measurement.TTFVSeconds != nil {
+		properties["ttfv-seconds"] = *measurement.TTFVSeconds
+	}
+	return properties
+}

--- a/gateway/api/orgs/orgttfvsurvey.go
+++ b/gateway/api/orgs/orgttfvsurvey.go
@@ -21,18 +21,25 @@ import (
 // ttfvActivityOther is the single option that also carries free text.
 const ttfvActivityOther = "other"
 
-// validTTFVActivities are the accepted answers to "what did you get done?".
-// These identifiers are the analytics contract and are duplicated in
+// validTTFVActivities are the accepted answers to "what have you gotten done so
+// far?". These identifiers are the analytics contract and are duplicated in
 // webapp_v2/src/features/TtfvSurvey/constants.js: renaming one breaks the TTFV
 // reports and the widget at the same time, so add new options instead of
 // repurposing existing ones. The user-facing labels live in the webapp.
+//
+// Every option names a moment the administrator *perceived* something, never a
+// moment they configured something. That is the bar a new option has to clear.
+// Connecting a resource, creating a policy and setting up a masking rule were
+// all removed or reworded for failing it: value backed by one of those would
+// stamp TTFV at the instant setup finished, which is the very thing this metric
+// exists to distinguish itself from. Hence "saw-guardrail-applied" rather than
+// the rule being created.
 var validTTFVActivities = []string{
-	"connected-infra-resource",
+	"saw-guardrail-applied",
+	"saw-data-masked",
 	"approved-or-denied-access-request",
 	"reviewed-recorded-session",
-	"created-or-activated-policy",
 	"opened-ai-analyzed-session-report",
-	"set-up-data-masking-rule",
 	ttfvActivityOther,
 }
 
@@ -83,7 +90,7 @@ func validateTTFVAnswer(req openapi.TTFVSurveyRequest) (services.TTFVSurveyAnswe
 // PostOrgTTFVSurvey
 //
 //	@Summary		Answer TTFV Survey
-//	@Description	Record whether an administrator got done what they came to do, and measure the time since the organization was created. A confirmed value is terminal — the organization is never asked again and a second attempt returns 409 — while a decline is recorded and followed by another ask after a cooldown. Dismissing the widget is not an answer and must not be submitted.
+//	@Description	Record whether an administrator has gotten what they needed yet, and measure the time since the organization was created. The question is cumulative rather than scoped to the current visit. A confirmed value is terminal — the organization is never asked again and a second attempt returns 409 — while a decline is recorded and followed by another ask after a cooldown. Dismissing the widget is not an answer and must not be submitted.
 //	@Tags			Server Management
 //	@Accept			json
 //	@Produce		json

--- a/gateway/api/orgs/orgttfvsurvey.go
+++ b/gateway/api/orgs/orgttfvsurvey.go
@@ -92,13 +92,14 @@ func validateTTFVAnswer(req openapi.TTFVSurveyRequest) (services.TTFVSurveyAnswe
 //	@Failure		400,403,404,409,500	{object}	openapi.HTTPError
 //	@Router			/orgs/ttfv-survey [post]
 func PostOrgTTFVSurvey(c *gin.Context) {
-	// experimental.ttfv_survey is deliberately not re-checked here. It gates
-	// visibility, and an answer only exists because the widget was rendered, so
-	// refusing it would discard a real data point rather than prevent one. It
-	// would also lose answers routinely: the flag cache is warmed once per
-	// process at startup and updated only on the node that served the admin's
-	// write, so a gateway serving this POST can still believe the flag is off
-	// while the one that served /userinfo knows it is on.
+	// The organization's analytics mode is deliberately not re-checked here. It
+	// gates whether the question is asked, and an answer only exists because the
+	// widget was rendered, so refusing it would discard a real data point rather
+	// than prevent one — an admin who answered and then opted out in another tab
+	// would lose the answer they had already given. Consent is still honoured
+	// where it counts: analytics.Track drops the event for a disabled
+	// organization, so the answer stays in that deployment's own database and
+	// never leaves it.
 	ctx := storagev2.ParseContext(c)
 	// Anonymous users are not the administrator whose confirmation defines
 	// TTFV, and have no record to attribute the answer to.

--- a/gateway/api/orgs/orgttfvsurvey_test.go
+++ b/gateway/api/orgs/orgttfvsurvey_test.go
@@ -2,6 +2,8 @@ package apiorgs
 
 import (
 	"net/http/httptest"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -26,9 +28,9 @@ func TestValidateTTFVAnswer(t *testing.T) {
 			name: "a confirmed value keeps its activity",
 			req: openapi.TTFVSurveyRequest{
 				ReachedValue: ptr(true),
-				Activity:     "connected-infra-resource",
+				Activity:     "saw-guardrail-applied",
 			},
-			wantActivity: ptr("connected-infra-resource"),
+			wantActivity: ptr("saw-guardrail-applied"),
 		},
 		{
 			// A decline is the answer that has to keep working: it is what
@@ -146,12 +148,12 @@ func TestTTFVEventProperties(t *testing.T) {
 	t.Run("a confirmed value reports the activity and the duration", func(t *testing.T) {
 		props := ttfvEventProperties("org-1", services.TTFVSurveyAnswer{
 			ReachedValue: true,
-			Activity:     ptr("connected-infra-resource"),
+			Activity:     ptr("saw-guardrail-applied"),
 		}, measured)
 
 		assertProp(t, props, "org-id", "org-1")
 		assertProp(t, props, "reached-value", true)
-		assertProp(t, props, "activity", "connected-infra-resource")
+		assertProp(t, props, "activity", "saw-guardrail-applied")
 		assertProp(t, props, "org-created-at", "2026-07-01T12:00:00Z")
 		assertProp(t, props, "ttfv-seconds", int64(864000))
 	})
@@ -234,6 +236,38 @@ func assertProp(t *testing.T, props map[string]any, key string, want any) {
 // survives binding. A plain bool would make false indistinguishable from an
 // omitted field, and required would then reject every decline — the survey
 // would become terminal on the first one, which is the opposite of the policy.
+// The activity identifiers exist in three places: this validator, the enums tag
+// on openapi.TTFVSurveyRequest that publishes them, and constants.js in the
+// webapp that renders them. Nothing links the three, and every way they can
+// drift is silent — an option the widget offers but the API rejects is a 400 the
+// user sees as a broken form, and one the API accepts but no report knows about
+// is a row nobody counts. So the list is pinned literally here, and the tag is
+// asserted to agree with it. Changing an identifier should mean changing this
+// test, the webapp, and saying so on the ticket.
+func TestTTFVActivityContract(t *testing.T) {
+	want := []string{
+		"saw-guardrail-applied",
+		"saw-data-masked",
+		"approved-or-denied-access-request",
+		"reviewed-recorded-session",
+		"opened-ai-analyzed-session-report",
+		"other",
+	}
+	if !slices.Equal(validTTFVActivities, want) {
+		t.Errorf("validTTFVActivities = %v, want %v", validTTFVActivities, want)
+	}
+
+	// The published contract is the struct tag, not the slice: the frontend
+	// reads the generated OpenAPI, so a tag that disagrees is a documented lie.
+	field, ok := reflect.TypeOf(openapi.TTFVSurveyRequest{}).FieldByName("Activity")
+	if !ok {
+		t.Fatal("openapi.TTFVSurveyRequest has no Activity field")
+	}
+	if got := strings.Split(field.Tag.Get("enums"), ","); !slices.Equal(got, want) {
+		t.Errorf("enums tag = %v, want %v", got, want)
+	}
+}
+
 func TestTTFVSurveyRequestBinding(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	for _, tc := range []struct {

--- a/gateway/api/orgs/orgttfvsurvey_test.go
+++ b/gateway/api/orgs/orgttfvsurvey_test.go
@@ -1,0 +1,282 @@
+package apiorgs
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/services"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestValidateTTFVAnswer(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		req               openapi.TTFVSurveyRequest
+		wantErr           bool
+		wantActivity      *string
+		wantActivityOther *string
+	}{
+		{
+			name: "a confirmed value keeps its activity",
+			req: openapi.TTFVSurveyRequest{
+				ReachedValue: ptr(true),
+				Activity:     "connected-infra-resource",
+			},
+			wantActivity: ptr("connected-infra-resource"),
+		},
+		{
+			// A decline is the answer that has to keep working: it is what
+			// starts the cooldown instead of closing the survey.
+			name:         "a decline needs nothing else",
+			req:          openapi.TTFVSurveyRequest{ReachedValue: ptr(false)},
+			wantActivity: nil,
+		},
+		{
+			// Whatever the client kept in its state for the branch not taken is
+			// dropped, so the stored row cannot describe two answers at once.
+			name: "a decline drops the activity it was sent with",
+			req: openapi.TTFVSurveyRequest{
+				ReachedValue:  ptr(false),
+				Activity:      "other",
+				ActivityOther: "Configured SSO",
+			},
+			wantActivity:      nil,
+			wantActivityOther: nil,
+		},
+		{
+			name: `"other" carries its free text`,
+			req: openapi.TTFVSurveyRequest{
+				ReachedValue:  ptr(true),
+				Activity:      "other",
+				ActivityOther: "  Configured SSO  ",
+			},
+			wantActivity:      ptr("other"),
+			wantActivityOther: ptr("Configured SSO"),
+		},
+		{
+			name: "free text is dropped for every other activity",
+			req: openapi.TTFVSurveyRequest{
+				ReachedValue:  ptr(true),
+				Activity:      "reviewed-recorded-session",
+				ActivityOther: "ignored",
+			},
+			wantActivity:      ptr("reviewed-recorded-session"),
+			wantActivityOther: nil,
+		},
+		{
+			name:    "a confirmed value without an activity is rejected",
+			req:     openapi.TTFVSurveyRequest{ReachedValue: ptr(true)},
+			wantErr: true,
+		},
+		{
+			name: "an unknown activity is rejected",
+			req: openapi.TTFVSurveyRequest{
+				ReachedValue: ptr(true),
+				Activity:     "wrote-a-poem",
+			},
+			wantErr: true,
+		},
+		{
+			name: `"other" without free text is rejected`,
+			req: openapi.TTFVSurveyRequest{
+				ReachedValue:  ptr(true),
+				Activity:      "other",
+				ActivityOther: "   ",
+			},
+			wantErr: true,
+		},
+		{
+			name: "free text past the limit is rejected",
+			req: openapi.TTFVSurveyRequest{
+				ReachedValue:  ptr(true),
+				Activity:      "other",
+				ActivityOther: strings.Repeat("a", maxTTFVActivityOtherLength+1),
+			},
+			wantErr: true,
+		},
+		{
+			// Measured in characters, not bytes: 255 multi-byte characters fit
+			// the contract even though they are far more than 255 bytes.
+			name: "free text is measured in characters",
+			req: openapi.TTFVSurveyRequest{
+				ReachedValue:  ptr(true),
+				Activity:      "other",
+				ActivityOther: strings.Repeat("é", maxTTFVActivityOtherLength),
+			},
+			wantActivity:      ptr("other"),
+			wantActivityOther: ptr(strings.Repeat("é", maxTTFVActivityOtherLength)),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			answer, err := validateTTFVAnswer(tc.req)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got answer %+v", answer)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if answer.ReachedValue != *tc.req.ReachedValue {
+				t.Errorf("ReachedValue = %v, want %v", answer.ReachedValue, *tc.req.ReachedValue)
+			}
+			assertOptionalString(t, "Activity", answer.Activity, tc.wantActivity)
+			assertOptionalString(t, "ActivityOther", answer.ActivityOther, tc.wantActivityOther)
+		})
+	}
+}
+
+// The event is the half of the measurement that product dashboards read, and
+// losing a property from it is silent — no build breaks, no other test fails,
+// the metric just goes to zero. So the payload is asserted key by key.
+func TestTTFVEventProperties(t *testing.T) {
+	orgCreatedAt := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	measured := &models.TTFVMeasurement{
+		OrgCreatedAt: &orgCreatedAt,
+		TTFVSeconds:  ptr(int64(864000)),
+	}
+
+	t.Run("a confirmed value reports the activity and the duration", func(t *testing.T) {
+		props := ttfvEventProperties("org-1", services.TTFVSurveyAnswer{
+			ReachedValue: true,
+			Activity:     ptr("connected-infra-resource"),
+		}, measured)
+
+		assertProp(t, props, "org-id", "org-1")
+		assertProp(t, props, "reached-value", true)
+		assertProp(t, props, "activity", "connected-infra-resource")
+		assertProp(t, props, "org-created-at", "2026-07-01T12:00:00Z")
+		assertProp(t, props, "ttfv-seconds", int64(864000))
+	})
+
+	// The free text is the one field that may carry personal data, so it must
+	// never reach an analytics destination — the database keeps it instead.
+	t.Run("the free text never leaves the database", func(t *testing.T) {
+		props := ttfvEventProperties("org-1", services.TTFVSurveyAnswer{
+			ReachedValue:  true,
+			Activity:      ptr("other"),
+			ActivityOther: ptr("Rotated the production credentials"),
+		}, measured)
+
+		for key, value := range props {
+			if s, ok := value.(string); ok && strings.Contains(s, "Rotated") {
+				t.Fatalf("property %q leaked the free text: %v", key, value)
+			}
+		}
+		if _, exists := props["activity-other"]; exists {
+			t.Error("activity-other must not be sent")
+		}
+		if _, exists := props["activity_other"]; exists {
+			t.Error("activity_other must not be sent")
+		}
+	})
+
+	t.Run("a decline reports no activity", func(t *testing.T) {
+		props := ttfvEventProperties("org-1", services.TTFVSurveyAnswer{ReachedValue: false}, measured)
+
+		assertProp(t, props, "reached-value", false)
+		if _, exists := props["activity"]; exists {
+			t.Error("a decline has no activity to report")
+		}
+	})
+
+	// An org with no creation timestamp has no duration; reporting one anyway
+	// would enter the dashboards as a TTFV of zero and understate the metric.
+	t.Run("an unmeasurable organization reports no duration", func(t *testing.T) {
+		props := ttfvEventProperties("org-1",
+			services.TTFVSurveyAnswer{ReachedValue: true, Activity: ptr("other")},
+			&models.TTFVMeasurement{})
+
+		for _, key := range []string{"org-created-at", "ttfv-seconds"} {
+			if _, exists := props[key]; exists {
+				t.Errorf("%s must be absent when the organization has no creation time", key)
+			}
+		}
+	})
+
+	// Every other event this gateway emits uses kebab-case. A stray snake_case
+	// property is not a style problem downstream, it is a second spelling of
+	// the same field that has to be reconciled in every report.
+	t.Run("property names are kebab-case", func(t *testing.T) {
+		props := ttfvEventProperties("org-1", services.TTFVSurveyAnswer{
+			ReachedValue: true,
+			Activity:     ptr("other"),
+		}, measured)
+
+		for key := range props {
+			if strings.Contains(key, "_") {
+				t.Errorf("property %q uses snake_case", key)
+			}
+		}
+	})
+}
+
+func assertProp(t *testing.T, props map[string]any, key string, want any) {
+	t.Helper()
+	got, exists := props[key]
+	if !exists {
+		t.Errorf("property %q is missing", key)
+		return
+	}
+	if got != want {
+		t.Errorf("property %q = %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}
+
+// reached_value is a *bool with binding:"required" precisely so that a "no"
+// survives binding. A plain bool would make false indistinguishable from an
+// omitted field, and required would then reject every decline — the survey
+// would become terminal on the first one, which is the opposite of the policy.
+func TestTTFVSurveyRequestBinding(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, tc := range []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{name: "an explicit no binds", body: `{"reached_value":false}`},
+		{name: "an explicit yes binds", body: `{"reached_value":true,"activity":"other"}`},
+		{name: "an omitted answer is rejected", body: `{"activity":"other"}`, wantErr: true},
+		{name: "a null answer is rejected", body: `{"reached_value":null}`, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest("POST", "/orgs/ttfv-survey", strings.NewReader(tc.body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			var req openapi.TTFVSurveyRequest
+			err := c.ShouldBindJSON(&req)
+			switch {
+			case tc.wantErr && err == nil:
+				t.Fatal("expected a binding error")
+			case !tc.wantErr && err != nil:
+				t.Fatalf("unexpected binding error: %v", err)
+			}
+		})
+	}
+}
+
+func assertOptionalString(t *testing.T, field string, got, want *string) {
+	t.Helper()
+	switch {
+	case got == nil && want == nil:
+	case got == nil || want == nil:
+		t.Errorf("%s = %v, want %v", field, derefOrNil(got), derefOrNil(want))
+	case *got != *want:
+		t.Errorf("%s = %q, want %q", field, *got, *want)
+	}
+}
+
+func derefOrNil(v *string) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -781,6 +781,20 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		r.AuthMiddleware,
 		apiorgs.GetOrgOnboarding)
 
+	// Administrator-only, and it must stay in agreement with the role that
+	// gates show_ttfv_survey on /userinfo: the flag is what makes the widget
+	// render, so widening one without the other either offers a survey nobody
+	// can answer or accepts answers from users never asked. TTFV is defined as
+	// the moment an administrator confirms value, so this is the role.
+	//
+	// EventTTFVSurveyAnswered is emitted from the handler rather than through
+	// TrackRequest, which runs before the body is validated and could carry
+	// neither the answer nor the measured duration.
+	r.POST("/orgs/ttfv-survey",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		apiorgs.PostOrgTTFVSurvey)
+
 	r.GET("/orgs/protection-profile",
 		apiroutes.AdminOnlyAccessRole,
 		r.AuthMiddleware,

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -782,7 +782,7 @@ func (api *Api) buildRoutes(r *apiroutes.Router) {
 		apiorgs.GetOrgOnboarding)
 
 	// Administrator-only, and it must stay in agreement with the role that
-	// gates show_ttfv_survey on /userinfo: the flag is what makes the widget
+	// gates show_ttfv_survey on /userinfo: that boolean is what makes the widget
 	// render, so widening one without the other either offers a survey nobody
 	// can answer or accepts answers from users never asked. TTFV is defined as
 	// the moment an administrator confirms value, so this is the role.

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/idp"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/services"
 	"github.com/hoophq/hoop/gateway/storagev2"
 	"github.com/hoophq/hoop/gateway/storagev2/types"
 	"golang.org/x/crypto/bcrypt"
@@ -501,6 +502,20 @@ func GetUserInfo(c *gin.Context) {
 		case !errors.Is(err, gorm.ErrRecordNotFound):
 			log.Warnf("failed resolving the signup origin survey state, err=%v", err)
 		}
+	}
+
+	// Outside the anonymous branch because the service owns that part of the
+	// policy and short-circuits before it reaches the database. Same degradation
+	// as the origin survey: a failure here only means the survey is not offered
+	// on this request, it must never fail the response the whole webapp boots
+	// from. Not found is silent — an organization can disappear between the
+	// token being issued and this lookup.
+	showTTFVSurvey, err := services.ShouldShowTTFVSurvey(models.DB, ctx.OrgID, ctx.IsAdminUser(), ctx.IsAnonymous())
+	switch {
+	case err == nil:
+		userInfoData.ShowTtfvSurvey = showTTFVSurvey
+	case !errors.Is(err, gorm.ErrRecordNotFound):
+		log.Warnf("failed resolving the ttfv survey state, err=%v", err)
 	}
 
 	if isOrgMultiTenant && !ctx.IsAnonymous() {

--- a/gateway/migrations/000114_ttfv_survey_responses.down.sql
+++ b/gateway/migrations/000114_ttfv_survey_responses.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+SET search_path TO private;
+
+-- The index is owned by the table and goes with it.
+DROP TABLE IF EXISTS ttfv_survey_responses;
+
+COMMIT;

--- a/gateway/migrations/000114_ttfv_survey_responses.up.sql
+++ b/gateway/migrations/000114_ttfv_survey_responses.up.sql
@@ -1,0 +1,40 @@
+BEGIN;
+SET search_path TO private;
+
+-- Answers to the in-app TTFV survey ("Did you get done what you came here to
+-- do?"). TTFV is the duration between orgs.created_at and the first answer
+-- with reached_value = true, which is why every answer is a row instead of a
+-- column on orgs: a "no" is a valid data point that has to be recorded and
+-- then followed by another ask, and keeping the full history means the metric
+-- can be recomputed if the policy behind it changes.
+--
+-- user_id is TEXT and unconstrained on purpose: it holds users.subject, which
+-- is the identity the API context carries, and the answer must survive the
+-- user being deleted. The org is what the metric is about, so only that FK
+-- cascades.
+CREATE TABLE IF NOT EXISTS ttfv_survey_responses (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id         UUID NOT NULL REFERENCES orgs (id) ON DELETE CASCADE,
+    user_id        TEXT NOT NULL,
+    reached_value  BOOLEAN NOT NULL,
+    activity       TEXT,
+    activity_other TEXT,
+    created_at     TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Every read is "the latest answers for this org": the terminal-yes check and
+-- the cooldown window both resolve against the head of this index.
+CREATE INDEX IF NOT EXISTS ttfv_survey_responses_org_id_idx
+    ON ttfv_survey_responses (org_id, created_at DESC);
+
+-- At most one confirmed value per organization, as a database invariant rather
+-- than as something the writing statement checks for itself. TTFV is a single
+-- moment per organization, so a second confirmation is a contradiction and not
+-- merely a duplicate — and under READ COMMITTED two concurrent submissions both
+-- see an organization that has not confirmed yet, both pass that check and both
+-- insert. This index is what actually decides between them; the loser gets a
+-- unique violation, which the caller reports as a conflict.
+CREATE UNIQUE INDEX IF NOT EXISTS ttfv_survey_responses_one_confirmed_value_idx
+    ON ttfv_survey_responses (org_id) WHERE reached_value;
+
+COMMIT;

--- a/gateway/models/ttfvsurvey.go
+++ b/gateway/models/ttfvsurvey.go
@@ -1,0 +1,132 @@
+package models
+
+import (
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// TTFVSurveyResponse is one answer to the in-app TTFV survey. The table is
+// append-only: repeated "no" answers each add a row, so the response history
+// is preserved rather than only the terminal state.
+type TTFVSurveyResponse struct {
+	OrgID        string
+	UserID       string
+	ReachedValue bool
+	// Which activity delivered the value. Set only when ReachedValue is true.
+	Activity *string
+	// Free text detail, set only when Activity is the "other" option.
+	ActivityOther *string
+}
+
+// TTFVMeasurement is the duration a recorded answer yields, measured entirely
+// by the database so the gateway's own clock never enters the metric.
+type TTFVMeasurement struct {
+	// The t0 of the duration. Nil when orgs.created_at holds NULL: the column
+	// carries a default but no NOT NULL constraint, so a row predating it is
+	// possible, and such an organization has no measurable TTFV.
+	OrgCreatedAt *time.Time `gorm:"column:org_created_at"`
+	// Seconds between the organization's creation and this answer. Nil exactly
+	// when OrgCreatedAt is.
+	TTFVSeconds *int64 `gorm:"column:ttfv_seconds"`
+}
+
+// ShouldShowTTFVSurvey reports whether the organization is in a state where the
+// TTFV survey may still be asked: it has a creation timestamp to measure from,
+// it never confirmed value, and it has not declined within the cooldown.
+//
+// The window is evaluated by Postgres on purpose, exactly like the signup
+// origin survey. orgs.created_at and ttfv_survey_responses.created_at are
+// TIMESTAMP WITHOUT TIME ZONE written by NOW(), so comparing them against the
+// gateway's clock would drift by the database's UTC offset. Both sides of this
+// comparison come from the same clock instead.
+//
+// The caller-dependent half of the policy — administrator, not anonymous,
+// feature flag — is not here; see services.ShouldShowTTFVSurvey.
+//
+// Propagates gorm.ErrRecordNotFound when no such organization exists.
+func ShouldShowTTFVSurvey(db *gorm.DB, orgID string, cooldownDays int) (bool, error) {
+	var showSurvey bool
+	// Every clause is an IS NOT NULL or a NOT EXISTS, neither of which can
+	// evaluate to NULL, so the result always scans into a plain bool.
+	res := db.Raw(`
+		SELECT o.created_at IS NOT NULL
+		   AND NOT EXISTS (
+		       SELECT 1 FROM private.ttfv_survey_responses r
+		       WHERE r.org_id = o.id AND r.reached_value)
+		   AND NOT EXISTS (
+		       SELECT 1 FROM private.ttfv_survey_responses r
+		       WHERE r.org_id = o.id AND NOT r.reached_value
+		         AND r.created_at > NOW() - make_interval(days => ?))
+		FROM private.orgs o
+		WHERE o.id::TEXT = ?`,
+		cooldownDays, orgID,
+	).Scan(&showSurvey)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return false, gorm.ErrRecordNotFound
+	}
+	return showSurvey, nil
+}
+
+// CreateTTFVSurveyResponse records one answer and returns the TTFV duration it
+// implies.
+//
+// The insert is conditional on no confirmed value existing yet, which settles
+// every submission that arrives after one was committed. It is not what makes
+// the rule safe under concurrency: two "yes" submissions racing each other both
+// read an organization that has not confirmed, so both pass. The partial unique
+// index on the table is the actual arbiter and turns the loser into a unique
+// violation, reported here as the same conflict.
+//
+// Returns ErrAlreadyExists when the organization already confirmed value, and
+// gorm.ErrRecordNotFound when no such organization exists.
+func CreateTTFVSurveyResponse(db *gorm.DB, resp *TTFVSurveyResponse) (*TTFVMeasurement, error) {
+	var measurement TTFVMeasurement
+	// The duration is subtracted inside the database so both endpoints come
+	// from one clock. It is NULL exactly when orgs.created_at is.
+	res := db.Raw(`
+		WITH org AS (
+		    SELECT id, created_at FROM private.orgs WHERE id::TEXT = ?
+		), inserted AS (
+		    INSERT INTO private.ttfv_survey_responses
+		        (org_id, user_id, reached_value, activity, activity_other)
+		    SELECT org.id, ?, ?, ?, ?
+		    FROM org
+		    WHERE NOT EXISTS (
+		        SELECT 1 FROM private.ttfv_survey_responses r
+		        WHERE r.org_id = org.id AND r.reached_value)
+		    RETURNING created_at
+		)
+		SELECT org.created_at AS org_created_at,
+		       EXTRACT(EPOCH FROM (inserted.created_at - org.created_at))::BIGINT AS ttfv_seconds
+		FROM inserted CROSS JOIN org`,
+		resp.OrgID, resp.UserID, resp.ReachedValue, resp.Activity, resp.ActivityOther,
+	).Scan(&measurement)
+	switch {
+	// The only unique constraint on the table is the one confirmed value per
+	// organization, so this is unambiguous: a concurrent submission committed
+	// first. Translation to this sentinel is enabled globally in database.go.
+	case errors.Is(res.Error, gorm.ErrDuplicatedKey):
+		return nil, ErrAlreadyExists
+	case res.Error != nil:
+		return nil, res.Error
+	}
+	if res.RowsAffected == 1 {
+		return &measurement, nil
+	}
+	// Nothing was inserted: either the organization is unknown or it already
+	// confirmed value. Disambiguate so the caller can tell those two apart.
+	var found bool
+	lookup := db.Raw(`SELECT true FROM private.orgs WHERE id::TEXT = ?`, resp.OrgID).Scan(&found)
+	if lookup.Error != nil {
+		return nil, lookup.Error
+	}
+	if lookup.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return nil, ErrAlreadyExists
+}

--- a/gateway/models/ttfvsurvey.go
+++ b/gateway/models/ttfvsurvey.go
@@ -33,8 +33,9 @@ type TTFVMeasurement struct {
 }
 
 // ShouldShowTTFVSurvey reports whether the organization is in a state where the
-// TTFV survey may still be asked: it has a creation timestamp to measure from,
-// it never confirmed value, and it has not declined within the cooldown.
+// TTFV survey may still be asked: it collects analytics at all, it has a
+// creation timestamp to measure from, it never confirmed value, and it has not
+// declined within the cooldown.
 //
 // The window is evaluated by Postgres on purpose, exactly like the signup
 // origin survey. orgs.created_at and ttfv_survey_responses.created_at are
@@ -42,16 +43,33 @@ type TTFVMeasurement struct {
 // gateway's clock would drift by the database's UTC offset. Both sides of this
 // comparison come from the same clock instead.
 //
-// The caller-dependent half of the policy — administrator, not anonymous,
-// feature flag — is not here; see services.ShouldShowTTFVSurvey.
+// The caller-dependent half of the policy — administrator, not anonymous — is
+// not here; see services.ShouldShowTTFVSurvey.
 //
 // Propagates gorm.ErrRecordNotFound when no such organization exists.
 func ShouldShowTTFVSurvey(db *gorm.DB, orgID string, cooldownDays int) (bool, error) {
 	var showSurvey bool
-	// Every clause is an IS NOT NULL or a NOT EXISTS, neither of which can
-	// evaluate to NULL, so the result always scans into a plain bool.
+	// Every clause is an IS NOT NULL, a NOT EXISTS or a comparison against a
+	// NOT NULL column, none of which can evaluate to NULL, so the result always
+	// scans into a plain bool.
+	//
+	// The analytics_mode clause is what the survey is gated on, in place of a
+	// feature flag: the survey ships on for everyone, because a default-off flag
+	// would measure TTFV only for the organizations somebody remembered to
+	// enable — a biased sample of exactly the population being measured. An
+	// organization on 'disabled' already asked not to be measured, and
+	// analytics.Track drops the event for it, so asking would put a question on
+	// screen whose answer can never leave the deployment.
+	//
+	// It is read here rather than through analytics.GetMode because that is a
+	// process-local cache updated only on the node that served
+	// PUT /orgs/analytics-mode. A gateway that missed the write would keep
+	// prompting an organization that just opted out — stale in the one direction
+	// that matters, which is consent. This row is already being selected, so the
+	// authoritative value is free.
 	res := db.Raw(`
-		SELECT o.created_at IS NOT NULL
+		SELECT o.analytics_mode <> 'disabled'
+		   AND o.created_at IS NOT NULL
 		   AND NOT EXISTS (
 		       SELECT 1 FROM private.ttfv_survey_responses r
 		       WHERE r.org_id = o.id AND r.reached_value)

--- a/gateway/models/ttfvsurvey.go
+++ b/gateway/models/ttfvsurvey.go
@@ -34,8 +34,8 @@ type TTFVMeasurement struct {
 
 // ShouldShowTTFVSurvey reports whether the organization is in a state where the
 // TTFV survey may still be asked: it collects analytics at all, it has a
-// creation timestamp to measure from, it never confirmed value, and it has not
-// declined within the cooldown.
+// creation timestamp to measure from, it has actually used the product, it
+// never confirmed value, and it has not declined within the cooldown.
 //
 // The window is evaluated by Postgres on purpose, exactly like the signup
 // origin survey. orgs.created_at and ttfv_survey_responses.created_at are
@@ -67,9 +67,26 @@ func ShouldShowTTFVSurvey(db *gorm.DB, orgID string, cooldownDays int) (bool, er
 	// prompting an organization that just opted out — stale in the one direction
 	// that matters, which is consent. This row is already being selected, so the
 	// authoritative value is free.
+	//
+	// The sessions clause is what keeps the first ask from being wasted. Without
+	// it the only precondition is the organization existing, so a brand-new admin
+	// can be asked minutes after signup — before anything has been run, when the
+	// question has no referent. That answer is a "no" about not having started
+	// yet, not about value, and it lands in the same column as a real one while
+	// also buying a cooldown. One session is the first moment the product did
+	// something for them, which is the earliest point the question means
+	// anything. Creating a connection is not enough: that is configuration.
+	//
+	// It is EXISTS rather than a count so Postgres stops at the first row, and
+	// index_sessions_org_created_at (migration 000109) leads on org_id, so this
+	// stays an index scan on a table that grows without bound. Sessions are never
+	// pruned, so the clause is monotonic — once an organization qualifies it
+	// cannot stop qualifying and silently re-suppress the survey.
 	res := db.Raw(`
 		SELECT o.analytics_mode <> 'disabled'
 		   AND o.created_at IS NOT NULL
+		   AND EXISTS (
+		       SELECT 1 FROM private.sessions s WHERE s.org_id = o.id)
 		   AND NOT EXISTS (
 		       SELECT 1 FROM private.ttfv_survey_responses r
 		       WHERE r.org_id = o.id AND r.reached_value)

--- a/gateway/models/ttfvsurvey_test.go
+++ b/gateway/models/ttfvsurvey_test.go
@@ -27,6 +27,18 @@ func seedTTFVOrg(t *testing.T, orgID, name string, createdDaysAgo float64) {
 	}
 }
 
+// setTTFVAnalyticsMode moves an organization off the 'identified' default.
+// Applied after seeding rather than as a seedTTFVOrg argument so that every
+// other case keeps exercising the default an ordinary organization really has.
+func setTTFVAnalyticsMode(t *testing.T, orgID, mode string) {
+	t.Helper()
+	err := models.DB.Exec(
+		`UPDATE private.orgs SET analytics_mode = ? WHERE id = ?`, mode, orgID).Error
+	if err != nil {
+		t.Fatalf("set analytics_mode=%s on org %s: %v", mode, orgID, err)
+	}
+}
+
 // seedTTFVResponse writes one answer createdDaysAgo days in the past.
 func seedTTFVResponse(t *testing.T, orgID string, reachedValue bool, createdDaysAgo float64) {
 	t.Helper()
@@ -48,14 +60,30 @@ func TestShouldShowTTFVSurvey(t *testing.T) {
 	startTestDB(t)
 
 	const (
-		orgNeverAnswered = "00000000-0000-0000-0000-0000000000b1"
-		orgDeclinedNow   = "00000000-0000-0000-0000-0000000000b2"
-		orgDeclinedOld   = "00000000-0000-0000-0000-0000000000b3"
-		orgAnsweredYes   = "00000000-0000-0000-0000-0000000000b4"
-		orgNoCreatedAt   = "00000000-0000-0000-0000-0000000000b5"
+		orgNeverAnswered      = "00000000-0000-0000-0000-0000000000b1"
+		orgDeclinedNow        = "00000000-0000-0000-0000-0000000000b2"
+		orgDeclinedOld        = "00000000-0000-0000-0000-0000000000b3"
+		orgAnsweredYes        = "00000000-0000-0000-0000-0000000000b4"
+		orgNoCreatedAt        = "00000000-0000-0000-0000-0000000000b5"
+		orgAnalyticsDisabled  = "00000000-0000-0000-0000-0000000000b6"
+		orgAnalyticsAnonymous = "00000000-0000-0000-0000-0000000000b7"
 	)
 
+	// Seeded without an analytics_mode, so it takes the 'identified' column
+	// default. That is the point: there is no feature flag any more, so an
+	// ordinary organization with nothing configured must be asked.
 	seedTTFVOrg(t, orgNeverAnswered, "ttfv-never-answered", 30)
+
+	// An organization that turned analytics off already asked not to be
+	// measured, and analytics.Track would drop the event, so the question is not
+	// put on screen at all.
+	seedTTFVOrg(t, orgAnalyticsDisabled, "ttfv-analytics-disabled", 30)
+	setTTFVAnalyticsMode(t, orgAnalyticsDisabled, "disabled")
+
+	// 'anonymous' still collects, it only strips the identity, so it is asked.
+	// Only 'disabled' suppresses the survey.
+	seedTTFVOrg(t, orgAnalyticsAnonymous, "ttfv-analytics-anonymous", 30)
+	setTTFVAnalyticsMode(t, orgAnalyticsAnonymous, "anonymous")
 
 	// Bracket the cooldown boundary from both sides without landing on it, so
 	// the assertions cannot flake on clock resolution.
@@ -86,11 +114,13 @@ func TestShouldShowTTFVSurvey(t *testing.T) {
 		orgID string
 		want  bool
 	}{
-		{name: "never answered", orgID: orgNeverAnswered, want: true},
+		{name: "never answered, nothing configured", orgID: orgNeverAnswered, want: true},
 		{name: "declined inside the cooldown", orgID: orgDeclinedNow, want: false},
 		{name: "declined outside the cooldown", orgID: orgDeclinedOld, want: true},
 		{name: "a yes is terminal", orgID: orgAnsweredYes, want: false},
 		{name: "organization without a creation timestamp", orgID: orgNoCreatedAt, want: false},
+		{name: "analytics disabled", orgID: orgAnalyticsDisabled, want: false},
+		{name: "analytics anonymous", orgID: orgAnalyticsAnonymous, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gateway/models/ttfvsurvey_test.go
+++ b/gateway/models/ttfvsurvey_test.go
@@ -1,0 +1,292 @@
+package models_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hoophq/hoop/gateway/models"
+	"gorm.io/gorm"
+)
+
+// ttfvCooldownDays mirrors the window services.ShouldShowTTFVSurvey passes in.
+// It is restated rather than imported so this file exercises the SQL at the
+// real width without the models package depending on the services package.
+const ttfvCooldownDays = 7
+
+// seedTTFVOrg creates an organization whose created_at is createdDaysAgo days
+// in the past, so a TTFV duration can be asserted without waiting.
+func seedTTFVOrg(t *testing.T, orgID, name string, createdDaysAgo float64) {
+	t.Helper()
+	err := models.DB.Exec(`
+		INSERT INTO private.orgs (id, name, created_at)
+		VALUES (?, ?, NOW() - make_interval(secs => ?))`,
+		orgID, name, createdDaysAgo*24*60*60,
+	).Error
+	if err != nil {
+		t.Fatalf("seed org %s: %v", name, err)
+	}
+}
+
+// seedTTFVResponse writes one answer createdDaysAgo days in the past.
+func seedTTFVResponse(t *testing.T, orgID string, reachedValue bool, createdDaysAgo float64) {
+	t.Helper()
+	err := models.DB.Exec(`
+		INSERT INTO private.ttfv_survey_responses (org_id, user_id, reached_value, created_at)
+		VALUES (?, 'seed-user', ?, NOW() - make_interval(secs => ?))`,
+		orgID, reachedValue, createdDaysAgo*24*60*60,
+	).Error
+	if err != nil {
+		t.Fatalf("seed response for org %s: %v", orgID, err)
+	}
+}
+
+func TestShouldShowTTFVSurvey(t *testing.T) {
+	// Reuses the embedded-database helper from user_signup_origin_test.go:
+	// same package, and the predicate below is raw SQL against the real schema,
+	// where an in-memory fake would exercise none of what can break — the
+	// NOT EXISTS subqueries and the interval arithmetic.
+	startTestDB(t)
+
+	const (
+		orgNeverAnswered = "00000000-0000-0000-0000-0000000000b1"
+		orgDeclinedNow   = "00000000-0000-0000-0000-0000000000b2"
+		orgDeclinedOld   = "00000000-0000-0000-0000-0000000000b3"
+		orgAnsweredYes   = "00000000-0000-0000-0000-0000000000b4"
+		orgNoCreatedAt   = "00000000-0000-0000-0000-0000000000b5"
+	)
+
+	seedTTFVOrg(t, orgNeverAnswered, "ttfv-never-answered", 30)
+
+	// Bracket the cooldown boundary from both sides without landing on it, so
+	// the assertions cannot flake on clock resolution.
+	seedTTFVOrg(t, orgDeclinedNow, "ttfv-declined-now", 30)
+	seedTTFVResponse(t, orgDeclinedNow, false, 6.95)
+
+	seedTTFVOrg(t, orgDeclinedOld, "ttfv-declined-old", 30)
+	seedTTFVResponse(t, orgDeclinedOld, false, 7.05)
+
+	// Two declines then a yes: the yes is terminal regardless of the older rows,
+	// including the one that has already aged out of the cooldown.
+	seedTTFVOrg(t, orgAnsweredYes, "ttfv-answered-yes", 30)
+	seedTTFVResponse(t, orgAnsweredYes, false, 20)
+	seedTTFVResponse(t, orgAnsweredYes, false, 10)
+	seedTTFVResponse(t, orgAnsweredYes, true, 1)
+
+	// orgs.created_at carries a default but no NOT NULL constraint, so a row
+	// can hold NULL there. Such an organization has no duration to measure, so
+	// asking it would produce an answer that cannot become a data point.
+	if err := models.DB.Exec(
+		`INSERT INTO private.orgs (id, name, created_at) VALUES (?, 'ttfv-no-created-at', NULL)`,
+		orgNoCreatedAt).Error; err != nil {
+		t.Fatalf("seed org without created_at: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		orgID string
+		want  bool
+	}{
+		{name: "never answered", orgID: orgNeverAnswered, want: true},
+		{name: "declined inside the cooldown", orgID: orgDeclinedNow, want: false},
+		{name: "declined outside the cooldown", orgID: orgDeclinedOld, want: true},
+		{name: "a yes is terminal", orgID: orgAnsweredYes, want: false},
+		{name: "organization without a creation timestamp", orgID: orgNoCreatedAt, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := models.ShouldShowTTFVSurvey(models.DB, tt.orgID, ttfvCooldownDays)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ShouldShowTTFVSurvey = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("unknown organization propagates not found", func(t *testing.T) {
+		_, err := models.ShouldShowTTFVSurvey(models.DB, "00000000-0000-0000-0000-0000000000ff", ttfvCooldownDays)
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Errorf("expected gorm.ErrRecordNotFound, got %v", err)
+		}
+	})
+}
+
+func TestCreateTTFVSurveyResponse(t *testing.T) {
+	startTestDB(t)
+
+	t.Run("measures the duration since the organization was created", func(t *testing.T) {
+		const orgID = "00000000-0000-0000-0000-0000000000c1"
+		// 10 days old, so the returned duration has a value worth asserting.
+		seedTTFVOrg(t, orgID, "ttfv-create", 10)
+
+		activity := "connected-infra-resource"
+		detail := "Configured SSO"
+		measurement, err := models.CreateTTFVSurveyResponse(models.DB, &models.TTFVSurveyResponse{
+			OrgID:         orgID,
+			UserID:        "admin@hoop.dev",
+			ReachedValue:  true,
+			Activity:      &activity,
+			ActivityOther: &detail,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if measurement.OrgCreatedAt == nil || measurement.TTFVSeconds == nil {
+			t.Fatalf("expected a measurable duration, got %+v", measurement)
+		}
+		// Both endpoints come from the database clock, so the gap is the seeded
+		// 10 days give or take the time the test itself took.
+		const tenDays = 10 * 24 * 60 * 60
+		if *measurement.TTFVSeconds < tenDays || *measurement.TTFVSeconds > tenDays+60 {
+			t.Errorf("ttfv_seconds = %d, want ~%d", *measurement.TTFVSeconds, tenDays)
+		}
+
+		showSurvey, err := models.ShouldShowTTFVSurvey(models.DB, orgID, ttfvCooldownDays)
+		if err != nil {
+			t.Fatalf("read state: %v", err)
+		}
+		if showSurvey {
+			t.Error("expected the stored yes to close the survey")
+		}
+	})
+
+	t.Run("an organization without a creation time yields no duration", func(t *testing.T) {
+		const orgID = "00000000-0000-0000-0000-0000000000c4"
+		if err := models.DB.Exec(
+			`INSERT INTO private.orgs (id, name, created_at) VALUES (?, 'ttfv-create-no-created-at', NULL)`,
+			orgID).Error; err != nil {
+			t.Fatalf("seed org without created_at: %v", err)
+		}
+
+		measurement, err := models.CreateTTFVSurveyResponse(models.DB, &models.TTFVSurveyResponse{
+			OrgID: orgID, UserID: "admin@hoop.dev",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The answer is still recorded; only the duration is unknown, and a
+		// NULL creation time must not be reported as a TTFV of zero.
+		if measurement.OrgCreatedAt != nil || measurement.TTFVSeconds != nil {
+			t.Errorf("expected no duration, got %+v", measurement)
+		}
+	})
+
+	t.Run("a decline stores no activity", func(t *testing.T) {
+		const orgID = "00000000-0000-0000-0000-0000000000c2"
+		seedTTFVOrg(t, orgID, "ttfv-decline", 3)
+
+		if _, err := models.CreateTTFVSurveyResponse(models.DB, &models.TTFVSurveyResponse{
+			OrgID: orgID, UserID: "admin@hoop.dev",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var bothNull bool
+		err := models.DB.Raw(`
+			SELECT activity IS NULL AND activity_other IS NULL
+			FROM private.ttfv_survey_responses WHERE org_id = ?`, orgID).Scan(&bothNull).Error
+		if err != nil {
+			t.Fatalf("read stored row: %v", err)
+		}
+		if !bothNull {
+			t.Error("expected activity and activity_other to stay null for a decline")
+		}
+	})
+
+	// The table is append-only on purpose: repeated declines are the response
+	// history the metric is reconstructed from, not state to overwrite.
+	t.Run("every decline adds a row", func(t *testing.T) {
+		const orgID = "00000000-0000-0000-0000-0000000000c3"
+		seedTTFVOrg(t, orgID, "ttfv-repeat", 40)
+
+		for range 3 {
+			if _, err := models.CreateTTFVSurveyResponse(models.DB, &models.TTFVSurveyResponse{
+				OrgID: orgID, UserID: "admin@hoop.dev",
+			}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+		if got := countTTFVResponses(t, orgID); got != 3 {
+			t.Errorf("stored %d rows, want 3", got)
+		}
+	})
+
+	t.Run("a second yes is rejected", func(t *testing.T) {
+		const orgID = "00000000-0000-0000-0000-0000000000c5"
+		seedTTFVOrg(t, orgID, "ttfv-second-yes", 5)
+		activity := "reviewed-recorded-session"
+
+		if _, err := models.CreateTTFVSurveyResponse(models.DB, &models.TTFVSurveyResponse{
+			OrgID: orgID, UserID: "admin@hoop.dev", ReachedValue: true, Activity: &activity,
+		}); err != nil {
+			t.Fatalf("first answer: %v", err)
+		}
+		// A decline after the yes is refused too: the survey is over for the
+		// organization, not merely answered positively once.
+		if _, err := models.CreateTTFVSurveyResponse(models.DB, &models.TTFVSurveyResponse{
+			OrgID: orgID, UserID: "other-admin@hoop.dev",
+		}); !errors.Is(err, models.ErrAlreadyExists) {
+			t.Errorf("expected models.ErrAlreadyExists, got %v", err)
+		}
+		if got := countTTFVResponses(t, orgID); got != 1 {
+			t.Errorf("stored %d rows, want 1", got)
+		}
+	})
+
+}
+
+// Two tabs answering "yes" at the same moment must not leave the organization
+// with two contradictory TTFV measurements. The conditional insert alone does
+// not prevent that — under READ COMMITTED both submissions read an organization
+// that has not confirmed yet — so the guarantee rests on the partial unique
+// index plus GORM reporting its violation as gorm.ErrDuplicatedKey, which is
+// what CreateTTFVSurveyResponse turns into ErrAlreadyExists.
+//
+// Both halves are asserted here with sequential writes that bypass the
+// conditional insert, because the embedded database serializes every client
+// onto a single session and cannot host a real race (see gateway/pglite). The
+// race itself is therefore not reproducible in this suite; what is reproducible
+// is that the invariant it relies on exists and surfaces the expected error.
+func TestTTFVConfirmedValueIsUniquePerOrg(t *testing.T) {
+	startTestDB(t)
+
+	const orgID = "00000000-0000-0000-0000-0000000000c6"
+	seedTTFVOrg(t, orgID, "ttfv-unique-yes", 15)
+
+	insertAnswer := func(reachedValue bool) error {
+		return models.DB.Exec(`
+			INSERT INTO private.ttfv_survey_responses (org_id, user_id, reached_value)
+			VALUES (?, 'admin@hoop.dev', ?)`, orgID, reachedValue).Error
+	}
+	if err := insertAnswer(true); err != nil {
+		t.Fatalf("first confirmed value: %v", err)
+	}
+	// Declines are deliberately outside the index: the response history is
+	// append-only and only the confirmation is one-per-organization.
+	for range 2 {
+		if err := insertAnswer(false); err != nil {
+			t.Fatalf("decline alongside a confirmed value: %v", err)
+		}
+	}
+	if got := countTTFVResponses(t, orgID); got != 3 {
+		t.Errorf("stored %d rows, want 3", got)
+	}
+
+	// Last, because a failed statement leaves the embedded database's single
+	// shared session unable to serve the next one ("cannot drop active portal").
+	// That is a property of the pglite bridge, not of this table.
+	if err := insertAnswer(true); !errors.Is(err, gorm.ErrDuplicatedKey) {
+		t.Fatalf("expected gorm.ErrDuplicatedKey from the partial unique index, got %v", err)
+	}
+}
+
+func countTTFVResponses(t *testing.T, orgID string) int64 {
+	t.Helper()
+	var count int64
+	if err := models.DB.Raw(
+		`SELECT count(*) FROM private.ttfv_survey_responses WHERE org_id = ?`,
+		orgID).Scan(&count).Error; err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	return count
+}

--- a/gateway/models/ttfvsurvey_test.go
+++ b/gateway/models/ttfvsurvey_test.go
@@ -11,7 +11,7 @@ import (
 // ttfvCooldownDays mirrors the window services.ShouldShowTTFVSurvey passes in.
 // It is restated rather than imported so this file exercises the SQL at the
 // real width without the models package depending on the services package.
-const ttfvCooldownDays = 7
+const ttfvCooldownDays = 3
 
 // seedTTFVOrg creates an organization whose created_at is createdDaysAgo days
 // in the past, so a TTFV duration can be asserted without waiting.
@@ -110,10 +110,10 @@ func TestShouldShowTTFVSurvey(t *testing.T) {
 	// Bracket the cooldown boundary from both sides without landing on it, so
 	// the assertions cannot flake on clock resolution.
 	seedTTFVActiveOrg(t, orgDeclinedNow, "ttfv-declined-now", 30)
-	seedTTFVResponse(t, orgDeclinedNow, false, 6.95)
+	seedTTFVResponse(t, orgDeclinedNow, false, 2.95)
 
 	seedTTFVActiveOrg(t, orgDeclinedOld, "ttfv-declined-old", 30)
-	seedTTFVResponse(t, orgDeclinedOld, false, 7.05)
+	seedTTFVResponse(t, orgDeclinedOld, false, 3.05)
 
 	// Two declines then a yes: the yes is terminal regardless of the older rows,
 	// including the one that has already aged out of the cooldown.

--- a/gateway/models/ttfvsurvey_test.go
+++ b/gateway/models/ttfvsurvey_test.go
@@ -91,8 +91,8 @@ func TestShouldShowTTFVSurvey(t *testing.T) {
 	// ordinary organization with nothing configured must be asked.
 	seedTTFVActiveOrg(t, orgNeverAnswered, "ttfv-never-answered", 30)
 
-	// Signed up but never ran anything, so "did you get done what you came here
-	// to do?" has nothing to refer to. Old enough that no age threshold would
+	// Signed up but never ran anything, so "have you gotten what you needed
+	// yet?" has nothing to refer to. Old enough that no age threshold would
 	// have caught it — the precondition is activity, not the calendar.
 	seedTTFVOrg(t, orgNoSessions, "ttfv-no-sessions", 30)
 
@@ -182,7 +182,7 @@ func TestCreateTTFVSurveyResponse(t *testing.T) {
 		// closes the survey — cannot pass merely because it was never eligible.
 		seedTTFVActiveOrg(t, orgID, "ttfv-create", 10)
 
-		activity := "connected-infra-resource"
+		activity := "saw-guardrail-applied"
 		detail := "Configured SSO"
 		measurement, err := models.CreateTTFVSurveyResponse(models.DB, &models.TTFVSurveyResponse{
 			OrgID:         orgID,

--- a/gateway/models/ttfvsurvey_test.go
+++ b/gateway/models/ttfvsurvey_test.go
@@ -27,6 +27,22 @@ func seedTTFVOrg(t *testing.T, orgID, name string, createdDaysAgo float64) {
 	}
 }
 
+// seedTTFVActiveOrg creates an organization that has run at least one session,
+// which is what an ordinary organization eligible for the survey looks like.
+// Use seedTTFVOrg directly only to build one that has never used the product.
+func seedTTFVActiveOrg(t *testing.T, orgID, name string, createdDaysAgo float64) {
+	t.Helper()
+	seedTTFVOrg(t, orgID, name, createdDaysAgo)
+	// Only the existence of a session matters to the query, so the row carries
+	// the minimum the schema requires.
+	err := models.DB.Exec(`
+		INSERT INTO private.sessions (org_id, connection, connection_type, verb, status)
+		VALUES (?, 'pgdemo', 'postgres', 'exec', 'done')`, orgID).Error
+	if err != nil {
+		t.Fatalf("seed session for org %s: %v", orgID, err)
+	}
+}
+
 // setTTFVAnalyticsMode moves an organization off the 'identified' default.
 // Applied after seeding rather than as a seedTTFVOrg argument so that every
 // other case keeps exercising the default an ordinary organization really has.
@@ -67,35 +83,41 @@ func TestShouldShowTTFVSurvey(t *testing.T) {
 		orgNoCreatedAt        = "00000000-0000-0000-0000-0000000000b5"
 		orgAnalyticsDisabled  = "00000000-0000-0000-0000-0000000000b6"
 		orgAnalyticsAnonymous = "00000000-0000-0000-0000-0000000000b7"
+		orgNoSessions         = "00000000-0000-0000-0000-0000000000b8"
 	)
 
 	// Seeded without an analytics_mode, so it takes the 'identified' column
 	// default. That is the point: there is no feature flag any more, so an
 	// ordinary organization with nothing configured must be asked.
-	seedTTFVOrg(t, orgNeverAnswered, "ttfv-never-answered", 30)
+	seedTTFVActiveOrg(t, orgNeverAnswered, "ttfv-never-answered", 30)
+
+	// Signed up but never ran anything, so "did you get done what you came here
+	// to do?" has nothing to refer to. Old enough that no age threshold would
+	// have caught it — the precondition is activity, not the calendar.
+	seedTTFVOrg(t, orgNoSessions, "ttfv-no-sessions", 30)
 
 	// An organization that turned analytics off already asked not to be
 	// measured, and analytics.Track would drop the event, so the question is not
 	// put on screen at all.
-	seedTTFVOrg(t, orgAnalyticsDisabled, "ttfv-analytics-disabled", 30)
+	seedTTFVActiveOrg(t, orgAnalyticsDisabled, "ttfv-analytics-disabled", 30)
 	setTTFVAnalyticsMode(t, orgAnalyticsDisabled, "disabled")
 
 	// 'anonymous' still collects, it only strips the identity, so it is asked.
 	// Only 'disabled' suppresses the survey.
-	seedTTFVOrg(t, orgAnalyticsAnonymous, "ttfv-analytics-anonymous", 30)
+	seedTTFVActiveOrg(t, orgAnalyticsAnonymous, "ttfv-analytics-anonymous", 30)
 	setTTFVAnalyticsMode(t, orgAnalyticsAnonymous, "anonymous")
 
 	// Bracket the cooldown boundary from both sides without landing on it, so
 	// the assertions cannot flake on clock resolution.
-	seedTTFVOrg(t, orgDeclinedNow, "ttfv-declined-now", 30)
+	seedTTFVActiveOrg(t, orgDeclinedNow, "ttfv-declined-now", 30)
 	seedTTFVResponse(t, orgDeclinedNow, false, 6.95)
 
-	seedTTFVOrg(t, orgDeclinedOld, "ttfv-declined-old", 30)
+	seedTTFVActiveOrg(t, orgDeclinedOld, "ttfv-declined-old", 30)
 	seedTTFVResponse(t, orgDeclinedOld, false, 7.05)
 
 	// Two declines then a yes: the yes is terminal regardless of the older rows,
 	// including the one that has already aged out of the cooldown.
-	seedTTFVOrg(t, orgAnsweredYes, "ttfv-answered-yes", 30)
+	seedTTFVActiveOrg(t, orgAnsweredYes, "ttfv-answered-yes", 30)
 	seedTTFVResponse(t, orgAnsweredYes, false, 20)
 	seedTTFVResponse(t, orgAnsweredYes, false, 10)
 	seedTTFVResponse(t, orgAnsweredYes, true, 1)
@@ -107,6 +129,13 @@ func TestShouldShowTTFVSurvey(t *testing.T) {
 		`INSERT INTO private.orgs (id, name, created_at) VALUES (?, 'ttfv-no-created-at', NULL)`,
 		orgNoCreatedAt).Error; err != nil {
 		t.Fatalf("seed org without created_at: %v", err)
+	}
+	// Given a session so the missing timestamp is the only reason it is not
+	// asked; otherwise the case would pass even if that clause were dropped.
+	if err := models.DB.Exec(`
+		INSERT INTO private.sessions (org_id, connection, connection_type, verb, status)
+		VALUES (?, 'pgdemo', 'postgres', 'exec', 'done')`, orgNoCreatedAt).Error; err != nil {
+		t.Fatalf("seed session for org without created_at: %v", err)
 	}
 
 	tests := []struct {
@@ -121,6 +150,7 @@ func TestShouldShowTTFVSurvey(t *testing.T) {
 		{name: "organization without a creation timestamp", orgID: orgNoCreatedAt, want: false},
 		{name: "analytics disabled", orgID: orgAnalyticsDisabled, want: false},
 		{name: "analytics anonymous", orgID: orgAnalyticsAnonymous, want: true},
+		{name: "never ran a session", orgID: orgNoSessions, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -148,7 +178,9 @@ func TestCreateTTFVSurveyResponse(t *testing.T) {
 	t.Run("measures the duration since the organization was created", func(t *testing.T) {
 		const orgID = "00000000-0000-0000-0000-0000000000c1"
 		// 10 days old, so the returned duration has a value worth asserting.
-		seedTTFVOrg(t, orgID, "ttfv-create", 10)
+		// Active, so that the assertion below — that the stored yes is what
+		// closes the survey — cannot pass merely because it was never eligible.
+		seedTTFVActiveOrg(t, orgID, "ttfv-create", 10)
 
 		activity := "connected-infra-resource"
 		detail := "Configured SSO"

--- a/gateway/services/ttfvsurvey.go
+++ b/gateway/services/ttfvsurvey.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"github.com/hoophq/hoop/common/featureflag"
+	"github.com/hoophq/hoop/gateway/models"
+	"gorm.io/gorm"
+)
+
+// TTFVSurveyFlagName gates the whole survey. Because the frontend derives its
+// entire visibility from show_ttfv_survey, flipping this off is a real kill
+// switch: no widget renders anywhere, with no frontend deploy.
+const TTFVSurveyFlagName = "experimental.ttfv_survey"
+
+// ttfvSurveyCooldownDays is how long a "no" suppresses the survey. A "no" is
+// not terminal — TTFV is the moment an admin *first* says yes, so declining is
+// a data point that has to be recorded and then followed by another ask later.
+const ttfvSurveyCooldownDays = 7
+
+// TTFVSurveyAnswer is one validated survey submission. Activity is set only
+// when ReachedValue is true, and ActivityOther only alongside the "other"
+// activity; enforcing that is the caller's job.
+type TTFVSurveyAnswer struct {
+	ReachedValue  bool
+	Activity      *string
+	ActivityOther *string
+}
+
+// ShouldShowTTFVSurvey computes the full ask policy for the caller.
+//
+// The caller-dependent clauses are checked first and short-circuit, so the
+// database is only consulted for a caller who could actually be asked.
+// Anonymous users, API keys and service accounts are excluded: they have no
+// row in private.users and are not the administrator whose confirmation the
+// metric is defined by.
+//
+// Propagates gorm.ErrRecordNotFound when the organization does not exist.
+func ShouldShowTTFVSurvey(db *gorm.DB, orgID string, isAdmin, isAnonymous bool) (bool, error) {
+	if !isAdmin || isAnonymous || !featureflag.IsEnabled(orgID, TTFVSurveyFlagName) {
+		return false, nil
+	}
+	return models.ShouldShowTTFVSurvey(db, orgID, ttfvSurveyCooldownDays)
+}
+
+// RecordTTFVSurveyAnswer stores one answer and returns the TTFV duration it
+// implies, for the analytics event.
+//
+// Only a confirmed value is terminal, so a decline inside the cooldown is still
+// recorded — it suppresses the next ask without closing the survey. Authorizing
+// the caller is the caller's responsibility.
+//
+// Returns models.ErrAlreadyExists when the organization already confirmed
+// value, and propagates gorm.ErrRecordNotFound when it does not exist.
+func RecordTTFVSurveyAnswer(db *gorm.DB, orgID, userID string, answer TTFVSurveyAnswer) (*models.TTFVMeasurement, error) {
+	return models.CreateTTFVSurveyResponse(db, &models.TTFVSurveyResponse{
+		OrgID:         orgID,
+		UserID:        userID,
+		ReachedValue:  answer.ReachedValue,
+		Activity:      answer.Activity,
+		ActivityOther: answer.ActivityOther,
+	})
+}

--- a/gateway/services/ttfvsurvey.go
+++ b/gateway/services/ttfvsurvey.go
@@ -8,7 +8,14 @@ import (
 // ttfvSurveyCooldownDays is how long a "no" suppresses the survey. A "no" is
 // not terminal — TTFV is the moment an admin *first* says yes, so declining is
 // a data point that has to be recorded and then followed by another ask later.
-const ttfvSurveyCooldownDays = 7
+//
+// The window is also the resolution of the metric. Value is reached somewhere
+// between the last decline and the yes, but only the yes carries a timestamp,
+// so every measurement is inflated by up to one cooldown. Three days keeps that
+// error small without putting the question in front of a daily administrator
+// more than about twice a week; at one day anyone who does not log in daily
+// would meet it on essentially every visit.
+const ttfvSurveyCooldownDays = 3
 
 // TTFVSurveyAnswer is one validated survey submission. Activity is set only
 // when ReachedValue is true, and ActivityOther only alongside the "other"

--- a/gateway/services/ttfvsurvey.go
+++ b/gateway/services/ttfvsurvey.go
@@ -28,9 +28,10 @@ type TTFVSurveyAnswer struct {
 // metric is defined by.
 //
 // There is no feature flag. The survey is on for every organization and closes
-// itself the first time an admin confirms value; the organization's own
-// analytics mode is the only thing that suppresses it, and that is checked in
-// SQL alongside the rest of the policy — see models.ShouldShowTTFVSurvey.
+// itself the first time an admin confirms value; the organization's analytics
+// mode and whether it has run anything at all are the only things that suppress
+// it, and both are checked in SQL alongside the rest of the policy — see
+// models.ShouldShowTTFVSurvey.
 //
 // Propagates gorm.ErrRecordNotFound when the organization does not exist.
 func ShouldShowTTFVSurvey(db *gorm.DB, orgID string, isAdmin, isAnonymous bool) (bool, error) {

--- a/gateway/services/ttfvsurvey.go
+++ b/gateway/services/ttfvsurvey.go
@@ -1,15 +1,9 @@
 package services
 
 import (
-	"github.com/hoophq/hoop/common/featureflag"
 	"github.com/hoophq/hoop/gateway/models"
 	"gorm.io/gorm"
 )
-
-// TTFVSurveyFlagName gates the whole survey. Because the frontend derives its
-// entire visibility from show_ttfv_survey, flipping this off is a real kill
-// switch: no widget renders anywhere, with no frontend deploy.
-const TTFVSurveyFlagName = "experimental.ttfv_survey"
 
 // ttfvSurveyCooldownDays is how long a "no" suppresses the survey. A "no" is
 // not terminal — TTFV is the moment an admin *first* says yes, so declining is
@@ -33,9 +27,14 @@ type TTFVSurveyAnswer struct {
 // row in private.users and are not the administrator whose confirmation the
 // metric is defined by.
 //
+// There is no feature flag. The survey is on for every organization and closes
+// itself the first time an admin confirms value; the organization's own
+// analytics mode is the only thing that suppresses it, and that is checked in
+// SQL alongside the rest of the policy — see models.ShouldShowTTFVSurvey.
+//
 // Propagates gorm.ErrRecordNotFound when the organization does not exist.
 func ShouldShowTTFVSurvey(db *gorm.DB, orgID string, isAdmin, isAnonymous bool) (bool, error) {
-	if !isAdmin || isAnonymous || !featureflag.IsEnabled(orgID, TTFVSurveyFlagName) {
+	if !isAdmin || isAnonymous {
 		return false, nil
 	}
 	return models.ShouldShowTTFVSurvey(db, orgID, ttfvSurveyCooldownDays)

--- a/gateway/services/ttfvsurvey_test.go
+++ b/gateway/services/ttfvsurvey_test.go
@@ -1,0 +1,65 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/hoophq/hoop/common/featureflag"
+)
+
+// The whole point of computing the visibility on the server is that the policy
+// can be re-tuned without a frontend deploy, which only holds while every
+// caller-dependent clause keeps answering false on its own.
+//
+// The database half of the policy — the terminal yes and the cooldown window —
+// is exercised against real SQL in gateway/models/ttfvsurvey_test.go. Here the
+// database handle is deliberately nil: any case that reaches it would panic,
+// which is exactly the assertion, since a caller who can never be asked must
+// not cost a query on every /userinfo.
+func TestShouldShowTTFVSurveyShortCircuits(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		isAdmin     bool
+		isAnonymous bool
+		flagEnabled bool
+	}{
+		{name: "never asks a non-admin", isAdmin: false, flagEnabled: true},
+		{name: "never asks an anonymous user", isAdmin: true, isAnonymous: true, flagEnabled: true},
+		{name: "never asks while the flag is off", isAdmin: true, flagEnabled: false},
+		{name: "never asks a non-admin while the flag is off"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Distinct per case so the process-local flag cache set by one
+			// subtest cannot leak into another.
+			orgID := "org-" + tc.name
+			featureflag.Set(orgID, TTFVSurveyFlagName, tc.flagEnabled)
+
+			got, err := ShouldShowTTFVSurvey(nil, orgID, tc.isAdmin, tc.isAnonymous)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got {
+				t.Error("ShouldShowTTFVSurvey = true, want false")
+			}
+		})
+	}
+}
+
+// A "no" is not terminal, so the cooldown is the only thing keeping the survey
+// from being re-offered on the very next page load.
+func TestTTFVSurveyCooldownIsPositive(t *testing.T) {
+	if ttfvSurveyCooldownDays <= 0 {
+		t.Fatalf("ttfvSurveyCooldownDays = %d, must be greater than zero", ttfvSurveyCooldownDays)
+	}
+}
+
+// The flag has to exist in the catalog or featureflag.IsEnabled logs a warning
+// and returns false forever, which would silently disable the survey for good.
+func TestTTFVSurveyFlagIsRegistered(t *testing.T) {
+	flag, ok := featureflag.Lookup(TTFVSurveyFlagName)
+	if !ok {
+		t.Fatalf("flag %q is not registered in the featureflag catalog", TTFVSurveyFlagName)
+	}
+	if flag.Default {
+		t.Error("the survey must be off on a fresh deployment")
+	}
+}

--- a/gateway/services/ttfvsurvey_test.go
+++ b/gateway/services/ttfvsurvey_test.go
@@ -2,38 +2,30 @@ package services
 
 import (
 	"testing"
-
-	"github.com/hoophq/hoop/common/featureflag"
 )
 
 // The whole point of computing the visibility on the server is that the policy
 // can be re-tuned without a frontend deploy, which only holds while every
 // caller-dependent clause keeps answering false on its own.
 //
-// The database half of the policy — the terminal yes and the cooldown window —
-// is exercised against real SQL in gateway/models/ttfvsurvey_test.go. Here the
-// database handle is deliberately nil: any case that reaches it would panic,
-// which is exactly the assertion, since a caller who can never be asked must
-// not cost a query on every /userinfo.
+// The database half of the policy — the analytics mode, the terminal yes and
+// the cooldown window — is exercised against real SQL in
+// gateway/models/ttfvsurvey_test.go. Here the database handle is deliberately
+// nil: any case that reaches it would panic, which is exactly the assertion,
+// since a caller who can never be asked must not cost a query on every
+// /userinfo.
 func TestShouldShowTTFVSurveyShortCircuits(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		isAdmin     bool
 		isAnonymous bool
-		flagEnabled bool
 	}{
-		{name: "never asks a non-admin", isAdmin: false, flagEnabled: true},
-		{name: "never asks an anonymous user", isAdmin: true, isAnonymous: true, flagEnabled: true},
-		{name: "never asks while the flag is off", isAdmin: true, flagEnabled: false},
-		{name: "never asks a non-admin while the flag is off"},
+		{name: "never asks a non-admin", isAdmin: false},
+		{name: "never asks an anonymous user", isAdmin: true, isAnonymous: true},
+		{name: "never asks an anonymous non-admin"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// Distinct per case so the process-local flag cache set by one
-			// subtest cannot leak into another.
-			orgID := "org-" + tc.name
-			featureflag.Set(orgID, TTFVSurveyFlagName, tc.flagEnabled)
-
-			got, err := ShouldShowTTFVSurvey(nil, orgID, tc.isAdmin, tc.isAnonymous)
+			got, err := ShouldShowTTFVSurvey(nil, "org-"+tc.name, tc.isAdmin, tc.isAnonymous)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -49,17 +41,5 @@ func TestShouldShowTTFVSurveyShortCircuits(t *testing.T) {
 func TestTTFVSurveyCooldownIsPositive(t *testing.T) {
 	if ttfvSurveyCooldownDays <= 0 {
 		t.Fatalf("ttfvSurveyCooldownDays = %d, must be greater than zero", ttfvSurveyCooldownDays)
-	}
-}
-
-// The flag has to exist in the catalog or featureflag.IsEnabled logs a warning
-// and returns false forever, which would silently disable the survey for good.
-func TestTTFVSurveyFlagIsRegistered(t *testing.T) {
-	flag, ok := featureflag.Lookup(TTFVSurveyFlagName)
-	if !ok {
-		t.Fatalf("flag %q is not registered in the featureflag catalog", TTFVSurveyFlagName)
-	}
-	if flag.Default {
-		t.Error("the survey must be off on a fresh deployment")
 	}
 }


### PR DESCRIPTION
## 📝 Description

Backend half of TTFV (Time To First Value) measurement. TTFV is defined as the
duration between `orgs.created_at` and the moment an **administrator first
confirms they got what they came for** — a perceived outcome, not a completed
setup step. Nothing in the product records that moment today, so this PR adds
the survey that asks for it and the storage/analytics path that measures it.

Two pieces:

- `show_ttfv_survey` on `GET /api/userinfo` — the full ask policy, resolved
  server-side. True for an administrator of an organization that collects
  analytics, has run at least one session, has never confirmed value, and has
  not declined within the last 3 days.
- `POST /api/orgs/ttfv-survey` (admin only) — records the answer and emits
  `hoop-ttfv-survey-answered` with the measured duration.

A **"yes" is terminal** — the organization is never asked again, and a second
attempt gets a 409. A **"no" is not**: it is recorded as a real data point and
followed by another ask after a 3-day cooldown. Dismissing the widget is not an
answer and is not submitted.

Design notes worth a reviewer's attention:

- **No feature flag.** The survey is on for every organization and closes itself
  on the first confirmed value. Analytics mode is the opt-out that already
  exists — an organization with `analytics_mode = 'disabled'` is never asked,
  and the clause is evaluated in SQL rather than through `analytics.GetMode`,
  which is a process-local cache that is stale in the consent direction.
- **Organizations that never ran a session are never asked.** The question is
  meaningless before there is a product to have gotten value from, and a decline
  from an empty org would add a cooldown's worth of noise to the metric.
- **The cooldown is the metric's resolution.** Value is reached somewhere
  between the last decline and the yes, but only the yes carries a timestamp, so
  every measurement is inflated by up to one cooldown. 3 days keeps that error
  small without putting the question in front of a daily administrator more than
  about twice a week.
- **Concurrency is arbitrated by the database.** A partial unique index
  `ON ttfv_survey_responses (org_id) WHERE reached_value` is what decides between
  two simultaneous confirmations; the loser's 23505 surfaces as
  `gorm.ErrDuplicatedKey` and is reported as a 409. The write does not rely on a
  read-then-check.
- **The free text never reaches an analytics destination.** It is user-supplied
  and may contain personal data, so it is stored in
  `private.ttfv_survey_responses` and deliberately excluded from the event
  payload.
- **The event is emitted from the gateway, not the browser.** A client-side call
  is blocked by the same ad blockers that ruled out measuring this through
  Intercom, which would bias the metric towards the users least likely to run
  one. The row is the system of record; the event is the copy dashboards read,
  and the duration is recomputable from SQL if the event is ever dropped.

## 📣 User-facing impact

Administrators are asked once in a while whether they have gotten what they
needed from hoop yet, and the question stops for good once the answer is yes.
Organizations with analytics disabled never see it.

## 🔗 Related Issue

[EVL-212 — TTFV Measurement Backend](https://linear.app/hoophq/issue/EVL-212/ttfv-measurement-backend)

Pairs with **EVL-211 (frontend, `webapp_v2`)**, which opens its own PR. The two
are independent at the code level — the widget fails closed if `show_ttfv_survey`
is absent — but they should be **released together**, since neither is useful
alone. The activity enum is a shared contract between this PR's
`validTTFVActivities` and `webapp_v2/src/features/TtfvSurvey/constants.js`;
please check the two lists agree element-for-element at merge time.

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

- **Migration `000114_ttfv_survey_responses`** — new table, an
  `(org_id, created_at DESC)` index for the "latest answers" reads, and the
  partial unique index that enforces one confirmed value per organization.
- **`gateway/models/ttfvsurvey.go`** — `ShouldShowTTFVSurvey` (the whole policy
  as one SQL predicate, with the time arithmetic done in Postgres so both sides
  of every comparison come from one clock) and `CreateTTFVSurveyResponse`
  (conditional insert, computes `ttfv_seconds` in the same statement, maps
  duplicates to `ErrAlreadyExists` and distinguishes unknown-org from
  already-answered).
- **`gateway/services/ttfvsurvey.go`** — cooldown constant, caller-dependent
  short-circuits (`!isAdmin || isAnonymous`), and the answer type.
- **`gateway/api/orgs/orgttfvsurvey.go`** — handler, the activity enum,
  request validation, and the pure `ttfvEventProperties` builder.
- **`gateway/api/user/user.go`** — resolves `show_ttfv_survey`; a failure only
  means the survey is not offered on that request, never a failed `/userinfo`.
- **`gateway/api/server.go`** — route registration under `AdminOnlyAccessRole`.
- **`gateway/analytics/events.go`** — new `EventTTFVSurveyAnswered` constant
  (`hoop-ttfv-survey-answered`). No existing event is removed or renamed. It is
  emitted from the handler rather than via `TrackRequest`, because that
  middleware runs before the body is validated and could carry neither the
  answer nor the measured duration.
- **OpenAPI** — annotations plus regenerated `autogen/docs.go` and
  `openapiv3.json`.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a — API only
- **OS**: macOS (darwin), gateway in Docker against the shared dev Postgres

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass — n/a, no integration suite covers this layer
- [x] Manual testing completed

**Automated.** `CGO_ENABLED=0 go test github.com/hoophq/hoop/...` is green.
`make test-oss` could not be run on this machine — its `generate-wasm`
prerequisite needs `cargo`, which is not installed here — so please confirm it
is green in CI. New tests:

- `gateway/models/ttfvsurvey_test.go` — the ask policy as a table against real
  Postgres (pglite), 8 cases including both sides of the cooldown boundary
  (declined 2d23h ago → suppressed, 3d1h ago → asked) and an organization that
  never ran a session.
- `gateway/api/orgs/orgttfvsurvey_test.go` — request validation, the binding
  behaviour that lets an explicit `false` through, the event payload key by key
  (including a test that the free text cannot leak into it), and
  `TestTTFVActivityContract`, which pins the enum literally and asserts the
  published `enums` struct tag agrees with it.

**Manual end-to-end**, against a gateway built from this branch talking to the
dev Postgres, driving the real HTTP API with a throwaway admin:

| Scenario | Expected | Result |
|---|---|---|
| Org with zero sessions | `show_ttfv_survey: false` | ✅ |
| After one real session (`POST /api/sessions`) | `true` | ✅ |
| Declined 2d23h ago | `false` | ✅ |
| Declined 3d1h ago | `true` | ✅ |
| `analytics_mode = 'disabled'` | `false` | ✅ |
| Anonymous user | `false` | ✅ |
| `{"reached_value": false}` sent with empty-string activity fields | 204, `activity`/`activity_other` stored as NULL | ✅ |
| `{"reached_value": true, "activity": "other", ...}` with accents and emoji | 204, stored intact | ✅ |
| `/userinfo` after a confirmed value | `false` | ✅ |
| Second confirmed value | 409 | ✅ |
| Unknown activity identifier | 400 | ✅ |

Test artifacts (the throwaway admin, its group and token, the survey rows, the
analytics-mode change) were cleaned up. The one real session row was left in
place — it is genuine audit data, and it leaves the org in the state the EVL-211
session needs in order to see the widget.

## 📄 Additional Notes

**The one thing a reviewer cannot catch by reading the diff:** the
Segment → Mixpanel leg is **unverified**. `segmentApiKey` is injected only at
build time (`Makefile:39`) and `scripts/dev/run.sh:65` omits it, so
`analytics.New()` returns a client with a nil `Client` and every `Track` call is
a no-op locally. The event payload is asserted by unit test and the call site is
in place, but nobody has watched `hoop-ttfv-survey-answered` actually land. If
you have Segment access, please confirm the event and its properties (`org-id`,
`reached-value`, `activity`, `org-created-at`, `ttfv-seconds`) arrive once this
ships.

**Migration rollback was not exercised.** The dev Postgres is shared with the
concurrent EVL-211 session, so running `migrate down 1` would have been visible
to them. The `.down.sql` is a plain `DROP TABLE` of a table nothing else
references.

**Worth reviewing specifically:** the SQL in `models.ShouldShowTTFVSurvey`. The
whole policy lives there, and a wrong clause is the difference between a survey
nobody sees and one that nags.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
