### PR TITLE
fix: keep large SQL query results from blocking the UI

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -18,6 +18,14 @@ concurrency:
   group: openapi-docs-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# proxy.golang.org intermittently resets HTTP/2 streams mid-download
+# ("stream error: stream ID N; INTERNAL_ERROR; received from peer"). cmd/go
+# turns that into a hard build failure after a ~60s stall: it does not retry,
+# and the `direct` GOPROXY fallback only covers 404/410. Frame-level resets
+# are HTTP/2-only, so fetch modules over HTTP/1.1.
+env:
+  GODEBUG: http2client=0
+
 jobs:
   regen-and-diff:
     runs-on: ubuntu-latest

--- a/.github/workflows/pullrequest-release.yml
+++ b/.github/workflows/pullrequest-release.yml
@@ -9,6 +9,14 @@ on:
       - 'LICENSE'
       - '.env.sample'
 
+# proxy.golang.org intermittently resets HTTP/2 streams mid-download
+# ("stream error: stream ID N; INTERNAL_ERROR; received from peer"). cmd/go
+# turns that into a hard build failure after a ~60s stall: it does not retry,
+# and the `direct` GOPROXY fallback only covers 404/410. Frame-level resets
+# are HTTP/2-only, so fetch modules over HTTP/1.1.
+env:
+  GODEBUG: http2client=0
+
 jobs:
   build-rust-binaries-darwin:
     runs-on: macos-latest

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -2,6 +2,14 @@ name: Test
 
 on: pull_request
 
+# proxy.golang.org intermittently resets HTTP/2 streams mid-download
+# ("stream error: stream ID N; INTERNAL_ERROR; received from peer"). cmd/go
+# turns that into a hard build failure after a ~60s stall: it does not retry,
+# and the `direct` GOPROXY fallback only covers 404/410. Frame-level resets
+# are HTTP/2-only, so fetch modules over HTTP/1.1.
+env:
+  GODEBUG: http2client=0
+
 jobs:
   test:
     name: Unit Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - "*.*.*"
 
+# proxy.golang.org intermittently resets HTTP/2 streams mid-download
+# ("stream error: stream ID N; INTERNAL_ERROR; received from peer"). cmd/go
+# turns that into a hard build failure after a ~60s stall: it does not retry,
+# and the `direct` GOPROXY fallback only covers 404/410. Frame-level resets
+# are HTTP/2-only, so fetch modules over HTTP/1.1.
+env:
+  GODEBUG: http2client=0
+
 jobs:
   test:
     name: Test

