### PR TITLE
feat(sidecar): limit the open source build to one guardrail and one masking rule

### DIFF
--- a/deploy/docker-compose/envoy-stack/README.md
+++ b/deploy/docker-compose/envoy-stack/README.md
@@ -90,12 +90,12 @@ and reuses it afterwards. After a library change:
 
 The image builds `hoop-inspect` with
 [alcatraz](https://github.com/hoophq/alcatraz) PII detection linked in, so the
-demo can mask Brazilian CPFs and IBANs and deny a query that embeds one. The
-`pii` section of `sidecar/config.yaml` names which of the 54 entity types are
-active, five here. Omitting the section activates all 54, and this file
-narrows on purpose: a mask rule naming `US_SSN` rewrites ordinary numeric
-columns, because that recognizer fires on roughly a third of random
-nine-digit business ids.
+demo can deny a query that embeds a Brazilian CPF and redact email addresses
+out of a response. The `pii` section of `sidecar/config.yaml` names which of
+the 54 entity types are active, five here. Omitting the section activates all
+54, and this file narrows on purpose: a mask rule naming `US_SSN` rewrites
+ordinary numeric columns, because that recognizer fires on roughly a third of
+random nine-digit business ids.
 
 Sidecar knobs live in `sidecar/config.yaml`; validate a change without
 starting anything:
@@ -135,8 +135,8 @@ owning identity. The one header the Rego does pass on is
 Both statements below cross the *same* Envoy TCP listener on the same port:
 
 ```sql
-SELECT name, email FROM customers;   -- fine
-DELETE FROM customers WHERE id = 1;  -- destructive
+SELECT name, email FROM customers;                    -- fine
+DELETE FROM customers WHERE cpf = '111.444.777-35';   -- refused
 ```
 
 Envoy cannot tell them apart. There is no pgwire parser in its filter chain, so
@@ -148,17 +148,34 @@ it in psql rather than watching a socket drop.
 ```bash
 docker compose exec -T client env PGPASSWORD=apppass PGSSLMODE=disable \
   psql -h envoy -p 5432 -U appuser -d appdb \
-       -c 'DELETE FROM customers WHERE id = 1;'
+       -c "DELETE FROM customers WHERE cpf = '111.444.777-35';"
 ```
+
+The rule that refuses it is `no-cpf-in-query`, and it is the **only** guardrail
+this stack runs: the sidecar build enforces one guardrail rule and one data
+masking rule for the whole process, so that DELETE is denied for the taxpayer
+id it carries rather than for being a DELETE. `no-destructive-sql`
+(`operations: [drop, delete, truncate]`) is the rule that refuses any
+destructive statement on its own, and `sidecar/config.yaml` carries it
+commented out beside the appdb lane. Spend the budget there instead, by
+restoring it and commenting out `no-cpf-in-query`, and a plain
+`DELETE FROM customers WHERE id = 1` is refused too. As shipped, that plain
+DELETE reaches the database.
 
 The same lane rewrites the result set on the way back:
 
 ```
-     name     |          email           |     ssn     |          iban
---------------+--------------------------+-------------+------------------------
- Ada Lovelace | [REDACTED:EMAIL_ADDRESS] | ***-**-6789 | ******************5432
- Grace Hopper | [REDACTED:EMAIL_ADDRESS] | ***-**-4321 | ******************3000
+     name     |          email           |     ssn     |            iban
+--------------+--------------------------+-------------+-----------------------------
+ Ada Lovelace | [REDACTED:EMAIL_ADDRESS] | 123-45-6789 | GB82WEST12345698765432
+ Grace Hopper | [REDACTED:EMAIL_ADDRESS] | 987-65-4321 | DE89370400440532013000
+ Alan Turing  | [REDACTED:EMAIL_ADDRESS] | 555-12-3456 | FR1420041010050500013M02606
 ```
+
+One column rewritten, because one rule. The limit that leaves this stack a
+single guardrail leaves it a single mask rule, and `emails` holds it, so `ssn`
+and `iban` come back in the clear. `sidecar/config.yaml` carries a rule for
+each of them commented out under the `mask:` block, beside `cards` and `cpf`.
 
 The codec rebuilds the frames around the new values rather than substituting
 bytes. A pgwire `DataRow` length-prefixes every row and every column, so
@@ -167,13 +184,14 @@ reframing lives in the codec itself, in the private
 `github.com/hoophq/libhoop/v2/codec/postgres`; `sidecar/codec/postgres`
 registers it with the inspector.
 
-A **column rule** masks the `ssn` column by position rather than by detection.
-The seeded value `123-45-6789` is one alcatraz refuses, because it rejects
-sequential digit runs as test fixtures, so the entity rule skips it and
-`columns: [ssn]` catches it anyway. A column rule works wherever the protocol
-names its values, and it does not care what the value looks like. The same
-placeholder posted to the HTTP lane survives unmasked, and `./demo.sh` shows
-that contrast.
+A **column rule** is the other way to mask, and where the protocol names its
+values it beats detection outright. `columns: [ssn]` masks by position, so it
+does not care what the value looks like: it catches the seeded `123-45-6789`
+and `987-65-4321`, which alcatraz refuses because it rejects sequential and
+descending digit runs as test fixtures. No detector-based rule reaches those
+two, at any budget. The appdb lane carries such a rule commented out in
+`sidecar/config.yaml`, where it doubles as the worked example of a lane
+override REPLACING the default `mask.rules` rather than extending them.
 
 ### Tier 2b: the HTTP response
 
@@ -182,17 +200,38 @@ otherwise loses a technical review. `ext_authz` sees method, path, headers and
 a bounded body slice. It structurally cannot see a **response**: it decides
 before the upstream is called.
 
-`sidecar/config.yaml` carries two rules that make the difference concrete:
+`sidecar/config.yaml` carries two rules that make the difference concrete, and
+**this build runs neither**: one guardrail rule for the whole process, and
+`no-cpf-in-query` in the defaults holds it. Both sit commented out beside the
+httpbin lane, and `./demo.sh` sends a request for each, printing the status it
+actually got next to the rule that would have refused it:
 
 - `no-internal-ids` denies `/anything/users/*/orders/*` with one rule for
   every id, because the codec normalizes the path to a stable resource rather
   than matching raw strings.
 - `no-upstream-5xx` suppresses a 5xx on the way back. There is no ext_authz
-  shape that does this.
+  shape that does this, which makes it the one to restore first here.
 
-Masking runs here too, by the simpler mechanism: `./demo.sh` posts a body with
-an email, an SSN, a card, a CPF and an IBAN, and reads back five rewritten
-values with `Content-Length` corrected to match.
+What the lane does enforce is the default it inherits. `no-cpf-in-query` scans
+the request line, so a taxpayer id in a path or a query string is refused with
+a 403 before httpbin is called:
+
+```bash
+curl -k 'https://localhost:8443/anything/customers?cpf=111.444.777-35' \
+  -H 'X-Hoop-User: alice'
+# do not put a taxpayer id in a query; it lands in the database's own logs
+```
+
+That is the same rule, and the same message, that refuses the pgwire DELETE in
+tier 2a: a top-level default hands both lanes its wording along with its
+verdict. Per-lane wording costs a second rule.
+
+Masking runs here too, by the simpler mechanism, and it spends no guardrail
+budget: `./demo.sh` posts a body with an email, an SSN, a card, a CPF and an
+IBAN, and reads back one value rewritten. The email returns as
+`[REDACTED:EMAIL_ADDRESS]` with `Content-Length` corrected to match. The other
+four return exactly as posted, each printed beside the commented rule that
+would have rewritten it.
 
 ### Check the recorded evidence
 
@@ -301,8 +340,8 @@ prose never travels, because OPA's decision log copies everything sent to it.
 Three things keep the model affordable. The **gate** excludes everything
 outside `inspect_sensitive`, so an ORM's traffic against other tables costs
 nothing. The **cache** keys on the statement shape, so `WHERE id = 1` and
-`WHERE id = 2` are one verdict. The analyzer runs after `no-destructive-sql`,
-so anything a free rule already refused never reaches a model.
+`WHERE id = 2` are one verdict. The analyzer runs after the free local
+rules, so anything they already refused never reaches a model.
 
 On the httpbin lane it also needs an `http:` block with `capture_body: true`.
 Without a body the model sees `POST /anything` and nothing else, and a request

--- a/deploy/docker-compose/envoy-stack/demo.sh
+++ b/deploy/docker-compose/envoy-stack/demo.sh
@@ -49,57 +49,88 @@ note "Envoy forwarded this as opaque TCP. It has no pgwire parser, so OPA was"
 note "never consulted -- there is nothing to consult it about."
 $PG -c 'SELECT name, id FROM customers;' 2>&1 | head -8
 
-h "POSTGRES / denied -- DELETE never reaches the database"
+h "POSTGRES / denied -- a destructive statement never reaches the database"
+note "This build enforces ONE guardrail rule for the whole process and spends"
+note "it on no-cpf-in-query, so the DELETE below is refused for the taxpayer id"
+note "it carries, not for being a DELETE. no-destructive-sql refuses any drop,"
+note "delete or truncate on its own; sidecar/config.yaml carries it commented"
+note "out, over the limit. The statement here is denied under either rule."
+note ""
 note "The message below is a real pgwire ErrorResponse, not a dropped socket."
 note "The developer reads it in psql and fixes it themselves."
-$PG -c 'DELETE FROM customers WHERE id = 1;' 2>&1 | head -2
+$PG -c "DELETE FROM customers WHERE cpf = '111.444.777-35';" 2>&1 | head -2
 
 note ""
 note "Proof nothing was deleted:"
-$PG -tAc 'SELECT count(*) FROM customers;' 2>&1 | head -1
+LEFT=$($PG -tAc 'SELECT count(*) FROM customers;' 2>&1 | tr -d '[:space:]')
+if [ "$LEFT" = "3" ]; then
+    printf '  3 rows, unchanged\n'
+else
+    printf '\033[1;31m  %s rows -- the guardrail did not hold\033[0m\n' "$LEFT"
+fi
 
 h "POSTGRES / masked -- the result set is rewritten on the way back"
 note "Postgres rows are length-prefixed binary frames, so this is not byte"
 note "substitution: the codec rebuilds every DataRow around the new values."
-note "psql never notices, and the client sees no unmasked cell."
+note "psql never notices that the row it prints is not the row appdb sent."
+note ""
+note "What it prints is one masked column. This build enforces ONE data masking"
+note "rule for the whole process and spends it on emails, so email comes back"
+note "redacted while ssn and iban come back in the clear. sidecar/config.yaml"
+note "carries the rules that would cover them commented out, over the limit."
 $PG -c 'SELECT name, email, ssn, iban FROM customers;' 2>&1 | head -8
 
 # -------------------------------------------------------------------- http
-h "HTTP / denied on the REQUEST -- normalized resource path"
-note "One rule covers every id: /anything/users/*/orders/* "
-curl -sk https://localhost:8443/anything/users/12345/orders/98765 \
+h "HTTP / denied on the REQUEST -- one guardrail, both protocols"
+note "no-cpf-in-query is a top-level default, so the rule that refused the"
+note "DELETE guards this lane too. It scans the request line, where a taxpayer"
+note "id lands in an access log, a Referer header and a trace span."
+curl -sk 'https://localhost:8443/anything/customers?cpf=111.444.777-35' \
     -H 'X-Hoop-User: alice' -w '\n  HTTP %{http_code}\n'
+note ""
+note "Both lanes inherit the wording as well as the verdict, which is why an"
+note "HTTP caller is told about a database's logs. Lane-specific wording is a"
+note "second rule, and there is no budget for one."
 
-h "HTTP / denied on the RESPONSE -- the thing ext_authz cannot do"
-note "ext_authz decides BEFORE the upstream is called, so it never sees a"
-note "status. hoop-inspect sees the 503 and suppresses it."
-curl -sk https://localhost:8443/status/503 \
-    -H 'X-Hoop-User: alice' -w '\n  HTTP %{http_code}\n'
+h "HTTP / the rules this build cannot afford"
+note "One guardrail rule for the whole process, and no-cpf-in-query holds it."
+note "Both requests below are ALLOWED as shipped. sidecar/config.yaml carries"
+note "the rule that would refuse each, commented out beside the httpbin lane."
+printf '  /anything/users/12345/orders/98765  HTTP %s  no-internal-ids would refuse it\n' \
+    "$(curl -sk https://localhost:8443/anything/users/12345/orders/98765 \
+        -H 'X-Hoop-User: alice' -o /dev/null -w '%{http_code}')"
+printf '  /status/503                         HTTP %s  no-upstream-5xx would suppress it\n' \
+    "$(curl -sk https://localhost:8443/status/503 \
+        -H 'X-Hoop-User: alice' -o /dev/null -w '%{http_code}')"
+note ""
+note "no-upstream-5xx is the one to restore first in a demo about Envoy:"
+note "ext_authz decides BEFORE the upstream is called, so a response status is"
+note "a question it structurally cannot ask. Response-side REWRITING costs no"
+note "guardrail budget and still runs -- that is the masking section below."
 
 # ----------------------------------------------------------------- masking
-h "MASKING / sensitive values rewritten on the way back"
+h "MASKING / the one entity this build rewrites"
 curl -sk -X POST https://localhost:8443/anything \
     -H 'X-Hoop-User: alice' -H 'Content-Type: application/json' \
     -d '{"email":"ada@example.com","ssn":"555-12-3456","card":"4111111111111111","cpf":"111.444.777-35","iban":"GB82WEST12345698765432"}' \
     2>/dev/null | grep -E '"(email|ssn|card|cpf|iban)"' | sed 's/^/  /' | head -6
 note ""
-note "One engine detects all five: alcatraz. email redacted; ssn, card and"
-note "iban partial-masked keeping the last 4; cpf redacted."
+note "Five values in, one rewritten. emails is the whole process's one mask"
+note "rule, so email comes back redacted and the other four come back exactly"
+note "as posted. sidecar/config.yaml carries the rule for each of them"
+note "commented out under the mask block, over the limit:"
+note "  ssn   -> ssn    US_SSN,      partial keeping the last 4"
+note "  card  -> cards  CREDIT_CARD, partial keeping the last 4"
+note "  cpf   -> cpf    BR_CPF,      redact"
+note "  iban  -> iban   IBAN_CODE,   partial keeping the last 4"
 note ""
-note "Card, CPF and IBAN are checksum-verified (Luhn, mod-11, ISO 7064), so"
-note "order ids and timestamps that merely look like them are left alone."
-
-h "MASKING / what a verified detector refuses to mask"
-curl -sk -X POST https://localhost:8443/anything \
-    -H 'X-Hoop-User: alice' -H 'Content-Type: application/json' \
-    -d '{"real":"555-12-3456","placeholder":"123-45-6789"}' \
-    2>/dev/null | grep -E '"(real|placeholder)"' | sed 's/^/  /' | head -2
-note ""
-note "123-45-6789 is left alone on purpose: alcatraz rejects sequential and"
-note "descending digit runs as obvious test fixtures. That is the trade a"
-note "validating detector makes - it cuts false positives on ordinary ids and"
-note "declines the fixtures. A shop that must mask placeholder SSNs too should"
-note "add a pattern rule for them rather than widen the detector."
+note "One engine detects all five: alcatraz. Card, CPF and IBAN are"
+note "checksum-verified (Luhn, mod-11, ISO 7064), so order ids and timestamps"
+note "that merely look like them are left alone. The same validation makes it"
+note "refuse 123-45-6789 as an obvious fixture, and no entity rule can reach a"
+note "value the detector declines. That is why the appdb lane's commented mask"
+note "override reaches for a columns: [ssn] rule: a column rule masks by"
+note "position and does not care what the value looks like."
 
 # -------------------------------------------------------------- guardrails
 h "GUARDRAIL / a national id in the query itself"

--- a/deploy/docker-compose/envoy-stack/sidecar/config.yaml
+++ b/deploy/docker-compose/envoy-stack/sidecar/config.yaml
@@ -112,6 +112,18 @@ mask:
     # ---- over the limit: four more entities this demo used to mask -------
     # The pii.entities list above still names all five, so uncommenting any
     # of these needs no other change.
+    #
+    # ./demo.sh is written to that state and prints the gap rather than
+    # hiding it. Its MASKING beat POSTs all five values and gets one back
+    # rewritten: [REDACTED:EMAIL_ADDRESS] for the email, ssn, card, cpf and
+    # iban echoed exactly as sent, each printed beside the name of the rule
+    # below that would rewrite it. The POSTGRES / masked beat is the same
+    # story on the other mechanism: redacted emails in the DataRow, cleartext
+    # ssn and iban.
+    #
+    # Swap the live rule for one of these and both beats flip for that entity
+    # with no other edit. sidecar/read-audit.py asserts the audit trail holds
+    # no value the live rule removed, so a swap wants that list widened too.
     # - {name: ssn, entities: [US_SSN], strategy: partial, keep_last: 4}
     # - {name: cards, entities: [CREDIT_CARD], strategy: partial, keep_last: 4}
     # - {name: cpf, entities: [BR_CPF], strategy: redact}
@@ -144,7 +156,16 @@ listeners:
         # Envoy cannot see the rule below: there is no pgwire parser in its
         # filter chain, so OPA is never consulted and never sees the
         # statement. That is the claim this stack exists to demonstrate, and
-        # it costs the free tier's single rule to show.
+        # it costs the free tier's single rule to show. no-cpf-in-query shows
+        # the same claim on the same lane, which is why it keeps the budget:
+        # it is also the only rule the httpbin lane has left.
+        #
+        # ./demo.sh is written to that choice. Its destructive statement is
+        # `DELETE FROM customers WHERE cpf = '111.444.777-35'`, refused by
+        # whichever of the two rules this process spends its budget on, so
+        # restoring the rule below and commenting out no-cpf-in-query leaves
+        # the demo correct and the row count at 3 either way. A plain
+        # `DELETE ... WHERE id = 1` reaches the database as this file ships.
         # - name: no-destructive-sql
         #   type: operation # lexer-derived, so SELECT 'DROP TABLE x' is a select
         #   operations: [drop, delete, truncate]
@@ -209,17 +230,22 @@ listeners:
     #   fail_open: false
     #   gate: true
     # ---- over the limit: this lane's mask override --------------------
+    # Four rules where the process allows one. It is kept whole anyway,
+    # because the shape is what it exists to show.
+    #
     # With this block commented out the lane inherits the default one, which
     # is the point of the defaults. It is also the worked example of
-    # `mask.rules` REPLACING rather than extending: restore it and appdb stops
-    # masking CREDIT_CARD while httpbin, which overrides nothing, keeps
-    # masking it.
+    # `mask.rules` REPLACING rather than extending: the block has to restate
+    # `emails` to keep it, since a lane that overrides the block inherits
+    # nothing from it. Delete that one line and appdb stops redacting email
+    # addresses while httpbin, which overrides nothing, keeps redacting them.
     #
     # Column rules are only possible where the protocol names its values, and
     # there they beat detection outright. alcatraz REFUSES 123-45-6789 as an
-    # obvious fixture (sequential digits), so the detector-based ssn rule
-    # leaves it in the clear. The column does not care what the value looks
-    # like.
+    # obvious fixture (sequential digits) and 987-65-4321 as its descending
+    # twin, which is two of the three seeded ssn values, so no detector-based
+    # ssn rule reaches them - not the commented one in the defaults either.
+    # The column does not care what the value looks like.
     # mask:
     #   rules:
     #     - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
@@ -238,6 +264,14 @@ listeners:
         # defaults. http_status is the one below worth restoring first: it is
         # response-side, and ext_authz decides before the upstream is called,
         # so it is a question Envoy structurally cannot ask.
+        #
+        # ./demo.sh is written to that state. It denies a request the
+        # inherited rule catches (`?cpf=111.444.777-35`, scanned in the
+        # request line), then sends one request per rule below and prints the
+        # status it actually got beside the rule that would have refused it.
+        # Uncomment a rule here, comment out no-cpf-in-query in the defaults,
+        # and the matching demo line flips from allowed to 403 with no other
+        # edit.
         # - name: no-admin-api
         #   type: http_resource
         #   resources: ["/admin/**"]

--- a/deploy/docker-compose/envoy-stack/sidecar/config.yaml
+++ b/deploy/docker-compose/envoy-stack/sidecar/config.yaml
@@ -10,6 +10,11 @@
 # Validate without starting anything:
 #   cd sidecar/cmd && go run . -validate \
 #     -config ../../deploy/docker-compose/envoy-stack/sidecar/config.yaml
+#
+# This build enforces ONE guardrail rule and ONE data masking rule for the
+# whole process. This file is written to that limit: the rest of what the demo
+# used to enforce is present as commented blocks, each marked "over the
+# limit", so uncommenting is the only step on a build without the limit.
 
 log_level: info
 
@@ -96,13 +101,21 @@ guardrails:
 # Masking is response-side, and both lanes get it by two different mechanisms:
 # HTTP by substituting bytes and correcting Content-Length, postgres by
 # rebuilding its length-prefixed row frames around the new values.
+#
+# One rule, and it is the whole process's one rule: both lanes inherit it,
+# because neither overrides the block. EMAIL_ADDRESS is the entity that
+# demonstrates both mechanisms, since httpbin returns it in a JSON body and
+# appdb returns it in a pgwire DataRow.
 mask:
   rules:
     - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
-    - {name: ssn, entities: [US_SSN], strategy: partial, keep_last: 4}
-    - {name: cards, entities: [CREDIT_CARD], strategy: partial, keep_last: 4}
-    - {name: cpf, entities: [BR_CPF], strategy: redact}
-    - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
+    # ---- over the limit: four more entities this demo used to mask -------
+    # The pii.entities list above still names all five, so uncommenting any
+    # of these needs no other change.
+    # - {name: ssn, entities: [US_SSN], strategy: partial, keep_last: 4}
+    # - {name: cards, entities: [CREDIT_CARD], strategy: partial, keep_last: 4}
+    # - {name: cpf, entities: [BR_CPF], strategy: redact}
+    # - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
 # ------------------------------------------------------------------- lanes
 listeners:
@@ -124,12 +137,18 @@ listeners:
       server_name: appdb
     guardrails:
       rules:
-        # Envoy cannot see this: there is no pgwire parser in its filter
-        # chain, so OPA is never consulted and never sees the statement.
-        - name: no-destructive-sql
-          type: operation # lexer-derived, so SELECT 'DROP TABLE x' is a select
-          operations: [drop, delete, truncate]
-          message: destructive statements are not permitted on appdb
+        # ---- over the limit: the lane's own guardrail ------------------
+        # This lane is NOT unguarded. The one rule this build allows is
+        # no-cpf-in-query in the defaults above, and it applies here.
+        #
+        # Envoy cannot see the rule below: there is no pgwire parser in its
+        # filter chain, so OPA is never consulted and never sees the
+        # statement. That is the claim this stack exists to demonstrate, and
+        # it costs the free tier's single rule to show.
+        # - name: no-destructive-sql
+        #   type: operation # lexer-derived, so SELECT 'DROP TABLE x' is a select
+        #   operations: [drop, delete, truncate]
+        #   message: destructive statements are not permitted on appdb
         # ---- PII entities -> Rego (off; needs no credential) ------------
         # `action: defer` on ANY local rule turns a match into a REPORT
         # instead of a denial: the rule records what it saw as a finding,
@@ -189,17 +208,24 @@ listeners:
     #   # undefined gate decision allows and requests nothing.
     #   fail_open: false
     #   gate: true
-    mask:
-      rules:
-        # Column rules are only possible where the protocol names its values,
-        # and there they beat detection outright. alcatraz REFUSES
-        # 123-45-6789 as an obvious fixture (sequential digits), so the
-        # detector-based ssn rule leaves it in the clear. The column does not
-        # care what the value looks like.
-        - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
-        - {name: cpf, entities: [BR_CPF], strategy: redact}
-        - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
+    # ---- over the limit: this lane's mask override --------------------
+    # With this block commented out the lane inherits the default one, which
+    # is the point of the defaults. It is also the worked example of
+    # `mask.rules` REPLACING rather than extending: restore it and appdb stops
+    # masking CREDIT_CARD while httpbin, which overrides nothing, keeps
+    # masking it.
+    #
+    # Column rules are only possible where the protocol names its values, and
+    # there they beat detection outright. alcatraz REFUSES 123-45-6789 as an
+    # obvious fixture (sequential digits), so the detector-based ssn rule
+    # leaves it in the clear. The column does not care what the value looks
+    # like.
+    # mask:
+    #   rules:
+    #     - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
+    #     - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+    #     - {name: cpf, entities: [BR_CPF], strategy: redact}
+    #     - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
   - name: httpbin
     protocol: http
@@ -207,22 +233,25 @@ listeners:
     upstream: httpbin:8080
     guardrails:
       rules:
-        - name: no-admin-api
-          type: http_resource
-          resources: ["/admin/**"]
-          message: the admin API is not reachable through this proxy
-        - name: no-internal-ids
-          type: http_resource
-          # Matched against the NORMALIZED resource, so one rule covers every
-          # id: /anything/users/12345/orders/98765 collapses to this shape.
-          resources: ["/anything/users/*/orders/*"]
-          message: direct id access is not permitted; use the search endpoint
-        - name: no-upstream-5xx
-          type: http_status
-          # Response-side. ext_authz decides before the upstream is called, so
-          # this is a question Envoy structurally cannot ask.
-          statuses: ["5xx"]
-          message: upstream failure suppressed by policy
+        # ---- over the limit: this lane's own guardrails ----------------
+        # As on appdb, the lane still inherits no-cpf-in-query from the
+        # defaults. http_status is the one below worth restoring first: it is
+        # response-side, and ext_authz decides before the upstream is called,
+        # so it is a question Envoy structurally cannot ask.
+        # - name: no-admin-api
+        #   type: http_resource
+        #   resources: ["/admin/**"]
+        #   message: the admin API is not reachable through this proxy
+        # - name: no-internal-ids
+        #   type: http_resource
+        #   # Matched against the NORMALIZED resource, so one rule covers every
+        #   # id: /anything/users/12345/orders/98765 collapses to this shape.
+        #   resources: ["/anything/users/*/orders/*"]
+        #   message: direct id access is not permitted; use the search endpoint
+        # - name: no-upstream-5xx
+        #   type: http_status
+        #   statuses: ["5xx"]
+        #   message: upstream failure suppressed by policy
         # Needs the http block below: without capture_body the analyzer sees
         # "POST /anything" and no payload, which tells a model nothing.
         # - name: risky-payloads

--- a/deploy/docker-compose/envoy-stack/sidecar/read-audit.py
+++ b/deploy/docker-compose/envoy-stack/sidecar/read-audit.py
@@ -45,10 +45,20 @@ def main() -> int:
             )
 
     # The audit trail must never contain a value that masking removed:
