### PR TITLE
feat: enhance token validation to include client_id in audience checks

### DIFF
--- a/gateway/idp/oidc/oidc.go
+++ b/gateway/idp/oidc/oidc.go
@@ -397,8 +397,8 @@ func (p *Provider) VerifyAccessTokenForResource(accessToken, expectedResource st
 	}
 
 	if !audienceContains(claims["aud"], expectedResource) && !tokenBoundToClient(claims, staticClientIDs) {
-		return uinfo, nil, fmt.Errorf("audience mismatch, got aud=%v azp=%v, want %q or a static client of %v",
-			claims["aud"], claims["azp"], expectedResource, staticClientIDs)
+		return uinfo, nil, fmt.Errorf("audience mismatch, got aud=%v azp=%v client_id=%v, want %q or a static client of %v",
+			claims["aud"], claims["azp"], claims["client_id"], expectedResource, staticClientIDs)
 	}
 
 	uinfo = p.parseUserInfo(claims)
@@ -456,17 +456,19 @@ func audienceContains(claim any, expected string) bool {
 
 // tokenBoundToClient reports whether the token is bound to one of the
 // statically pre-registered client IDs, either through the `aud` claim (IdPs
-// that mint the client ID as audience) or the `azp` authorized-party claim
+// that mint the client ID as audience), the `azp` authorized-party claim
 // (OIDC Core §3.1.3.7 — IdPs that keep their own default `aud` and record the
-// requesting client in `azp`). Client IDs are compared exactly and
-// case-sensitively; empty entries are ignored.
+// requesting client in `azp`), or the `client_id` claim (RFC 9068 §2.2 —
+// IdPs such as JumpCloud that leave `aud` empty and omit `azp`). Client IDs
+// are compared exactly and case-sensitively; empty entries are ignored.
 func tokenBoundToClient(claims jwt.MapClaims, clientIDs []string) bool {
 	azp, _ := claims["azp"].(string)
+	tokenClientID, _ := claims["client_id"].(string)
 	for _, clientID := range clientIDs {
 		if clientID == "" {
 			continue
 		}
-		if azp == clientID || audienceContainsExact(claims["aud"], clientID) {
+		if azp == clientID || tokenClientID == clientID || audienceContainsExact(claims["aud"], clientID) {
 			return true
 		}
 	}

--- a/gateway/idp/oidc/oidc_test.go
+++ b/gateway/idp/oidc/oidc_test.go
@@ -101,6 +101,25 @@ func TestTokenBoundToClient(t *testing.T) {
 		assert.True(t, tokenBoundToClient(claims, []string{clientID}))
 	})
 
+	// JumpCloud-style (RFC 9068 §2.2): aud is empty, azp is absent, and the
+	// requesting client surfaces only through the client_id claim.
+	t.Run("client id in client_id with empty aud", func(t *testing.T) {
+		claims := jwt.MapClaims{
+			"aud":       []any{},
+			"client_id": clientID,
+		}
+		assert.True(t, tokenBoundToClient(claims, []string{clientID}))
+	})
+
+	t.Run("unrelated client_id rejected", func(t *testing.T) {
+		claims := jwt.MapClaims{"aud": []any{}, "client_id": "other-client"}
+		assert.False(t, tokenBoundToClient(claims, []string{clientID}))
+	})
+
+	t.Run("client_id is case-sensitive exact", func(t *testing.T) {
+		assert.False(t, tokenBoundToClient(jwt.MapClaims{"client_id": "HOOP-mcp-client"}, []string{clientID}))
+	})
+
 	t.Run("unrelated client rejected", func(t *testing.T) {
 		claims := jwt.MapClaims{"aud": "something-else", "azp": "web-app-client"}
 		assert.False(t, tokenBoundToClient(claims, []string{clientID}))
@@ -125,7 +144,7 @@ func TestTokenBoundToClient(t *testing.T) {
 	})
 
 	t.Run("empty client ids never match", func(t *testing.T) {
-		assert.False(t, tokenBoundToClient(jwt.MapClaims{"aud": "", "azp": ""}, []string{""}))
+		assert.False(t, tokenBoundToClient(jwt.MapClaims{"aud": "", "azp": "", "client_id": ""}, []string{""}))
 		assert.False(t, tokenBoundToClient(jwt.MapClaims{"azp": clientID}, nil))
 	})
 


### PR DESCRIPTION
## What & Why

Fixes #1734 

MCP OAuth static-client validation only recognized a configured static client through the aud or azp claims. Some IdPs (e.g. JumpCloud Hydra) emit the OAuth client identity in the client_id access-token claim (RFC 9068 §2.2) while leaving aud empty and omitting azp — so a correctly signed token whose client_id exactly matched the configured MCP static client was still rejected with 401 invalid_token: audience mismatch.

Changes in gateway/idp/oidc/oidc.go:

- tokenBoundToClient now also reads the client_id claim and compares it exactly and case-sensitively against the explicitly configured static client IDs, alongside the existing aud and azp checks. Empty configured IDs still never match.
- The audience-mismatch error now includes client_id in the diagnostic for easier debugging.
- Doc comment updated to describe the third binding path.

This remains limited to explicitly configured static client IDs, matching the existing security posture of the azp fallback: since the IdP supplies no resource audience, the configured public PKCE client must be dedicated to MCP access for that gateway.