### PR TITLE
EVL-217: list access_control groups in GET /users/groups

### DIFF
--- a/gateway/api/mcpserver/tools_usergroups.go
+++ b/gateway/api/mcpserver/tools_usergroups.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/hoophq/hoop/gateway/models"
@@ -61,6 +62,13 @@ func usergroupsListHandler(ctx context.Context, _ *mcp.CallToolRequest, _ usergr
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed listing user groups: %w", err)
 	}
+	// Same union as GET /users/groups, or an agent cannot see a group that only
+	// exists as an access_control permission and calls usergroups_create on a
+	// name that already grants access (EVL-217).
+	pluginGroups, err := models.ListAccessControlGroupNames(models.DB, sc.GetOrgID())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed listing user groups: %w", err)
+	}
 
 	// Deduplicate group names
 	seen := make(map[string]bool)
@@ -71,6 +79,13 @@ func usergroupsListHandler(ctx context.Context, _ *mcp.CallToolRequest, _ usergr
 			names = append(names, g.Name)
 		}
 	}
+	for _, name := range pluginGroups {
+		if !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
 
 	return jsonResult(names)
 }

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -10218,7 +10218,7 @@ const docTemplate = `{
         },
         "/users/groups": {
             "get": {
-                "description": "List all groups from all users",
+                "description": "List every group name known to the organization: the ones bound to users, service accounts, API keys and AI agents, plus the ones referenced by the access_control plugin. Sorted alphabetically.",
                 "produces": [
                     "application/json"
                 ],

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -21460,7 +21460,7 @@
     },
     "/users/groups": {
       "get": {
-        "description": "List all groups from all users",
+        "description": "List every group name known to the organization: the ones bound to users, service accounts, API keys and AI agents, plus the ones referenced by the access_control plugin. Sorted alphabetically.",
         "responses": {
           "200": {
             "content": {

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -672,10 +672,8 @@ func ListAllGroups(c *gin.Context) {
 		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed listing groups")
 		return
 	}
-	// private.user_groups is a membership table, so it only knows a group while
-	// something is bound to it. A group the IDP stopped emitting keeps its
-	// access_control association but loses its rows, which used to hide it from
-	// every group picker while its permissions kept applying.
+	// user_groups only knows a group while a membership row exists; the plugin
+	// config is the other half (EVL-217).
 	pluginGroups, err := models.ListAccessControlGroupNames(models.DB, ctx.OrgID)
 	if err != nil {
 		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed listing groups")

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -659,7 +659,7 @@ func PatchSlackID(c *gin.Context) {
 // ListUserGroups
 //
 //	@Summary		List User Groups
-//	@Description	List all groups from all users
+//	@Description	List every group name known to the organization: the ones bound to users, service accounts, API keys and AI agents, plus the ones referenced by the access_control plugin. Sorted alphabetically.
 //	@Tags			User Management
 //	@Produce		json
 //	@Success		200	{array}		string				"Array of group names"
@@ -672,14 +672,30 @@ func ListAllGroups(c *gin.Context) {
 		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed listing groups")
 		return
 	}
-	dedupeGroups := map[string]string{}
-	for _, ug := range userGroups {
-		dedupeGroups[ug.Name] = ug.Name
+	// private.user_groups is a membership table, so it only knows a group while
+	// something is bound to it. A group the IDP stopped emitting keeps its
+	// access_control association but loses its rows, which used to hide it from
+	// every group picker while its permissions kept applying.
+	pluginGroups, err := models.ListAccessControlGroupNames(models.DB, ctx.OrgID)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed listing groups")
+		return
 	}
-	var groupsList []string
+
+	dedupeGroups := map[string]any{}
+	for _, ug := range userGroups {
+		dedupeGroups[ug.Name] = nil
+	}
+	for _, groupName := range pluginGroups {
+		dedupeGroups[groupName] = nil
+	}
+	groupsList := make([]string, 0, len(dedupeGroups))
 	for groupName := range dedupeGroups {
 		groupsList = append(groupsList, groupName)
 	}
+	// Map iteration is randomized, so without this the picker reshuffles on
+	// every page load.
+	slices.Sort(groupsList)
 	c.JSON(http.StatusOK, groupsList)
 }
 

--- a/gateway/models/plugin_connections.go
+++ b/gateway/models/plugin_connections.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
 )
@@ -55,6 +56,33 @@ func UpsertPluginConnection(orgID, pluginName, connID string, config pq.StringAr
 		}
 		return nil
 	})
+}
+
+// ListAccessControlGroupNames returns the distinct group names referenced by the
+// access_control plugin configuration.
+//
+// These are permission-side names. A group that the IDP stopped emitting loses
+// its private.user_groups rows on the next login of its members, but keeps the
+// plugin association, so it has to stay listable: otherwise its permissions are
+// unreachable in the UI while they keep applying at connection time.
+func ListAccessControlGroupNames(db *gorm.DB, orgID string) ([]string, error) {
+	var rows []struct{ Name string }
+	err := db.Raw(`
+		SELECT DISTINCT unnest(pc.config) AS name
+		FROM private.plugin_connections pc
+		INNER JOIN private.plugins p ON p.id = pc.plugin_id
+		WHERE pc.org_id = ? AND p.name = ? AND pc.enabled = 't'`,
+		orgID, plugintypes.PluginAccessControlName).
+		Scan(&rows).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(rows))
+	for _, r := range rows {
+		names = append(names, r.Name)
+	}
+	return names, nil
 }
 
 func GetPluginConnection(orgID, pluginName, connID string) (*PluginConnection, error) {

--- a/gateway/models/plugin_connections.go
+++ b/gateway/models/plugin_connections.go
@@ -61,28 +61,21 @@ func UpsertPluginConnection(orgID, pluginName, connID string, config pq.StringAr
 // ListAccessControlGroupNames returns the distinct group names referenced by the
 // access_control plugin configuration.
 //
-// These are permission-side names. A group that the IDP stopped emitting loses
-// its private.user_groups rows on the next login of its members, but keeps the
-// plugin association, so it has to stay listable: otherwise its permissions are
-// unreachable in the UI while they keep applying at connection time.
+// This is the permission half of a group. A group the IDP stops emitting loses
+// its private.user_groups rows on the next login of its members but keeps this
+// association, so it has to stay listable: otherwise its permissions are
+// unreachable in the UI while they keep applying at connection time (EVL-217).
 func ListAccessControlGroupNames(db *gorm.DB, orgID string) ([]string, error) {
-	var rows []struct{ Name string }
+	var names []string
 	err := db.Raw(`
 		SELECT DISTINCT unnest(pc.config) AS name
 		FROM private.plugin_connections pc
 		INNER JOIN private.plugins p ON p.id = pc.plugin_id
 		WHERE pc.org_id = ? AND p.name = ? AND pc.enabled = 't'`,
 		orgID, plugintypes.PluginAccessControlName).
-		Scan(&rows).
+		Scan(&names).
 		Error
-	if err != nil {
-		return nil, err
-	}
-	names := make([]string, 0, len(rows))
-	for _, r := range rows {
-		names = append(names, r.Name)
-	}
-	return names, nil
+	return names, err
 }
 
 func GetPluginConnection(orgID, pluginName, connID string) (*PluginConnection, error) {

--- a/gateway/models/plugin_connections.go
+++ b/gateway/models/plugin_connections.go
@@ -65,13 +65,19 @@ func UpsertPluginConnection(orgID, pluginName, connID string, config pq.StringAr
 // its private.user_groups rows on the next login of its members but keeps this
 // association, so it has to stay listable: otherwise its permissions are
 // unreachable in the UI while they keep applying at connection time (EVL-217).
+// The predicate mirrors the one that enforces access at connection time
+// (GetConnectionByNameOrID, GetResourceByName): join on plugin_id, scope the org
+// through private.plugins. Do not narrow it. Enforcement ignores pc.enabled, so
+// filtering on it here would hide a group whose permissions still apply, which is
+// the bug this function exists to fix. It also scopes by p.org_id because
+// pc.org_id is nullable.
 func ListAccessControlGroupNames(db *gorm.DB, orgID string) ([]string, error) {
 	var names []string
 	err := db.Raw(`
 		SELECT DISTINCT unnest(pc.config) AS name
 		FROM private.plugin_connections pc
 		INNER JOIN private.plugins p ON p.id = pc.plugin_id