-    # recording what you masked, in the clear, has un-masked it.
+    # recording what you masked, in the clear, has un-masked it. So the list
+    # below tracks the live mask rules, not the fixtures: this build enforces
+    # ONE data masking rule and spends it on emails, so email addresses are
+    # the only values it can assert anything about. The card, SSN, CPF and
+    # IBAN fixtures the demo sends reach the audit trail in the clear because
+    # nothing masked them, and listing them here would fail a check this
+    # build was never asked to pass. Restore a mask rule in
+    # sidecar/config.yaml and add its fixtures back beside these:
+    # 4111111111111111 (cards), 123-45-6789 and 555-12-3456 (ssn),
+    # 111.444.777-35 (cpf), GB82WEST12345698765432 (iban).
     blob = json.dumps(rows)
     print()
-    leaks = [v for v in ("ada@example.com", "4111111111111111", "123-45-6789") if v in blob]
+    masked_values = ("ada@example.com", "grace@example.com", "alan@example.com")
+    leaks = [v for v in masked_values if v in blob]
     if leaks:
         print(f"  LEAK: masked values present in the audit trail: {leaks}")
         return 1

--- a/deploy/docker-compose/metabase-stack/README.md
+++ b/deploy/docker-compose/metabase-stack/README.md
@@ -138,22 +138,27 @@ column security also covers, on Pro, and not on the container running here.
 
 **3. Native SQL editor.** The path column security answers by being switched
 off. Here the editor stays on, the analyst writes whatever they like, and the
