### PR TITLE
EVL-218: keep the legacy API_KEY organization when authconfig is empty

### DIFF
--- a/gateway/idp/core.go
+++ b/gateway/idp/core.go
@@ -433,18 +433,11 @@ func NewUserInfoTokenVerifierProvider() (UserInfoTokenVerifier, idptypes.ServerC
 	// set server configuration falling back to appconfig
 	appc := appconfig.Get()
 	var orgLicenseData json.RawMessage
-
-	// legacy api key organization id
-	orgID := strings.Split(appc.ApiKey(), "|")[0]
-	// fallback loading from the server auth config in case it's set
 	if serverAuthConfig != nil {
-		if serverAuthConfig.OrgID != "" {
-			orgID = serverAuthConfig.OrgID
-		}
 		orgLicenseData = serverAuthConfig.OrgLicenseData
 	}
 	serverConfig := idptypes.ServerConfig{
-		OrgID:          orgID,
+		OrgID:          resolveServerOrgID(appc.ApiKey(), serverAuthConfig),
 		OrgLicenseData: orgLicenseData,
 		AuthMethod:     providerType,
 		ApiKey:         appc.ApiKey(),
@@ -452,7 +445,6 @@ func NewUserInfoTokenVerifierProvider() (UserInfoTokenVerifier, idptypes.ServerC
 	}
 
 	if serverAuthConfig != nil {
-		serverConfig.OrgID = serverAuthConfig.OrgID
 		if serverAuthConfig.ApiKey != nil {
 			serverConfig.ApiKey = *serverAuthConfig.ApiKey
 		}
@@ -465,6 +457,21 @@ func NewUserInfoTokenVerifierProvider() (UserInfoTokenVerifier, idptypes.ServerC
 
 	singletonStore.Set(singletonStoreKey, &wrapper)
 	return wrapper, wrapper.serverConfig, nil
+}
+
+// resolveServerOrgID resolves the organization of the server configuration. The legacy
+// `orgID|key` API_KEY carries it in its prefix, and the server auth config overrides it.
+//
+// The override must be guarded. GetServerAuthConfig full outer joins private.authconfig
+// with private.serverconfig, so it returns a record with an empty OrgID while the
+// authconfig row does not exist. An empty value that overrides the legacy organization
+// makes every consumer of ServerConfig.OrgID unable to find the organization: the grpc
+// auth interceptor then rejects a valid API_KEY with `invalid authentication`.
+func resolveServerOrgID(apiKey string, serverAuthConfig *models.ServerAuthConfig) string {
+	if serverAuthConfig != nil && serverAuthConfig.OrgID != "" {
+		return serverAuthConfig.OrgID
+	}
+	return strings.Split(apiKey, "|")[0]
 }
 
 func NewTokenVerifierProvider() (TokenVerifier, idptypes.ServerConfig, error) {

--- a/gateway/idp/core_test.go
+++ b/gateway/idp/core_test.go
@@ -350,3 +350,49 @@ func TestUserInfoTokenVerifier_hasServerConfigChanged(t *testing.T) {
 		})
 	})
 }
+
+func TestResolveServerOrgID(t *testing.T) {
+	const legacyOrgID = "ebbc9916-6654-4079-bd44-e9e8cb789818"
+
+	for _, tt := range []struct {
+		msg              string
+		apiKey           string
+		serverAuthConfig *models.ServerAuthConfig
+		want             string
+	}{
+		{
+			msg:              "it should keep the legacy org id when the authconfig row does not exist",
+			apiKey:           legacyOrgID + "|secret",
+			serverAuthConfig: &models.ServerAuthConfig{OrgID: ""},
+			want:             legacyOrgID,
+		},
+		{
+			msg:              "it should keep the legacy org id when there is no server auth config",
+			apiKey:           legacyOrgID + "|secret",
+			serverAuthConfig: nil,
+			want:             legacyOrgID,
+		},
+		{
+			msg:              "it should prefer the server auth config org id",
+			apiKey:           legacyOrgID + "|secret",
+			serverAuthConfig: &models.ServerAuthConfig{OrgID: "6b1d1f7e-0000-4000-8000-000000000001"},
+			want:             "6b1d1f7e-0000-4000-8000-000000000001",
+		},
+		{
+			msg:              "it should use the server auth config org id for xapi keys",
+			apiKey:           "xapi-Zm9vYmFy",
+			serverAuthConfig: &models.ServerAuthConfig{OrgID: legacyOrgID},
+			want:             legacyOrgID,
+		},
+		{
+			msg:              "it should be empty when the api key is not set and there is no org id",
+			apiKey:           "",
+			serverAuthConfig: &models.ServerAuthConfig{OrgID: ""},
+			want:             "",
+		},
+	} {
+		t.Run(tt.msg, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveServerOrgID(tt.apiKey, tt.serverAuthConfig))
+		})
+	}
+}

