### PR TITLE
fix(gateway): refresh expired IdP token instead of ending session

### DIFF
--- a/gateway/broker/session.go
+++ b/gateway/broker/session.go
@@ -81,6 +81,10 @@ func (s *Session) ReadFromAgent() (int, []byte, error) {
 	return l, message, err
 }
 
+func (s *Session) Context() context.Context {
+	return s.ctx
+}
+
 func (s *Session) Close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/gateway/rdp/irongw.go
+++ b/gateway/rdp/irongw.go
@@ -1,7 +1,6 @@
 package rdp
 
 import (
-	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -340,7 +339,7 @@ func (r *IronRDPGateway) handle(c *gin.Context) {
 	}
 
 	if !isMachineCredential {
-		usertoken.PollingUserToken(context.Background(), func(cause error) {
+		usertoken.PollingUserToken(session.Context(), func(cause error) {
 			session.Close()
 		}, tokenVerifier, dba.UserSubject)
 	}

--- a/gateway/rdp/rdp.go
+++ b/gateway/rdp/rdp.go
@@ -209,7 +209,7 @@ func (r *RDPProxy) handleRDPClient(conn net.Conn, peerAddr net.Addr) {
 	}
 
 	if !isMachineCredential {
-		usertoken.PollingUserToken(context.Background(), func(cause error) {
+		usertoken.PollingUserToken(session.Context(), func(cause error) {
 			session.Close()
 		}, tokenVerifier, dba.UserSubject)
 	}

--- a/gateway/transport/client.go
+++ b/gateway/transport/client.go
@@ -116,7 +116,9 @@ func (s *Server) subscribeClient(stream *streamclient.ProxyStream) (err error) {
 		// but have no IDP-issued user token to poll — skip polling for them.
 		if pctx.IdentityType != plugintypes.IdentityTypeMachine &&
 			pctx.IdentityType != plugintypes.IdentityTypeAPIKey {
-			usertoken.PollingUserToken(pctx.Context, func(cause error) {
+			// pctx.Context is context.Background() here, so a poller started on
+			// it would outlive the session and keep refreshing a departed user.
+			usertoken.PollingUserToken(stream.Context(), func(cause error) {
 				_ = stream.Close(cause)
 			}, tokenVerifier, pctx.UserID)
 		}

--- a/gateway/transport/usertoken/usertoken.go
+++ b/gateway/transport/usertoken/usertoken.go
@@ -1,3 +1,5 @@
+// Package usertoken checks the access token stored for a session user, on a
+// timer and at proxy session start. It refuses or ends a session that fails.
 package usertoken
 
 import (
@@ -13,8 +15,17 @@ import (
 
 const pollingInterval = 5 * time.Minute
 
+// Test seams: the real ones need models.DB and a live identity provider.
+var (
+	loadUserToken = func(userID string) (*models.UserToken, error) {
+		return models.GetUserToken(models.DB, userID)
+	}
+	idpRefreshExpiredToken = idp.TryRefreshExpiredToken
+)
+
+// CheckUserToken may refresh: it makes a network call and writes a new token.
 func CheckUserToken(tokenVerifier idp.UserInfoTokenVerifier, userID string) error {
-	userToken, err := models.GetUserToken(models.DB, userID)
+	userToken, err := loadUserToken(userID)
 	if err != nil {
 		return err
 	}
@@ -24,8 +35,16 @@ func CheckUserToken(tokenVerifier idp.UserInfoTokenVerifier, userID string) erro
 
 	uinfo, err := tokenVerifier.VerifyAccessToken(userToken.Token)
 	if err != nil {
+		// local and SAML flatten the JWT error (common/keys/keys.go), so only
+		// the text is common to them and the OIDC JWT path.
 		if strings.Contains(err.Error(), "token is expired") {
-			return fmt.Errorf("access token is expired, try logging in again")
+			if err := refreshSessionToken(tokenVerifier, userID, userToken.Token); err != nil {
+				// The Postgres proxy and the CLI show this string to the user,
+				// so the wording stays as it was. The reason goes to the log.
+				log.With("subject", userID).Warnf("failed to refresh the expired access token: %v", err)
+				return fmt.Errorf("access token is expired, try logging in again")
+			}
+			return nil
 		}
 
 		return err
@@ -38,9 +57,53 @@ func CheckUserToken(tokenVerifier idp.UserInfoTokenVerifier, userID string) erro
 	return nil
 }
 
+// refreshSessionToken exchanges the stored refresh token. Only the OIDC
+// provider implements that, so a local or SAML session ends here.
+func refreshSessionToken(tokenVerifier idp.UserInfoTokenVerifier, userID, expiredToken string) error {
+	subject, newAccessToken, err := idpRefreshExpiredToken(tokenVerifier, expiredToken)
+	if err != nil {
+		return err
+	}
+	// The database keys the token by subject. A different subject means the
+	// refresh got the token of another user, so this session ends.
+	if subject != userID {
+		return fmt.Errorf("refreshed subject does not match the session subject")
+	}
+	// A good exchange does not prove the new token verifies.
+	newSubject, err := tokenVerifier.VerifyAccessToken(newAccessToken)
+	if err != nil {
+		return fmt.Errorf("the refreshed access token does not verify: %w", err)
+	}
+	if newSubject != userID {
+		return fmt.Errorf("the refreshed access token is not for the session subject")
+	}
+
+	log.With("subject", userID).Infof("access token refreshed, the session continues")
+	return nil
+}
+
+// PollingUserToken calls cancel with the check error when the token is not
+// usable. ctx must end with the session, or the poller outlives it.
 func PollingUserToken(ctx context.Context, cancel context.CancelCauseFunc, tokenVerifier idp.UserInfoTokenVerifier, userID string) {
+	pollUserToken(ctx, cancel, tokenVerifier, userID, pollingInterval)
+}
+
+// pollUserToken takes the interval and returns a stop channel, which
+// PollingUserToken hides from the API. Only tests need them.
+func pollUserToken(ctx context.Context, cancel context.CancelCauseFunc, tokenVerifier idp.UserInfoTokenVerifier, userID string, interval time.Duration) <-chan struct{} {
+	stopped := make(chan struct{})
+	// A nil Done channel means the context can never cancel, so the poller
+	// would outlive the session and keep refreshing a departed user's token.
+	if ctx.Done() == nil {
+		err := fmt.Errorf("user token poller got a context that never cancels")
+		log.With("subject", userID).Error(err.Error())
+		cancel(err)
+		close(stopped)
+		return stopped
+	}
 	go func() {
-		ticker := time.NewTicker(pollingInterval)
+		defer close(stopped)
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
 		for {
@@ -57,4 +120,5 @@ func PollingUserToken(ctx context.Context, cancel context.CancelCauseFunc, token
 			}
 		}
 	}()
+	return stopped
 }

--- a/gateway/transport/usertoken/usertoken_test.go
+++ b/gateway/transport/usertoken/usertoken_test.go
@@ -1,0 +1,372 @@
+package usertoken
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/hoophq/hoop/gateway/idp"
+	idptypes "github.com/hoophq/hoop/gateway/idp/types"
+	"github.com/hoophq/hoop/gateway/models"
+)
+
+const (
+	testSubject       = "subject-1"
+	storedExpired     = "expired-access-token"
+	validToken        = "valid-access-token"
+	badToken          = "bad-access-token"
+	noSubjectToken    = "no-subject-access-token"
+	otherSubjectToken = "other-subject-access-token"
+)
+
+// errExpired is built from the upstream sentinel, so a golang-jwt reword
+// fails this test instead of silently breaking the strings.Contains match.
+var (
+	errExpired   = fmt.Errorf("failed to parse access token: token has invalid claims: %v", jwt.ErrTokenExpired)
+	errDatabase  = errors.New("dial tcp: connection refused")
+	errSignature = errors.New("failed to verify the token signature")
+	errNoRefresh = errors.New("no refresh token available")
+)
+
+type fakeVerifier struct {
+	verifyFn func(accessToken string) (string, error)
+}
+
+func (f *fakeVerifier) VerifyAccessToken(accessToken string) (string, error) {
+	return f.verifyFn(accessToken)
+}
+
+func (f *fakeVerifier) VerifyAccessTokenWithUserInfo(string) (*idptypes.ProviderUserInfo, error) {
+	return &idptypes.ProviderUserInfo{Subject: testSubject}, nil
+}
+
+func rejectExpired(accessToken string) (string, error) {
+	switch accessToken {
+	case storedExpired:
+		return "", errExpired
+	case badToken:
+		return "", errSignature
+	case noSubjectToken:
+		return "", nil
+	case otherSubjectToken:
+		return "another-subject", nil
+	}
+	return testSubject, nil
+}
+
+// startPolling hangs off seams so stubSeams is the way in. Keep it a method,
+// and keep stubSeams the only constructor.
+type seams struct{ t *testing.T }
+
+// stubSeams puts the package variables back after the test. Tests in this file
+// must not call t.Parallel: the seams are package level.
+func stubSeams(t *testing.T) *seams {
+	t.Helper()
+	load, refresh := loadUserToken, idpRefreshExpiredToken
+	loadUserToken = func(string) (*models.UserToken, error) {
+		panic("the test must replace loadUserToken")
+	}
+	idpRefreshExpiredToken = func(idp.TokenVerifier, string) (string, string, error) {
+		panic("the test must replace idpRefreshExpiredToken")
+	}
+	t.Cleanup(func() { loadUserToken, idpRefreshExpiredToken = load, refresh })
+	return &seams{t: t}
+}
+
+// startPolling drives the poller at 1ms. It waits for the goroutine to stop
+// before the seams go back, so the poller never reads a variable under change.
+func (s *seams) startPolling(verifyFn func(string) (string, error)) (context.Context, chan error) {
+	s.t.Helper()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancelled := make(chan error, 1)
+	stopped := pollUserToken(ctx, func(cause error) {
+		select {
+		case cancelled <- cause:
+		default:
+		}
+		cancel(cause)
+	}, &fakeVerifier{verifyFn: verifyFn}, testSubject, time.Millisecond)
+	s.t.Cleanup(func() {
+		cancel(context.Canceled)
+		select {
+		case <-stopped:
+		case <-time.After(5 * time.Second):
+			s.t.Error("the poller goroutine did not stop")
+		}
+	})
+	return ctx, cancelled
+}
+
+func TestCheckUserToken(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		userToken      *models.UserToken
+		getErr         error
+		verifyFn       func(string) (string, error)
+		refreshSubject string
+		refreshToken   string
+		refreshErr     error
+		wantErr        string
+		wantErrIs      error
+		wantRefresh    int64
+	}{
+		{
+			name:      "a valid token does not start a refresh",
+			userToken: &models.UserToken{Token: validToken},
+		},
+		{
+			name:           "an expired token continues after a good refresh",
+			userToken:      &models.UserToken{Token: storedExpired},
+			refreshSubject: testSubject,
+			wantRefresh:    1,
+		},
+		{
+			name:        "an expired token ends the session when the refresh fails",
+			userToken:   &models.UserToken{Token: storedExpired},
+			refreshErr:  errNoRefresh,
+			wantErr:     "access token is expired, try logging in again",
+			wantRefresh: 1,
+		},
+		{
+			name:           "a refreshed token that does not verify ends the session",
+			userToken:      &models.UserToken{Token: storedExpired},
+			refreshSubject: testSubject,
+			refreshToken:   badToken,
+			wantErr:        "access token is expired, try logging in again",
+			wantRefresh:    1,
+		},
+		{
+			name:           "a refreshed token with no subject ends the session",
+			userToken:      &models.UserToken{Token: storedExpired},
+			refreshSubject: testSubject,
+			refreshToken:   noSubjectToken,
+			wantErr:        "access token is expired, try logging in again",
+			wantRefresh:    1,
+		},
+		{
+			name:           "a refreshed token for another subject ends the session",
+			userToken:      &models.UserToken{Token: storedExpired},
+			refreshSubject: testSubject,
+			refreshToken:   otherSubjectToken,
+			wantErr:        "access token is expired, try logging in again",
+			wantRefresh:    1,
+		},
+		{
+			name:           "a refresh for a different subject ends the session",
+			userToken:      &models.UserToken{Token: storedExpired},
+			refreshSubject: "another-subject",
+			wantErr:        "access token is expired, try logging in again",
+			wantRefresh:    1,
+		},
+		{
+			// models.GetUserToken gives (nil, nil) when it finds no row.
+			name:    "no token record for the user",
+			wantErr: "access token not found for user subject",
+		},
+		{
+			name:      "a database error goes to the caller",
+			getErr:    errDatabase,
+			wantErrIs: errDatabase,
+		},
+		{
+			name:      "an empty subject ends the session",
+			userToken: &models.UserToken{Token: validToken},
+			verifyFn:  func(string) (string, error) { return "", nil },
+			wantErr:   "user subject not found using the access token",
+		},
+		{
+			name:      "a signature error does not start a refresh",
+			userToken: &models.UserToken{Token: validToken},
+			verifyFn:  func(string) (string, error) { return "", errSignature },
+			wantErrIs: errSignature,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stubSeams(t)
+			var refreshCount atomic.Int64
+			loadUserToken = func(string) (*models.UserToken, error) { return tt.userToken, tt.getErr }
+			idpRefreshExpiredToken = func(_ idp.TokenVerifier, gotToken string) (string, string, error) {
+				refreshCount.Add(1)
+				if tt.userToken != nil && gotToken != tt.userToken.Token {
+					t.Errorf("want the stored token %q, got %q", tt.userToken.Token, gotToken)
+				}
+				if tt.refreshErr != nil {
+					return "", "", tt.refreshErr
+				}
+				newToken := tt.refreshToken
+				if newToken == "" {
+					newToken = validToken
+				}
+				return tt.refreshSubject, newToken, nil
+			}
+			verifyFn := tt.verifyFn
+			if verifyFn == nil {
+				verifyFn = rejectExpired
+			}
+
+			err := CheckUserToken(&fakeVerifier{verifyFn: verifyFn}, testSubject)
+
+			switch {
+			case tt.wantErrIs != nil:
+				if !errors.Is(err, tt.wantErrIs) {
+					t.Errorf("want error %v, got %v", tt.wantErrIs, err)
+				}
+			case tt.wantErr != "":
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("want an error that contains %q, got %v", tt.wantErr, err)
+				}
+				if tt.refreshErr != nil && errors.Is(err, tt.refreshErr) {
+					t.Error("the refresh failure reached the caller")
+				}
+			default:
+				if err != nil {
+					t.Errorf("want no error, got %v", err)
+				}
+			}
+			if got := refreshCount.Load(); got != tt.wantRefresh {
+				t.Errorf("want %v refresh calls, got %v", tt.wantRefresh, got)
+			}
+		})
+	}
+}
+
+func TestPollingUserTokenEndsTheSession(t *testing.T) {
+	s := stubSeams(t)
+	loadUserToken = func(string) (*models.UserToken, error) {
+		return &models.UserToken{Token: storedExpired}, nil
+	}
+	idpRefreshExpiredToken = func(idp.TokenVerifier, string) (string, string, error) {
+		return "", "", errNoRefresh
+	}
+
+	_, cancelled := s.startPolling(rejectExpired)
+
+	select {
+	case cause := <-cancelled:
+		if cause == nil || !strings.Contains(cause.Error(), "access token is expired") {
+			t.Errorf("want an expired token cause, got %v", cause)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the poller did not end the session")
+	}
+}
+
+// The regression net: the refresh engine writes the new token, so the session
+// stays open and the poller refreshes one time for each expiry.
+func TestPollingUserTokenKeepsTheSessionAfterARefresh(t *testing.T) {
+	s := stubSeams(t)
+	var mu sync.Mutex
+	stored, refreshes, reads := storedExpired, 0, 0
+	loadUserToken = func(string) (*models.UserToken, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		reads++
+		return &models.UserToken{Token: stored}, nil
+	}
+	idpRefreshExpiredToken = func(_ idp.TokenVerifier, gotToken string) (string, string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if gotToken != storedExpired {
+			t.Errorf("want the stored token %q, got %q", storedExpired, gotToken)
+		}
+		refreshes++
+		stored = validToken
+		return testSubject, validToken, nil
+	}
+
+	ctx, cancelled := s.startPolling(rejectExpired)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		mu.Lock()
+		done := reads >= 5
+		mu.Unlock()
+		if done {
+			break
+		}
+		select {
+		case cause := <-cancelled:
+			t.Fatalf("the session ended after a good refresh: %v", cause)
+		case <-deadline:
+			t.Fatal("the poller did not run 5 rounds")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	if ctx.Err() != nil {
+		t.Errorf("want an open session, got %v", context.Cause(ctx))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if refreshes != 1 {
+		t.Errorf("want 1 refresh for 1 expiry, got %v", refreshes)
+	}
+}
+
+// An immortal context would leak the poller, so the session ends instead. The
+// panicking seam defaults prove the poll loop never ran.
+func TestPollUserTokenRefusesAnImmortalContext(t *testing.T) {
+	stubSeams(t)
+	cancelled := make(chan error, 1)
+
+	stopped := pollUserToken(context.Background(), func(cause error) {
+		select {
+		case cancelled <- cause:
+		default:
+		}
+	}, &fakeVerifier{verifyFn: rejectExpired}, testSubject, time.Millisecond)
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("want the stop channel closed at once")
+	}
+	select {
+	case cause := <-cancelled:
+		if cause == nil || !strings.Contains(cause.Error(), "never cancels") {
+			t.Errorf("want a never-cancels cause, got %v", cause)
+		}
+	default:
+		t.Error("want the session ended, not a silent leak")
+	}
+}
+
+// A valid token must not start a refresh or end the session. Every polling
+// test asserts the goroutine stops, in the startPolling cleanup.
+func TestPollingUserTokenKeepsAValidSessionOpen(t *testing.T) {
+	s := stubSeams(t)
+	var reads atomic.Int64
+	loadUserToken = func(string) (*models.UserToken, error) {
+		reads.Add(1)
+		return &models.UserToken{Token: validToken}, nil
+	}
+	idpRefreshExpiredToken = func(idp.TokenVerifier, string) (string, string, error) {
+		t.Error("a valid token must not start a refresh")
+		return "", "", errNoRefresh
+	}
+
+	ctx, cancelled := s.startPolling(rejectExpired)
+
+	deadline := time.After(5 * time.Second)
+	for reads.Load() < 3 {
+		select {
+		case cause := <-cancelled:
+			t.Fatalf("the session ended with a valid token: %v", cause)
+		case <-deadline:
+			t.Fatalf("want 3 polling rounds, got %v", reads.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	// The cleanup that startPolling registered cancels the context and waits
+	// for the goroutine, so it fails the test if the poller ignores Done.
+	if ctx.Err() != nil {
+		t.Errorf("want an open session before the cleanup, got %v", context.Cause(ctx))
+	}
+}


### PR DESCRIPTION
## 📝 Description

The user token poller ended a live session when the IdP access token expired,
even when a valid refresh token was stored. It now refreshes the token first,
and ends the session only if the refresh fails.

The poller also gets a per-session context. Three call sites passed a context
that never cancels, so the goroutine and its ticker stayed after the session
ended. This is a prerequisite, not a cleanup: a successful refresh removes the
poller's only self-termination path, so the old context would have kept a dead
session's poller rotating a live user's tokens for the life of the process.

**Security, please read.** The refresh does not re-check the hoop-side user
status. Nothing on that path acts on `users.status`: `refreshForSubject`
(`gateway/idp/core.go:187`) reaches it through `syncUserGroupsFromUserInfo`, but
only to copy the status back unchanged (`core.go:244`, `:284`). A user set to
inactive in hoop therefore keeps a session that is already open. Before this
change the expiring token ended it within one poll.

The exposure is bounded, but longer than before. A `hoop connect` session ends
at `proxyMaxTimeoutDuration`, 48 hours
(`gateway/transport/streamclient/proxy.go:51`); an approved JIT session ends at
its granted window, which `plugins/review/review.go:127` caps at 48 hours only when the
connection sets no `AccessMaxDuration`. A proxy or RDP session ends at
the credential `expire_at`, which is the sentinel `9999-12-31` for a persistent
credential (`api/connections/connection_credentials.go:42`). Previously such a session ended at
the access token expiry plus one poll, often under an hour.

`CheckUserToken` also gates session start. For the Postgres, SSH and HTTP proxies
that is safe: they dial the gateway with impersonation headers, so the auth
interceptor refuses an inactive user first (`interceptors/auth/auth.go:286`).
SSM never calls `CheckUserToken`, so this change does not reach it.
The two RDP paths do not — `rdp.go:187` calls `broker.CreateRDPSession`
directly. So an inactive user with a working refresh token can now also **open**
an RDP session, where before the expired token refused it.

Everything else still ends a session: an IdP-side disable or refresh-token
revocation makes the exchange fail, credential `RevokedAt` is immediate, and
`POST /sessions/:session_id/kill` is unaffected. To offboard a user, revoke the refresh
token at the IdP. A follow-up must add a status check to the poller. I kept it
out to match the fix the issue asks for.

> **State of this PR — three blockers, all maintainer-side.**
>
> 1. **`CLAAssistant` is red for a reason I cannot fix.** I posted the required
>    signature comment. The action then failed writing `signatures/version1/cla.json`:
>    `Repository rule violations found — Changes must be made through a pull request`.
>    It commits to `main`, and the ruleset there blocks it. The last signature it
>    recorded was 2025-08-06. Filed as #1777 with proposed fixes.
> 2. **No test has run.** Every workflow sits at `action_required`, pending approval
>    for a first-time fork contributor. Expect the Go jobs to fail once approved:
>    fork PRs get no repository secrets, so `Authenticate private modules` cannot
>    reach the private `libhoop` module. That failure is not in this diff.
> 3. **The `patch` label is missing** and I cannot set labels from a fork.
>
> Consequence worth stating plainly: **this diff has never been compiled or tested
> by CI.** Everything in the Build note below was verified locally against a
> module-resolution placeholder.

## 📣 User-facing impact

Long interactive sessions no longer stop when the identity provider access
token expires. The gateway refreshes the token in the background.

## 🔗 Related Issue

Fixes #1740
Refs #1540 — fixes the gateway half of the Azure Conditional Access report.
Refs #1364 — the HTTP-only refresh support this extends to the session poller.
Refs #1626 — this change is inert on Google Workspace until that is fixed.
Not #915. That issue asks for sessions to expire; this makes them last longer.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📋 Changes Made

- `gateway/transport/usertoken/usertoken.go` — on the expired-token branch call
  `idp.TryRefreshExpiredToken` before giving up.
- Same file — end the session when the refresh returns a different subject, or
  when the new access token does not verify to the session subject.
- Same file — add test seams, so the package runs without a database or an IdP.
- Same file — split the poll loop into `pollUserToken`, so a test sets the
  interval and waits on a stop channel instead of sleeping.
- `gateway/broker/session.go` — add the `Session.Context()` accessor.
- `gateway/transport/client.go` — pass `stream.Context()`. `pctx.Context` is
  `context.Background()` (`gateway/transport/server.go:144`).
- `gateway/rdp/rdp.go`, `gateway/rdp/irongw.go` — pass `session.Context()`.
- `gateway/transport/usertoken/usertoken_test.go` — new. The package had none.

## 🧪 Testing

### Build note

I cannot compile this repository: `github.com/hoophq/libhoop` is private and I
have no credentials. Because it is a direct `require`, **no** package in the
gateway module resolves without it, so every local result below used a
placeholder module. `go test ./gateway/transport/usertoken/` fails at setup
here; that is module resolution, not this diff.

What the placeholder does and does not affect: `go list -deps` reports 0 libhoop
packages for `gateway/transport/usertoken` and `gateway/broker`, so their
compilation is identical to CI. `gateway/transport` and `gateway/rdp` do import
libhoop (2 and 1 packages), so those were checked against invented stub
signatures; my edits there change one expression each and touch no libhoop
symbol. `go vet` is clean, the new tests pass under `-race -count=10` (11 table
cases and 3 poller tests), and 49 gateway packages pass. **CI is the first
authoritative check.**

### How a maintainer verifies

```bash
export GOPRIVATE=github.com/hoophq/libhoop
go vet ./gateway/transport/... ./gateway/broker/... ./gateway/rdp/...
go test -race -count=10 ./gateway/transport/usertoken/
make test-oss
```

Manual check, with an OIDC provider that returns refresh tokens:

1. Put `offline_access` in `IDP_CUSTOM_SCOPES`, and set the access token
   lifetime to 2 minutes at the IdP.
2. Start `hoop connect <connection>` and hold the session.
3. Wait for more than the token lifetime plus one 5-minute poll.
4. The session stays open. The log shows
   `access token refreshed, the session continues`.
5. Revoke the refresh token at the IdP, then wait one more poll. The session
   ends with `access token is expired, try logging in again`.

For the context fix: open and close 20 RDP sessions, then read
`/debug/pprof/goroutine?debug=1`. No `PollingUserToken` goroutine stays.

## 📄 Additional Notes

**Precondition.** Without `offline_access` in `IDP_CUSTOM_SCOPES` or the DB
scopes, the IdP issues no refresh token and this change does nothing.

**Mostly not covered.** Opaque access tokens go to the userinfo endpoint, whose
error (`gateway/idp/oidc/oidc.go:534`) wraps the IdP response. When that text
lacks `token is expired` the refresh is never tried. When it happens to contain
it, the refresh is entered and then fails: `VerifyExpiredTokenSubject`
(`oidc.go:222`) parses the expired token as a JWT, and an opaque token has no
segments to parse. Either way the session ends as before, so this costs a wasted
IdP round trip at most. A JWT access token under `_userinfo=1` is the exception:
it parses, so refresh works there. Local and SAML store no refresh token, so
they keep the old behavior.

**Known, not fixed here.** `refreshForSubject` passes `context.Background()` to
the token exchange, so a hung IdP can block session setup. The Postgres, HTTP
and SSH proxies dial the gateway as a client, so each of those sessions runs two
pollers for one subject. The subject check runs after the exchange, so it ends
this session but does not undo the `UpsertUserToken` write (`core.go:211`). The
two RDP call sites discard the cancel cause, which this change makes more useful
than it was. A stream waiting for review approval is skipped by the sweeper
(`proxy.go:36`) and holds no deadline, so the poller was what eventually tore it
down; with the refresh working, it no longer does.