--- a/webapp/src/webapp/audit/views/results_container.cljs
+++ b/webapp/src/webapp/audit/views/results_container.cljs
@@ -10,9 +10,10 @@
    [webapp.components.tabs :as tabs]))
 
 (defn- parse-results
-  [results connection-type]
+  [cache results connection-type]
   (when (some? results)
     (results-matrix/parse-results
+     cache
      (if (= connection-type "oracledb")
        (string/join "\n" (drop 1 (string/split results #"\n")))
        results))))
@@ -59,11 +60,12 @@
     [logs/virtualized-container {:status status :logs results :classes classes}]]])
 
 (defn main []
-  (let [log-view (r/atom "Plain text")]
+  (let [log-view (r/atom "Plain text")
+        matrix-cache (results-matrix/new-cache)]
 
     (fn [connection-subtype {:keys [results results-status fixed-height? classes
                                     session-id connection-name has-large-payload?]}]
-      (let [parsed (parse-results results connection-subtype)
+      (let [parsed (parse-results matrix-cache results connection-subtype)
             results-heads (:heads parsed)
             results-body (:body parsed)
             sql-subtypes #{"mysql-csv" "mysql" "postgres" "sql-server" "mssql"

--- a/webapp/src/webapp/audit/views/results_container.cljs
+++ b/webapp/src/webapp/audit/views/results_container.cljs
@@ -1,21 +1,21 @@
 (ns webapp.audit.views.results-container
   (:require
    ["@radix-ui/themes" :refer [Box Flex]]
-   ["papaparse" :as papa]
    [clojure.string :as string]
    [reagent.core :as r]
    [webapp.components.ag-grid-table :as ag-grid-table]
    [webapp.components.logs-container :as logs]
    [webapp.components.results-download-menu :as download-menu]
+   [webapp.components.results-matrix :as results-matrix]
    [webapp.components.tabs :as tabs]))
 
-(defn- transform-results->matrix
+(defn- parse-results
   [results connection-type]
-  (let [res (if (= connection-type "oracledb")
-              (string/join "\n" (drop 1 (string/split results #"\n")))
-              results)]
-    (when-not (nil? results)
-      (get (js->clj (papa/parse res (clj->js {"delimiter" "\t"}))) "data"))))
+  (when (some? results)
+    (results-matrix/parse-results
+     (if (= connection-type "oracledb")
+       (string/join "\n" (drop 1 (string/split results #"\n")))
+       results))))
 
 (defn tab-container
   [{:keys [results-heads results-body log-view download-props]}
@@ -34,7 +34,8 @@
       "Table" [ag-grid-table/main results-heads results-body false true
                {:height "100%"
                 :theme "alpine"
-                :pagination? (> (count results-body) 100)
+                :pagination? (boolean (and results-body
+                                           (> (.-length results-body) 100)))
                 :auto-size-columns? true}])]])
 
 (defmulti results-view identity)
@@ -62,18 +63,19 @@
 
     (fn [connection-subtype {:keys [results results-status fixed-height? classes
                                     session-id connection-name has-large-payload?]}]
-      (let [results-transformed (transform-results->matrix results connection-subtype)
-            results-heads (first results-transformed)
-            results-body (next results-transformed)
+      (let [parsed (parse-results results connection-subtype)
+            results-heads (:heads parsed)
+            results-body (:body parsed)
             sql-subtypes #{"mysql-csv" "mysql" "postgres" "sql-server" "mssql"
                            "postgres-csv" "sql-server-csv" "oracledb" "database"}
             is-sql? (contains? sql-subtypes connection-subtype)
-            tabular? (and is-sql?
-                          (seq results-heads)
-                          (seq results-body))
+            tabular? (boolean (and is-sql?
+                                   results-heads results-body
+                                   (pos? (.-length results-heads))
+                                   (pos? (.-length results-body))))
             download-props (when (= results-status :success)
                              {:results results
-                              :matrix results-transformed
+                              :matrix (:matrix parsed)
                               :tabular? tabular?
                               :session-id session-id
                               :connection-name connection-name

--- a/webapp/src/webapp/components/ag_grid_table.cljs
+++ b/webapp/src/webapp/components/ag_grid_table.cljs
@@ -22,71 +22,65 @@
       (.withPart colorSchemeDarkBlue)
       (.withPart icon-overrides)))
 
-(defn normalize-row-data
-  "Normalizes rows data to ensure consistency with the number of header columns,
-   removing empty cells when there are excess columns."
+(defn- field-name [header]
+  (if (string? header) header (str header)))
+
+(defn- row-source
+  "Wide rows drop their empty cells first, so ragged output still lines up."
+  [row column-count]
+  (if (> (.-length row) column-count)
+    (.filter row (fn [cell] (and (some? cell) (not= cell ""))))
+    row))
+
+(defn headers->col-defs [headers]
+  (let [out (array)]
+    (dotimes [i (.-length headers)]
+      (let [field (field-name (aget headers i))]
+        (.push out #js {:field field
+                        :cellEditor "agTextCellEditor"
+                        :headerName field})))
+    out))
+
+(defn rows->row-data
+  "Normalizes each row to the header count and keys it by column name."
   [headers rows]
-  (mapv (fn [row]
-          (let [header-count (count headers)
-                row-count (count row)]
-            (cond
-              ;; If there are more columns than needed, remove empty cells
-              (> row-count header-count)
-              (let [;; Filter non-empty cells
-                    non-empty-cells (filterv #(and (not (nil? %))
-                                                   (or (not (string? %))
-                                                       (not (empty? %))))
-                                             row)
-                    ;; Number of non-empty cells
-                    non-empty-count (count non-empty-cells)]
-                ;; If we have enough non-empty cells, use only them
-                ;; Otherwise, fill with empty cells up to the required number
-                (if (>= non-empty-count header-count)
-                  (subvec non-empty-cells 0 header-count)  ;; Still need to truncate if there are more non-empty cells than expected
-                  (into non-empty-cells (repeat (- header-count non-empty-count) ""))))
-
-              ;; If there are fewer columns than needed, add empty cells
-              (< row-count header-count)
-              (into row (repeat (- header-count row-count) ""))
-
-              ;; If the number of columns is exact, keep the row as is
-              :else row)))
-        rows))
+  (let [column-count (.-length headers)
+        fields (.map headers (fn [header] (field-name header)))
+        out (array)]
+    (dotimes [i (.-length rows)]
+      (let [src (row-source (aget rows i) column-count)
+            obj #js {}]
+        (dotimes [j column-count]
+          (let [cell (aget src j)]
+            (aset obj (aget fields j) (if (nil? cell) "" cell))))
+        (.push out obj)))
+    out))
 
 (defn ag-grid
-  "An efficient table component using AG Grid to display SQL query results.
+  "Renders AG Grid over JS column definitions and row objects.
 
-   Parameters:
-   - columns: vector of column definitions in the format [{:field 'field_name' :headerName 'Title' ...}]
-   - rows: vector of row data as maps
-   - options: map of additional options for the AG Grid
-     - :theme - theme to use (default, alpine, balham, material)
-     - :height - table height (default 400px)
-     - :pagination? - enable pagination (default false)
-     - :auto-size-columns? - automatically adjust columns (default true)"
-  [{:keys [columns rows options]}]
-  (let [default-options {:height "400px"
-                         :pagination? false
-                         :auto-size-columns? true}
-        merged-options (merge default-options options)]
-
-    (fn [{:keys [dark-mode?]}]
-      [:section {:style {:height (:height merged-options)
-                         :width "100%"}
-                 :aria-label "Query results table"}
-       [:> AgGridReact {:theme (if dark-mode? alpine-dark alpine-light)
-                        :columnDefs (clj->js columns)
-                        :rowData (clj->js rows)
-                        :defaultColDef (clj->js {:resizable true
-                                                 :sortable true
-                                                 :filter true
-                                                 :editable true})
-                        :pagination (boolean (:pagination? merged-options))
-                        :paginationPageSize (or (:page-size merged-options) 20)
-                        :onGridReady (fn [params]
-                                       (when (and (:auto-size-columns? merged-options)
-                                                  (aget params "columnApi"))
-                                         (.autoSizeAllColumns (aget params "columnApi"))))}]])))
+   - columns: JS array of column defs
+   - rows: JS array of row objects
+   - options: :height, :pagination?, :page-size, :auto-size-columns?"
+  [{:keys [columns rows options dark-mode?]}]
+  (let [{:keys [height pagination? page-size auto-size-columns?]}
+        (merge {:height "400px" :pagination? false :auto-size-columns? true}
+               options)]
+    [:section {:style {:height height :width "100%"}
+               :aria-label "Query results table"}
+     [:> AgGridReact {:theme (if dark-mode? alpine-dark alpine-light)
+                      :columnDefs columns
+                      :rowData rows
+                      :defaultColDef #js {:resizable true
+                                          :sortable true
+                                          :filter true
+                                          :editable true}
+                      :pagination (boolean pagination?)
+                      :paginationPageSize (or page-size 20)
+                      :onGridReady (fn [params]
+                                     (when (and auto-size-columns?
+                                                (aget params "columnApi"))
+                                       (.autoSizeAllColumns (aget params "columnApi"))))}]]))
 
 (defn error-message
   "Component to display error message with malformed data"
@@ -102,12 +96,15 @@
    [:p {:class "mt-4 text-sm text-center text-gray-500"}
     "Check if the data contains tab characters (\\t) within values or if there are inconsistencies in the format."]])
 
+(defn- empty-js-array? [a]
+  (or (nil? a) (zero? (.-length a))))
+
 (defn main
   "Main component to display an AG Grid table with SQL query results.
 
    Parameters:
-   - headers: vector of column headers as strings ['Column1', 'Column2', ...]
-   - rows: vector of vectors with the data of the rows [['val1', 'val2'], ['val3', 'val4']]
+   - headers: JS array of column headers
+   - rows: JS array of JS arrays with the row data
    - loading?: boolean flag indicating if the data is loading
    - options: additional options to pass to ag-grid"
   [headers rows loading? dark-mode? & [options]]
@@ -118,36 +115,17 @@
                         :size 24
                         :color (if dark-mode? "white" "gray")}]]]
 
-    (let [empty-data? (or (nil? headers) (empty? headers) (nil? rows) (empty? rows))]
-      (if empty-data?
-        [:div {:class "flex justify-center items-center h-full text-gray-500"}
-         "No results available"]
+    (if (or (empty-js-array? headers) (empty-js-array? rows))
+      [:div {:class "flex justify-center items-center h-full text-gray-500"}
+       "No results available"]
 
-        (try
-          ;; Process data with normalization and render the grid
-          (let [normalized-rows (normalize-row-data headers rows)
-                columns (mapv (fn [header]
-                                (let [field-name (if (string? header) header (str header))]
-                                  {:field field-name
-                                   :cellEditor "agTextCellEditor"
-                                   :headerName field-name}))
-                              headers)
-                row-data (mapv (fn [row]
-                                 (reduce (fn [acc [idx val]]
-                                           (let [field-name (if (string? (nth headers idx))
-                                                              (nth headers idx)
-                                                              (str (nth headers idx)))]
-                                             (assoc acc field-name val)))
-                                         {}
-                                         (map-indexed vector row)))
-                               normalized-rows)]
-            [ag-grid {:columns columns
-                      :rows row-data
-                      :options options
-                      :dark-mode? dark-mode?}])
+      (try
+        [ag-grid {:columns (headers->col-defs headers)
+                  :rows (rows->row-data headers rows)
+                  :options options
+                  :dark-mode? dark-mode?}]
 
-          ;; Catch any unexpected errors during processing
-          (catch :default e
-            (let [error-msg (str "Error processing data: " (.-message e))]
-              (.error js/console error-msg e)
-              [error-message error-msg dark-mode?])))))))
+        (catch :default e
+          (let [error-msg (str "Error processing data: " (.-message e))]
+            (.error js/console error-msg e)
+            [error-message error-msg dark-mode?]))))))

--- a/webapp/src/webapp/components/ag_grid_table.cljs
+++ b/webapp/src/webapp/components/ag_grid_table.cljs
@@ -57,11 +57,7 @@
     out))
 
 (defn ag-grid
-  "Renders AG Grid over JS column definitions and row objects.
-
-   - columns: JS array of column defs
-   - rows: JS array of row objects
-   - options: :height, :pagination?, :page-size, :auto-size-columns?"
+  "Renders AG Grid over JS column definitions and row objects."
   [{:keys [columns rows options dark-mode?]}]
   (let [{:keys [height pagination? page-size auto-size-columns?]}
         (merge {:height "400px" :pagination? false :auto-size-columns? true}

--- a/webapp/src/webapp/components/results_download_menu.cljs
+++ b/webapp/src/webapp/components/results_download_menu.cljs
@@ -7,7 +7,7 @@
    [clojure.string :as cs]
    [re-frame.core :as rf]))
 
-(def ^:private client-side-threshold (* 2 1024 1024))
+(def client-side-threshold (* 2 1024 1024))
 
 (defn- pad2 [n] (if (< n 10) (str "0" n) (str n)))
 
@@ -40,20 +40,22 @@
     (js/setTimeout #(js/URL.revokeObjectURL url) 0)))
 
 (defn- matrix->csv [matrix]
-  (papa/unparse (clj->js matrix)))
+  (papa/unparse matrix))
 
-(defn- matrix->json [heads body]
-  (let [head-keys (vec (map-indexed
-                        (fn [idx h]
-                          (if (or (nil? h) (cs/blank? h))
-                            (str "column_" (inc idx))
-                            h))
-                        heads))
-        rows (mapv (fn [row]
-                     (into {}
-                           (map vector head-keys row)))
-                   body)]
-    (.stringify js/JSON (clj->js rows) nil 2)))
+(defn- matrix->json [matrix]
+  (let [heads (aget matrix 0)
+        head-keys (.map heads (fn [h idx]
+                                (if (or (nil? h) (cs/blank? h))
+                                  (str "column_" (inc idx))
+                                  h)))
+        out (array)]
+    (dotimes [i (dec (.-length matrix))]
+      (let [row (aget matrix (inc i))
+            obj #js {}]
+        (dotimes [j (min (.-length head-keys) (.-length row))]
+          (aset obj (aget head-keys j) (aget row j)))
+        (.push out obj)))
+    (.stringify js/JSON out nil 2)))
 
 (defn- use-backend? [{:keys [has-large-payload? results session-id]}]
   (and session-id
@@ -68,10 +70,8 @@
                            (matrix->csv matrix)
                            results)]
              (trigger-download! (build-filename filename-meta "csv") "text/csv" content))
-      :json (let [heads (first matrix)
-                  body (next matrix)
-                  content (matrix->json heads body)]
-              (trigger-download! (build-filename filename-meta "json") "application/json" content)))))
+      :json (trigger-download! (build-filename filename-meta "json") "application/json"
+                               (matrix->json matrix)))))
 
 (defn- handle-download [{:keys [session-id] :as props} format]
   (if (use-backend? props)

--- a/webapp/src/webapp/components/results_matrix.cljs
+++ b/webapp/src/webapp/components/results_matrix.cljs
@@ -1,0 +1,30 @@
+(ns webapp.components.results-matrix
+  "Parses tab separated output into the JS arrays AG Grid and the CSV/JSON
+  writers consume. Memoized: it used to re-parse on every render (EVL-121)."
+  (:require ["papaparse" :as papa]))
+
+(defonce ^:private cache (atom nil))
+
+(defn- parse [response]
+  (when (some? response)
+    (let [data (.-data (papa/parse response #js {:delimiter "\t"}))]
+      {:matrix data
+       :heads (aget data 0)
+       :body (.slice data 1)})))
+
+(defn parse-results
+  "Returns {:matrix :heads :body} of JS arrays for `response`, or nil.
+  Reference stable, so Reagent can skip re-rendering the grid."
+  [response]
+  (let [cached @cache]
+    (if (and cached (= (:key cached) response))
+      (:parsed cached)
+      (let [parsed (parse response)]
+        (reset! cache {:key response :parsed parsed})
+        parsed))))
+
+(defn rows?
+  "Whether the output has rows below the header, without parsing it.
+  papaparse emits one row per line, so this is just a second line."
+  [response]
+  (boolean (and response (.includes response "\n"))))

--- a/webapp/src/webapp/components/results_matrix.cljs
+++ b/webapp/src/webapp/components/results_matrix.cljs
@@ -3,7 +3,10 @@
   writers consume. Memoized: it used to re-parse on every render (EVL-121)."
   (:require ["papaparse" :as papa]))
 
-(defonce ^:private cache (atom nil))
+(defn new-cache
+  "One per component, so the matrix is released on unmount."
+  []
+  (atom nil))
 
 (defn- parse [response]
   (when (some? response)
@@ -15,7 +18,7 @@
 (defn parse-results
   "Returns {:matrix :heads :body} of JS arrays for `response`, or nil.
   Reference stable, so Reagent can skip re-rendering the grid."
-  [response]
+  [cache response]
   (let [cached @cache]
     (if (and cached (= (:key cached) response))
       (:parsed cached)
@@ -23,8 +26,15 @@
         (reset! cache {:key response :parsed parsed})
         parsed))))
 
+(defn release-stale!
+  "Drops a matrix parsed for an older response. Returns nil."
+  [cache response]
+  (when-let [cached @cache]
+    (when-not (= (:key cached) response)
+      (reset! cache nil)))
+  nil)
+
 (defn rows?
-  "Whether the output has rows below the header, without parsing it.
-  papaparse emits one row per line, so this is just a second line."
+  "Whether the output has rows below the header, without parsing it."
   [response]
   (boolean (and response (.includes response "\n"))))

--- a/webapp/src/webapp/webclient/log_area/main.cljs
+++ b/webapp/src/webapp/webclient/log_area/main.cljs
@@ -1,20 +1,15 @@
 (ns webapp.webclient.log-area.main
-  (:require ["papaparse" :as papa]
-            ["@radix-ui/themes" :refer [Box Flex]]
+  (:require ["@radix-ui/themes" :refer [Box Flex]]
             [clojure.string :as cs]
             [re-frame.core :as rf]
             [reagent.core :as r]
             [webapp.audit.views.session-details :as session-details]
             [webapp.components.ag-grid-table :as ag-grid-table]
             [webapp.components.results-download-menu :as download-menu]
+            [webapp.components.results-matrix :as results-matrix]
             [webapp.features.activation-journey.views.terminal-banner :as terminal-banner]
             [webapp.webclient.log-area.output-tabs :refer [tabs]]
             [webapp.webclient.log-area.logs :as logs]))
-
-(defn- transform-results->matrix
-  [results connection-type]
-  (when-not (nil? results)
-    (get (js->clj (papa/parse results (clj->js {"delimiter" "\t"}))) "data")))
 
 (def selected-tab (r/atom (or (.getItem js/localStorage "webclient-selected-tab")
                               "Logs")))
@@ -64,21 +59,28 @@
             tabular-loading? (= tabular-status :loading)
             connection-type-database? (some (partial = connection-type)
                                             ["mysql" "postgres" "sql-server" "oracledb" "mssql" "database"])
-            ;; papaparse + js->clj walk the whole payload on every render, and
-            ;; only database connections consume the matrix (Tabular tab,
-            ;; CSV/JSON downloads). Everything else paid the scan for nothing.
-            results-transformed (when connection-type-database?
-                                  (transform-results->matrix response connection-type))
-            results-heads (first results-transformed)
-            results-body (next results-transformed)
+            ;; Above the threshold downloads go to the backend, so the matrix
+            ;; only feeds the Tabular tab.
+            build-matrix? (boolean
+                           (and connection-type-database?
+                                (or (= @selected-tab "Tabular")
+                                    (<= (count response)
+                                        download-menu/client-side-threshold))))
+            parsed (when build-matrix?
+                     (results-matrix/parse-results response))
+            results-heads (:heads parsed)
+            results-body (:body parsed)
             available-tabs (merge
                             {:logs "Logs"}
                             (when (and connection-type-database?
                                        (not parallel-mode-active?))
                               {:tabular "Tabular"}))
             tabular-data? (and connection-type-database?
-                               (seq results-heads)
-                               (seq results-body))
+                               (if build-matrix?
+                                 (boolean (and results-heads results-body
+                                               (pos? (.-length results-heads))
+                                               (pos? (.-length results-body))))
+                                 (results-matrix/rows? response)))
             session-id (:session_id (:data @script-response))
             on-view-session-details (when session-id
                                       #(rf/dispatch
@@ -89,7 +91,7 @@
                                                     {:id session-id :verb "exec"}]}]))
             menu-props (when session-id
                          {:results response
-                          :matrix results-transformed
+                          :matrix (:matrix parsed)
                           :tabular? (boolean (and (= tabular-status :success)
                                                   tabular-data?))
                           :session-id session-id
@@ -127,7 +129,8 @@
            (case @selected-tab
              "Tabular" [ag-grid-table/main results-heads results-body tabular-loading? dark-mode?
                         {:height "100%"
-                         :pagination? (> (count results-body) 100)
+                         :pagination? (boolean (and results-body
+                                                    (> (.-length results-body) 100)))
                          :auto-size-columns? true}]
              "Logs" [logs/main :logs logs-content]
              :else [logs/main logs-content])]]]))))