-response comes back rewritten:
+address comes back rewritten:
 
 ```
-  id  name          email                     ssn          cpf                 iban
-  1   Ada Lovelace  [REDACTED:EMAIL_ADDRESS]  ***-**-6789  [REDACTED:BR_CPF]   ******************5432
+  id  name          email                     ssn          cpf             iban
+  1   Ada Lovelace  [REDACTED:EMAIL_ADDRESS]  123-45-6789  111.444.777-35  GB82WEST12345698765432
 ```
 
-`ssn` carries **both** a column rule and an entity rule, because the two kinds
-fail in opposite directions and neither is sufficient alone.
+One mask rule for the whole process, spent on the `EMAIL_ADDRESS` entity, so
+`ssn`, `cpf` and `iban` arrive as stored. [`sidecar/config.yaml`](sidecar/config.yaml)
+carries a rule for each of them commented out beside the live one, and the
+demo prints the row above rather than a version of it nothing produces.
 
-A **column rule** keys on the output column name in `RowDescription` and does
-not care what the value looks like, which is what catches the two SSNs
-[alcatraz](https://github.com/hoophq/alcatraz) rejects as obvious test
-fixtures (`123-45-6789`, `987-65-4321`). An **entity rule** keys on the value,
-so it survives an alias, a join, or a CTE that surfaces the column under a
-name no config predicted. Measured against this stack:
+The budget goes to an entity rule because an entity rule keys on the **value**:
+it covers `customers.email` and `events.actor_email` without anyone
+enumerating column names, which is what the 5,000-row export below needs. A
+**column rule** keys on the output column name in `RowDescription` and does
+not care what the value looks like, which is the only thing that catches the
+two SSNs [alcatraz](https://github.com/hoophq/alcatraz) rejects as obvious
+test fixtures (`123-45-6789`, `987-65-4321`). Neither kind is sufficient
+alone, which is why `ssn` wants both. Measured against this stack with the
+pair restored:
 
 | Query | masked |
 |---|---|
@@ -162,9 +167,9 @@ name no config predicted. Measured against this stack:
 | `SELECT ssn AS whatever FROM customers` | 1/3 |
 | `SELECT substring(email,1,6) FROM customers` | 0/3 |
 
-[Known gaps](#known-gaps) explains the last two rows. `cpf`, `iban` and the
-emails are entity-only, because the same class of value turns up under names
-nobody enumerates in advance.
+As shipped, the three `ssn` rows all read 0/3: that pair is over the limit.
+The last row holds either way, and [Known gaps](#known-gaps) explains it along
+with the third.
 
 **4. CSV export, 5,000 rows.** A download is where masking usually fails: the
 rows are already inside the BI tool and whatever it writes to disk is out of
@@ -185,12 +190,13 @@ flushes what it holds *masked* and keeps going, so exceeding the buffer
 changes the batching granularity and nothing else.
 
 **5. Guardrail.** The lane is read-only by policy, not by `GRANT`, so the
-analyst gets a sentence an operator wrote instead of a permission error. Which
-sentence depends on the table:
+analyst gets a sentence an operator wrote instead of a permission error. One
+guardrail rule for the whole process, and it is the lane-wide backstop, so
+every table gets the same sentence:
 
 ```
   DELETE FROM customers WHERE id = 1
-  Metabase reports: FATAL: customers is written by the CRM sync; change it there
+  Metabase reports: FATAL: this Metabase connection is read-only; writes are not permitted
 
   WITH gone AS (DELETE FROM events RETURNING *) SELECT count(*) FROM gone
   Metabase reports: FATAL: this Metabase connection is read-only; writes are not permitted
@@ -199,10 +205,13 @@ sentence depends on the table:
   Metabase reports: FATAL: this Metabase connection is read-only; writes are not permitted
 ```
 
-`customers` has a rule naming its owner; `events` has none and falls to the
-lane-wide backstop, which is the rule that still covers the table somebody
-adds next month. The second statement also shows classification by effect
-rather than by leading verb: it reads as a `SELECT` and it is a delete.
+The backstop is the right rule to spend a single-rule budget on: it covers
+every table nobody wrote a rule for, including the one added next month.
+`customers` has a rule naming the CRM sync as its owner, and it is commented
+out in `sidecar/config.yaml`; restore it on a build without the cap and put it
+BEFORE the backstop, because first match wins and a reversed order gives every
+refusal the generic message. The second statement shows classification by
+effect rather than by leading verb: it reads as a `SELECT` and it is a delete.
 
 The third is the one to copy carefully. An `operation` rule matches exact
 operations, so a lane called read-only has to name `create`, `alter`, `grant`,
@@ -217,51 +226,58 @@ that never comes, and a hang is a worse answer than a sentence
 (`proxy/deny.go`). For a pooled client that means a refused query costs one
 pooled connection, which c3p0 replaces on the next checkout.
 
-**6. A table reporting cannot read.** `payroll` is refused rather than masked.
-Masking answers *who may see this value*; a table rule answers *may this table
-be reached at all*. Every path gets the rule's own message:
+**6. The table reporting can still read.** `payroll` is the case an operation
+rule cannot answer. Masking says *who may see this value*, a `type: table`
+rule says *may this table be reached at all*, and
+`operations: [insert, update, ...]` says neither about a `SELECT`. With
+`payroll-off-limits` over the limit and commented out, reporting reads
+salaries:
 
 ```
-  SELECT employee, salary_cents FROM payroll ORDER BY id
-  Metabase reports: FATAL: payroll is not exposed to reporting
-
-  SELECT c.name, p.salary_cents FROM customers c JOIN payroll p ON p.employee = c.name
-  Metabase reports: FATAL: payroll is not exposed to reporting
+  SELECT employee, salary_cents, bank_iban FROM payroll ORDER BY id
+  Ada Lovelace  21500000  GB82WEST12345698765432
+  Grace Hopper  23800000  DE89370400440532013000
+  Alan Turing   20900000  FR1420041010050500013M02606
 ```
 
-The join is the part worth watching. A `type: table` rule reads every relation
-the statement touches rather than the first one named, so the table cannot be
-reached through a join, a subquery or a CTE. Metabase still lists `payroll` in
-its data browser, because a schema sync reads `pg_catalog` and no rule here
-covers the catalogue; clicking the table returns the refusal instead of rows,
-and its columns stay unfingerprinted.
+`./demo.sh` prints those rows and asserts that they arrive, so the beat fails
+loudly the day somebody restores the rule and forgets this section.
+`bank_iban` is in the clear for the same reason one level down: the `iban`
+mask rule is over the limit too.
+
+Restore `payroll-off-limits` and every path gets the rule's own message,
+including a join where `payroll` is not the first table named, because a
+`type: table` rule reads every relation the statement touches rather than the
+first one. Metabase lists `payroll` in its data browser either way, since a
+schema sync reads `pg_catalog` and no rule here covers the catalogue; with the
+rule in force, clicking the table returns the refusal instead of rows and its
+columns stay unfingerprinted.
 
 **7. Audit.** Metabase was not configured to log anything. A first boot, a
 full schema sync and a complete `./demo.sh` produce, on this lane:
 
 ```
-  99 statements recorded (41 set, 37 select, 10 show, 6 begin, 2 rollback, 2 delete)
-  92 allowed, 7 denied, 38 result sets
-  10034 values masked across 23 result sets (EMAIL_ADDRESS, BR_CPF, IBAN_CODE, column:ssn, US_SSN)
-  verified: none of the 13 seeded values appears in the audit trail
+  86 statements recorded (37 set, 33 select, 6 show, 6 begin, 2 delete, 1 rollback)
+  83 allowed, 3 denied, 34 result sets
+  10009 values masked across 23 result sets (EMAIL_ADDRESS)
+  verified: none of the 4 seeded values appears in the audit trail
 ```
 
 That last line is an assertion too. Recording, in the clear, a value that
-masking removed would have un-masked it. The 13 are read out of
-[`upstream/seed.sql`](upstream/seed.sql) at runtime rather than listed in the
-script, so a row added to the seed is covered without anyone remembering to
-add it here.
+masking removed would have un-masked it. The 4 are the three seeded addresses
+and one generated one, read out of [`upstream/seed.sql`](upstream/seed.sql) at
+runtime rather than listed in the script, so a row added to the seed is
+covered without anyone remembering to add it here. The list tracks the LIVE
+mask rules: `ssn`, `cpf` and `iban` are absent because nothing masks them in
+this build, and a trail that records them is correct rather than leaking.
+Restore a mask rule and widen `PII_COLUMNS` in
+[`sidecar/read-audit.py`](sidecar/read-audit.py) in the same edit.
 
-One of those seven denials is nobody's query. Metabase's sync fingerprints
-`payroll` on its own initiative and the lane refuses it:
-
-```
-  DENY  SELECT SUBSTRING("public"."payroll"."employee", 1, 1234) AS "sub
-        rule=payroll-off-limits  payroll is not exposed to reporting
-```
-
-It carries no `userID` comment because no human asked for it. The other six
-name the analyst.
+All three denials name the analyst, and all three carry the same rule. On a
+build without the cap, a fourth appears that nobody asked for: Metabase's sync
+fingerprints `payroll` on its own initiative, `payroll-off-limits` refuses it,
+and the row carries no `userID` comment because no human ran it. Here the sync
+reads the table and the count is three.
 
 Those counts are from the **first** `./demo.sh` after a fresh `./run.sh`. The
 summary reads a 180-second log window, wide enough to catch the schema sync,
@@ -282,14 +298,15 @@ that cost time to rediscover:
 - **First match wins, in slice order.** Narrow rules first, the lane-wide
   backstop last. Reversed, every refusal carries the generic message.
 - **`access:` narrows a table rule to one direction.** `access: write` on
-  `customers` leaves reads working, masked. Omit it, as `payroll` does, and
-  the table is unreachable in both directions.
+  `customers` leaves reads working. Omit it, as the `payroll` rule does, and
+  the table is unreachable in both directions. Both rules are commented out
+  here, under the one-guardrail cap.
 - **A bare table name matches any schema qualification.** `tables: [payroll]`
   also matches `public.payroll` and `hr.payroll`, and a rule cannot separate
   them. If that distinction is the requirement, it is a `GRANT`.
 - **`require_table_match: true` also denies statements whose relations could
   not be resolved.** That includes `SET`, `SHOW`, `BEGIN` and `ROLLBACK`,
-  which are 59 of the 99 statements above, so it refuses most of what a BI
+  which are 50 of the 86 statements above, so it refuses most of what a BI
   tool sends before it ever runs a query. It reads like the safe setting and
   it is not. To fail closed on unclassifiable statements, use the `operation`
   rule with `unknown` and `other` that is written out and commented in the
@@ -297,7 +314,7 @@ that cost time to rediscover:
 
 Masking has no equivalent. A mask rule has no `tables:` field: it keys on the
 result-set column name or on the detected entity and applies to every result
-set on the lane, so the `iban` rule covers `customers.iban` and
+set on the lane, so the commented `iban` rule would cover `customers.iban` and
 `payroll.bank_iban` alike. One lane, one masking policy.
 
 **The lane is called `metabase`.** It used to set `name: appdb` for the
@@ -372,7 +389,7 @@ concurrently with whatever dashboards are loading. A lane at its cap
 a table that silently never finished syncing. Set the lane at or above the
 pool. This stack sets 64 as headroom; it actually opens 11 connections in
 total across a first boot and a full `./demo.sh`, which you can read off
-`/stats`. The demo's seven denials account for most of that growth: a refusal
+`/stats`. The demo's three denials account for part of that growth: a refusal
 closes the connection and c3p0 opens a fresh one at the next checkout, so a
 lane that refuses often opens more connections than its query rate suggests.
 
@@ -413,9 +430,10 @@ Metabase publishes for Cloud.
     recognises, and alcatraz deliberately rejects fixture-shaped values like
     `123-45-6789`.
 
-  So `SELECT ssn AS whatever FROM customers` returns 1 of 3 rows masked here:
-  the one real-shaped SSN, caught by the entity rule; the two fixtures, missed
-  by both. Enumerate the columns you know about *and* run the detector, and
+  So `SELECT ssn AS whatever FROM customers` returns 1 of 3 rows masked with
+  both rules live: the one real-shaped SSN, caught by the entity rule; the two
+  fixtures, missed by both. In this build it returns 0 of 3, because neither
+  `ssn` rule fits under the one-mask-rule cap. Enumerate the columns you know about *and* run the detector, and
   accept that an analyst with a native SQL editor can reshape a value out of
   both. If that matters more than the editor does, deny the operation instead
   of masking the response: policy runs on the request, where there is nothing
@@ -434,13 +452,15 @@ Metabase publishes for Cloud.
   reads `'Q'` Query and `'P'` Parse; it does not decode `'B'` Bind. A query
   builder filter arrives as `WHERE "customers"."ssn" = $1` with the value in
   a later message, so a rule that denies on statement content never sees it.
-  Verified against this stack: filtering `ssn` for `123-45-6789` in the query
-  builder records the `$1` shape and the literal appears nowhere in the audit
-  trail.
+  Verified against this stack: filtering `customers` on `email` in the query
+  builder records the `$1` shape and the address appears nowhere in the audit
+  trail, even though it is the value the lane masks.
 
   Two consequences, opposite in sign. **Response masking is unaffected**,
-  because that same filtered query came back `***-**-6789`: masking works on
-  the result set and does not care how the request was framed. But a
+  because masking works on the result set and does not care how the request
+  was framed. Filtering `customers` on `email` in the query builder records
+  `WHERE "public"."customers"."email" = $1`, the address appears nowhere in
+  the trail, and the row still comes back `[REDACTED:EMAIL_ADDRESS]`. But a
   `type: pii` rule that refuses a national id typed into the SQL editor will
   not refuse the same id entered into a query-builder filter box.
 

--- a/deploy/docker-compose/metabase-stack/demo.sh
+++ b/deploy/docker-compose/metabase-stack/demo.sh
@@ -62,12 +62,19 @@ h "SQL EDITOR / the path column security cannot cover"
 note "Pro's answer here is to switch the editor off. This one stays on."
 $MB sql 'SELECT id, name, email, ssn, cpf, iban FROM customers ORDER BY id'
 note ""
-note "ssn has a column rule AND an entity rule: each misses what the other"
-note "catches. README 'Known gaps' has the hole they still leave."
+note "One mask rule for the whole process, spent on the EMAIL_ADDRESS entity."
+note "It keys on the value, so email is rewritten under any name a query gives"
+note "it. ssn, cpf and iban arrive as stored: sidecar/config.yaml carries a"
+note "rule for each, commented out, over the limit. ssn wants two of them --"
+note "a column rule for the fixture-shaped values alcatraz declines, an entity"
+note "rule for the aliases a column rule misses -- and README 'Known gaps' has"
+note "the hole that pair still leaves."
 
 # --------------------------------------------------------------------- export
 h "CSV EXPORT / 5,000 rows leaving Metabase entirely"
 note "5,000 outruns maxDecodedRows (1,000), which bounds AUDIT decoding only."
+note "This is what the one mask rule is spent on: actor_email is a column name"
+note "no columns: list predicted, and an entity rule keys on the value."
 
 CSV=$($MB csv 'SELECT id, actor_email, action FROM events ORDER BY id')
 ROWS=$(printf '%s\n' "$CSV" | tail -n +2 | grep -c '.')
@@ -84,15 +91,17 @@ expect "$LEAKED"   0    "0 addresses survived the export"
 # ------------------------------------------------------------------ guardrail
 h "GUARDRAIL / a write from the SQL editor never reaches the database"
 note "Read-only by policy, not by GRANT, so the message is one an operator wrote."
-note "Two rules answer here: customers has an owner named in its own rule,"
-note "events has nobody, so the lane-wide backstop takes it."
+note "One guardrail rule for the whole process, and it is the lane-wide"
+note "backstop, so every table answers with the same sentence. The per-table"
+note "rule that would name the CRM sync as the owner of customers is commented"
+note "out in sidecar/config.yaml, over the limit."
 WRITE=$($MB sql 'DELETE FROM customers WHERE id = 1' 2>&1)
 printf '%s\n' "$WRITE"
-OWNED=$(printf '%s\n' "$WRITE" | grep -c 'written by the CRM sync')
-expect "$OWNED" 1 "the customers rule answered, not the backstop"
+OWNED=$(printf '%s\n' "$WRITE" | grep -c 'read-only')
+expect "$OWNED" 1 "the backstop answered for customers"
 note ""
-note "events has no rule of its own, and this is a delete by effect rather"
-note "than by leading verb:"
+note "events was never going to have a rule of its own, and this is a delete"
+note "by effect rather than by leading verb:"
 BACKSTOP=$($MB sql 'WITH gone AS (DELETE FROM events RETURNING *) SELECT count(*) FROM gone' 2>&1)
 printf '%s\n' "$BACKSTOP"
 GENERIC=$(printf '%s\n' "$BACKSTOP" | grep -c 'read-only')
@@ -114,31 +123,32 @@ PROBE=$($PG_DIRECT -tAc "SELECT count(*) FROM pg_tables WHERE tablename = 'zzz_p
 expect "$PROBE" 0 "no zzz_probe table exists, so the statement never landed"
 
 # ---------------------------------------------------------------- table scope
-h "TABLE SCOPE / a table reporting cannot read at all"
-note "payroll is refused rather than masked. Masking answers who may see a"
-note "value; a table rule answers whether the table can be reached."
+h "TABLE SCOPE / the protection this build cannot afford"
+note "payroll-off-limits is a type: table rule, and it is commented out:"
+note "one guardrail rule for the whole process, held by read-only-lane."
+note "An operation rule cannot deny a SELECT, so reporting reads payroll."
 note ""
-note "It exists and it has rows. Read directly from appdb:"
+note "Read directly from appdb, sidecar bypassed:"
 $PG_DIRECT -c 'SELECT employee, salary_cents, bank_iban FROM payroll;' 2>&1 | head -8
 note ""
-note "Through Metabase, from the SQL editor:"
-DENIED=$($MB sql 'SELECT employee, salary_cents FROM payroll ORDER BY id' 2>&1)
-printf '%s\n' "$DENIED"
-HIT=$(printf '%s\n' "$DENIED" | grep -c 'payroll is not exposed to reporting')
-expect "$HIT" 1 "payroll refused with the message its own rule carries"
+note "And through Metabase, which gets the same rows, bank_iban included,"
+note "because the iban mask rule is over the limit as well:"
+PAYROLL=$($MB sql 'SELECT employee, salary_cents, bank_iban FROM payroll ORDER BY id' 2>&1)
+printf '%s\n' "$PAYROLL"
+READS=$(printf '%s\n' "$PAYROLL" | grep -c 'Lovelace')
+expect "$READS" 1 "payroll is readable in this build, and the demo says so"
 note ""
-note "And through a join, where payroll is not the first table named:"
-JOINED=$($MB sql 'SELECT c.name, p.salary_cents FROM customers c JOIN payroll p ON p.employee = c.name' 2>&1)
-printf '%s\n' "$JOINED"
-HITJ=$(printf '%s\n' "$JOINED" | grep -c 'payroll is not exposed to reporting')
-expect "$HITJ" 1 "the join is refused too, because the rule reads every relation"
+note "That is what the cap costs, and it is the rule to restore first if this"
+note "lane is the one you are copying. With payroll-off-limits in force every"
+note "path is refused with its own message: the SQL editor, a join where"
+note "payroll is not the first table named, and the query builder, because a"
+note "table rule reads every relation a statement touches rather than the"
+note "first one. Metabase lists the table either way, since sync reads"
+note "pg_catalog and no rule covers the catalogue."
 note ""
-note "Metabase still lists the table: sync reads pg_catalog, which no rule"
-note "covers. Clicking it returns the refusal instead of rows."
-BUILDER=$($MB table payroll 5 2>&1)
-printf '%s\n' "$BUILDER"
-HITB=$(printf '%s\n' "$BUILDER" | grep -c 'payroll is not exposed to reporting')
-expect "$HITB" 1 "the query builder path is refused as well"
+note "Masking cannot stand in for it. A mask rule has no tables: field, so"
+note "masking bank_iban would mask customers.iban too, and a salary is not a"
+note "value masking has an answer for."
 
 # ---------------------------------------------------------------------- audit
 h "AUDIT / every statement Metabase ran, including its own"
@@ -156,9 +166,11 @@ cat <<'EOF'
   before Metabase received the bytes. Audited per statement, with no agent
   in Metabase and no plugin.
 
-  Policy is per table: payroll is refused outright, customers refuses
-  writes and names its owner, and every other table falls to the read-only
-  backstop. Masking is not per table; a mask rule covers the whole lane.
+  One guardrail rule and one mask rule for the whole process, so this run
+  shows the lane-wide backstop refusing every write and the EMAIL_ADDRESS
+  entity rule rewriting every address. The per-table rules and the other
+  mask rules are in sidecar/config.yaml, commented, and the beats above
+  print what their absence costs instead of claiming they ran.
 
   The control is on the WAREHOUSE, so the same lane also covers dbt,
   DBeaver, notebooks and psql. Metabase is the client under test here,

--- a/deploy/docker-compose/metabase-stack/sidecar/config.yaml
+++ b/deploy/docker-compose/metabase-stack/sidecar/config.yaml
@@ -9,6 +9,11 @@
 # Validate without starting anything:
 #   cd sidecar/cmd && go run . -validate \
 #     -config ../../deploy/docker-compose/metabase-stack/sidecar/config.yaml
+#
+# This build enforces ONE guardrail rule and ONE data masking rule for the
+# whole process. This file is written to that limit: the rest of what the demo
+# used to enforce is present as commented blocks, each marked "over the
+# limit", so uncommenting is the only step on a build without the limit.
 
 log_level: info
 
@@ -66,29 +71,33 @@ listeners:
       # the lane-wide backstop comes last. Reverse them and every refusal
       # carries the generic message instead of the useful one.
       rules:
-        # ---- per-table ------------------------------------------------
-        # Reporting has no business here at all, in either direction. No
-        # `access`, so this covers reads as well as writes.
+        # ---- over the limit: two per-table rules ----------------------
+        # These are what the ordering note above was written for, and with
+        # the cap in force there is nothing left to order. Restore them on a
+        # build without it and put them back BEFORE the backstop.
         #
-        # Matching is by bare name and a bare name matches any schema
-        # qualification, so this also catches public.payroll and hr.payroll.
-        # If you need one schema and not another, that distinction does not
-        # exist in a table rule; use a GRANT.
-        - name: payroll-off-limits
-          type: table
-          tables: [payroll]
-          message: payroll is not exposed to reporting
-
+        # payroll-off-limits matches by bare name, and a bare name matches any
+        # schema qualification, so it also catches public.payroll and
+        # hr.payroll. If you need one schema and not another, that distinction
+        # does not exist in a table rule; use a GRANT.
+        # - name: payroll-off-limits
+        #   type: table
+        #   tables: [payroll]
+        #   message: payroll is not exposed to reporting
+        #
         # `access: write` narrows the same rule type to one direction, which
         # is how a table gets a refusal that names its owner instead of the
         # generic one below. Reads of customers still pass, masked.
-        - name: customers-is-crm-owned
-          type: table
-          tables: [customers]
-          access: write
-          message: customers is written by the CRM sync; change it there
+        # - name: customers-is-crm-owned
+        #   type: table
+        #   tables: [customers]
+        #   access: write
+        #   message: customers is written by the CRM sync; change it there
 
         # ---- lane-wide backstop ---------------------------------------
+        # The one rule this build allows, and the right one to spend it on:
+        # it catches every table nobody wrote a rule for, the two above
+        # included.
         # Catches every table nobody wrote a rule for, including the one
         # added next month. type: operation is lexer-derived, so it keys on
         # the effect and not the leading verb: a DELETE inside a CTE is
@@ -137,17 +146,21 @@ listeners:
       # needs a guardrail rule and not a mask rule. To mask a column in one
       # table and leave it clear in another, give each table its own lane.
       rules:
+        # The column rule rather than the entity rule, because a column rule
+        # keys on the name in RowDescription and so catches the two
+        # fixture-shaped SSNs alcatraz rejects. What it loses is an alias:
+        # `SELECT ssn AS employee_code` defeats it, and that is the cost of
+        # having one rule instead of the pair.
+        - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
+        # ---- over the limit: the pair and the other entities ------------
         # ssn carries both kinds of rule because they fail in opposite
-        # directions. A column rule keys on the name in RowDescription, so it
-        # catches the two fixture-shaped SSNs alcatraz rejects, and an alias
-        # defeats it. An entity rule keys on the value, so it survives any
+        # directions. An entity rule keys on the value, so it survives any
         # alias, and reshaping the value defeats it. README "Known gaps" has
         # the hole the pair still leaves.
-        - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: ssn-entity, entities: [US_SSN], strategy: partial, keep_last: 4}
+        # - {name: ssn-entity, entities: [US_SSN], strategy: partial, keep_last: 4}
         # Entity rules for the rest: the same value turns up under names
         # nobody enumerates in advance (email, actor_email, whatever a join
         # calls them).
-        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
-        - {name: cpf, entities: [BR_CPF], strategy: redact}
-        - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
+        # - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+        # - {name: cpf, entities: [BR_CPF], strategy: redact}
+        # - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}

--- a/deploy/docker-compose/metabase-stack/sidecar/config.yaml
+++ b/deploy/docker-compose/metabase-stack/sidecar/config.yaml
@@ -76,6 +76,15 @@ listeners:
         # the cap in force there is nothing left to order. Restore them on a
         # build without it and put them back BEFORE the backstop.
         #
+        # Two things follow from their absence, and ./demo.sh shows both
+        # rather than pretending otherwise. A write to customers is refused
+        # by the backstop's generic sentence, not by one naming the CRM sync.
+        # And payroll is READABLE: an operation rule cannot deny a SELECT, so
+        # reporting reads salaries and bank_iban until payroll-off-limits is
+        # the rule this process spends its budget on. Masking is no
+        # substitute; a mask rule has no `tables:` field, so masking iban
+        # would cover customers.iban too.
+        #
         # payroll-off-limits matches by bare name, and a bare name matches any
         # schema qualification, so it also catches public.payroll and
         # hr.payroll. If you need one schema and not another, that distinction
@@ -117,7 +126,7 @@ listeners:
         # `require_table_match: true` on a table rule ALSO denies statements
         # whose relations could not be resolved. It reads like the safe
         # choice and it would break this lane: SET, SHOW, BEGIN and ROLLBACK
-        # carry no relations, and they are 59 of the 99 statements Metabase
+        # carry no relations, and they are 50 of the 86 statements Metabase
         # sends here. Reach for the operation rule below instead, which
         # denies unclassifiable statements without touching session setup.
 
@@ -146,21 +155,31 @@ listeners:
       # needs a guardrail rule and not a mask rule. To mask a column in one
       # table and leave it clear in another, give each table its own lane.
       rules:
-        # The column rule rather than the entity rule, because a column rule
-        # keys on the name in RowDescription and so catches the two
-        # fixture-shaped SSNs alcatraz rejects. What it loses is an alias:
-        # `SELECT ssn AS employee_code` defeats it, and that is the cost of
-        # having one rule instead of the pair.
-        - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        # ---- over the limit: the pair and the other entities ------------
-        # ssn carries both kinds of rule because they fail in opposite
-        # directions. An entity rule keys on the value, so it survives any
-        # alias, and reshaping the value defeats it. README "Known gaps" has
-        # the hole the pair still leaves.
+        # The entity rule for EMAIL_ADDRESS is the one rule this build allows,
+        # and the 5,000-row CSV export is what it is spent on. That export
+        # reads events.actor_email, a column name no `columns:` list here
+        # predicted, and an entity rule keys on the VALUE, so it covers
+        # customers.email, events.actor_email and whatever a join calls them
+        # without anyone enumerating names in advance. It is also the only
+        # rule that can carry the claim this stack is built to make: masking
+        # does not stop at maxDecodedRows.
+        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+        # ---- over the limit: the ssn pair and the other entities --------
+        # ssn wants BOTH kinds of rule, because they fail in opposite
+        # directions. A column rule keys on the name in RowDescription, so it
+        # catches the two fixture-shaped SSNs alcatraz rejects (123-45-6789,
+        # 987-65-4321) and is defeated by `SELECT ssn AS employee_code`. An
+        # entity rule keys on the value, so it survives any alias and is
+        # defeated by reshaping the value. README "Known gaps" has the hole
+        # the pair still leaves.
+        #
+        # With one rule live, ssn, cpf and iban reach Metabase as stored.
+        # ./demo.sh prints them that way beside the redacted email rather than
+        # claiming otherwise; swap one of these for `emails` above and that
+        # column changes in the SQL editor beat, while the CSV export beat
+        # stops asserting anything, because events carries no other maskable
+        # column.
+        # - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
         # - {name: ssn-entity, entities: [US_SSN], strategy: partial, keep_last: 4}
-        # Entity rules for the rest: the same value turns up under names
-        # nobody enumerates in advance (email, actor_email, whatever a join
-        # calls them).
-        # - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
         # - {name: cpf, entities: [BR_CPF], strategy: redact}
         # - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}

--- a/deploy/docker-compose/metabase-stack/sidecar/read-audit.py
+++ b/deploy/docker-compose/metabase-stack/sidecar/read-audit.py
@@ -23,9 +23,16 @@ from pathlib import Path
 # this check exists to catch exactly the value nobody remembered.
 SEED = Path(__file__).resolve().parent.parent / "upstream" / "seed.sql"
 
-# Columns ../sidecar/config.yaml masks, by name (ssn) or by the entity
-# their values carry (EMAIL_ADDRESS, US_SSN, BR_CPF, IBAN_CODE).
-PII_COLUMNS = {"email", "ssn", "cpf", "iban", "bank_iban", "actor_email"}
+# Columns ../sidecar/config.yaml masks. One mask rule for the whole process,
+# spent on the EMAIL_ADDRESS entity, so these two columns and nothing else.
+#
+# ssn, cpf, iban and bank_iban are NOT listed, and leaving them in would be a
+# check for a property this build does not have: their rules are commented out
+# over the limit, the values reach Metabase as stored, and the audit trail
+# recording them is then correct rather than a leak. Restore a mask rule and
+# add its columns back here in the same edit; the check is only worth its
+# runtime while the two lists agree.
+PII_COLUMNS = {"email", "actor_email"}
 
 # events is filled by a SELECT rather than by literal tuples, so the parser
 # below never sees its addresses. One of the generated series stands in for all

--- a/deploy/docker-compose/metabase-stack/upstream/seed.sql
+++ b/deploy/docker-compose/metabase-stack/upstream/seed.sql
@@ -23,15 +23,21 @@ CREATE TABLE customers (
 -- The three SSNs disagree on purpose. 555-12-3456 is ordinary. 123-45-6789
 -- and 987-65-4321 are the sequential and descending runs every fixture uses,
 -- and alcatraz rejects both as placeholders, so an entity rule alone would
--- leave two of the three in the clear. Hence the column rule beside it in
--- ../sidecar/config.yaml.
+-- leave two of the three in the clear. That is the argument for the column
+-- rule in ../sidecar/config.yaml, which is commented out there: one mask rule
+-- for the whole process, spent on EMAIL_ADDRESS. These three arrive at
+-- Metabase as stored, and the fixtures are kept so the disagreement is
+-- visible the moment the pair is restored.
 INSERT INTO customers (name, email, ssn, cpf, iban) VALUES
     ('Ada Lovelace', 'ada@example.com',   '123-45-6789', '111.444.777-35', 'GB82WEST12345698765432'),
     ('Grace Hopper', 'grace@example.com', '987-65-4321', '529.982.247-25', 'DE89370400440532013000'),
     ('Alan Turing',  'alan@example.com',  '555-12-3456', '390.533.447-05', 'FR1420041010050500013M02606');
 
--- One maskable value per row, so ./demo.sh can assert exactly: 5,000 rows in,
--- 5,000 redactions out, zero surviving '@'.
+-- One maskable value per row, and it is the value the process's single mask
+-- rule covers, so ./demo.sh can assert exactly: 5,000 rows in, 5,000
+-- redactions out, zero surviving '@'. actor_email rather than email on
+-- purpose: no `columns:` list predicts that name, so the export only passes
+-- with an ENTITY rule, which is why the one rule is one.
 CREATE TABLE events (
     id           serial PRIMARY KEY,
     occurred_at  timestamp NOT NULL,

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -210,6 +210,33 @@ and the extension picks the parser: `.yaml` and `.yml` go through the nested
 `config/yaml` module, anything else is read as JSON. Decoding is strict, so a
 mistyped key fails the startup instead of silently disabling a control.
 
+### What this build limits
+
+One guardrail rule and one data masking rule, for the whole process. The count
+is what the file AUTHORS, not what each lane resolves: a rule in the top-level
+`guardrails` block is one rule however many listeners inherit it, and a lane
+that overrides `mask.rules` with `[]` spends nothing. `ai_analysis` rules are
+counted apart and are not capped, because their controls are the trigger and
+`analyzer.max_calls` rather than a number of rules.
+
+A config over either cap is refused at startup, naming every block that
+authored rules and how many each holds, so the message reads as a map of what
+to merge:
+
+```
+hoop-inspect: invalid config:
+  - 2 guardrail rules are configured (guardrails: 1, appdb: 1) and this build
+    enforces at most 1; merge them into one rule, or contact our support at
+    https://help.hoop.dev. ai_analysis rules are counted separately and are
+    not limited
+```
+
+The numbers are constants in `sidecar/daemon/limits.go` rather than config
+keys, because a cap the file it limits can raise is documentation. They mirror
+the control plane's free tier, which caps the same two things per
+organization. `-validate` prints them, `/config` serves them under `limits`,
+and lifting them is a build without that file.
+
 ### Deprecated fields
 
 0.1.0 renamed six keys, removed one, and reversed two defaults. Both
@@ -341,6 +368,14 @@ listeners:
           message: upstream failure suppressed by policy
 ```
 
+That file is over both caps and this build refuses it as written: four
+guardrail rules and four mask rules, where one of each is allowed. It stays
+whole because a config holding one rule per section cannot show a listener
+overriding a default at all, and inheritance is what the section is teaching.
+The stack config in `deploy/docker-compose/envoy-stack/sidecar/config.yaml` is
+the version that loads: same shape, the rest commented out and marked. See
+[What this build limits](#what-this-build-limits).
+
 Rule types and what each one matches are in [Guardrails and
 OPA](#guardrails-and-opa); masking strategies and the entity-versus-column
 choice are in [Masking and PII](#masking-and-pii).
@@ -378,8 +413,9 @@ cd cmd && go build -o hoop-inspect . && \
 
 ```
 config OK: 2 listener(s)
-  appdb            postgres  enforcing 2 rule(s) + masking
-  httpbin          http      enforcing 4 rule(s) + masking
+  limits: 1 guardrail rule(s), 1 data masking rule(s)
+  appdb            postgres  enforcing 1 rule(s) + masking
+  httpbin          http      enforcing 1 rule(s) + masking
 ```
 
 Each line is the RESOLVED lane, so the counts include what it inherited. A lane
@@ -398,6 +434,9 @@ Validation builds every lane, so it catches what a syntax check cannot, and it
 reports every problem in one run rather than one per restart. It refuses these
 outright:
 
+- More guardrail rules or more mask rules than this build allows, naming every
+  block that authored one. See [What this build
+  limits](#what-this-build-limits).
 - `mask.rules` on a protocol whose codec can carry neither masking mechanism,
   naming the lane. This check used to sit behind `mask.enabled`, so a lane
   omitting the flag skipped it and loaded rules that could never fire.
@@ -429,16 +468,19 @@ curl -s localhost:19000/config | python3 -m json.tool
 ```json
 {"lanes": [
   {"name": "appdb", "protocol": "postgres", "enforcing": true,
-   "rules": ["no-destructive-sql", "no-cpf-in-query"], "masking": true},
+   "rules": ["no-cpf-in-query"], "masking": true},
   {"name": "httpbin", "protocol": "http", "enforcing": true,
-   "rules": ["no-admin-api", "no-internal-ids", "no-upstream-5xx",
-             "no-cpf-in-query"], "masking": true}
-]}
+   "rules": ["no-cpf-in-query"], "masking": true}
+ ],
+ "limits": {"guardrail_rules": 1, "mask_rules": 1}}
 ```
 
-Both lanes inherited `no-cpf-in-query`, and neither inherited the other's
-rules. Rule names only: a `pattern_regex` can encode business logic, and this
-endpoint already sits beside a read interface to the audit trail.
+Both lanes resolved the same rule, because the process's one guardrail rule is
+a top-level default and neither lane authors its own. Rule names only: a
+`pattern_regex` can encode business logic, and this endpoint already sits
+beside a read interface to the audit trail. `limits` is what this build
+refuses to exceed, served here so an operator asking why a second rule will
+not load reads the answer from the endpoint that told them what did.
 
 ### Sharing a rule block between lanes
 

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -764,6 +764,14 @@ func (c *Config) Validate() error {
 	// Detection is always available now, so the analyzer's redacting send
 	// modes always have a scanner to use.
 	problems = append(problems, c.Analyzer.validate(true)...)
+
+	// The feature caps are checked here and again in buildLanes, for a
+	// sharper version of the same reason: Run and the exported Validate
+	// never call this function at all, so a cap that lived only here would
+	// be skipped by every caller that builds a Config in Go rather than
+	// loading one from a file.
+	problems = append(problems, c.checkLimits()...)
+
 	seen := map[string]bool{}
 	for i, l := range c.Listeners {
 		name := l.displayName(i)

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -197,6 +197,7 @@ func ReportDeprecations(w io.Writer, notes []string) {
 // one config.
 func PrintLanes(w io.Writer, lanes []LaneInfo) {
 	fmt.Fprintln(w, "config OK:", len(lanes), "listener(s)")
+	fmt.Fprintf(w, "  %s\n", LimitsSummary())
 	for _, ln := range lanes {
 		fmt.Fprintf(w, "  %-16s %-9s %s\n", ln.Name, ln.Protocol, ln.Summary())
 		for _, n := range ln.Notes {
@@ -323,6 +324,9 @@ func Run(cfg *Config, det Plugin) error {
 		return err
 	}
 	log := newLogger(cfg.LogLevel)
+	log.Info("rule limits",
+		"guardrail_rules", maxGuardrailRules,
+		"mask_rules", maxMaskRules)
 
 	ac, err := buildAudit(cfg.Audit)
 	if err != nil {
@@ -498,6 +502,12 @@ type lane struct {
 func buildLanes(cfg *Config, det Plugin, ac *analyzerDeps) ([]lane, error) {
 	out := make([]lane, 0, len(cfg.Listeners))
 	var problems []string
+
+	// Here rather than only in (*Config).Validate because this is the one
+	// function Main, Run and the exported Validate all reach. An embedder
+	// assembling a Config in Go and calling Run never passes through the
+	// file validator, and a cap with a documented way around it is not one.
+	problems = append(problems, cfg.checkLimits()...)
 
 	for i, lc := range cfg.Listeners {
 		name := lc.displayName(i)
@@ -892,6 +902,13 @@ func serveAdmin(
 			// control plane can warn its own developers without reading
 			// prose. These keys still carry correct values.
 			"deprecated_fields": []string{"enforcing", "rules", "opa", "masking"},
+			// What this build refuses to exceed. An operator asking why a
+			// second rule will not load gets the answer from the same
+			// endpoint that tells them what did load.
+			"limits": map[string]int{
+				"guardrail_rules": maxGuardrailRules,
+				"mask_rules":      maxMaskRules,
+			},
 		}
 		// The analyzer view names the provider, the model and the HOST it
 		// talks to — never the path, never a query string, and never the

--- a/sidecar/daemon/limits.go
+++ b/sidecar/daemon/limits.go
@@ -1,0 +1,209 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hoophq/hoop/sidecar/policy"
+)
+
+// The rule counts this build enforces.
+//
+// They are CONSTANTS, and the distinction from a config field is the whole
+// design. A limit an operator can raise in the same file it limits is not a
+// limit, it is documentation with extra steps: the person the cap applies to
+// is exactly the person holding the editor. So the number lives in the
+// binary, and raising it means forking and rebuilding.
+//
+// That is not a security boundary and must not be described as one. The
+// source is public; anyone who wants these rules gone can delete this file
+// and run `go build`. What the cap does is mark the edge of the free tier at
+// the moment an operator crosses it, in the place they are already reading —
+// startup output — rather than after a support conversation. Treat it the
+// same way as the require_review refusal in analyzer/evaluator.go: a
+// capability this build declines to provide, refused by name, with the
+// alternative in the message.
+//
+// They mirror the control-plane free tier, which caps the same two things at
+// the same number per organization (gateway/api/guardrails/guardrails.go and
+// gateway/api/datamasking/datamasking.go). One product, one limit, two
+// engines.
+//
+// There is no way to lift them in this build. Adding one — a signed license
+// file, most likely, reusing the "guardrails" and "data-masking" feature keys
+// that common/license already defines — is a change to this file, not a
+// config field.
+const (
+	maxGuardrailRules = 1
+	maxMaskRules      = 1
+)
+
+// LimitsSummary renders the caps as the one line -validate prints.
+//
+// Exported because both entry points report a validated config and neither
+// should learn the numbers by hand: sidecar/cmd through Main, and the CLI
+// through `hoop start sidecar --validate`.
+func LimitsSummary() string {
+	return fmt.Sprintf("limits: %d guardrail rule(s), %d data masking rule(s)",
+		maxGuardrailRules, maxMaskRules)
+}
+
+// ruleSite is one place in the config that authors rules, named the way the
+// operator wrote it.
+//
+// The count alone is useless in a file with a defaults block and five lanes:
+// "6 rules, at most 1" sends someone reading from the top, and the top is
+// usually the one rule they meant to keep. Carrying the per-site breakdown
+// costs a slice and turns the message into a map of what to merge.
+type ruleSite struct {
+	name  string
+	count int
+}
+
+// checkLimits counts what the config AUTHORS and refuses a config that
+// exceeds this build's caps.
+//
+// Authored, not resolved, and the difference is not cosmetic. resolve()
+// concatenates the top-level guardrails.rules into every lane, so counting
+// resolved lanes reports one global rule N times and refuses a two-lane
+// config that holds exactly one rule. Counting what is written also gives an
+// operator a number they can find in their own file.
+//
+// The cap is therefore per PROCESS rather than per lane, which matches the
+// control plane's per-organization cap. A lane-scoped cap would let one
+// process hold one rule per listener, and a config with eight lanes is not
+// the free tier by any reading. Running eight processes still is, and nothing
+// here pretends otherwise.
+//
+// Returns a problem per violation rather than an error, so it composes with
+// the collecting validators either side of it: every problem in one run,
+// never one error per restart.
+func (c *Config) checkLimits() []string {
+	var problems []string
+
+	if sites, total := c.guardrailSites(); total > maxGuardrailRules {
+		problems = append(problems, fmt.Sprintf(
+			"%d guardrail rules are configured (%s) and this build enforces at most %d; "+
+				"merge them into one rule, or contact our support at https://help.hoop.dev. "+
+				"ai_analysis rules are counted separately and are not limited",
+			total, renderSites(sites), maxGuardrailRules))
+	}
+
+	sites, total, errs := c.maskSites()
+	problems = append(problems, errs...)
+	if total > maxMaskRules {
+		problems = append(problems, fmt.Sprintf(
+			"%d data masking rules are configured (%s) and this build enforces at most %d; "+
+				"one rule may name several columns or one entity, so two rules can often "+
+				"become one. Contact our support at https://help.hoop.dev",
+			total, renderSites(sites), maxMaskRules))
+	}
+
+	return problems
+}
+
+// guardrailSites counts the non-ai_analysis rules each guardrails block
+// authors.
+//
+// Only the canonical `guardrails` spelling is read. The deprecated `policy`
+// block folds onto it in normalize, which every loader runs before anything
+// validates, so counting both would double every rule written the old way.
+//
+// ai_analysis rules are excluded because they are not guardrails: they leave
+// the process, they cost money per statement, and their own controls are the
+// trigger and the max_calls budget rather than a count. Capping them here
+// would also cap them by accident, since both kinds share one slice.
+func (c *Config) guardrailSites() ([]ruleSite, int) {
+	var sites []ruleSite
+	total := 0
+
+	add := func(name string, gc *GuardrailsConfig) {
+		if gc == nil {
+			return
+		}
+		n := 0
+		for _, r := range gc.Rules {
+			if r.Type != policy.MatchAIAnalysis {
+				n++
+			}
+		}
+		if n > 0 {
+			sites = append(sites, ruleSite{name, n})
+			total += n
+		}
+	}
+
+	add("guardrails", c.Guardrails)
+	for i, lc := range c.Listeners {
+		add(lc.displayName(i), lc.Guardrails)
+	}
+	return sites, total
+}
+
+// maskSites counts the rules each mask block authors, and reports any block
+// whose rules are not a JSON array.
+//
+// The decode is the only way to get a count: MaskConfig.Rules is raw JSON so
+// the daemon does not link a detector, and its shape belongs to the plugin.
+// Reporting a malformed block here rather than leaving it to BuildMasker
+// covers the case the plugin never sees — a broken top-level block that every
+// lane overrides is decoded by nothing and would load as a silent zero.
+func (c *Config) maskSites() (sites []ruleSite, total int, problems []string) {
+	// site names the block in the breakdown, where names it in an error.
+	// They differ because the breakdown reads as a list of places to merge
+	// ("mask: 5, appdb: 4") and the error reads as a path to a typo
+	// ("appdb: mask.rules: ...").
+	add := func(site, where string, mc *MaskConfig) {
+		if mc == nil {
+			return
+		}
+		n, err := countMaskRules(mc.Rules)
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("%s: %v", where, err))
+			return
+		}
+		if n > 0 {
+			sites = append(sites, ruleSite{site, n})
+			total += n
+		}
+	}
+
+	add("mask", "mask.rules", c.Mask)
+	for i, lc := range c.Listeners {
+		name := lc.displayName(i)
+		add(name, name+": mask.rules", lc.Mask)
+	}
+	return sites, total, problems
+}
+
+// countMaskRules reports how many rules a raw mask block holds.
+//
+// It exists because `len(mc.Rules) == 0` measures BYTES, not rules:
+// MaskConfig.Rules is a json.RawMessage, so a list holding three rules and a
+// list holding one are both "non-empty" to a length test. hasRules answers
+// on/off from the same bytes; this answers how many, which is what a cap
+// needs.
+//
+// Decoding into []json.RawMessage rather than the plugin's rule type keeps
+// the daemon ignorant of the shape, which is the reason the field is raw in
+// the first place. Element-level validation stays with the plugin.
+func countMaskRules(raw json.RawMessage) (int, error) {
+	if len(raw) == 0 {
+		return 0, nil
+	}
+	var rules []json.RawMessage
+	if err := json.Unmarshal(raw, &rules); err != nil {
+		return 0, fmt.Errorf("not a JSON array of rules: %w", err)
+	}
+	return len(rules), nil
+}
+
+// renderSites turns the per-block counts into "guardrails: 1, appdb: 3".
+func renderSites(sites []ruleSite) string {
+	parts := make([]string, 0, len(sites))
+	for _, s := range sites {
+		parts = append(parts, fmt.Sprintf("%s: %d", s.name, s.count))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/sidecar/daemon/limits_test.go
+++ b/sidecar/daemon/limits_test.go
@@ -1,0 +1,223 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/policy"
+)
+
+// limitsLane is a minimal valid listener, so a limits test fails on the limit
+// it is about and not on a missing upstream.
+func limitsLane(name, listen string) ListenerConfig {
+	return ListenerConfig{
+		Name: name, Protocol: "postgres", Listen: listen, Upstream: "h:5432",
+	}
+}
+
+func maskRule(entity string) []byte {
+	return []byte(`[{"name":"r","entity":"` + entity + `","strategy":"redact"}]`)
+}
+
+// The cap fires on the second guardrail rule, and the message says where both
+// of them are. A bare count sends an operator reading a config from the top,
+// which is usually the rule they meant to keep.
+func TestSecondGuardrailRuleIsRefused(t *testing.T) {
+	lane := limitsLane("appdb", ":1")
+	lane.Guardrails = &GuardrailsConfig{Rules: []policy.Rule{rule("no-drop-on-appdb")}}
+	cfg := &Config{
+		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("no-drop")}},
+		Listeners:  []ListenerConfig{lane},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("two guardrail rules were accepted")
+	}
+	for _, want := range []string{"2 guardrail rules", "guardrails: 1", "appdb: 1", "at most 1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("message does not contain %q: %v", want, err)
+		}
+	}
+}
+
+// The deprecated `policy` block folds onto `guardrails` before anything
+// validates, so the cap counts the same rule once however it was spelled. A
+// counter reading both fields would refuse a one-rule config written the old
+// way.
+func TestDeprecatedPolicySpellingCountsOnce(t *testing.T) {
+	p := writeConfig(t, `{
+      "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
+      "policy": {"rules": [{"name":"no-drop","type":"operation","operations":["drop"]}]}
+    }`)
+
+	if _, err := LoadConfig(p); err != nil {
+		t.Fatalf("one rule in the deprecated spelling was refused: %v", err)
+	}
+}
+
+// One rule is one rule however many lanes inherit it. resolve() copies the
+// defaults into every lane, so a cap counting RESOLVED lanes would report
+// this config as two rules and refuse a free-tier config that holds one.
+func TestOneGlobalRuleAcrossTwoLanesIsAccepted(t *testing.T) {
+	cfg := &Config{
+		Guardrails: &GuardrailsConfig{Mode: ModeEnforce, Rules: []policy.Rule{rule("no-drop")}},
+		Listeners:  []ListenerConfig{limitsLane("a", ":1"), limitsLane("b", ":2")},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("one global rule inherited by two lanes was refused: %v", err)
+	}
+}
+
+// ai_analysis rules share a slice with guardrails and are not guardrails.
+// They leave the process and cost money per statement, and their controls are
+// the trigger and the max_calls budget, not a count. Capping the slice would
+// cap them by accident.
+func TestAIAnalysisRulesAreNotCountedAsGuardrails(t *testing.T) {
+	cfg := &Config{
+		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{
+			rule("no-drop"), aiRule("risky-1"), aiRule("risky-2"),
+		}},
+		Listeners: []ListenerConfig{limitsLane("appdb", ":1")},
+	}
+
+	if problems := cfg.checkLimits(); len(problems) != 0 {
+		t.Errorf("ai_analysis rules counted against the guardrail cap: %v", problems)
+	}
+}
+
+// Masking is capped the same way and across the same scope. mask.rules
+// REPLACES rather than concatenates, so a global block and a lane block are
+// two authored rules even though no single byte path sees both.
+func TestSecondMaskRuleIsRefused(t *testing.T) {
+	lane := limitsLane("appdb", ":1")
+	lane.Mask = &MaskConfig{Rules: maskRule("US_SSN")}
+	cfg := &Config{
+		Mask:      &MaskConfig{Rules: maskRule("EMAIL_ADDRESS")},
+		Listeners: []ListenerConfig{lane},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("two data masking rules were accepted")
+	}
+	for _, want := range []string{"2 data masking rules", "mask: 1", "appdb: 1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("message does not contain %q: %v", want, err)
+		}
+	}
+}
+
+// `rules: []` is how a lane switches inherited masking off, so it authors
+// nothing and must not spend the one rule this build allows. The count is a
+// decode rather than len() on the raw JSON, which those two bytes would pass.
+func TestLaneOptingOutOfMaskingCostsNothing(t *testing.T) {
+	lane := limitsLane("appdb", ":1")
+	lane.Mask = &MaskConfig{Rules: []byte(`[]`)}
+	cfg := &Config{
+		Mask:      &MaskConfig{Rules: maskRule("EMAIL_ADDRESS")},
+		Listeners: []ListenerConfig{lane},
+	}
+
+	if problems := cfg.checkLimits(); len(problems) != 0 {
+		t.Errorf("an empty override was counted as a rule: %v", problems)
+	}
+}
+
+// A mask block that is not an array is named once, against the block that
+// authored it. Reporting it per inheriting lane would print one typo as many
+// times as there are listeners.
+func TestMalformedMaskRulesAreReportedOnceAtTheirSite(t *testing.T) {
+	cfg := &Config{
+		Mask:      &MaskConfig{Rules: []byte(`{"entity":"US_SSN"}`)},
+		Listeners: []ListenerConfig{limitsLane("a", ":1"), limitsLane("b", ":2")},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("a mask block that is not an array was accepted")
+	}
+	if n := strings.Count(err.Error(), "mask.rules: not a JSON array"); n != 1 {
+		t.Errorf("reported %d times, want 1: %v", n, err)
+	}
+}
+
+// Run and the exported Validate never call (*Config).Validate, so a cap that
+// lived only in the file validator would be skipped by every caller that
+// assembles a Config in Go. buildLanes is the one function all of them reach.
+func TestLimitsHoldWhenTheFileValidatorIsSkipped(t *testing.T) {
+	lane := limitsLane("appdb", ":1")
+	lane.Guardrails = &GuardrailsConfig{Rules: []policy.Rule{rule("second")}}
+	cfg := &Config{
+		Guardrails: &GuardrailsConfig{Mode: ModeEnforce, Rules: []policy.Rule{rule("first")}},
+		Listeners:  []ListenerConfig{lane},
+	}
+
+	if _, err := buildLanes(cfg, nil, nil); err == nil {
+		t.Fatal("buildLanes accepted a config over the guardrail cap")
+	} else if !strings.Contains(err.Error(), "guardrail rules") {
+		t.Errorf("error does not name the cap: %v", err)
+	}
+}
+
+// Every problem in one run: a config over both caps reports both, and still
+// reports the unrelated lane errors beside them.
+func TestLimitsAreReportedWithEveryOtherProblem(t *testing.T) {
+	lane := limitsLane("appdb", ":1")
+	lane.Guardrails = &GuardrailsConfig{Rules: []policy.Rule{rule("second")}}
+	lane.Mask = &MaskConfig{Rules: maskRule("US_SSN")}
+	cfg := &Config{
+		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("first")}},
+		Mask:       &MaskConfig{Rules: maskRule("EMAIL_ADDRESS")},
+		Listeners:  []ListenerConfig{lane, {Name: "broken"}},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("an invalid config was accepted")
+	}
+	for _, want := range []string{"guardrail rules", "data masking rules", "broken: no protocol"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("message does not contain %q: %v", want, err)
+		}
+	}
+}
+
+// The caps are reported, not just enforced. An operator who has to discover a
+// limit by hitting it learns it in the worst place.
+func TestLimitsSummaryNamesBothCaps(t *testing.T) {
+	got := LimitsSummary()
+	for _, want := range []string{"1 guardrail rule(s)", "1 data masking rule(s)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("LimitsSummary() = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestCountMaskRules(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    int
+		wantErr bool
+	}{
+		{"absent", "", 0, false},
+		{"null", "null", 0, false},
+		{"empty array", "[]", 0, false},
+		{"one rule", `[{"name":"a"}]`, 1, false},
+		{"two rules", `[{"name":"a"},{"name":"b"}]`, 2, false},
+		{"object not array", `{"name":"a"}`, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := countMaskRules([]byte(tc.raw))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("count = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/sidecar/scripts/dev/01-validate.sh
+++ b/sidecar/scripts/dev/01-validate.sh
@@ -11,6 +11,10 @@
 # fires is the failure this whole config surface exists to prevent. Each
 # negative case below is a config that would otherwise look fine.
 #
+# The last two are the free-tier caps rather than a misconfiguration: this
+# build enforces one guardrail rule and one data masking rule per process, and
+# a cap nobody tests is a cap that stops firing.
+#
 # Usage:
 #   HOOP_PROJECT=my-project ./01-validate.sh
 #
@@ -156,6 +160,19 @@ elif edit == "bad-provider":
     s = s.replace("  provider: vertex", "  provider: bedrock")
 elif edit == "auth-header":
     s = s.replace("      headers: [Content-Type]", "      headers: [Content-Type, Authorization]")
+elif edit == "second-guardrail":
+    s = s.replace("        - name: no-drops\n",
+                  "        - name: no-deletes\n"
+                  "          type: operation\n"
+                  "          operations: [delete]\n"
+                  "          message: deletes are not permitted on appdb\n"
+                  "        - name: no-drops\n")
+elif edit == "two-mask-rules":
+    s = s.replace("guardrails:\n  mode: enforce\n",
+                  "guardrails:\n  mode: enforce\n\n"
+                  "mask:\n  rules:\n"
+                  "    - {name: ssn, entities: [US_SSN], strategy: redact}\n"
+                  "    - {name: cpf, entities: [BR_CPF], strategy: redact}\n")
 open(dst, "w").write(s)
 PY
     local got
@@ -176,6 +193,8 @@ refuse "negative max_calls"                     "max_calls is negative"     nega
 refuse "require_review, which this build cannot honor" "require_review"     review
 refuse "a provider the binary does not link"    "not linked"                bad-provider
 refuse "Authorization in the header allowlist"  "may not be exposed"        auth-header
+refuse "a second guardrail rule"                "2 guardrail rules"         second-guardrail
+refuse "a second data masking rule"             "2 data masking rules"      two-mask-rules
 rm -f "$WORKDIR/bad.yaml"
 
 [[ $FAILED -eq 0 ]] || die "a refusal did not fire. The config surface is not doing its job."


### PR DESCRIPTION

## 📝 Description


   Caps the standalone relay at **one guardrail rule and one data masking rule per process**, enforced from constants in the binary rather than fields in
 the config file. A limit an operator can raise in the same file it limits is not a limit.

   No license, no build tag, no new config surface. The refusal follows the existing `require_review` pattern: refused by name at startup, alongside
 every other config problem in one run, with the alternative in the message.


   **Upgrade impact:** a relay running more than one rule of either kind will refuse to start after this change. The installed base is effectively this
 repo (version is `0.1.0`, built only by a compose Dockerfile, no release target and no CI job builds it), which is why this is labelled `minor` rather
 than `major`.

   ## 🚀 Type of Change

   - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
   - [x] ✨ New feature (non-breaking change which adds functionality)
   - [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
   - [ ] 📚 Documentation update
   - [ ] 🎨 Style/UI update
   - [ ] ♻️ Code refactor
   - [ ] ⚡ Performance improvement
   - [ ] ✅ Test update
   - [ ] 🔧 Build configuration change
   - [ ] 🧹 Chore

   ## 📋 Changes Made

   - **`sidecar/daemon/limits.go`** (new): `maxGuardrailRules = 1`, `maxMaskRules = 1`, and `checkLimits`, which counts what the config **authors**
 rather than what a lane resolves to.
   - Enforced in **both** `(*Config).Validate` and `buildLanes`. `Run` and the exported `Validate` never call the file validator, so a check placed only
 there is skipped by any caller that builds a `Config` in Go.
   - **Bug fix:** `if len(mc.Rules) == 0` measured *bytes* of a `json.RawMessage`. `rules: []` is two bytes, so it passed, `BuildMasker` returned `nil,
 nil`, and the lane came up logging `masking=true` while rewriting nothing. Counting forces a decode, which closes it.
   - Caps reported in three places: `-validate` on both entry points (`sidecar/cmd` and `hoop start sidecar`), `GET :19000/config` as a `limits` object,
 and one startup log line.
   - Both compose configs were over the cap (`envoy-stack` 5+9, `metabase-stack` 3+5) and are trimmed to their single best rule, with the surplus kept as
 commented blocks marked `over the limit`, matching the idiom those files already use for the analyzer and OPA.
   - `01-validate.sh`: two refusal cases, because a cap nobody tests is a cap that stops firing.
## 📋 Changes Made

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->
<!-- Please also list any relevant details for your test configuration -->

### Test Configuration:
- **Browser(s)**: 
- **OS**:

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## ✅ Checklist

<!-- Please check off the following items by replacing [ ] with [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

<!-- Add any additional notes, concerns, or discussion points here -->
<!-- Is there anything specific you'd like reviewers to focus on? -->

---

<!-- Thank you for contributing to our project! 🙏 --> 