--- a/gateway/transport/interceptors/auth/auth.go
+++ b/gateway/transport/interceptors/auth/auth.go
@@ -208,6 +208,8 @@ func (i *interceptor) StreamServerInterceptor(srv any, ss grpc.ServerStream, inf
 			deterministicUuid := uuid.NewSHA1(uuid.NameSpaceURL, []byte(`API_KEY`))
 			org, err := models.GetOrganizationByNameOrID(serverConfig.OrgID)
 			if err != nil {
+				log.Errorf("failed fetching the organization of the server api key, org=%q, err=%v",
+					serverConfig.OrgID, err)
 				return status.Errorf(codes.Unauthenticated, "invalid authentication")
 			}
 			ctx := &models.Context{


### PR DESCRIPTION
## 📝 Description

`GET /api/connections/:nameOrID/test` returned `400` with `rpc error: code = Unauthenticated desc = invalid authentication` for an `Api-Key` that authenticates correctly on every other endpoint.

The test endpoint opens a loopback grpc stream back into the gateway (`gateway/clientexec`) and replays the caller credential. The grpc auth interceptor resolves the organization of the server api key from `ServerConfig.OrgID`, and that value was empty.

`models.GetServerAuthConfig` full outer joins `private.authconfig` with `private.serverconfig`. While the `authconfig` row does not exist, the join still returns a record, with an empty `OrgID`. `NewUserInfoTokenVerifierProvider` computed the organization from the legacy `orgID|key` API_KEY, then overwrote it with that empty value, undoing the guard three lines above.

The REST middleware was unaffected because it derives the organization from the api key itself, so the same credential worked on `GET /connections/:name` and failed on `/test`.

## 📣 User-facing impact

An `Api-Key` that works on the rest of the API now also works on `GET /connections/{name}/test`, and on the other endpoints that execute a command on behalf of the caller (`/sessions/{id}/exec`, runbooks, database explorer, MCP tools).

## 🔗 Related Issue

Fixes EVL-218

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- `gateway/idp/core.go`: extract `resolveServerOrgID`, which only lets the server auth config override the legacy API_KEY organization when it is not empty. Removes the unguarded re-assignment.
- `gateway/transport/interceptors/auth/auth.go`: log the organization lookup error. It was discarded, so the failure was only visible as a generic `invalid authentication`.
- `gateway/idp/core_test.go`: table test for `resolveServerOrgID`.

## 🧪 Testing

### Test Configuration:
- **OS**: macOS (darwin/arm64), gateway in the dev container, PostgreSQL 17

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

**How to test**

Reproduce on a gateway whose `private.authconfig` table is empty, with a legacy API_KEY:

```bash
# .env — the prefix must be the real organization id
API_KEY=<org-id>|somesecret
make run-dev

curl -s -o /dev/null -w '%{http_code}\n' -H "Api-Key: $API_KEY" \
  localhost:8009/api/connections/<name>
curl -s -H "Api-Key: $API_KEY" \
  localhost:8009/api/connections/<name>/test
```

Before this change:

| request | result |
|---|---|
| `GET /connections/<name>` | `200` |
| `GET /connections/<name>/test` | `400` `connection test failed: failed issuing test command, output=rpc error: code = Unauthenticated desc = invalid authentication` |

After this change the grpc stream authenticates: the gateway logs `proxy connected: user=API_KEY, origin=client-api, verb=plain-exec` and the session reaches the agent.

Control that isolates the cause, with an unmodified binary: `INSERT INTO private.authconfig (org_id, updated_at) VALUES ('<org-id>', now());` and restart the gateway. `/test` returns `200`. Delete the row, restart, and it returns `400` again.

Automated:

```bash
make test-oss       # green
make test-gateway   # only TestHealthzDegraded fails, and it also fails on a clean main
```

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Workaround for a customer already hitting this, with no upgrade: use an org scoped `hpk_` API key in the `Authorization: Bearer` header, instead of the static key in the `Api-Key` header. The `hpk_` branch of the grpc interceptor resolves the organization from the `private.api_keys` row, so it never reads `ServerConfig.OrgID` and is not affected.

Measured on the same unfixed binary, with `private.authconfig` empty:

| credential | header | `GET /connections/{name}` | `GET /connections/{name}/test` |
|---|---|---|---|
| static `API_KEY` | `Api-Key` | 200 | 400 `Unauthenticated` |
| `hpk_` | `Authorization: Bearer` | 200 | authenticates, reaches the agent |
| `hpk_` | `Api-Key` | 401 | - |

The third row is the trap: an `hpk_` key sent in the `Api-Key` header is compared against the static server key and rejected, so the header has to change together with the key.

Saving the auth configuration once from the UI also works, because it creates the `private.authconfig` row and populates `org_id`.

Two adjacent issues found while investigating, not addressed here:

1. `apiroutes.GetAccessTokenFromRequest` returns the expired bearer token even when `AuthMiddleware` just refreshed it through `tryRefreshFromRequest`. That is a second, independent source of `Unauthenticated` on these same endpoints.
2. `Api-Key` is absent from the OpenAPI spec, which only declares `OAuth2AccessCode`. An API consumer cannot learn which header carries which key type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