-		WHERE pc.org_id = ? AND p.name = ? AND pc.enabled = 't'`,
+		WHERE p.org_id = ? AND p.name = ?`,
 		orgID, plugintypes.PluginAccessControlName).
 		Scan(&names).
 		Error

--- a/gateway/models/plugin_connections_test.go
+++ b/gateway/models/plugin_connections_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 // seedPluginConnection wires a connection to a plugin with the given group
-// config, creating both if they do not exist yet.
+// config. The plugin is reused when it already exists; connName must be unique,
+// because seedConnection has no conflict clause.
 func seedPluginConnection(t *testing.T, pluginName, connName string, enabled bool, config []string) {
 	t.Helper()
 	execSQL(t, `
@@ -32,8 +33,9 @@ func TestListAccessControlGroupNames(t *testing.T) {
 	// Same group on a second connection: the result is deduped.
 	seedPluginConnection(t, "access_control", "ac-conn-two", true,
 		[]string{"CG-Hoop-BANKING-PF", "sre"})
-	// A disabled association is invisible to GetPluginByName, so it must be
-	// invisible here too, or the two disagree.
+	// enabled = false must still be listed. GetConnectionByNameOrID and
+	// GetResourceByName join plugin_connections without reading this column, so
+	// the group keeps granting access; hiding it here would recreate EVL-217.
 	seedPluginConnection(t, "access_control", "ac-conn-disabled", false,
 		[]string{"CG-Hoop-DISABLED"})
 	// Another plugin's config is not a group list.
@@ -47,16 +49,19 @@ func TestListAccessControlGroupNames(t *testing.T) {
 	}
 	slices.Sort(names)
 
-	want := []string{"CG-Hoop-BANKING-PF", "CG-Hoop-BANKING-PJ", "sre"}
+	want := []string{"CG-Hoop-BANKING-PF", "CG-Hoop-BANKING-PJ", "CG-Hoop-DISABLED", "sre"}
 	if !slices.Equal(names, want) {
 		t.Errorf("group names: want %v, got %v", want, names)
 	}
 }
 
-// An org with no access_control plugin at all is the common case and must not
-// error: it simply contributes nothing to the group listing.
+// An org with no access_control plugin contributes nothing. The audit row makes
+// the plugin-name filter load-bearing: without it the assertion would pass for
+// an implementation that reads every plugin's config.
 func TestListAccessControlGroupNamesWithoutPlugin(t *testing.T) {
 	startTestDB(t)
+
+	seedPluginConnection(t, "audit", "audit-conn", true, []string{"not-a-group"})
 
 	names, err := models.ListAccessControlGroupNames(models.DB, testOrgID)
 	if err != nil {

--- a/gateway/models/plugin_connections_test.go
+++ b/gateway/models/plugin_connections_test.go
@@ -24,11 +24,6 @@ func seedPluginConnection(t *testing.T, pluginName, connName string, enabled boo
 		testOrgID, enabled, pq.StringArray(config), testOrgID, pluginName, testOrgID, connName)
 }
 
-// The access_control config is the permission side of a group. A group the IDP
-// stopped emitting loses every private.user_groups row on the next login of its
-// members but keeps this association, so /users/groups has to read it or the
-// group vanishes from every picker while its permissions keep applying
-// (EVL-217).
 func TestListAccessControlGroupNames(t *testing.T) {
 	startTestDB(t)
 

--- a/gateway/models/plugin_connections_test.go
+++ b/gateway/models/plugin_connections_test.go
@@ -1,0 +1,73 @@
+package models_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/lib/pq"
+)
+
+// seedPluginConnection wires a connection to a plugin with the given group
+// config, creating both if they do not exist yet.
+func seedPluginConnection(t *testing.T, pluginName, connName string, enabled bool, config []string) {
+	t.Helper()
+	execSQL(t, `
+		INSERT INTO private.plugins (org_id, name) VALUES (?, ?)
+		ON CONFLICT (org_id, name) DO NOTHING`, testOrgID, pluginName)
+	seedConnection(t, connName, "enabled")
+	execSQL(t, `
+		INSERT INTO private.plugin_connections (org_id, plugin_id, connection_id, enabled, config)
+		SELECT ?, p.id, c.id, ?, ?
+		FROM private.plugins p, private.connections c
+		WHERE p.org_id = ? AND p.name = ? AND c.org_id = ? AND c.name = ?`,
+		testOrgID, enabled, pq.StringArray(config), testOrgID, pluginName, testOrgID, connName)
+}
+
+// The access_control config is the permission side of a group. A group the IDP
+// stopped emitting loses every private.user_groups row on the next login of its
+// members but keeps this association, so /users/groups has to read it or the
+// group vanishes from every picker while its permissions keep applying
+// (EVL-217).
+func TestListAccessControlGroupNames(t *testing.T) {
+	startTestDB(t)
+
+	seedPluginConnection(t, "access_control", "ac-conn-one", true,
+		[]string{"CG-Hoop-BANKING-PF", "CG-Hoop-BANKING-PJ"})
+	// Same group on a second connection: the result is deduped.
+	seedPluginConnection(t, "access_control", "ac-conn-two", true,
+		[]string{"CG-Hoop-BANKING-PF", "sre"})
+	// A disabled association is invisible to GetPluginByName, so it must be
+	// invisible here too, or the two disagree.
+	seedPluginConnection(t, "access_control", "ac-conn-disabled", false,
+		[]string{"CG-Hoop-DISABLED"})
+	// Another plugin's config is not a group list.
+	seedPluginConnection(t, "audit", "ac-conn-audit", true, []string{"not-a-group"})
+	// A row the Access Control page never wrote carries a null config.
+	seedPluginConnection(t, "access_control", "ac-conn-null", true, nil)
+
+	names, err := models.ListAccessControlGroupNames(models.DB, testOrgID)
+	if err != nil {
+		t.Fatalf("list access control group names: %v", err)
+	}
+	slices.Sort(names)
+
+	want := []string{"CG-Hoop-BANKING-PF", "CG-Hoop-BANKING-PJ", "sre"}
+	if !slices.Equal(names, want) {
+		t.Errorf("group names: want %v, got %v", want, names)
+	}
+}
+
+// An org with no access_control plugin at all is the common case and must not
+// error: it simply contributes nothing to the group listing.
+func TestListAccessControlGroupNamesWithoutPlugin(t *testing.T) {
+	startTestDB(t)
+
+	names, err := models.ListAccessControlGroupNames(models.DB, testOrgID)
+	if err != nil {
+		t.Fatalf("list access control group names: %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("group names: want empty, got %v", names)
+	}
+}

--- a/webapp_v2/COMPONENTS.md
+++ b/webapp_v2/COMPONENTS.md
@@ -787,8 +787,10 @@ Non-obvious notes only:
   send tomorrow to include today). Never send `group_by`.
 - `reviews.js` — `/reviews` returns a bare array, accepts **no query params** and
   is unbounded; fetch it once and filter client-side.
-- `userGroups.js` — `list()` returns a bare string array, and `null` (not
-  `[]`) when the organization has no groups; callers must coalesce.
+- `userGroups.js` — `list()` returns a bare string array, sorted, unioning the
+  identity side (users, service accounts, API keys, AI agents) with the
+  `access_control` plugin config. Empty organizations get `[]`; gateways older
+  than EVL-217 answer `null`, so callers still coalesce.
 
 ---
 

--- a/webapp_v2/src/pages/Features/AccessControl/helpers.js
+++ b/webapp_v2/src/pages/Features/AccessControl/helpers.js
@@ -34,10 +34,11 @@ export function groupsWithPermissions(connections) {
   return byGroup
 }
 
-// Groups come from two places that can disagree: /users/groups (the identity
-// side) and the plugin config (the permission side). A group removed from the
-// IDP but still referenced by a connection has to stay visible, otherwise its
-// permissions become unreachable and silently keep applying.
+// /users/groups already unions the identity side with the plugin config
+// (EVL-217), so this second union is not what makes an IDP-dropped group
+// visible any more. It stays because this page rewrites the plugin config
+// without refetching /users/groups: a group attached in the current session
+// would otherwise disappear from the list until a reload.
 export function allGroups(userGroups, connections) {
   const names = new Set(userGroups ?? [])
   for (const connection of connections ?? []) {

--- a/webapp_v2/src/pages/Features/AccessControl/helpers.js
+++ b/webapp_v2/src/pages/Features/AccessControl/helpers.js
@@ -34,11 +34,10 @@ export function groupsWithPermissions(connections) {
   return byGroup
 }
 
-// /users/groups already unions the identity side with the plugin config
-// (EVL-217), so this second union is not what makes an IDP-dropped group
-// visible any more. It stays because this page rewrites the plugin config
-// without refetching /users/groups: a group attached in the current session
-// would otherwise disappear from the list until a reload.
+// Redundant with the gateway since EVL-217: /users/groups now unions the
+// identity side with the plugin config itself. Kept as a cheap guard, because
+// this page is the only way to detach a plugin-only group and losing it from
+// the list would strand its permissions.
 export function allGroups(userGroups, connections) {
   const names = new Set(userGroups ?? [])
   for (const connection of connections ?? []) {

--- a/webapp_v2/src/pages/Features/AccessRequest/store.js
+++ b/webapp_v2/src/pages/Features/AccessRequest/store.js
@@ -54,7 +54,7 @@ export const useAccessRequestStore = create((set) => ({
   fetchUserGroups: async () => {
     set({ userGroupsStatus: 'loading' })
     try {
-      // The gateway answers `null` — not `[]` — when there are no groups.
+      // Gateways older than EVL-217 answer `null` instead of `[]`.
       const { data } = await userGroupsService.list()
       set({ userGroups: data ?? [], userGroupsStatus: 'success' })
     } catch {

--- a/webapp_v2/src/pages/Roles/Configure/components/ReviewSection.jsx
+++ b/webapp_v2/src/pages/Roles/Configure/components/ReviewSection.jsx
@@ -31,6 +31,7 @@ export default function ReviewSection({ kind = 'command' }) {
   const setDraft = useConfigureRoleStore((s) => s.setDraft)
   const userGroupsList = useConfigureRoleStore((s) => s.userGroupsList)
   const isFreeLicense = useUserStore((s) => s.isFreeLicense)
+  const currentUser = useUserStore((s) => s.user)
 
   const groupOptions = (userGroupsList || []).map((g) => ({ value: g, label: g }))
   const reviewEnabled = drafts.reviewers.length > 0
@@ -38,11 +39,16 @@ export default function ReviewSection({ kind = 'command' }) {
   const handleReviewToggle = (enabled) => {
     if (enabled) {
       // Surfacing the toggle without any approval groups would be invalid, so
-      // seed one. Prefer admin: /users/groups is sorted since EVL-217, so
-      // position 0 is now whichever group sorts first and would hand approval
-      // to an arbitrary customer group if the user saves without editing.
+      // seed one, and seed a group the operator is actually in. /users/groups
+      // is sorted and now lists access_control-only groups (EVL-217), so
+      // position 0 can be a group with no members that nobody could approve
+      // with. This route is admin-only, so the current user's groups always
+      // include the admin group. 'admin' is a preference, not an assumption:
+      // the gateway allows renaming it (ADMIN_USERNAME / admin_role_name) and
+      // does not expose the configured name to the webapp.
       if (drafts.reviewers.length === 0 && userGroupsList.length > 0) {
-        const seed = userGroupsList.includes('admin') ? 'admin' : userGroupsList[0]
+        const ownGroups = (currentUser?.groups ?? []).filter((g) => userGroupsList.includes(g))
+        const seed = ownGroups.includes('admin') ? 'admin' : (ownGroups[0] ?? userGroupsList[0])
         setDraft({ reviewers: [seed] })
       }
     } else {

--- a/webapp_v2/src/pages/Roles/Configure/components/ReviewSection.jsx
+++ b/webapp_v2/src/pages/Roles/Configure/components/ReviewSection.jsx
@@ -37,10 +37,13 @@ export default function ReviewSection({ kind = 'command' }) {
 
   const handleReviewToggle = (enabled) => {
     if (enabled) {
-      // Surfacing the toggle without any approval groups would be invalid
-      // — seed with the first available group so the section is usable.
+      // Surfacing the toggle without any approval groups would be invalid, so
+      // seed one. Prefer admin: /users/groups is sorted since EVL-217, so
+      // position 0 is now whichever group sorts first and would hand approval
+      // to an arbitrary customer group if the user saves without editing.
       if (drafts.reviewers.length === 0 && userGroupsList.length > 0) {
-        setDraft({ reviewers: [userGroupsList[0]] })
+        const seed = userGroupsList.includes('admin') ? 'admin' : userGroupsList[0]
+        setDraft({ reviewers: [seed] })
       }
     } else {
       setDraft({

--- a/webapp_v2/src/services/userGroups.js
+++ b/webapp_v2/src/services/userGroups.js
@@ -1,8 +1,10 @@
 import api from './api'
 
 export const userGroupsService = {
-  // The gateway returns a bare string array, and `null` — not `[]` — when the
-  // organization has no groups. Callers must coalesce.
+  // Bare string array, sorted, unioning the identity side (users, service
+  // accounts, API keys, AI agents) with the access_control plugin config. Empty
+  // organizations return `[]`; older gateways return `null`, so callers still
+  // coalesce.
   list: () => api.get('/users/groups'),
   // Only `name` is read from the request body — the handler binds
   // openapi.UserGroup, which has no other field, so a description would be


### PR DESCRIPTION
## 📝 Description

`GET /users/groups` read only `private.user_groups`. That table is a membership
table, not a group catalog: a row exists only while a user, service account, API
key or AI agent is bound to the group.

IdP sync (OIDC and SAML) deletes and reinserts a user's rows on every login. When
the last Hoop member of a group stopped carrying it, every row disappeared, so
the group vanished from the endpoint. Its `access_control` association survived
and kept applying at connection time, so the permission stayed live but became
unreachable in the UI.

The endpoint now unions the identity side with the group names referenced by the
`access_control` plugin config, and sorts the result. The MCP `usergroups_list`
tool gets the same union so the two surfaces cannot disagree.

## 🎯 User-facing impact

Admins can again assign a group to an API key when that group only exists as an
`access_control` permission. Same for AI Agent identities, Roles → Configure,
Access Request, and agents using the MCP tool.

Two smaller fixes ride along: the list was in random order (Go map iteration), and
an org with no groups serialized as `null` instead of `[]`.

## 🔗 Related Issue

EVL-217

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## 📋 Changes Made

- `gateway/models/plugin_connections.go`: new `ListAccessControlGroupNames`,
  reading the distinct group names from `plugin_connections.config` for the
  `access_control` plugin. The predicate deliberately mirrors the enforcement
  queries in `GetConnectionByNameOrID` and `GetResourceByName`: join on
  `plugin_id`, scope the org through `private.plugins`. It does **not** filter
  `pc.enabled`, because enforcement does not either, and it scopes by `p.org_id`
  because `pc.org_id` is nullable. Narrowing it would hide a group whose
  permissions still apply, which is the bug being fixed.
- `gateway/api/user/user.go`: `ListAllGroups` unions both sources, sorts with
  `slices.Sort`, and returns an empty slice instead of `nil`.
- `gateway/api/mcpserver/tools_usergroups.go`: `usergroups_list` gets the same
  union. Without it an agent cannot see a group that exists only as a permission,
  and may call `usergroups_create` on a name that already grants access.
- `webapp_v2/src/pages/Roles/Configure/components/ReviewSection.jsx`: the approver
  seed was `userGroupsList[0]`, which was `admin` only because the list happened to
  be unsorted. Sorting plus the union made position 0 a group that may have no
  members. The seed now comes from the current user's own groups intersected with
  the available list, preferring `admin`. The route is `adminOnly`, so that
  intersection is never empty.
- `gateway/models/plugin_connections_test.go`: pglite tests covering dedup, a
  disabled association (listed, with the reason), another plugin's config, a null
  config, and an org with no `access_control` plugin.
- Comment and doc corrections for the `null` → `[]` change:
  `webapp_v2/COMPONENTS.md`, `webapp_v2/src/services/userGroups.js`,
  `webapp_v2/src/pages/Features/AccessRequest/store.js`,
  `webapp_v2/src/pages/Features/AccessControl/helpers.js`.
- OpenAPI regenerated for the new endpoint description.

## 🧪 Testing

### Test Configuration

- Go 1.26.5, `make test-oss` (exit 0, zero failures)
- Model tests run against embedded PGlite with the full migration set

### Tests performed

- [x] Unit tests pass locally
- [x] Integration tests pass locally
- [ ] Manual testing completed
- [x] Tested with different user roles
- [x] Tested edge cases

`TestListAccessControlGroupNames` covers two connections sharing a group (deduped),
a **disabled** association (must be listed: enforcement ignores the column), an
`audit` plugin config (excluded), and a null config (no crash).
`TestListAccessControlGroupNamesWithoutPlugin` seeds an `audit` row so the
plugin-name filter is load-bearing rather than passing vacuously.

Role coverage is by route: `GET /users/groups` is `ReadOnlyAccessRole`, unchanged.

**How to test manually**

1. Start the gateway with a fresh DB, log in as admin.
2. Create a connection and go to Access Control → New group. Name it `test-orphan`
   and attach it to that connection. Save.
3. Confirm `test-orphan` appears at Settings → API Keys → Create → Groups.
4. Reproduce the customer state: delete the identity-side row only, leaving the
   plugin association intact.
   `DELETE FROM private.user_groups WHERE org_id = '<org>' AND name = 'test-orphan';`
5. Reload Settings → API Keys → Create. Before this PR the group is gone from the
   picker; with this PR it is still listed, and selecting it saves normally.
6. Check `GET /api/users/groups` returns the list sorted, and `[]` (not `null`) on
   an org with no groups.

## 📸 Screenshots

Not applicable. No UI change; the pickers are fed by the endpoint.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 📌 Additional Notes

**Customer workaround while this ships.** `POST /api/users/groups {"name":"<group>"}`
writes a standalone row with a null `user_id`, so the group reappears in every
picker without touching permissions. Sent to the customer on EVL-217.

**Follow-ups found during the investigation, not fixed here:**

1. EVL-221 - the access_control write path never creates the standalone
   `user_groups` row, which is the invariant this PR works around on the read
   side. Also closes an asymmetry: MCP `usergroups_delete` hard-errors on a
   plugin-only group while the webapp swallows the same 404.
2. EVL-223 - the reported screenshot shows two pills both reading
   `CG-Hoop-FINANCIAL-SERVICES-PF` on one API key. The partial unique index
   `idx_user_groups_api_key_name` on `(api_key_id, name)` makes an exact duplicate
   impossible, so the two names differ invisibly, most likely by trailing
   whitespace. Nothing in the sync path trims group names, and a stray space
   silently breaks the `config && user_groups` overlap test. Asked the customer to
   confirm.
3. EVL-222 - no handling for Entra ID group-claim overage (`_claim_names` /
   `_claim_sources`). A user in more than 150 SAML or 200 JWT groups receives no
   groups at all. Same symptom as this bug from the user's side.
4. EVL-224 - `gateway/idp/saml/saml.go:90-92` computes the `groups_claim` default
   and uses it only in the log line at 126, so the provider keeps the raw value.
   Latent, not live: `gateway/api/serverconfig/auth.go:341-342` already defaults
   the field before the row is written, and `newSamlProvider` reads only from that
   row. The log line still reports a default that is not applied.
5. EVL-225 - `admin_role_name` is absent from `/serverinfo`, so `webapp_v2`
   hardcodes `'admin'` in three places.
6. `private.user_groups` has no index on `org_id`, so `GetUserGroupsByOrgID` is a
   sequential scan returning one row per binding. Not a regression, and the query
   added here is smaller, but it is the dominant cost of this endpoint. No ticket.
