### PR TITLE
fix: make text selection visible in the terminal editor (EVL-215)

### DIFF
--- a/webapp/src/css/codemirror-surface.css
+++ b/webapp/src/css/codemirror-surface.css
@@ -21,7 +21,10 @@
   border-right: none;
 }
 
-.cm-editor.cm-editor .cm-activeLine,
+.cm-editor.cm-editor .cm-activeLine {
+  background-color: rgb(0 0 20 / 4%);
+}
+
 .cm-editor.cm-editor .cm-activeLineGutter {
   background-color: var(--gray-5);
 }
@@ -34,7 +37,10 @@
   background-color: #2e3235;
 }
 
-.dark .cm-editor.cm-editor .cm-activeLine,
+.dark .cm-editor.cm-editor .cm-activeLine {
+  background-color: rgb(255 255 255 / 6%);
+}
+
 .dark .cm-editor.cm-editor .cm-activeLineGutter {
   background-color: #3a3f43;
 }

--- a/webapp/src/webapp/webclient/panel.cljs
+++ b/webapp/src/webapp/webclient/panel.cljs
@@ -216,7 +216,8 @@
         :height "100%"
         :className "h-full text-sm"
         :theme theme
-        :basicSetup #js{:defaultKeymap false}
+        :basicSetup #js{:defaultKeymap false
+                        :highlightSelectionMatches false}
         :onChange on-change
         :extensions (clj->js extensions)}])}))
 


### PR DESCRIPTION
## 📝 Description

Text selection in the terminal editor was invisible, and every identical word in the buffer looked selected alongside it. Two independent causes, both in the editor chrome.

**1. Opaque `.cm-activeLine` covered the selection.** `drawSelection` blanks the native `::selection` and paints the highlight into `.cm-selectionLayer` at `z-index: -1`. Per CSS paint order, a negative-z-index layer renders *before* in-flow block backgrounds — so a solid line background hides it. `codemirror-surface.css` set `--gray-5` there in EVL-171 (shipped 1.136.0). CM6 (`#cceeff44`) and materialLight (`#CCD7DA50`) both ship alpha for exactly this reason. Now alpha, composited to the same shade.

**2. Match highlighting was indistinguishable from the selection.** `basicSetup` left `highlightSelectionMatches` on, and materialLight/materialDark give `selectionMatch` the *same* colour as `selection` (`#80CBC440` / `#d7d4f063`). Selecting `join` marked every other `join` identically. Turned off, so no decoration is emitted at all.

## 📣 User-facing impact

Selecting text in the web terminal editor shows the highlight again, and only the text you actually selected is highlighted.

## 🔗 Related Issue

EVL-215

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- `webapp/src/css/codemirror-surface.css` — `.cm-activeLine` uses alpha (`rgb(0 0 20 / 4%)` light, `rgb(255 255 255 / 6%)` dark) instead of an opaque fill. `.cm-activeLineGutter` stays opaque: no selection is drawn in the gutter.
- `webapp/src/webapp/webclient/panel.cljs` — `:highlightSelectionMatches false` in `basicSetup`.

Ctrl+F search highlighting is unaffected (`searchKeymap` stays on, different class `.cm-searchMatch`).

## 💻  Screenshots

<img width="1018" height="441" alt="CleanShot 2026-08-24 at 18 43 08" src="https://github.com/user-attachments/assets/9f627ed4-2e2d-483e-80d5-e6df3074f160" />

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS

### Tests performed:
- [x] Manual testing completed

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