--- a/webapp/src/webapp/webclient/log_area/main.cljs
+++ b/webapp/src/webapp/webclient/log_area/main.cljs
@@ -39,7 +39,8 @@
     :else response))
 
 (defn main [_]
-  (let [script-response (rf/subscribe [:editor-plugin->script])]
+  (let [script-response (rf/subscribe [:editor-plugin->script])
+        matrix-cache (results-matrix/new-cache)]
     (fn [connection-type parallel-mode-active? dark-mode?]
       (let [response (sanitize-response (:output (:data @script-response)) connection-type)
             logs-content {:status (:status @script-response)
@@ -59,15 +60,16 @@
             tabular-loading? (= tabular-status :loading)
             connection-type-database? (some (partial = connection-type)
                                             ["mysql" "postgres" "sql-server" "oracledb" "mssql" "database"])
-            ;; Above the threshold downloads go to the backend, so the matrix
-            ;; only feeds the Tabular tab.
+            ;; Above the threshold downloads go to the backend, so only
+            ;; Tabular needs the matrix.
             build-matrix? (boolean
                            (and connection-type-database?
                                 (or (= @selected-tab "Tabular")
                                     (<= (count response)
                                         download-menu/client-side-threshold))))
-            parsed (when build-matrix?
-                     (results-matrix/parse-results response))
+            parsed (if build-matrix?
+                     (results-matrix/parse-results matrix-cache response)
+                     (results-matrix/release-stale! matrix-cache response))
             results-heads (:heads parsed)
             results-body (:body parsed)
             available-tabs (merge

--- a/webapp/test/webapp/components/ag_grid_table_test.cljs
+++ b/webapp/test/webapp/components/ag_grid_table_test.cljs
@@ -1,0 +1,55 @@
+(ns webapp.components.ag-grid-table-test
+  "Command output is ragged — a value holding a tab makes a row wider than the
+  header — so these transforms carry the normalization the grid needs."
+  (:require
+   [cljs.test :refer-macros [deftest testing is]]
+   [webapp.components.ag-grid-table :as ag-grid-table]))
+
+(defn- col-defs [headers]
+  (js->clj (ag-grid-table/headers->col-defs (clj->js headers)) :keywordize-keys true))
+
+(defn- row-data [headers rows]
+  (js->clj (ag-grid-table/rows->row-data (clj->js headers) (clj->js rows))))
+
+(deftest col-defs-carry-the-header-as-field-and-name
+  (is (= [{:field "id" :cellEditor "agTextCellEditor" :headerName "id"}
+          {:field "name" :cellEditor "agTextCellEditor" :headerName "name"}]
+         (col-defs ["id" "name"]))))
+
+(deftest non-string-headers-are-stringified
+  (is (= ["1" "2"] (map :field (col-defs [1 2]))))
+  (is (= [{"1" "a"}] (row-data [1] [["a"]]))))
+
+(deftest rows-matching-the-header-are-keyed-by-column
+  (is (= [{"id" "1" "name" "alice"} {"id" "2" "name" "bob"}]
+         (row-data ["id" "name"] [["1" "alice"] ["2" "bob"]]))))
+
+(deftest short-rows-are-padded
+  (is (= [{"a" "1" "b" "2" "c" ""} {"a" "1" "b" "" "c" ""}]
+         (row-data ["a" "b" "c"] [["1" "2"] ["1"]]))))
+
+(deftest nil-cells-become-empty-strings
+  (is (= [{"a" "1" "b" ""}]
+         (row-data ["a" "b"] [["1" nil]]))))
+
+(deftest wide-rows-drop-their-empty-cells-first
+  (testing "dropping the blanks realigns the rest with the header"
+    (is (= [{"a" "1" "b" "2"}]
+           (row-data ["a" "b"] [["1" "2" "" ""]])))
+    (is (= [{"a" "x" "b" "y"}]
+           (row-data ["a" "b"] [["" "x" "" "y"]])))))
+
+(deftest wide-rows-that-stay-wide-are-truncated-to-the-header
+  (is (= [{"a" "1" "b" "2"}]
+         (row-data ["a" "b"] [["1" "2" "3"]]))))
+
+(deftest wide-rows-shorter-after-filtering-are-padded
+  (is (= [{"a" "1" "b" "" "c" ""}]
+         (row-data ["a" "b" "c"] [["1" "" "" ""]]))))
+
+(deftest duplicate-header-names-keep-the-last-column
+  (is (= [{"a" "2"}]
+         (row-data ["a" "a"] [["1" "2"]]))))
+
+(deftest no-rows-produces-no-row-data
+  (is (= [] (row-data ["a" "b"] []))))

--- a/webapp/test/webapp/components/ag_grid_table_test.cljs
+++ b/webapp/test/webapp/components/ag_grid_table_test.cljs
@@ -1,6 +1,5 @@
 (ns webapp.components.ag-grid-table-test
-  "Command output is ragged — a value holding a tab makes a row wider than the
-  header — so these transforms carry the normalization the grid needs."
+  "Command output is ragged: a value holding a tab widens its row."
   (:require
    [cljs.test :refer-macros [deftest testing is]]
    [webapp.components.ag-grid-table :as ag-grid-table]))

--- a/webapp/test/webapp/components/results_matrix_test.cljs
+++ b/webapp/test/webapp/components/results_matrix_test.cljs
@@ -1,0 +1,43 @@
+(ns webapp.components.results-matrix-test
+  "Reference stability is a contract: the grid only skips a re-render when its
+  props are identical (EVL-121)."
+  (:require
+   [cljs.test :refer-macros [deftest testing is]]
+   [webapp.components.results-matrix :as results-matrix]))
+
+(def ^:private response "id\tname\n1\talice\n2\tbob\n")
+
+(deftest parses-heads-and-body
+  (let [{:keys [matrix heads body]} (results-matrix/parse-results response)]
+    (is (= [["id" "name"] ["1" "alice"] ["2" "bob"] [""]] (js->clj matrix)))
+    (is (= ["id" "name"] (js->clj heads)))
+    (is (= [["1" "alice"] ["2" "bob"] [""]] (js->clj body)))))
+
+(deftest nil-response-parses-to-nil
+  (is (nil? (results-matrix/parse-results nil))))
+
+(deftest repeated-parse-returns-the-same-arrays
+  (let [a (results-matrix/parse-results response)
+        b (results-matrix/parse-results response)]
+    (is (identical? (:matrix a) (:matrix b)))
+    (is (identical? (:heads a) (:heads b)))
+    (is (identical? (:body a) (:body b)))))
+
+(deftest a-new-response-invalidates-the-cache
+  (let [a (results-matrix/parse-results response)
+        b (results-matrix/parse-results "id\n9\n")]
+    (is (not (identical? (:matrix a) (:matrix b))))
+    (is (= ["id"] (js->clj (:heads b))))))
+
+(deftest rows?-matches-a-full-parse
+  (testing "papaparse emits one row per line, blank lines included"
+    (doseq [[response expected] {nil false
+                                 "" false
+                                 "header only" false
+                                 "\n" true
+                                 "id\tname\n" true
+                                 "id\tname\n1\talice" true
+                                 "\nid\tname" true
+                                 "   \n  " true}]
+      (is (= expected (results-matrix/rows? response))
+          (pr-str response)))))

--- a/webapp/test/webapp/components/results_matrix_test.cljs
+++ b/webapp/test/webapp/components/results_matrix_test.cljs
@@ -1,6 +1,5 @@
 (ns webapp.components.results-matrix-test
-  "Reference stability is a contract: the grid only skips a re-render when its
-  props are identical (EVL-121)."
+  "The grid only skips a re-render when its props are identical (EVL-121)."
   (:require
    [cljs.test :refer-macros [deftest testing is]]
    [webapp.components.results-matrix :as results-matrix]))
@@ -8,26 +7,50 @@
 (def ^:private response "id\tname\n1\talice\n2\tbob\n")
 
 (deftest parses-heads-and-body
-  (let [{:keys [matrix heads body]} (results-matrix/parse-results response)]
+  (let [{:keys [matrix heads body]} (results-matrix/parse-results
+                                     (results-matrix/new-cache) response)]
     (is (= [["id" "name"] ["1" "alice"] ["2" "bob"] [""]] (js->clj matrix)))
     (is (= ["id" "name"] (js->clj heads)))
     (is (= [["1" "alice"] ["2" "bob"] [""]] (js->clj body)))))
 
 (deftest nil-response-parses-to-nil
-  (is (nil? (results-matrix/parse-results nil))))
+  (is (nil? (results-matrix/parse-results (results-matrix/new-cache) nil))))
 
 (deftest repeated-parse-returns-the-same-arrays
-  (let [a (results-matrix/parse-results response)
-        b (results-matrix/parse-results response)]
+  (let [cache (results-matrix/new-cache)
+        a (results-matrix/parse-results cache response)
+        b (results-matrix/parse-results cache response)]
     (is (identical? (:matrix a) (:matrix b)))
     (is (identical? (:heads a) (:heads b)))
     (is (identical? (:body a) (:body b)))))
 
 (deftest a-new-response-invalidates-the-cache
-  (let [a (results-matrix/parse-results response)
-        b (results-matrix/parse-results "id\n9\n")]
+  (let [cache (results-matrix/new-cache)
+        a (results-matrix/parse-results cache response)
+        b (results-matrix/parse-results cache "id\n9\n")]
     (is (not (identical? (:matrix a) (:matrix b))))
     (is (= ["id"] (js->clj (:heads b))))))
+
+(deftest caches-do-not-evict-each-other
+  (let [one (results-matrix/new-cache)
+        two (results-matrix/new-cache)
+        a (results-matrix/parse-results one response)]
+    (results-matrix/parse-results two "id\n9\n")
+    (is (identical? (:matrix a) (:matrix (results-matrix/parse-results one response))))))
+
+(deftest a-skipped-parse-releases-a-replaced-result
+  (let [cache (results-matrix/new-cache)
+        a (results-matrix/parse-results cache response)]
+    (is (nil? (results-matrix/release-stale! cache "id\n9\n")))
+    (is (not (identical? (:matrix a)
+                         (:matrix (results-matrix/parse-results cache response)))))))
+
+(deftest a-skipped-parse-keeps-the-result-on-screen
+  (let [cache (results-matrix/new-cache)
+        a (results-matrix/parse-results cache response)]
+    (results-matrix/release-stale! cache response)
+    (is (identical? (:matrix a)
+                    (:matrix (results-matrix/parse-results cache response))))))
 
 (deftest rows?-matches-a-full-parse
   (testing "papaparse emits one row per line, blank lines included"


### PR DESCRIPTION
## 📝 Description

Large SQL results still froze the web client after #1703. That PR bounded the string reaching the DOM, but the tab-separated matrix behind the Tabular tab was still parsed in full, eagerly, on every render — including on the Logs tab, where it is never displayed. Cost tracks cell count, not bytes, so a 6.5 MB single-cell result was smooth while a same-size 2.4M-cell result blocked the main thread.

## 📣 User-facing impact

Large query results no longer lock up the browser tab.

## 🔗 Related Issue

EVL-121

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [x] ⚡ Performance improvement
- [x] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- New `webapp.components.results-matrix` — one memoized parse, shared by the web client and session details, which had near-duplicate copies.
- Skip the matrix on the Logs tab above the 2 MB download threshold, where it only feeds Tabular. Below the threshold the path is unchanged.
- Keep the grid data as JS arrays end to end; `js->clj`/`clj->js` walked every cell twice for nothing.
- `ag-grid` was a form-2 component capturing `columns`/`rows` at mount, so a second query while on Tabular showed stale rows. Now form-1.
- Tests for the parse and for the ragged-row normalization.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Chrome
- **OS**: macOS

Measured with `PerformanceObserver` on `longtask`, using a 2.4M-cell / 4.8 MB result (100k rows × 24 columns):

| | before | after |
|---|---|---|
| Logs tab | 738 / 424 / 345 / 343 ms | 53–72 ms |
| Tabular tab | peak 1497 ms (3.4 s total) | 305 ms first switch, 157–251 ms after |

Downloads were checked against an independent oracle — a result's CSV/JSON must equal its TXT re-serialized by papaparse:

| Query | CSV | JSON |
|---|---|---|
| 50 rows | MATCH | MATCH |
| Values containing `,` `"` `'` | MATCH | MATCH |
| Whitespace-only header (`column_N` fallback) | MATCH | MATCH |
| 18k rows, 1.91 MB — largest client-side payload | MATCH | MATCH |
| 21k rows, 2.24 MB | routed to the backend, full file | — |

Also exercised: zero rows, duplicate column names, NULL and empty cells, and a value containing a tab.

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## 📄 Additional Notes

Three things reviewers should know:

- **The Logs tab still blocks ~500 ms on the first render of a large result, and again on returning from Tabular.** That is not this code — it is #1703's 512 KB display string laid out into one unvirtualized `whitespace-pre` node, remounted on every tab switch. `logs-container/virtualized-container` already solves this and is what session details uses; the web client never adopted it. Follow-up, deliberately out of scope here.
- **Found while testing, also not this PR:** Download JSON on a result above the 2 MB threshold hangs the tab. That takes the `use-backend?` branch — `window.open` on a gateway-generated file — which this branch does not touch. Same symptom customers reported, different mechanism. Separate ticket.
- The cache is one entry per mounted view: released on unmount, and dropped when a new result arrives that the Logs tab does not parse.

Not covered: the `oracledb` branch, for lack of an Oracle connection.
