### PR TITLE
 DEP-178: revamp sidecar config into guardrails, opa and mask

### DIFF
--- a/client/cmd/startsidecar.go
+++ b/client/cmd/startsidecar.go
@@ -28,6 +28,7 @@ const deprecatedSidecarAlias = "inspect"
 var (
 	sidecarConfigFlag   string
 	sidecarValidateFlag bool
+	sidecarStrictFlag   bool
 )
 
 var startSidecarCmd = &cobra.Command{
@@ -50,9 +51,14 @@ does not require a different binary. The file may be YAML or JSON; the
 extension picks the parser.
 
 This command was named "inspect". That name still works as a deprecated
-alias.`,
+alias.
+
+The config schema changed in ADR-0011: "policy" split into "guardrails" and
+"opa", and three fields were dropped. Both spellings load, and the old one
+prints a warning naming its replacement. Use --strict to fail on one.`,
 	Example: `  hoop start sidecar --config /etc/hoop-inspect/config.yaml
-  hoop start sidecar --config config.yaml --validate`,
+  hoop start sidecar --config config.yaml --validate
+  hoop start sidecar --config config.yaml --validate --strict`,
 	// A bad config is not a usage error, and dumping the flag list under one
 	// buries the message that says which field is wrong.
 	SilenceUsage: true,
@@ -70,15 +76,20 @@ alias.`,
 			return err
 		}
 
+		// Same channel as the rename notice above, and for the same reason:
+		// --validate writes a parseable report to stdout.
+		daemon.ReportDeprecations(os.Stderr, cfg.Deprecations)
+		if sidecarStrictFlag && len(cfg.Deprecations) > 0 {
+			return fmt.Errorf("%d deprecated config field(s) in use and --strict is set",
+				len(cfg.Deprecations))
+		}
+
 		if sidecarValidateFlag {
 			lanes, err := daemon.Validate(cfg, det)
 			if err != nil {
 				return err
 			}
-			fmt.Println("config OK:", len(lanes), "listener(s)")
-			for _, ln := range lanes {
-				fmt.Printf("  %-16s %-9s %s\n", ln.Name, ln.Protocol, ln.Summary())
-			}
+			daemon.PrintLanes(os.Stdout, lanes)
 			return nil
 		}
 
@@ -117,8 +128,12 @@ func sidecarConfigFromEnv() string {
 // buildSidecarPlugin constructs the PII detector from the config's "pii"
 // section.
 //
-// A nil alcatraz.Plugin converts to a nil daemon.Plugin, so an absent section
-// stays nil rather than becoming a non-nil interface holding a nil pointer,
+// An absent section no longer disables detection: the plugin builds a
+// detector over every entity type it knows, and the section narrows it. A nil
+// Plugin means only that a build linked no detector, which this one does not.
+//
+// The conversion still matters. A nil alcatraz.Plugin converts to a nil
+// daemon.Plugin rather than to a non-nil interface holding a nil pointer,
 // which the sidecar would call through.
 func buildSidecarPlugin(raw json.RawMessage) (daemon.Plugin, error) {
 	return alcatraz.PluginFromConfig(raw)
@@ -134,6 +149,9 @@ func init() {
 		"Path to the inspection config file (YAML or JSON)")
 	startSidecarCmd.Flags().BoolVar(&sidecarValidateFlag, "validate", false,
 		"Validate the config, report what each listener resolved to, and exit")
+	startSidecarCmd.Flags().BoolVar(&sidecarStrictFlag, "strict", false,
+		"Fail when the config uses a deprecated field, so a pipeline can catch it "+
+			"before the release that removes it")
 
 	startCmd.AddCommand(startSidecarCmd)
 }

--- a/deploy/docker-compose/envoy-stack/README.md
+++ b/deploy/docker-compose/envoy-stack/README.md
@@ -91,10 +91,11 @@ and reuses it afterwards. After a library change:
 The image builds `hoop-inspect` with
 [alcatraz](https://github.com/hoophq/alcatraz) PII detection linked in, so the
 demo can mask Brazilian CPFs and IBANs and deny a query that embeds one. The
-`pii` section of `sidecar/config.yaml` names which of the 45 entity types
-are active, five here. The section is required rather than defaulted: turning
-on every recognizer rewrites ordinary numeric columns, because `US_SSN` fires
-on roughly a third of random nine-digit business ids.
+`pii` section of `sidecar/config.yaml` names which of the 54 entity types are
+active, five here. Omitting the section activates all 54, and this file
+narrows on purpose: a mask rule naming `US_SSN` rewrites ordinary numeric
+columns, because that recognizer fires on roughly a third of random
+nine-digit business ids.
 
 Sidecar knobs live in `sidecar/config.yaml`; validate a change without
 starting anything:
@@ -218,7 +219,10 @@ Two producers sit commented out in `sidecar/config.yaml`:
 
 - **`pii`**: a `type: pii` rule carrying `action: defer`. No credential, no
   per-statement cost: the detector in the `pii:` section is already running
-  for masking. Uncomment the rule and the `opa:` block, nothing else.
+  for masking. Uncomment the rule and the `opa:` block together. `defer` on a
+  lane with no `opa.url` denies on a match instead of reporting it, so the
+  rule on its own turns this lane into a hard block on those four entity
+  classes.
 - **`ai_analysis`**: sends a statement to a language model and reports the
   risk it comes back with. Needs a credential and spends money per statement,
   so it also needs the `analyzer:` block.
@@ -242,7 +246,11 @@ analyzer:
 
 listeners:
   - name: appdb
-    policy:
+    opa:                               # its own section, beside guardrails
+      url: http://opa:8181/v1/data/envoy/authz/inspect
+      fail_open: false
+      gate: true                       # ask Rego what is worth a model call
+    guardrails:
       rules:
         - name: sensitive-columns
           type: pii
@@ -253,10 +261,6 @@ listeners:
           high: defer                  # the analyzer classifies; Rego decides
           medium: defer
           low: defer
-      opa:
-        url: http://opa:8181/v1/data/envoy/authz/inspect
-        fail_open: false
-        gate: true                     # ask Rego what is worth a model call
 ```
 
 BR_CPF is missing from that entity list because `no-cpf-in-query` in the

--- a/deploy/docker-compose/envoy-stack/mssql/config-mssql.yaml
+++ b/deploy/docker-compose/envoy-stack/mssql/config-mssql.yaml
@@ -4,8 +4,8 @@
 #   envoy :5432 --cluster hoop_inspect_pg----> :15432  lane "appdb"
 #
 # Each lane resolves its own rules, its own masking and its own OPA endpoint.
-# The top-level policy/mask blocks are DEFAULTS every lane inherits unless it
-# overrides them; the resolved result is served at :19000/config.
+# The top-level guardrails/mask blocks are DEFAULTS every lane inherits
+# unless it overrides them; the resolved result is served at :19000/config.
 #
 # Validate without starting anything:
 #   cd sidecar/cmd && go run . -validate \
@@ -22,10 +22,12 @@ audit:
   async_queue_size: 1024 # a slow disk must not block a user's query
   query_sessions: 500 # backs /api/sessions
 
-# One detector engine for the process: the union of every entity any lane
-# references below. Required — there is no all-entities default, because
-# enabling all 45 recognizers rewrites ordinary numeric columns (US_SSN fires
-# on roughly a third of random nine-digit business ids).
+# One detector engine for the process. The section is optional now and it
+# NARROWS a permissive default: omit it and all 54 entity types are active.
+# It is kept because the recognizers it leaves out rewrite ordinary numeric
+# columns (US_SSN fires on roughly a third of random nine-digit business
+# ids), and these five are the union of every entity any lane references
+# below.
 pii:
   entities:
     - EMAIL_ADDRESS
@@ -77,8 +79,8 @@ pii:
 # ---------------------------------------------------------------- defaults
 # Applies to every lane. Lane rules are evaluated BEFORE these, so a lane's
 # specific message wins over a generic one for the same statement.
-policy:
-  enforce: true
+guardrails:
+  mode: enforce
   rules:
     # Cross-protocol: a taxpayer id in a statement lands in the database's own
     # query log, slow-query log and EXPLAIN output. Masking the response does
@@ -92,13 +94,12 @@ policy:
 # HTTP by substituting bytes and correcting Content-Length, postgres by
 # rebuilding its length-prefixed row frames around the new values.
 mask:
-  enabled: true
   rules:
-    - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-    - {name: ssn, entity: US_SSN, strategy: partial, keep_last: 4}
-    - {name: cards, entity: CREDIT_CARD, strategy: partial, keep_last: 4}
-    - {name: cpf, entity: BR_CPF, strategy: redact}
-    - {name: iban, entity: IBAN_CODE, strategy: partial, keep_last: 4}
+    - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+    - {name: ssn, entities: [US_SSN], strategy: partial, keep_last: 4}
+    - {name: cards, entities: [CREDIT_CARD], strategy: partial, keep_last: 4}
+    - {name: cpf, entities: [BR_CPF], strategy: redact}
+    - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
 # ------------------------------------------------------------------- lanes
 listeners:
@@ -122,7 +123,6 @@ listeners:
     protocol: mssql
     listen: 0.0.0.0:11433
     upstream: mssql:1433
-    connection: mssqldb
     # NO upstream_tls, unlike the appdb lane above, and the reason is a
     # product limit rather than a shortcut.
     #
@@ -138,7 +138,7 @@ listeners:
     # means teaching starttls.go the 0x12-wrapped handshake (libhoop's
     # agent/mssql/net.go already implements exactly that and is the obvious
     # source), not flipping a config key.
-    policy:
+    guardrails:
       rules:
         - name: no-destructive-tsql
           type: operation
@@ -150,13 +150,12 @@ listeners:
         # alcatraz refuses 123-45-6789 as an obvious fixture, so the entity
         # rule alone would leave the seeded SSNs in the clear.
         - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
+        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
 
   - name: appdb
     protocol: postgres
     listen: 0.0.0.0:15432
     upstream: appdb:5432
-    connection: appdb
     # The hop to the database is encrypted. hoop-inspect speaks the pgwire
     # SSLRequest handshake, then wraps the connection: it is the TLS CLIENT,
     # so it decrypts on read and the gate below still inspects and masks
@@ -169,7 +168,7 @@ listeners:
     upstream_tls:
       ca_file: /etc/hoop-inspect/certs/appdb.crt
       server_name: appdb
-    policy:
+    guardrails:
       rules:
         # Envoy cannot see this: there is no pgwire parser in its filter
         # chain, so OPA is never consulted and never sees the statement.
@@ -196,16 +195,15 @@ listeners:
         # detector-based ssn rule leaves it in the clear. The column does not
         # care what the value looks like.
         - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-        - {name: cpf, entity: BR_CPF, strategy: redact}
-        - {name: iban, entity: IBAN_CODE, strategy: partial, keep_last: 4}
+        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+        - {name: cpf, entities: [BR_CPF], strategy: redact}
+        - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
   - name: httpbin
     protocol: http
     listen: 0.0.0.0:18080
     upstream: httpbin:8080
-    connection: httpbin
-    policy:
+    guardrails:
       rules:
         - name: no-admin-api
           type: http_resource

--- a/deploy/docker-compose/envoy-stack/mssql2019/config-mssql2019.yaml
+++ b/deploy/docker-compose/envoy-stack/mssql2019/config-mssql2019.yaml
@@ -1,3 +1,7 @@
+# Deliberately still on the pre-0011 config spelling (policy:, mask.enabled:,
+# connection:). It is the regression test for the deprecation path: this file
+# must keep loading, with warnings, until the fields are removed.
+#
 # hoop-inspect for the TDS 7.4 lane. One listener, one upstream, no Envoy.
 #
 # Validate without starting anything:

--- a/deploy/docker-compose/envoy-stack/postgres/config-postgres.yaml
+++ b/deploy/docker-compose/envoy-stack/postgres/config-postgres.yaml
@@ -4,8 +4,8 @@
 #   envoy :5432 --cluster hoop_inspect_pg----> :15432  lane "appdb"
 #
 # Each lane resolves its own rules, its own masking and its own OPA endpoint.
-# The top-level policy/mask blocks are DEFAULTS every lane inherits unless it
-# overrides them; the resolved result is served at :19000/config.
+# The top-level guardrails/mask blocks are DEFAULTS every lane inherits
+# unless it overrides them; the resolved result is served at :19000/config.
 #
 # Validate without starting anything:
 #   cd sidecar/cmd && go run . -validate \
@@ -22,10 +22,12 @@ audit:
   async_queue_size: 1024 # a slow disk must not block a user's query
   query_sessions: 500 # backs /api/sessions
 
-# One detector engine for the process: the union of every entity any lane
-# references below. Required — there is no all-entities default, because
-# enabling all 45 recognizers rewrites ordinary numeric columns (US_SSN fires
-# on roughly a third of random nine-digit business ids).
+# One detector engine for the process. The section is optional now and it
+# NARROWS a permissive default: omit it and all 54 entity types are active.
+# It is kept because the recognizers it leaves out rewrite ordinary numeric
+# columns (US_SSN fires on roughly a third of random nine-digit business
+# ids), and these five are the union of every entity any lane references
+# below.
 pii:
   entities:
     - EMAIL_ADDRESS
@@ -77,8 +79,8 @@ pii:
 # ---------------------------------------------------------------- defaults
 # Applies to every lane. Lane rules are evaluated BEFORE these, so a lane's
 # specific message wins over a generic one for the same statement.
-policy:
-  enforce: true
+guardrails:
+  mode: enforce
   rules:
     # Cross-protocol: a taxpayer id in a statement lands in the database's own
     # query log, slow-query log and EXPLAIN output. Masking the response does
@@ -92,13 +94,12 @@ policy:
 # HTTP by substituting bytes and correcting Content-Length, postgres by
 # rebuilding its length-prefixed row frames around the new values.
 mask:
-  enabled: true
   rules:
-    - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-    - {name: ssn, entity: US_SSN, strategy: partial, keep_last: 4}
-    - {name: cards, entity: CREDIT_CARD, strategy: partial, keep_last: 4}
-    - {name: cpf, entity: BR_CPF, strategy: redact}
-    - {name: iban, entity: IBAN_CODE, strategy: partial, keep_last: 4}
+    - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+    - {name: ssn, entities: [US_SSN], strategy: partial, keep_last: 4}
+    - {name: cards, entities: [CREDIT_CARD], strategy: partial, keep_last: 4}
+    - {name: cpf, entities: [BR_CPF], strategy: redact}
+    - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
 # ------------------------------------------------------------------- lanes
 listeners:
@@ -107,7 +108,6 @@ listeners:
     protocol: postgres
     listen: 0.0.0.0:15432
     upstream: appdb:5432
-    connection: appdb
     # The hop to the database is encrypted. hoop-inspect speaks the pgwire
     # SSLRequest handshake, then wraps the connection: it is the TLS CLIENT,
     # so it decrypts on read and the gate below still inspects and masks
@@ -120,7 +120,7 @@ listeners:
     upstream_tls:
       ca_file: /etc/hoop-inspect/certs/appdb.crt
       server_name: appdb
-    policy:
+    guardrails:
       rules:
         # Envoy cannot see this: there is no pgwire parser in its filter
         # chain, so OPA is never consulted and never sees the statement.
@@ -147,16 +147,15 @@ listeners:
         # detector-based ssn rule leaves it in the clear. The column does not
         # care what the value looks like.
         - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-        - {name: cpf, entity: BR_CPF, strategy: redact}
-        - {name: iban, entity: IBAN_CODE, strategy: partial, keep_last: 4}
+        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+        - {name: cpf, entities: [BR_CPF], strategy: redact}
+        - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
   - name: httpbin
     protocol: http
     listen: 0.0.0.0:18080
     upstream: httpbin:8080
-    connection: httpbin
-    policy:
+    guardrails:
       rules:
         - name: no-admin-api
           type: http_resource

--- a/deploy/docker-compose/envoy-stack/sidecar-binary.md
+++ b/deploy/docker-compose/envoy-stack/sidecar-binary.md
@@ -57,23 +57,20 @@ audit:
   file: "-"                 # stdout as JSON lines
   memory_buffer: 256
   query_sessions: 500       # required for GET /api/sessions; omit it and that route 404s
+  fail_open: false          # the default: a statement whose audit write failed is refused
 
-pii:
+pii:                        # optional; omit it and all 54 entity types are active
   entities: [EMAIL_ADDRESS, US_SSN]
 
-policy:
-  enforce: true             # false is observe-only: inspect and audit, deny nothing
-
-mask:
-  enabled: true
+guardrails:                 # Hoop's own rules, inherited by every listener
+  mode: enforce             # the default; observe evaluates and records, denying nothing
 
 listeners:
   - name: appdb
     protocol: postgres
     listen: 0.0.0.0:15432   # what your client connects to
     upstream: appdb:5432    # the real database
-    connection: appdb       # the name audit rows key on
-    policy:
+    guardrails:
       rules:
         - name: no-destructive-sql
           type: operation
@@ -82,7 +79,7 @@ listeners:
     mask:
       rules:
         - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
+        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
 ```
 
 Check it before you deploy it. This starts no listener and needs nothing
@@ -101,8 +98,9 @@ config OK: 1 listener(s)
 
 That line is the **resolved** lane, so the rule count includes anything it
 inherited from the top-level defaults. Validation builds every lane, which
-catches what a syntax check cannot: a key typo, a bad regex, a `pii` rule
-naming an entity that `pii.entities` never enabled.
+catches what a syntax check cannot: a key typo, a bad regex, mask rules on a
+protocol whose codec cannot mask, and both spellings of a renamed field set at
+one scope.
 
 Full config reference, every rule type and every masking strategy:
 [`sidecar/README.md`](../../../sidecar/README.md).
@@ -310,7 +308,7 @@ analyzer:
 listeners:
   - name: appdb
     # ... as above
-    policy:
+    guardrails:
       rules:
         - name: risky-writes
           type: ai_analysis
@@ -364,7 +362,7 @@ The HTTP codec exposes nothing by default. Without a body the model sees `POST
       capture_body: true
       max_body_bytes: 8192
       headers: [Content-Type]      # authorization is refused at startup
-    policy:
+    guardrails:
       rules:
         - name: risky-payloads
           type: ai_analysis
@@ -478,17 +476,39 @@ log.
 
 ---
 
-## Three things that cost people time
+## What costs people time
 
-**`enforce` defaults to `false`.** A lane with rules and no `enforce: true`
-inspects and audits and denies nothing. It says `observe-only` in the startup
-log and in `/config`. That default is deliberate — a misconfigured rule should
-not take production down on first deploy — but it surprises everyone once.
+**`guardrails.mode` defaults to `enforce`.** A lane with rules denies on the
+first deploy, and there is no third key to remember. The old field was
+`policy.enforce`, it defaulted to `false`, and a lane with rules and no
+`enforce: true` audited everything and denied nothing. Configs upgrading from
+that spelling start denying on the next restart, so run `--validate` and read
+the resolved rule count per lane before you restart.
 
-**A `pii` rule naming an entity absent from `pii.entities` is refused at
-startup.** Without that check the rule would load, evaluate and match nothing,
-so a guardrail would look live while allowing everything it was written to
-stop.
+**`mode: observe` runs every rule and denies nothing.** The lane builds the
+same chain, allows the statement, and writes the rule that would have refused
+it into the audit record. A week of that tells you what
+enforcement would cost:
+
+```bash
+jq -r 'select(.metadata["guardrails.would_deny"]) | .metadata["guardrails.would_deny"]' \
+  audit.jsonl | sort | uniq -c | sort -rn
+    412 customers-is-crm-owned
+      7 no-unbounded-delete
+      1 no-schema-changes
+```
+
+It costs what enforcement costs, because nothing reports what would have been
+denied without evaluating it. A lane that wants the work skipped sets
+`guardrails: {rules: []}`.
+
+**Omitting `pii` activates every entity type.** The section used to be
+required before anything could detect, and it now subtracts from a detector
+holding all 54. A `pii` guardrail rule naming an entity the section never
+listed used to be refused at startup; that check is gone with the requirement
+behind it. Narrow with `pii.ignored` where the noisy recognizers cost you:
+`US_SSN` fires on about a third of random nine-digit business ids, and `URL`
+matches every HTTP response body.
 
 **Masking column rules beat detection.** `{columns: [ssn]}` masks whatever is
 in that column, whatever it looks like. Entity rules depend on the detector

--- a/deploy/docker-compose/envoy-stack/sidecar/config.yaml
+++ b/deploy/docker-compose/envoy-stack/sidecar/config.yaml
@@ -4,8 +4,8 @@
 #   envoy :5432 --cluster hoop_inspect_pg----> :15432  lane "appdb"
 #
 # Each lane resolves its own rules, its own masking and its own OPA endpoint.
-# The top-level policy/mask blocks are DEFAULTS every lane inherits unless it
-# overrides them; the resolved result is served at :19000/config.
+# The top-level guardrails/mask blocks are DEFAULTS every lane inherits
+# unless it overrides them; the resolved result is served at :19000/config.
 #
 # Validate without starting anything:
 #   cd sidecar/cmd && go run . -validate \
@@ -22,10 +22,12 @@ audit:
   async_queue_size: 1024 # a slow disk must not block a user's query
   query_sessions: 500 # backs /api/sessions
 
-# One detector engine for the process: the union of every entity any lane
-# references below. Required: there is no all-entities default, because
-# enabling all 45 recognizers rewrites ordinary numeric columns (US_SSN fires
-# on roughly a third of random nine-digit business ids).
+# One detector engine for the process. The section is optional now and it
+# NARROWS a permissive default: omit it and all 54 entity types are active.
+# It is kept because the recognizers it leaves out rewrite ordinary numeric
+# columns (US_SSN fires on roughly a third of random nine-digit business
+# ids), and these five are the union of every entity any lane references
+# below.
 pii:
   entities:
     - EMAIL_ADDRESS
@@ -45,8 +47,8 @@ pii:
 # stripped, so `WHERE id = 1` and `WHERE id = 2` are one verdict), and the
 # rule runs after the free local rules, so nothing already refused is paid
 # for. The appdb lane below moves the first of the three into Rego with
-# `policy.opa.gate`, which is the same cost control asked of the policy
-# engine instead of a YAML trigger.
+# `opa.gate`, which is the same cost control asked of the policy engine
+# instead of a YAML trigger.
 #
 # analyzer:
 #   provider: vertex            # vertex | anthropic | openai
@@ -80,8 +82,8 @@ pii:
 # ---------------------------------------------------------------- defaults
 # Applies to every lane. Lane rules are evaluated BEFORE these, so a lane's
 # specific message wins over a generic one for the same statement.
-policy:
-  enforce: true
+guardrails:
+  mode: enforce
   rules:
     # Cross-protocol: a taxpayer id in a statement lands in the database's own
     # query log, slow-query log and EXPLAIN output. Masking the response does
@@ -95,13 +97,12 @@ policy:
 # HTTP by substituting bytes and correcting Content-Length, postgres by
 # rebuilding its length-prefixed row frames around the new values.
 mask:
-  enabled: true
   rules:
-    - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-    - {name: ssn, entity: US_SSN, strategy: partial, keep_last: 4}
-    - {name: cards, entity: CREDIT_CARD, strategy: partial, keep_last: 4}
-    - {name: cpf, entity: BR_CPF, strategy: redact}
-    - {name: iban, entity: IBAN_CODE, strategy: partial, keep_last: 4}
+    - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+    - {name: ssn, entities: [US_SSN], strategy: partial, keep_last: 4}
+    - {name: cards, entities: [CREDIT_CARD], strategy: partial, keep_last: 4}
+    - {name: cpf, entities: [BR_CPF], strategy: redact}
+    - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
 # ------------------------------------------------------------------- lanes
 listeners:
@@ -109,7 +110,6 @@ listeners:
     protocol: postgres
     listen: 0.0.0.0:15432
     upstream: appdb:5432
-    connection: appdb
     # The hop to the database is encrypted. hoop-inspect speaks the pgwire
     # SSLRequest handshake, then wraps the connection: it is the TLS CLIENT,
     # so it decrypts on read and the gate below still inspects and masks
@@ -122,7 +122,7 @@ listeners:
     upstream_tls:
       ca_file: /etc/hoop-inspect/certs/appdb.crt
       server_name: appdb
-    policy:
+    guardrails:
       rules:
         # Envoy cannot see this: there is no pgwire parser in its filter
         # chain, so OPA is never consulted and never sees the statement.
@@ -176,19 +176,19 @@ listeners:
         #   high: defer
         #   medium: defer
         #   low: defer
-      # opa:
-      #   # The same OPA container the fat gate uses, a different rule:
-      #   # ext_authz answers Envoy at envoy/authz/result, this answers the
-      #   # sidecar over the Data API. Required by either deferring rule
-      #   # above: `defer` with no OPA endpoint defers to a decision that
-      #   # does not exist, which allows everything, so it is refused at
-      #   # startup.
-      #   url: http://opa:8181/v1/data/envoy/authz/inspect
-      #   # A policy engine outage stops appdb rather than silently
-      #   # disabling enforcement. The gate phase is exempt by design: an
-      #   # undefined gate decision allows and requests nothing.
-      #   fail_open: false
-      #   gate: true
+    # opa:
+    #   # The same OPA container the fat gate uses, a different rule:
+    #   # ext_authz answers Envoy at envoy/authz/result, this answers the
+    #   # sidecar over the Data API. Required by either deferring rule
+    #   # above: `defer` with no OPA endpoint defers to a decision that
+    #   # does not exist, which allows everything, so it is refused at
+    #   # startup.
+    #   url: http://opa:8181/v1/data/envoy/authz/inspect
+    #   # A policy engine outage stops appdb rather than silently
+    #   # disabling enforcement. The gate phase is exempt by design: an
+    #   # undefined gate decision allows and requests nothing.
+    #   fail_open: false
+    #   gate: true
     mask:
       rules:
         # Column rules are only possible where the protocol names its values,
@@ -197,16 +197,15 @@ listeners:
         # detector-based ssn rule leaves it in the clear. The column does not
         # care what the value looks like.
         - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-        - {name: cpf, entity: BR_CPF, strategy: redact}
-        - {name: iban, entity: IBAN_CODE, strategy: partial, keep_last: 4}
+        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+        - {name: cpf, entities: [BR_CPF], strategy: redact}
+        - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
   - name: httpbin
     protocol: http
     listen: 0.0.0.0:18080
     upstream: httpbin:8080
-    connection: httpbin
-    policy:
+    guardrails:
       rules:
         - name: no-admin-api
           type: http_resource

--- a/deploy/docker-compose/envoy-stack/uds/config-uds.yaml
+++ b/deploy/docker-compose/envoy-stack/uds/config-uds.yaml
@@ -1,8 +1,8 @@
 # hoop-inspect listening on unix sockets instead of TCP ports.
 #
 # Identical to ../sidecar/config.yaml except for the two `network`/`listen`
-# pairs. Policy, masking, audit and upstream TLS are untouched: the transport
-# under the relay does not change what the relay does.
+# pairs. Guardrails, masking, audit and upstream TLS are untouched: the
+# transport under the relay does not change what the relay does.
 #
 # Validate without starting anything:
 #   cd sidecar/cmd && go run . -validate \
@@ -29,8 +29,8 @@ pii:
     - BR_CPF
     - IBAN_CODE
 
-policy:
-  enforce: true
+guardrails:
+  mode: enforce
   rules:
     - name: no-cpf-in-query
       type: pii
@@ -38,13 +38,12 @@ policy:
       message: do not put a taxpayer id in a query; it lands in the database's own logs
 
 mask:
-  enabled: true
   rules:
-    - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-    - {name: ssn, entity: US_SSN, strategy: partial, keep_last: 4}
-    - {name: cards, entity: CREDIT_CARD, strategy: partial, keep_last: 4}
-    - {name: cpf, entity: BR_CPF, strategy: redact}
-    - {name: iban, entity: IBAN_CODE, strategy: partial, keep_last: 4}
+    - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+    - {name: ssn, entities: [US_SSN], strategy: partial, keep_last: 4}
+    - {name: cards, entities: [CREDIT_CARD], strategy: partial, keep_last: 4}
+    - {name: cpf, entities: [BR_CPF], strategy: redact}
+    - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
 listeners:
   - name: appdb
@@ -55,11 +54,10 @@ listeners:
     network: unix
     listen: /run/hoop-inspect/pg.sock
     upstream: appdb:5432
-    connection: appdb
     upstream_tls:
       ca_file: /etc/hoop-inspect/certs/appdb.crt
       server_name: appdb
-    policy:
+    guardrails:
       rules:
         - name: no-destructive-sql
           type: operation
@@ -68,17 +66,16 @@ listeners:
     mask:
       rules:
         - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-        - {name: cpf, entity: BR_CPF, strategy: redact}
-        - {name: iban, entity: IBAN_CODE, strategy: partial, keep_last: 4}
+        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+        - {name: cpf, entities: [BR_CPF], strategy: redact}
+        - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}
 
   - name: httpbin
     protocol: http
     network: unix
     listen: /run/hoop-inspect/http.sock
     upstream: httpbin:8080
-    connection: httpbin
-    policy:
+    guardrails:
       rules:
         - name: no-admin-api
           type: http_resource

--- a/deploy/docker-compose/metabase-stack/README.md
+++ b/deploy/docker-compose/metabase-stack/README.md
@@ -276,8 +276,8 @@ docker compose logs hoop-inspect | ./sidecar/read-audit.py
 ## Adapting the rules to your schema
 
 [`sidecar/config.yaml`](sidecar/config.yaml) exists to be copied and
-edited. Four things about `policy.rules` that the file repeats inline and that
-cost time to rediscover:
+edited. Four things about `guardrails.rules` that the file repeats inline and
+that cost time to rediscover:
 
 - **First match wins, in slice order.** Narrow rules first, the lane-wide
   backstop last. Reversed, every refusal carries the generic message.
@@ -299,6 +299,21 @@ Masking has no equivalent. A mask rule has no `tables:` field: it keys on the
 result-set column name or on the detected entity and applies to every result
 set on the lane, so the `iban` rule covers `customers.iban` and
 `payroll.bank_iban` alike. One lane, one masking policy.
+
+**The lane is called `metabase`.** It used to set `name: appdb` for the
+upstream and `connection: metabase` for the consumer. `listeners[].connection`
+is gone and the audit key follows `name`, so the file keeps the string the
+audit trail should read and drops the other. `/api/sessions`,
+`input.context.connection` in Rego and `sidecar/read-audit.py` all print
+`metabase`. Rows written before the rename carry `appdb`, so a trail spanning
+the upgrade holds both keys.
+
+**Rules live under `guardrails`, OPA under `opa`.** The section used to be
+`policy`, holding both. `guardrails.mode` replaces `policy.enforce` and
+defaults to `enforce`, so this file needs no key to switch enforcement on.
+Set `mode: observe` on the lane to evaluate every rule, allow the statement,
+and read `metadata["guardrails.would_deny"]` out of the audit trail for a week
+before letting it deny for real.
 
 ## Identity
 

--- a/deploy/docker-compose/metabase-stack/sidecar/config.yaml
+++ b/deploy/docker-compose/metabase-stack/sidecar/config.yaml
@@ -1,6 +1,6 @@
 # hoop-inspect in front of the database Metabase reports on.
 #
-#   metabase --pgwire--> :15432 lane "appdb" --pgwire+TLS--> appdb:5432
+#   metabase --pgwire--> :15432 lane "metabase" --pgwire+TLS--> appdb:5432
 #
 # One lane, because there is one thing to protect. Metabase's own application
 # database is H2 in its container and must not come here: a read-only rule
@@ -21,10 +21,11 @@ audit:
   async_queue_size: 1024 # a slow disk must not block a dashboard load
   query_sessions: 500 # backs /api/sessions
 
-# The union of every entity the lane uses below. Required, and there is no
-# all-entities default: enabling all 45 recognizers rewrites ordinary numeric
-# columns, since US_SSN fires on roughly a third of random nine-digit ids and
-# this schema has an amount_cents column that would qualify.
+# The union of every entity the lane uses below. The section is optional now
+# and it NARROWS a permissive default: omit it and all 54 entity types are
+# active. It is kept because the recognizers it leaves out rewrite ordinary
+# numeric columns, since US_SSN fires on roughly a third of random nine-digit
+# ids and this schema has an amount_cents column that would qualify.
 pii:
   entities:
     - EMAIL_ADDRESS
@@ -33,15 +34,11 @@ pii:
     - BR_CPF
     - IBAN_CODE
 
-mask:
-  enabled: true
-
 listeners:
-  - name: appdb
+  - name: metabase # the name audit rows key on
     protocol: postgres
     listen: 0.0.0.0:15432
     upstream: appdb:5432
-    connection: metabase # the name audit rows key on
 
     # Headroom, not a measurement: this stack peaks at 6 connections. Size a
     # real one at or above MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE,
@@ -62,8 +59,8 @@ listeners:
       ca_file: /etc/hoop-inspect/certs/appdb.crt
       server_name: appdb
 
-    policy:
-      enforce: true
+    guardrails:
+      mode: enforce
 
       # ORDER MATTERS. First match wins, so the narrow rules come first and
       # the lane-wide backstop comes last. Reverse them and every refusal
@@ -128,15 +125,16 @@ listeners:
         #     message: this statement cannot be classified, so it is refused
 
     mask:
-      # This block REPLACES the default rather than extending it, so every
-      # rule the lane needs is listed here.
+      # There is no top-level mask block, so every rule the lane needs is
+      # listed here. A lane block REPLACES an inherited set rather than
+      # extending it, which is what would happen if one were added.
       #
-      # Mask rules have no table scoping, unlike the policy rules above.
+      # Mask rules have no table scoping, unlike the guardrail rules above.
       # There is no `tables:` field on a mask rule: it keys on the column
       # name in RowDescription or on the detected entity, and it applies to
       # every result set on the lane. `iban` below therefore covers
       # customers.iban and payroll.bank_iban alike, which is why payroll
-      # needs a policy rule and not a mask rule. To mask a column in one
+      # needs a guardrail rule and not a mask rule. To mask a column in one
       # table and leave it clear in another, give each table its own lane.
       rules:
         # ssn carries both kinds of rule because they fail in opposite
@@ -146,10 +144,10 @@ listeners:
         # alias, and reshaping the value defeats it. README "Known gaps" has
         # the hole the pair still leaves.
         - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: ssn-entity, entity: US_SSN, strategy: partial, keep_last: 4}
+        - {name: ssn-entity, entities: [US_SSN], strategy: partial, keep_last: 4}
         # Entity rules for the rest: the same value turns up under names
         # nobody enumerates in advance (email, actor_email, whatever a join
         # calls them).
-        - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-        - {name: cpf, entity: BR_CPF, strategy: redact}
-        - {name: iban, entity: IBAN_CODE, strategy: partial, keep_last: 4}
+        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+        - {name: cpf, entities: [BR_CPF], strategy: redact}
+        - {name: iban, entities: [IBAN_CODE], strategy: partial, keep_last: 4}

--- a/docs/adr/0006-sidecar-config-defaults-and-overrides.md
+++ b/docs/adr/0006-sidecar-config-defaults-and-overrides.md
@@ -1,11 +1,19 @@
 # ADR-0006: Global defaults and per-lane overrides in the sidecar config
 
-- **Status:** Accepted
+- **Status:** Superseded by [ADR-0011](0011-sidecar-config-schema.md) and [ADR-0012](0012-sidecar-enforcement-defaults.md)
 - **Date:** 2026-08-27
 - **Author:** @matheusfrancisco
 - **Code:** [`sidecar/daemon/config.go`](../../sidecar/daemon/config.go), [`sidecar/policy/`](../../sidecar/policy)
 - **Related:** [ADR-0005](0005-sidecar-flow.md) (request flow, current state), [ADR-0008](0008-analyzer-enforces-without-opa.md) (why everything else in the analyzer is OPA-free), [ADR-0009](0009-guardrails-and-masking-architecture.md) (where the rules these defaults resolve are evaluated)
-- **Supersedes / Superseded by:** —
+- **Supersedes / Superseded by:** Superseded by [ADR-0011](0011-sidecar-config-schema.md) (the schema and the merge table, restated under `guardrails` and `opa`) and [ADR-0012](0012-sidecar-enforcement-defaults.md) (the enforcement defaults and the `defer` refusal)
+
+> **Superseded (2026-08-31):** the merge *mechanics* below are unchanged and
+> still describe the code. Every key name in them has moved: `policy.rules` →
+> `guardrails.rules`, `policy.opa` → `opa`, `policy.enforce` →
+> `guardrails.mode`, and `mask.enabled` is gone. Two rows of the refusal table
+> also changed behaviour rather than spelling. Read ADR-0011 and ADR-0012 for
+> what ships; this file is preserved for the per-field reasoning, which the
+> rename did not invalidate.
 
 ## Context
 

--- a/docs/adr/0009-guardrails-and-masking-architecture.md
+++ b/docs/adr/0009-guardrails-and-masking-architecture.md
@@ -1,11 +1,22 @@
 # ADR-0009: Where guardrails and masking run, and the deny/mask split
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-08-31 — permissive `pii` default; see "Amendment" below)
 - **Date:** 2026-08-27
 - **Author:** @matheusfrancisco
 - **Code:** [`libhoop/agent/`](../../libhoop/agent), [`libhoop/redactor/`](../../libhoop/redactor), [`sidecar/policy/`](../../sidecar/policy), [`sidecar/gate/`](../../sidecar/gate), [`sidecar/pii/alcatraz/`](../../sidecar/pii/alcatraz), [`sidecar/lexer/`](../../sidecar/lexer)
 - **Related:** [ADR-0005](0005-sidecar-flow.md) (one request through the relay, current state), [ADR-0006](0006-sidecar-config-defaults-and-overrides.md) (how a lane resolves its rules), [ADR-0008](0008-analyzer-enforces-without-opa.md) (the AI evaluator's half of the same chain), [ADR-0010](0010-local-sql-rule-set.md) (the local rule set this decision's rule 7 feeds)
 - **Supersedes / Superseded by:** —
+
+> **Amendment (2026-08-31):** [ADR-0011](0011-sidecar-config-schema.md)
+> reverses the `pii.entities` requirement recorded below. Omitting the `pii`
+> section now enables all 54 entity types instead of disabling detection. The
+> measured false-positive rates in this ADR stand and are still the reason not
+> to write a `US_SSN` mask rule casually; ADR-0011 shows why they do not reach
+> the omitted case, since `NewMasker` narrows the engine to the entities its
+> own rules name. Everything else here, including the two-engine split and the
+> decision not to federate the gateway and sidecar rule vocabularies, is
+> unchanged. ADR-0011 does rename the sidecar's config key to `guardrails`
+> while keeping the engines separate.
 
 ## Context
 

--- a/docs/adr/0010-local-sql-rule-set.md
+++ b/docs/adr/0010-local-sql-rule-set.md
@@ -1,11 +1,18 @@
 # ADR-0010: One ordered rule list, six matchers, first denial wins
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-08-31 — observe mode; see "Amendment" below)
 - **Date:** 2026-08-27
 - **Author:** @matheusfrancisco
 - **Code:** [`sidecar/policy/policy.go`](../../sidecar/policy/policy.go), [`sidecar/policy/pii.go`](../../sidecar/policy/pii.go), [`sidecar/lexer/`](../../sidecar/lexer), [`sidecar/inspect/sqlmeta.go`](../../sidecar/inspect/sqlmeta.go)
 - **Related:** [ADR-0005](0005-sidecar-flow.md) (the flow this sits in), [ADR-0006](0006-sidecar-config-defaults-and-overrides.md) (how a lane's list is assembled from global + lane), [ADR-0008](0008-analyzer-enforces-without-opa.md) (the `ai_analysis` rule, which this set deliberately does not evaluate), [ADR-0009](0009-guardrails-and-masking-architecture.md) (where enforcement runs at all)
 - **Supersedes / Superseded by:** —
+
+> **Amendment (2026-08-31):** the section "`enforce: false` is not a dry
+> run" below described the code correctly and is fixed by
+> [ADR-0012](0012-sidecar-enforcement-defaults.md). The field is now
+> `guardrails.mode`, and `observe` evaluates every rule, denies nothing, and
+> records `guardrails.would_deny` on the audit line. The rest of this ADR,
+> including the `require_table_match` defect, is unchanged.
 
 ## Context
 
@@ -177,7 +184,7 @@ to the client direction. Until that lands, treat `require_table_match` as
 unusable on a postgres lane. It is recorded here rather than fixed quietly
 because it changes what an existing config does.
 
-### `enforce: false` is not a dry run
+### `enforce: false` is not a dry run (fixed by ADR-0012)
 
 `buildPolicy` returns nil for a non-enforcing lane, so no rule is evaluated at
 all. The trail then carries `statement` rows and no `violation` rows, even for

--- a/docs/adr/0011-sidecar-config-schema.md
+++ b/docs/adr/0011-sidecar-config-schema.md
@@ -176,13 +176,20 @@ starts denying, which ADR-0012 explains.
 
 ## Consequences
 
-**Two shipped behaviours reverse, and both need release-note prose.** A lane
+**One shipped behaviour reverses, and it needs release-note prose.** A lane
 with `mask.enabled: true` and no `pii` section refuses to start today
 (`daemon/daemon.go:590-592`) and will start and mask, because a detector now
-always exists. A lane with mask rules on MSSQL loads clean today and will
-refuse to start, because the check at `daemon/config.go:537` stops being
-skipped. The second is the dangerous direction: a deployment that boots today
-may not boot after the upgrade.
+always exists.
+
+**No deployment stops booting over masking.** Dropping `mask.enabled` makes the
+protocol check at `daemon/config.go:537` run on every lane that carries rules,
+where the flag used to skip it. That reads like a new way to fail an upgrade
+and is not one: `gate.MaskSupported` asks the codec for a `Reframer` rather
+than listing protocol names (`gate/gate.go:544-554`), and all three shipped
+codecs have one, HTTP through Content-Length re-tagging. Verified by loading a
+config with mask rules on postgres, mssql and http lanes: all three validate
+clean and report `+ masking`. The check earns its place as the guard for a
+future codec that relays without re-framing, not as a migration hazard.
 
 **`analyzer.send: redacted` and `refuse` start working without a `pii`
 section.** The refusal at `daemon/analyzer.go:206-212` tests for a section that
@@ -319,8 +326,9 @@ listeners:
     guardrails: {mode: observe}
     mask: {rules: []}             # the empty list opts out of the inherited set
 
-  # TDS rows are length-prefixed binary frames with no reframer, so a mask
-  # block here is refused at startup. The empty list is required.
+  # MSSQL masks: its codec re-frames, so this lane could carry mask rules.
+  # It opts out to show the spelling, since `rules: []` is the only way a lane
+  # refuses a set the top level configured.
   - name: mssqldb
     protocol: mssql
     listen: "127.0.0.1:1434"
@@ -370,7 +378,7 @@ Resolved:
 |---|---|---|---|---|
 | `appdb` | enforce | 5 inherited | none | 4 rules |
 | `reporting` | observe | 5 inherited, evaluated, none enforced | none | off |
-| `mssqldb` | enforce | 1 own + 5 inherited, own first | none | off |
+| `mssqldb` | enforce | 1 own + 5 inherited, own first | none | off, by `rules: []` |
 | `api` | enforce | 3 own + 5 inherited | gate and decide | 2 rules |
 | `internal-jobs` | enforce | 5 inherited | none | 4 rules |
 
@@ -383,8 +391,10 @@ or without OPA, safe at both ends.
 
 - `hoop-inspect -validate` against all six shipped configs in the deprecated
   spelling (loads, warns) and the new spelling (loads, silent).
-- A config setting both spellings of each of the seven renamed fields, which
-  must produce seven refusals in one run.
+- A config setting both spellings of every field that has two, which must
+  produce every refusal in one run. Four qualify: `policy.rules`,
+  `policy.enforce`, `policy.opa` and `audit.fail_closed`. The other three
+  changes fold with no conflicting pair to write.
 - `make test-sidecar`, which walks every `go.mod` under `sidecar/`.
 - `TestOPAInputDocumentShape` (`policy/policy_test.go:308-351`) and
   `policy/evalcontext_test.go:67-256`, unchanged and passing, proving the Rego

--- a/docs/adr/0011-sidecar-config-schema.md
+++ b/docs/adr/0011-sidecar-config-schema.md
@@ -149,16 +149,30 @@ section with three.
 
 | Field | Global → lane | Why |
 |---|---|---|
-| `guardrails.rules` | **concatenate**, lane's first | Every local rule denies or defers and the first match wins, so concatenating is monotonic in the allow/deny outcome. Order picks which name and message the user reads. |
+| `guardrails.rules` | **concatenate**, lane's first | Every local rule denies or defers and the first match wins, so concatenating is monotonic in the allow/deny outcome. Order picks which name and message the user reads. `rules: []` opts the lane out entirely. |
 | `guardrails.mode` | **replace** when set | A lane rolling out behind an enforcing default has to be able to say observe. |
 | `opa` | **replace** when set | One lane has one decision endpoint. |
 | `mask.rules` | **replace** when set | A rule owns an entity or a column. Concatenating leaves two rewrites of one value. |
 | `pii`, `analyzer`, `audit`, `admin` | process-wide | One detector engine and one analyzer per process. |
 
-`mask.rules: []` is how a lane opts out of an inherited set. The empty list is
-non-empty as JSON bytes, so `len(o.Rules) > 0` at `daemon/config.go:382` reads
-it as an override rather than as silence. A test pins it, because the
-distinction is invisible in the type.
+Each of the three sections a lane can override also has a spelling for
+wanting none of it, and they are the same shape on purpose:
+
+| Section | Opt out with | Reads as |
+|---|---|---|
+| `guardrails` | `guardrails: {rules: []}` | no rules on this lane |
+| `opa` | `opa: {}` | no decision endpoint on this lane |
+| `mask` | `mask: {rules: []}` | no rewriting on this lane |
+
+All three hang on the decoder distinguishing an empty collection from an absent
+key. `mask.rules` is a `json.RawMessage`, so `[]` arrives as two bytes rather
+than as nil. `guardrails.rules` is a `[]policy.Rule`, and `[]` decodes to a
+non-nil slice of length zero, which is why the merge reads presence rather than
+length: `len(o.Rules) > 0` would read the opt-out as silence and hand the lane
+the defaults it just refused. An empty list meaning "adds nothing" is the other
+defensible reading for a field that concatenates, and it would leave a lane no
+way to say the thing at all. Tests pin each one, because the distinction is
+invisible in the type.
 
 ### Startup refusals, restated
 
@@ -212,12 +226,15 @@ constants rather than from config (`policy/opa.go:86,89`), and
 fills it. No Rego policy needs an edit. `session/session_test.go:108` pins the
 context shape as a public contract and keeps passing.
 
-**A lane still cannot opt out of an inherited `opa`.** `resolve` replaces when
-the listener sets one (`daemon/config.go:369-371`), and `opa: {url: ""}` is
-refused (`:487-489`), so a top-level OPA reaches every lane with no escape.
-`mask` has `rules: []` and `guardrails` has `mode: observe`; `opa` has nothing
-equivalent. We read an explicitly empty `opa: {}` on a listener as "no OPA on
-this lane" and close the gap while the section is being rewritten.
+**Every inheritable section gains an opt-out, which two of them lacked.** A
+top-level `opa` used to reach every lane with no escape: `resolve` replaces only
+when the listener sets one, and `opa: {url: ""}` is refused. `guardrails.rules`
+had the same hole, and `mode: observe` did not fill it, since an observing lane
+still evaluates and evaluating is what costs money on a lane with `ai_analysis`
+rules. Both are closed by the table above, and closing them was cheap while the
+sections were being rewritten anyway. `opa: {}` is read as the opt-out only
+when every field in the block is zero; a block naming a timeout with no url is
+still refused, because that configures a client that cannot be built.
 
 **Deprecated fields stay in the Go structs until a named release removes
 them.** Constraint C from the Context leaves no alternative. The window runs

--- a/docs/adr/0011-sidecar-config-schema.md
+++ b/docs/adr/0011-sidecar-config-schema.md
@@ -1,0 +1,395 @@
+# ADR-0011: Splitting `policy` into `guardrails` and `opa` in the sidecar config
+
+- **Status:** Proposed
+- **Date:** 2026-08-31
+- **Author:** @matheusfrancisco
+- **Code:** [`sidecar/daemon/config.go`](../../sidecar/daemon/config.go), [`sidecar/pii/alcatraz/`](../../sidecar/pii/alcatraz), [`sidecar/config/yaml/`](../../sidecar/config/yaml)
+- **Related:** [ADR-0005](0005-sidecar-flow.md) (request flow, current state), [ADR-0009](0009-guardrails-and-masking-architecture.md) (where these rules are evaluated; this ADR reverses its `pii.entities` requirement), [ADR-0012](0012-sidecar-enforcement-defaults.md) (the behaviour half of the same change)
+- **Supersedes / Superseded by:** Supersedes [ADR-0006](0006-sidecar-config-defaults-and-overrides.md)
+
+## Context
+
+One word, `policy`, names two products in `config.yaml`. `policy.rules` is
+Hoop's own rule set, evaluated in-process against a decoded statement.
+`policy.opa` is a client for someone else's Rego. A reader cannot tell from the
+key which of the two a line configures, and neither can a control-plane UI that
+has to render both.
+
+Five smaller frictions sit beside it, and all five cost an operator time on
+their first config:
+
+- `mask.rules[].entity` takes one entity. `policy.rules[].entities` takes a
+  list. Both name the same alcatraz classes
+  (`pii/alcatraz/masker.go:85`, `policy/policy.go:430`).
+- `pii` must be declared before anything that detects can start. Six shipped
+  configs carry the same hand-written list, four of them under the same copied
+  comment. Omit the section and masking refuses to build
+  (`daemon/daemon.go:590-592`).
+- `listeners[].connection` and `listeners[].name` both name a lane.
+  `displayName` falls back from one to the other
+  (`daemon/daemon.go:379-385`), and seven of the eight configs in this repo
+  set them to the same string.
+- `mask.enabled` gates a list that already says whether it is empty. Worse, an
+  absent or false `enabled` skips the whole validation block at
+  `daemon/config.go:537-547`, so a lane can carry mask rules for a protocol
+  that cannot mask and still load clean.
+- `policy.enforce` reads like a global kill switch and gates only the evaluator
+  chain. Masking, audit and the unswitchable denials all keep running without
+  it. ADR-0012 covers that field.
+
+One constraint shapes every option below. `LoadConfigBytes` decodes with
+`DisallowUnknownFields` (`daemon/config.go:334`), and the YAML front end
+transcodes to JSON and calls the same function
+(`config/yaml/yaml.go:91-96`). A key that is not a declared Go struct field
+fails the whole file. Deleting a field from the struct and keeping old configs
+working are therefore mutually exclusive, and no leftover-map escape hatch
+exists.
+
+## Options considered
+
+1. **Rename in place and break old configs.** One release, one schema, no
+   compat code. Rejected: every running deployment fails to start on upgrade,
+   and the failure arrives as `unknown field "policy"` with no instruction.
+2. **Accept both spellings forever.** No migration pressure and no removal
+   work. Rejected on the evidence of `hoop start inspect`, deprecated in
+   1.149.0 with the message "removed in a future release"
+   (`client/cmd/startsidecar.go:96-105`) and still shipping. Six permanent
+   aliases would leave the schema more complicated than the one this ADR
+   simplifies.
+3. **A two-spelling window with a single normalize step and a named removal
+   release.** Both spellings load, the old one warns, and one function knows
+   the mapping so nothing downstream carries compat logic. Chosen.
+
+## Decision
+
+We split the section by product and drop the fields that restate what a list
+already says.
+
+| Today | New | Note |
+|---|---|---|
+| `policy.rules` | `guardrails.rules` | shape unchanged, all 8 rule types |
+| `policy.enforce` | `guardrails.mode` | `enforce` \| `observe`; see ADR-0012 |
+| `policy.opa.*` | `opa.*` | top level and per listener |
+| `mask.rules[].entity: X` | `mask.rules[].entities: [X]` | list only, no scalar form |
+| `mask.enabled` | removed | rules present means masking on |
+| `listeners[].connection` | removed | `name` fills the audit key |
+| `pii.entities` required | optional | omitting the section enables all 54 |
+
+We keep `guardrails` as the name even though the gateway already ships a
+feature under that word. The two engines stay separate, as ADR-0009 decided,
+but their rule-type strings are identical rather than similar:
+`deny_words_list` and `pattern_match` appear verbatim in
+`gateway/guardrails/guardrails.go:12-15` and `policy/policy.go:315,318`. The
+sidecar set is a superset of the gateway set, so one word over both is a
+promise the sidecar can keep. The alternatives lose on their own terms:
+`policy` is the word being freed for OPA, and `rules` cannot survive a UI.
+
+### One funnel for compatibility
+
+```
+LoadConfigBytes
+  → json.Decode with DisallowUnknownFields      unchanged
+  → cfg.normalize()                             NEW: fold deprecated → canonical, collect warnings
+  → cfg.Validate()                              unchanged, reads canonical fields only
+```
+
+`normalize` is the only function that knows a deprecated field exists.
+`resolve`, `validateLane`, `buildPolicy` and `buildMasker` read the canonical
+shape. Without the funnel the compat logic smears across five functions and two
+modules.
+
+Setting both spellings at one scope refuses the config. Picking a winner
+silently would contradict the rule that already governs this decoder: "a typo
+in a key must not silently disable a control" (`daemon/config.go:334`).
+
+Presence detection makes three fields pointers. `Config.Policy` and
+`Config.Mask` are value types today (`daemon/config.go:34,38`), so absent and
+empty are indistinguishable, and `AuditConfig.FailClosed` has the same problem
+for the polarity flip in ADR-0012. All three become pointers before any of the
+rest lands.
+
+### Omitting `pii` enables everything
+
+Six code locations and four config comments argue that `pii.entities` is
+required because turning on all recognizers corrupts ordinary data, citing a
+measured 32% false-positive rate for `US_SSN` on nine-digit business ids
+(`pii/alcatraz/alcatraz.go:33-41`, `:80-107`, `:110-126`).
+
+The measurement is right. The conclusion does not reach the case of an omitted
+section, for two reasons found in the code that does the scanning:
+
+- `NewMasker` narrows the engine to exactly the entities its own rules name:
+  `opts.Entities = entities` at `pii/alcatraz/masker.go:249-250`. A permissive
+  detector with 54 entities active, driving a masker with two rules, scans for
+  two. The `order_id` corruption in the docs needs someone to write a `US_SSN`
+  mask rule, which is an explicit act either way.
+- `matchesPII` intersects the scanner output with the rule's own `Entities`
+  (`policy/pii.go:83-86`), and the finding published to OPA carries the
+  intersection (`policy/policy.go:618,623-625`). A permissive detector reports
+  no entity class a rule did not ask about.
+
+One real cost survives. `ScanText` runs over the detector's full active set
+(`pii/alcatraz/alcatraz.go:317-337` reading `d.opts`), so a permissive default
+would run 54 recognizers per statement instead of the five a typical config
+names, then discard the extras. We narrow `ScanText` to the union of entities
+named by the lane's `pii` rules, mirroring what `NewMasker` already does for
+the response path. The two changes ship together.
+
+`AllEntities()` returns 54: 51 alcatraz built-ins plus `AWS_ACCESS_KEY`, `JWT`
+and `PRIVATE_KEY` from `pii/alcatraz/secrets.go:23-27`. The figure "45" in six
+code and doc locations is stale; ADR-0009 already carried the correct count.
+`pii.ignored` (`pii/alcatraz/alcatraz.go:128-130`) becomes the recommended
+knob, subtracting the seven recognizers listed in `alcatraz.Noisy`.
+
+### The merge table, restated
+
+Mechanics unchanged from ADR-0006. The keys change, and the split makes the
+per-field rules legible: two sections with two behaviours instead of one
+section with three.
+
+| Field | Global → lane | Why |
+|---|---|---|
+| `guardrails.rules` | **concatenate**, lane's first | Every local rule denies or defers and the first match wins, so concatenating is monotonic in the allow/deny outcome. Order picks which name and message the user reads. |
+| `guardrails.mode` | **replace** when set | A lane rolling out behind an enforcing default has to be able to say observe. |
+| `opa` | **replace** when set | One lane has one decision endpoint. |
+| `mask.rules` | **replace** when set | A rule owns an entity or a column. Concatenating leaves two rewrites of one value. |
+| `pii`, `analyzer`, `audit`, `admin` | process-wide | One detector engine and one analyzer per process. |
+
+`mask.rules: []` is how a lane opts out of an inherited set. The empty list is
+non-empty as JSON bytes, so `len(o.Rules) > 0` at `daemon/config.go:382` reads
+it as an override rather than as silence. A test pins it, because the
+distinction is invisible in the type.
+
+### Startup refusals, restated
+
+| Config | Refused unless |
+|---|---|
+| `opa.gate: true` | the lane has at least one `ai_analysis` rule |
+| an `ai_analysis` rule with no `trigger:` | the lane has `opa.gate: true` |
+| any `ai_analysis` rule | the config has an `analyzer:` section, the protocol has a content builder, and on HTTP `http.capture_body: true` |
+| `mask.rules` non-empty | the protocol supports masking (`gate.MaskSupported`) |
+| both spellings of one field | never; the config is refused |
+
+Two rows leave the table. `mask.enabled: true` with empty rules stops being
+expressible. A rule with `action: defer` and no OPA stops being a refusal and
+starts denying, which ADR-0012 explains.
+
+## Consequences
+
+**Two shipped behaviours reverse, and both need release-note prose.** A lane
+with `mask.enabled: true` and no `pii` section refuses to start today
+(`daemon/daemon.go:590-592`) and will start and mask, because a detector now
+always exists. A lane with mask rules on MSSQL loads clean today and will
+refuse to start, because the check at `daemon/config.go:537` stops being
+skipped. The second is the dangerous direction: a deployment that boots today
+may not boot after the upgrade.
+
+**`analyzer.send: redacted` and `refuse` start working without a `pii`
+section.** The refusal at `daemon/analyzer.go:206-212` tests for a section that
+now always resolves to a detector.
+
+**The audit key follows `name` instead of `connection`.** Seven of the eight
+configs in this repo set them to the same value, so nothing moves.
+`metabase-stack/sidecar/config.yaml:40,44` sets `name: appdb` and
+`connection: metabase`, which is the one in-repo demonstration of why the field
+existed: the listener is named for the upstream and the connection for the
+consumer. That stack's audit rows change key, and
+`envoy-stack/sidecar/read-audit.py:42` prints the new value. Operators whose
+two fields differ rename the listener before upgrading, or their audit history
+splits across two keys.
+
+**The OPA input document does not move.** All 13 fields at
+`policy/opa.go:106-137` stay byte-identical, `input.phase` derives from Go
+constants rather than from config (`policy/opa.go:86,89`), and
+`input.context.connection` keeps its key while changing which config field
+fills it. No Rego policy needs an edit. `session/session_test.go:108` pins the
+context shape as a public contract and keeps passing.
+
+**A lane still cannot opt out of an inherited `opa`.** `resolve` replaces when
+the listener sets one (`daemon/config.go:369-371`), and `opa: {url: ""}` is
+refused (`:487-489`), so a top-level OPA reaches every lane with no escape.
+`mask` has `rules: []` and `guardrails` has `mode: observe`; `opa` has nothing
+equivalent. We read an explicitly empty `opa: {}` on a listener as "no OPA on
+this lane" and close the gap while the section is being rewritten.
+
+**Deprecated fields stay in the Go structs until a named release removes
+them.** Constraint C from the Context leaves no alternative. The window runs
+two minor releases warning, one refusing with instructions, then removal.
+`hoop-inspect -validate` gains `-strict`, which exits non-zero on a
+deprecation so a team can fail its own pipeline before the release that fails
+it for them.
+
+**Documentation drifts in fifteen files at once.** `sidecar/README.md` carries
+the reference (L201-620 and L922-1260), and ADR-0005 restates the merge and
+refusal tables at L267-271 and L1194-1237. The migration table lands at
+README L207, before the first example, and the blockquote at README L3-4
+promising the schema will hold gets rewritten.
+
+### Migration
+
+| Old | New | While deprecated | On removal |
+|---|---|---|---|
+| `policy.rules` | `guardrails.rules` | works, warns | — |
+| `policy.enforce: true\|false` | `guardrails.mode: enforce\|observe` | works, warns | see ADR-0012 |
+| `policy.opa.*` | `opa.*` | works, warns | — |
+| `mask.enabled: true` | drop the key | works, warns | — |
+| `mask.enabled: false` + rules | drop the rules from that scope | **stays authoritative**, masking stays off, warns | masking turns **on** |
+| `mask.rules[].entity: X` | `entities: [X]` | works, warns | — |
+| `listeners[].connection` | `listeners[].name` | maps to `name` when `name` is empty, warns | audit key follows `name` |
+| `pii` omitted | still omitted | — | detector gains all 54 entities |
+
+## Worked example
+
+Five lanes, all eight rule types, both protocols that mask, one that does not.
+
+```yaml
+log_level: info
+admin: {listen: "127.0.0.1:9090"}
+
+audit:
+  file: "-"
+  async_queue_size: 1024
+  query_sessions: 500
+  fail_open: false                # renamed and reversed; see ADR-0012
+
+pii:
+  # Omit this section and all 54 entity types are active. It exists to
+  # subtract: these six are the recognizers that fire on ordinary business
+  # data. US_SSN is absent because this deployment holds real ones.
+  ignored: [URL, DATE_TIME, ABA_ROUTING, AU_TFN, AU_ACN, US_ITIN]
+  allow_list: ["4111111111111111"]
+
+analyzer:
+  provider: anthropic
+  model: claude-sonnet-4-5
+  fail_open: true                 # the one deliberate fail-open; see ADR-0012
+  send: redacted
+  cache: {size: 4096, ttl_sec: 900}
+
+guardrails:
+  mode: enforce
+  rules:
+    - name: no-schema-changes
+      type: operation
+      operations: [drop, truncate, alter]
+      message: schema changes go through migrations
+
+    - name: customers-is-crm-owned
+      type: table
+      tables: [customers]
+      access: write               # writes only, not every mention
+      require_table_match: true   # a statement whose tables could not be read also denies
+      message: customers is owned by the CRM; write through it
+
+    - name: no-server-file-access
+      type: deny_words_list
+      words: [pg_read_file, pg_ls_dir, lo_import, lo_export]
+
+    - name: no-unbounded-delete
+      type: pattern_match
+      pattern_regex: '(?i)\bdelete\s+from\s+\w+\s*;?\s*$'
+
+    - name: no-identifiers-in-query
+      type: pii
+      entities: [US_SSN, CREDIT_CARD, BR_CPF, IBAN_CODE]
+      action: defer               # denies on a lane with no opa; see ADR-0012
+      message: a national identifier in a query lands in the database's own log
+
+mask:
+  rules:
+    - {name: contact-details, entities: [EMAIL_ADDRESS, PHONE_NUMBER], strategy: redact}
+    - {name: card-numbers,    entities: [CREDIT_CARD], strategy: partial, keep_last: 4}
+    - {name: national-ids,    entities: [US_SSN, BR_CPF], strategy: hash}
+    - {name: risk-columns,    columns: [risk_score], strategy: redact}
+
+listeners:
+  # Inherits everything. No OPA, so the deferring rule above denies.
+  - name: appdb
+    protocol: postgres
+    listen: "127.0.0.1:5433"
+    upstream: "db.internal:5432"
+    upstream_tls: {ca_file: /etc/hoop/ca.pem, server_name: db.internal}
+    downstream_tls: {cert_file: /etc/hoop/relay.crt, key_file: /etc/hoop/relay.key}
+
+  # Dry run over the same rules. See ADR-0012.
+  - name: reporting
+    protocol: postgres
+    listen: "127.0.0.1:5434"
+    upstream: "warehouse.internal:5432"
+    guardrails: {mode: observe}
+    mask: {rules: []}             # the empty list opts out of the inherited set
+
+  # TDS rows are length-prefixed binary frames with no reframer, so a mask
+  # block here is refused at startup. The empty list is required.
+  - name: mssqldb
+    protocol: mssql
+    listen: "127.0.0.1:1434"
+    upstream: "mssql.internal:1433"
+    guardrails:
+      rules:                      # concatenates, this lane's first
+        - {name: no-xp-cmdshell, type: deny_words_list, words: [xp_cmdshell, sp_OACreate]}
+    mask: {rules: []}
+
+  # HTTP with the analyzer and a two-phase gate.
+  - name: api
+    protocol: http
+    listen: "127.0.0.1:8081"
+    upstream: "orders.internal:8080"
+    identity_header: x-hoop-user
+    http: {capture_body: true, max_body_bytes: 65536}
+    opa:
+      url: http://opa:8181/v1/data/hoop/inspect/result
+      fail_open: false
+      gate: true                  # ask Rego whether a model call is worth it
+    guardrails:
+      rules:
+        - {name: no-admin-api, type: http_resource, resources: ["/admin/**"]}
+        - {name: leaking-server-errors, type: http_status, statuses: ["5xx"]}
+        - name: risky-payloads
+          type: ai_analysis
+          trigger: {methods: [POST, PUT], resources: ["/orders/**"]}
+          high: defer
+          medium: warn
+          low: allow
+    mask:
+      rules:                      # replaces the default set
+        - {name: response-emails, entities: [EMAIL_ADDRESS], strategy: redact}
+        - {name: credentials, entities: [AWS_ACCESS_KEY, JWT, PRIVATE_KEY], strategy: redact}
+
+  # Filesystem permissions decide who reaches this one.
+  - name: internal-jobs
+    protocol: postgres
+    network: unix
+    listen: /run/hoop/jobs.sock
+    upstream: "db.internal:5432"
+```
+
+Resolved:
+
+| Lane | mode | guardrail rules | OPA | masking |
+|---|---|---|---|---|
+| `appdb` | enforce | 5 inherited | none | 4 rules |
+| `reporting` | observe | 5 inherited, evaluated, none enforced | none | off |
+| `mssqldb` | enforce | 1 own + 5 inherited, own first | none | off |
+| `api` | enforce | 3 own + 5 inherited | gate and decide | 2 rules |
+| `internal-jobs` | enforce | 5 inherited | none | 4 rules |
+
+`no-identifiers-in-query` shows the split. On `appdb` the match denies, because
+nothing can rule on the finding. On `api` the same rule reports
+`input.findings.pii.values.entities` and Rego decides. One file, deployed with
+or without OPA, safe at both ends.
+
+## How this will be verified
+
+- `hoop-inspect -validate` against all six shipped configs in the deprecated
+  spelling (loads, warns) and the new spelling (loads, silent).
+- A config setting both spellings of each of the seven renamed fields, which
+  must produce seven refusals in one run.
+- `make test-sidecar`, which walks every `go.mod` under `sidecar/`.
+- `TestOPAInputDocumentShape` (`policy/policy_test.go:308-351`) and
+  `policy/evalcontext_test.go:67-256`, unchanged and passing, proving the Rego
+  contract held.
+- `deploy/docker-compose/metabase-stack/demo.sh`, the only end-to-end assertion
+  over `mask.rules` against a real result set.
+- A new test for `PluginFromConfig` (`pii/alcatraz/config.go`), which has no
+  coverage today and owns the omitted-section branch this ADR changes.

--- a/docs/adr/0011-sidecar-config-schema.md
+++ b/docs/adr/0011-sidecar-config-schema.md
@@ -1,6 +1,6 @@
 # ADR-0011: Splitting `policy` into `guardrails` and `opa` in the sidecar config
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-08-31
 - **Author:** @matheusfrancisco
 - **Code:** [`sidecar/daemon/config.go`](../../sidecar/daemon/config.go), [`sidecar/pii/alcatraz/`](../../sidecar/pii/alcatraz), [`sidecar/config/yaml/`](../../sidecar/config/yaml)

--- a/docs/adr/0012-sidecar-enforcement-defaults.md
+++ b/docs/adr/0012-sidecar-enforcement-defaults.md
@@ -1,6 +1,6 @@
 # ADR-0012: Deny by default, fail closed without OPA, and observe as a dry run
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-08-31
 - **Author:** @matheusfrancisco
 - **Code:** [`sidecar/daemon/config.go`](../../sidecar/daemon/config.go), [`sidecar/policy/`](../../sidecar/policy), [`sidecar/gate/gate.go`](../../sidecar/gate/gate.go), [`sidecar/audit/`](../../sidecar/audit)

--- a/docs/adr/0012-sidecar-enforcement-defaults.md
+++ b/docs/adr/0012-sidecar-enforcement-defaults.md
@@ -1,0 +1,235 @@
+# ADR-0012: Deny by default, fail closed without OPA, and observe as a dry run
+
+- **Status:** Proposed
+- **Date:** 2026-08-31
+- **Author:** @matheusfrancisco
+- **Code:** [`sidecar/daemon/config.go`](../../sidecar/daemon/config.go), [`sidecar/policy/`](../../sidecar/policy), [`sidecar/gate/gate.go`](../../sidecar/gate/gate.go), [`sidecar/audit/`](../../sidecar/audit)
+- **Related:** [ADR-0008](0008-analyzer-enforces-without-opa.md) (the analyzer already enforces without OPA), [ADR-0010](0010-local-sql-rule-set.md) (its "`enforce: false` is not a dry run" section is what this ADR fixes), [ADR-0011](0011-sidecar-config-schema.md) (the naming half of the same change)
+- **Supersedes / Superseded by:** Supersedes the enforcement half of [ADR-0006](0006-sidecar-config-defaults-and-overrides.md)
+
+## Context
+
+A sidecar exists to refuse statements. Three of its defaults do the opposite,
+and a fourth advertises a capability it does not deliver.
+
+**Enforcement defaults to off.** `enforcing()` returns false for an unset
+pointer (`daemon/config.go:390`), and `buildPolicy` returns a nil evaluator on
+that (`:599`), before rules compile and before any OPA client exists. A config
+with a broad `table` rule and no `enforce: true` starts, logs green, and denies
+nothing. Five of the six configs in this repo set the field, so the repo's own
+examples hide the trap rather than demonstrating it.
+
+**`action: defer` with no OPA refuses the config.** `daemon/config.go:477-485`
+for a local rule, `daemon/analyzer.go:604-611` for an `ai_analysis` risk level.
+The reasoning is sound and stated at `analyzer.go:605-606`: "Deferring to a
+decision that does not exist allows everything. The operator asked for the
+opposite." Enforcing it by refusing to boot means one config file cannot serve
+a deployment with OPA and a deployment without it, and a team wiring OPA later
+writes `defer` into a file that will not load until the day OPA arrives.
+
+**One failure knob reads backwards.** Three sections spell the same idea three
+ways:
+
+| Failure | Field | Default | Reads as |
+|---|---|---|---|
+| OPA unreachable | `opa.fail_open` | `false` | closed |
+| classifier failed | `analyzer.fail_open` | `true` | open |
+| audit write failed | `audit.fail_closed` | `false` | **open** |
+
+The third is negated against the other two, so `false` means opposite things
+one section apart. Its own doc comment calls the default "the uncomfortable
+default" (`daemon/config.go:299-305`). None of the eight configs in this repo
+sets it.
+
+**Observe-only is not a dry run, and its name says otherwise.** The README
+sells it as the rollout path: "run this way for a week before turning
+enforcement on" (`daemon/config.go:182-185`, `sidecar/README.md:388-390`). It
+evaluates nothing. `buildPolicy` returns nil, `Gate.evaluate` returns
+`policy.Allow()` on its first line (`gate/gate.go:564-566`), and the audit
+record carries an empty rule and an empty message
+(`gate/gate.go:383-384`). An operator reading that trail after a week learns
+nothing about what would have been refused. ADR-0010 already says so, in a
+section titled "`enforce: false` is not a dry run".
+
+## Options considered
+
+1. **Delete `enforce` and always enforce.** Simplest schema, and it removes the
+   dangerous default. Rejected: it also removes the rollout mode, and every
+   config that omitted the field starts denying on the next restart with
+   nothing to fall back to when a rule turns out too broad.
+2. **Keep the field, flip nothing, document the trap harder.** No migration
+   risk. Rejected: the trap is a default that silently disables the product,
+   and six documentation locations already describe it correctly. More prose
+   will not fix a wrong default.
+3. **Rename the field, flip the default, and make the off position earn its
+   keep.** `guardrails.mode` defaults to `enforce`; `observe` stops meaning
+   "skip evaluation" and starts meaning "evaluate and record". Chosen.
+
+For `defer` the choice was between two placements of the same fail-closed
+posture: refuse at startup, which is stricter and already implemented, or deny
+at runtime, which lets one file serve both deployments. They cannot coexist,
+because the startup refusal prevents the runtime case from occurring.
+
+## Decision
+
+**Guardrails enforce by default.** `guardrails.mode` takes `enforce` or
+`observe` and defaults to `enforce`. The string replaces the `*bool` three-state
+hack: an empty value means inherit, which a zero `bool` could never express and
+which ADR-0006 solved with a pointer.
+
+**A lane with nothing to enforce relays normally.** `buildPolicy` returns nil
+when the chain ends up empty (`daemon/config.go:661-663`), so `mode: enforce`
+with no rules and no OPA is a pass-through rather than an error. The existing
+warning at `daemon/daemon.go:336-338` covers it and gets reworded to name both
+causes, since its current text tells the operator to set a field that no longer
+exists.
+
+**An unconsumed `defer` denies.** The keyword means: hand the match to a
+decision-maker; with no decision-maker, deny. The startup refusals at
+`daemon/config.go:477-485` and `daemon/analyzer.go:604-611` become warnings that
+keep their diagnostic text.
+
+"No consumer" means no OPA, never "no analyzer". The analyzer produces findings
+and never reads local ones; only the decide-phase client reads them
+(`policy/opa.go:193-197`). `anyDeferred` already makes a lane two-phase only
+when `pc.OPA.enabled()` (`daemon/config.go:627-628`), so nothing else moves.
+
+`policy.Rules` carries `DenyDeferred bool` beside the existing `FailOpen`
+(`policy/policy.go:482-484`), set by `buildPolicy` when OPA is absent. The two
+defer branches at `policy/policy.go:622-627` and `:646-649` deny instead of
+recording.
+
+Everything else already works without OPA and keeps working: all eight rule
+types, response masking, PII detection, the audit trail, and the analyzer's own
+`block` and `warn` actions, which ADR-0008 established decide in-process.
+
+**`observe` evaluates and records.** The chain builds as usual and a wrapper
+converts denials:
+
+```go
+ev, err := buildChain(...)          // unchanged
+if gc.Mode == ModeObserve {
+    ev = policy.Observe{Evaluator: ev}
+}
+```
+
+`policy.Observe` calls through and returns
+`Verdict{Denied: false, Rule: v.Rule, Message: v.Message}` with an annotation
+`guardrails.would_deny`. The gate needs no change: `audit.StatementEvent` takes
+`allowed`, `rule` and `message` as independent arguments
+(`audit/event.go:154`), the gate already passes all three
+(`gate/gate.go:383-384`), and annotations already ride onto the event metadata
+(`gate/gate.go:389-396`).
+
+```json
+{"kind":"statement","allowed":true,"connection":"reporting",
+ "principal":"ana@corp","operation":"update","tables":["customers"],
+ "rule":"customers-is-crm-owned",
+ "message":"customers is owned by the CRM; write through it",
+ "metadata":{"guardrails.would_deny":"customers-is-crm-owned"}}
+```
+
+The kind stays `statement`. `audit/event.go:152-153` reserves `KindViolation`
+for `allowed=false` "so a security team can select violations directly", and
+statements that ran have no business in that stream.
+
+A week of that answers the question the mode exists for:
+
+```bash
+jq -r 'select(.metadata["guardrails.would_deny"]) | .metadata["guardrails.would_deny"]' \
+  audit.jsonl | sort | uniq -c | sort -rn
+    412 customers-is-crm-owned
+      7 no-unbounded-delete
+      1 no-schema-changes
+```
+
+Observe still switches off nothing else. `ErrStreamUnsafe` denies
+(`gate/gate.go:354-368`), a failed audit write denies when audit is fail-closed
+(`:399-407`), and startup validation runs in full.
+
+**`audit.fail_closed` becomes `audit.fail_open`, defaulting to `false`.** All
+three failure knobs then read the same direction, and a statement whose audit
+record cannot be written is refused.
+
+**`analyzer.fail_open` keeps its `true` default.** It guards a third-party
+network call on the request path, and `sidecar/README.md:465-468` has the
+argument: "A classifier that denies whenever its provider has an outage takes
+the database down with it." Every other evaluator in the chain is local or is a
+policy engine the operator runs. After this ADR the sidecar has one stated
+exception rather than one inverted name plus one exception.
+
+## Consequences
+
+**Configs that omitted `enforce` start denying.** That is the point of the
+change and the sharpest edge in it. A rule set nobody validated because it never
+fired now fires. The migration note says so in those words, and `-validate`
+prints the resolved rule count per lane so an operator can read what is about
+to become live.
+
+**Renaming `audit.fail_closed` inverts polarity, and that is the most dangerous
+line in either ADR.** `fail_closed: false` and `fail_open: false` mean opposite
+things. `normalize` therefore reads the old field rather than pattern-matching
+the new one:
+
+| Config says | Result |
+|---|---|
+| `audit.fail_closed: false` | `fail_open: true`, warn. **Behaviour preserved.** |
+| `audit.fail_closed: true` | `fail_open: false`, warn |
+| `audit.fail_open: <x>` | used as written |
+| both | config refused |
+| neither | `fail_open: false`, the flip |
+
+Only a config that omitted the field changes behaviour. Anyone who wrote it down
+keeps what they had, and that property is what makes the rename survivable.
+`AuditConfig.FailClosed` becomes `*bool` so the table is implementable
+(`daemon/config.go:305`).
+
+**Audit-sink availability becomes traffic availability.** All eight configs in
+this repo run `audit.file: "-"`, six with `async_queue_size: 1024`. After the
+flip, a blocked stdout pipe or a full queue refuses statements. Correct posture
+for a system that exists to prove who did what, and a new way for traffic to
+stop.
+
+**A dry run costs what enforcement costs.** An observe lane with `ai_analysis`
+rules makes model calls, and one with OPA makes round trips, because nothing can
+report what would have been denied without evaluating it. Today's observe mode
+is free because it does nothing. Teams that used it as a cheap "off" switch
+should set `guardrails: {rules: []}` on that lane instead.
+
+**`defer` short-circuits on a lane with no OPA.** Today a deferring rule records
+and evaluation continues, so a later hard rule can still deny and Rego sees
+every match (`policy/policy.go` `Action` doc). Once it denies, it stops the set,
+so the first deferring rule wins. The same config run with and without OPA can
+therefore report a different rule name in the denial and in the audit record.
+No regression, since that config does not load today, and it belongs in the docs
+because meeting it in an audit trail is confusing.
+
+**We are committed to `mode` being a string, not a bool.** ADR-0006 pinned
+`*bool` "forever" and guarded it with
+`TestResolveListenerCanDisableEnforcementAgainstEnabledDefault`. That test
+survives with a string; the reasoning behind it (a lane must be able to say
+less) survives unchanged. A future third mode has somewhere to go.
+
+**Observe mode gains a real definition, so it can be tested.** A test can now
+assert that a denying rule on an observe lane produces `allowed: true` with the
+rule name attached, which no test could express before.
+
+## How this will be verified
+
+- A postgres lane with `mode: observe` and a `table` rule, driven with a
+  matching UPDATE: the statement reaches the upstream, and the audit line
+  carries `allowed: true`, the rule name, and `guardrails.would_deny`.
+- The same lane at `mode: enforce`: `kind: violation`, `allowed: false`, same
+  rule name.
+- A lane with `action: defer` and no `opa` block: loads, warns at startup,
+  denies on match. `twophase_test.go:227-236`
+  (`TestLocalDeferWithoutOPAIsRefused`) inverts, and its analyzer twin with it.
+- The same rule on a lane with OPA: still records a finding, still does not
+  short-circuit. `twophase_test.go:190-222` unchanged.
+- A config omitting `audit.fail_closed`, with a sink wired to fail: statements
+  refused. The same config with `audit.fail_closed: false` written out
+  explicitly: statements allowed, deprecation warning printed.
+- `TestFailOpenDefaultsTrue` (`daemon/analyzer_test.go:240-247`) unchanged, so
+  the analyzer exception stays deliberate rather than drifting.
+- `hoop-inspect -validate` on all six shipped configs after the migration,
+  reporting the resolved rule count per lane.

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -248,6 +248,23 @@ before the restart:
   with rules that could never fire. The check now runs on `mask.rules` alone,
   and such a lane refuses to start.
 
+`entity` renames the same way beside `columns`, and that pairing is worth a
+second look because the two keys do different jobs on one rule. The columns
+decide which cells are masked; the entity only names them in the audit trail.
+So the list holds at most one entry there:
+
+```yaml
+- {name: taxpayer, entity: US_SSN, columns: [taxpayer_id]}      # old
+- {name: taxpayer, entities: [US_SSN], columns: [taxpayer_id]}  # new, same rows
+```
+
+Both mask every `taxpayer_id` cell whatever it holds, and both record the
+masked cells as `US_SSN`. Two entities beside `columns` is refused: one cell is
+audited under one name and nothing can pick between two. Name none and the
+cells are reported as `column:taxpayer_id` instead. The label is not checked
+against `pii.entities`, because a column rule runs no detector — it is a name
+for an audit row, not a class a recognizer has to produce.
+
 Omitting `pii` reverses direction too, in the safe one. The section used to be
 required before anything could detect, and it now subtracts from a detector
 that already holds every entity type. Nothing that worked stops working.
@@ -302,7 +319,7 @@ listeners:
           message: destructive statements are not permitted on appdb
     mask:
       rules:                # REPLACES the default list rather than extending it
-        - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
+        - {name: ssn-column, entities: [US_SSN], columns: [ssn], strategy: partial, keep_last: 4}
         - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
 
   - name: httpbin
@@ -1395,7 +1412,10 @@ every HTTP response body and `DATE_TIME` every row with a timestamp.
 `alcatraz.Noisy` records those seven with their rates, and it is the list
 `pii.ignored` was written against. Reach for a `columns:` rule where the
 protocol names the value, because a column rule masks what is in the column
-whatever it looks like.
+whatever it looks like. Name one entity beside the columns and the audit rows
+read `US_SSN` rather than `column:ssn`; name none and `column:ssn` is what
+they carry. The entity is a label there and nothing else — it enables no
+detection, and two of them are refused because a masked cell gets one name.
 
 The same validation cuts the other way, which will bite you in a demo:
 alcatraz **declines** `123-45-6789` and `987-65-4321`, rejecting sequential

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -1,7 +1,10 @@
 # sidecar
 
-> **0.1.0**: the API is settling. Expect the config schema to hold and the Go
-> interfaces to move.
+> **0.1.0**: the API is settling. The config schema moved in this release.
+> `policy` split into `guardrails` and `opa`, `mask.enabled` went away, and two
+> defaults reversed. [Deprecated fields](#deprecated-fields) carries the
+> migration table and the three behaviour changes that can move traffic. The
+> Go interfaces will keep moving.
 
 Turn raw database wire-protocol bytes into structured statements, and
 structured statements into allow/deny verdicts.
@@ -160,7 +163,7 @@ That binary is already in the images you pull: `hoophq/hoopdev` (agent) and
 onward as `sidecar`. Running the relay out of one
 without building anything (`docker exec` into a live container, extending the
 image and swapping `CMD`, or adding a second container to the agent pod) is
-[QUICKSTART-AGENT-IMAGE.md](./QUICKSTART-AGENT-IMAGE.md).
+[sidecar-binary.md](../deploy/docker-compose/envoy-stack/sidecar-binary.md).
 
 **As a standalone binary**, when a sidecar container should carry the relay and
 nothing else. It lives in the nested `cmd` module, which is where the optional
@@ -190,9 +193,10 @@ docker build -f deploy/docker-compose/envoy-stack/sidecar/Dockerfile \
 
 There are no build tags. The config file decides every capability, so an
 operator turning on PII detection does not also have to swap the binary. Omit
-the `pii` section and detection is off, which makes masking unavailable and a
-`pii` policy rule a config error: both are refused at startup rather than
-silently skipped.
+the `pii` section and the detector still runs, holding all 54 entity types:
+the section narrows that set rather than switching it on. A binary built
+without the alcatraz plugin is the case that refuses a `mask` block at
+startup.
 
 To embed the relay in your own process, call `daemon.Setup` to load the config
 and build the detector, then `daemon.Run`. That is all `hoop start sidecar`
@@ -205,6 +209,51 @@ every listener, and then tells you what it resolved. YAML and JSON both work
 and the extension picks the parser: `.yaml` and `.yml` go through the nested
 `config/yaml` module, anything else is read as JSON. Decoding is strict, so a
 mistyped key fails the startup instead of silently disabling a control.
+
+### Deprecated fields
+
+0.1.0 renamed six keys, removed one, and reversed two defaults. Both
+spellings load for two minor releases and the old one prints a warning.
+Setting both spellings of one field at one scope refuses the config, because
+picking a winner silently would contradict the rule the decoder already
+enforces: a typo in a key must not disable a control. Read this before the
+example below. Every config written against the old reference needs a pass.
+
+| Old | New | While deprecated |
+|---|---|---|
+| `policy.rules` | `guardrails.rules` | works, warns |
+| `policy.enforce: true\|false` | `guardrails.mode: enforce\|observe` | works, warns |
+| `policy.opa.*` | `opa.*` | works, warns |
+| `mask.rules[].entity: X` | `mask.rules[].entities: [X]` | works, warns |
+| `mask.enabled: true` | drop the key; rules present means masking is on | works, warns |
+| `mask.enabled: false` with rules | drop the rules from that scope | stays authoritative, masking stays off, warns |
+| `listeners[].connection` | `listeners[].name` | maps onto `name` when `name` is empty, warns |
+| `audit.fail_closed: <x>` | `audit.fail_open: <the opposite of x>` | works, warns |
+| `pii` omitted | still omitted | the detector gains all 54 entity types |
+
+Three of those move traffic on the upgrade, and each one deserves a read
+before the restart:
+
+- **A config that never set `enforce` starts denying.** `guardrails.mode`
+  defaults to `enforce`, so a rule set nobody validated because it never fired
+  now fires. Run `-validate` first and read the resolved rule count per lane.
+- **A config that never set `audit.fail_closed` starts refusing statements
+  whose audit write failed.** `audit.fail_open` defaults to `false`. The two
+  keys are negations of each other, so the migration reads the old field
+  rather than pattern-matching the new one: a config that wrote
+  `fail_closed: false` resolves to `fail_open: true` and keeps the behaviour
+  it had. Only a config that omitted the field changes.
+- **Mask rules on a protocol that cannot mask stop loading.** `mask.enabled`
+  used to gate that check, so a lane omitting the flag skipped it and booted
+  with rules that could never fire. The check now runs on `mask.rules` alone,
+  and such a lane refuses to start.
+
+Omitting `pii` reverses direction too, in the safe one. The section used to be
+required before anything could detect, and it now subtracts from a detector
+that already holds every entity type. Nothing that worked stops working.
+
+`hoop-inspect -validate -strict` exits non-zero on any deprecation, so a
+pipeline can fail on the old spelling before the release that removes it does.
 
 ### 1. Write the file
 
@@ -222,13 +271,13 @@ audit:
   async_queue_size: 1024    # a slow sink must not block a user's query
   memory_buffer: 256        # last N events, readable at GET /events
   query_sessions: 500       # backs GET /api/sessions
-  fail_closed: false        # true refuses a statement whose audit write failed
+  fail_open: false          # the default: a statement whose audit write failed is refused
 
-pii:                        # omit the section to disable detection entirely
+pii:                        # omit the section and all 54 entity types are active
   entities: [EMAIL_ADDRESS, US_SSN, CREDIT_CARD, BR_CPF, IBAN_CODE]
 
-policy:                     # inherited by every listener
-  enforce: true             # false is observe-only: inspect and audit, deny nothing
+guardrails:                 # Hoop's own rules, inherited by every listener
+  mode: enforce             # the default; observe evaluates and records, denying nothing
   rules:
     - name: no-cpf-in-query
       type: pii
@@ -236,18 +285,16 @@ policy:                     # inherited by every listener
       message: do not put a taxpayer id in a query; it lands in the database's own logs
 
 mask:                       # inherited by every listener
-  enabled: true
-  rules:
-    - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
-    - {name: ssn, entity: US_SSN, strategy: partial, keep_last: 4}
+  rules:                    # a non-empty list is the whole switch
+    - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
+    - {name: ssn, entities: [US_SSN], strategy: partial, keep_last: 4}
 
 listeners:
-  - name: appdb
+  - name: appdb             # audit rows and input.context.connection key on this
     protocol: postgres
     listen: 0.0.0.0:15432
     upstream: appdb:5432
-    connection: appdb       # the name audit rows and policy key on
-    policy:
+    guardrails:
       rules:
         - name: no-destructive-sql
           type: operation   # classifier-derived, so SELECT 'DROP TABLE x' is a select
@@ -256,17 +303,16 @@ listeners:
     mask:
       rules:                # REPLACES the default list rather than extending it
         - {name: ssn-column, columns: [ssn], strategy: partial, keep_last: 4}
-        - {name: emails, entity: EMAIL_ADDRESS, strategy: redact}
+        - {name: emails, entities: [EMAIL_ADDRESS], strategy: redact}
 
   - name: httpbin
     protocol: http
     listen: 0.0.0.0:18080
     upstream: httpbin:8080
-    connection: httpbin
-    policy:
-      opa:
-        url: http://opa:8181/v1/data/hoop/inspect
-        fail_open: false
+    opa:                    # someone else's Rego, its own section beside guardrails
+      url: http://opa:8181/v1/data/hoop/inspect
+      fail_open: false
+    guardrails:
       rules:
         - name: no-admin-api
           type: http_resource
@@ -278,9 +324,13 @@ listeners:
           message: upstream failure suppressed by policy
 ```
 
-Rule types and what each one matches are in [Policy](#policy); masking
-strategies and the entity-versus-column choice are in
-[Masking and PII](#masking-and-pii).
+Rule types and what each one matches are in [Guardrails and
+OPA](#guardrails-and-opa); masking strategies and the entity-versus-column
+choice are in [Masking and PII](#masking-and-pii).
+
+`audit.fail_open` replaced `audit.fail_closed` and inverted with the rename, so
+`fail_closed: false` and `fail_open: false` mean opposite things and only a
+config that wrote neither changes behaviour.
 
 Other listener fields worth knowing: `network: unix` binds a filesystem socket
 instead of a port (see [Transport](#transport)), `upstream_tls` encrypts the
@@ -293,10 +343,11 @@ concurrency.
 
 | Field | Merge | Why |
 |---|---|---|
-| `policy.rules` | concatenate, listener first | Every rule denies and the first match wins, so concatenating cannot change the allow/deny outcome. Order only picks which message the user reads. |
-| `policy.opa` | replace | One lane has one decision endpoint. |
-| `policy.enforce` | replace | A lane rolling out behind an enforcing default has to be able to say observe-only. |
-| `mask` | replace | A rule owns an entity type, and two concatenated lists leave two rules competing for one entity. |
+| `guardrails.rules` | concatenate, listener first | Every local rule denies or defers and the first match wins, so concatenating is monotonic in the allow/deny outcome. Order picks which name and message the user reads. |
+| `guardrails.mode` | replace when set | A lane rolling out behind an enforcing default has to be able to say observe. |
+| `opa` | replace when set | One lane has one decision endpoint. An explicitly empty `opa: {}` on a listener drops an inherited one. |
+| `mask.rules` | replace when set | A rule owns an entity or a column, and two concatenated lists leave two rewrites of one value. `mask.rules: []` is how a lane opts out of an inherited set. |
+| `pii`, `analyzer`, `audit`, `admin` | process-wide | One detector engine and one analyzer per process. |
 
 ### 3. Validate before you deploy
 
@@ -315,18 +366,26 @@ config OK: 2 listener(s)
 ```
 
 Each line is the RESOLVED lane, so the counts include what it inherited. A lane
-with an `opa` block reads `+ opa`, and one with `enforce: false` reads
-`observe-only`.
+with an `opa` block reads `+ opa`, and one with `guardrails.mode: observe`
+reads `observing N rule(s), denying none` with a note under it. Observe is a
+dry run rather than an off switch: the lane builds the same chain, evaluates
+every rule, allows the statement, and files the rule that would have refused
+it under `guardrails.would_deny`. A lane that should skip the work sets
+`guardrails: {rules: []}`.
+
+`-validate` also prints a note where a resolved lane behaves in a way the file
+does not show. A rule carrying `action: defer` on a lane with no `opa.url`
+gets one, because that match denies rather than reporting a finding.
 
 Validation builds every lane, so it catches what a syntax check cannot, and it
 reports every problem in one run rather than one per restart. It refuses these
 outright:
 
-- `mask.enabled` on a protocol whose codec can carry neither masking
-  mechanism, naming the lane.
-- A `pii` rule naming an entity absent from `pii.entities`, naming the entity.
-  Without this check the rule loads, evaluates, and matches nothing, so a
-  guardrail looks live while allowing everything it was written to stop.
+- `mask.rules` on a protocol whose codec can carry neither masking mechanism,
+  naming the lane. This check used to sit behind `mask.enabled`, so a lane
+  omitting the flag skipped it and loaded rules that could never fire.
+- Both spellings of one renamed field at one scope, naming the field. See
+  [Deprecated fields](#deprecated-fields).
 - A key typo, in YAML or JSON.
 - A bad regex in any lane's rules, naming the lane.
 - An `ai_analysis` rule with no `analyzer` section, no trigger, or no action
@@ -377,16 +436,42 @@ x-readonly: &readonly
     operations: [insert, update, delete, drop, truncate]
     message: this credential is read-only
 
-policy:
-  enforce: true   # without this every lane below is observe-only
-
 listeners:
-  - {name: replica-a, protocol: postgres, listen: 0.0.0.0:15432, upstream: a:5432, policy: {rules: *readonly}}
-  - {name: replica-b, protocol: postgres, listen: 0.0.0.0:15433, upstream: b:5432, policy: {rules: *readonly}}
+  - {name: replica-a, protocol: postgres, listen: 0.0.0.0:15432, upstream: a:5432, guardrails: {rules: *readonly}}
+  - {name: replica-b, protocol: postgres, listen: 0.0.0.0:15433, upstream: b:5432, guardrails: {rules: *readonly}}
 ```
 
-`enforce` defaults to false so a misconfigured rule cannot take production down
-on first deploy. A lane running observe-only says so in the startup log and in
+`guardrails.mode` defaults to `enforce`, so both lanes deny on the first
+deploy with no third key to remember. The rollout path is `mode: observe`,
+which evaluates the same chain, allows the statement anyway, and records the
+rule that would have refused it. The audit line stays `kind: statement` with
+`allowed: true`, carries the rule name and message, and adds one annotation:
+
+```json
+{"kind":"statement","allowed":true,"connection":"reporting",
+ "principal":"ana@corp","operation":"update","tables":["customers"],
+ "rule":"customers-is-crm-owned",
+ "message":"customers is owned by the CRM; write through it",
+ "metadata":{"guardrails.would_deny":"customers-is-crm-owned"}}
+```
+
+A week of that answers the question the mode exists for:
+
+```bash
+jq -r 'select(.metadata["guardrails.would_deny"]) | .metadata["guardrails.would_deny"]' \
+  audit.jsonl | sort | uniq -c | sort -rn
+    412 customers-is-crm-owned
+      7 no-unbounded-delete
+      1 no-schema-changes
+```
+
+A dry run costs what enforcement costs, because nothing can report what would
+have been denied without evaluating it. An observe lane with `ai_analysis`
+rules makes model calls and one with OPA makes round trips. Set
+`guardrails: {rules: []}` on a lane that wants the cheap off switch instead.
+Observe switches off nothing else: `ErrStreamUnsafe` still denies, a failed
+audit write still denies while `audit.fail_open` is false, and startup
+validation runs in full. A lane in observe says so in the startup log and in
 `/config`.
 
 ### Analyzing statements with a model
@@ -405,7 +490,7 @@ left classifying nothing, which is what a relay-only protocol would otherwise
 get: no statements to render means no verdict, silently.
 
 ```yaml
-pii:
+pii:                           # optional; omitting it activates all 54 types
   entities: [EMAIL_ADDRESS, US_SSN, BR_CPF]
 
 analyzer:                      # one provider serves every lane
@@ -426,7 +511,7 @@ listeners:
     protocol: postgres
     listen: 0.0.0.0:15432
     upstream: appdb:5432
-    policy:
+    guardrails:
       rules:
         - name: risky-writes
           type: ai_analysis
@@ -444,7 +529,7 @@ listeners:
       capture_body: true
       max_body_bytes: 8192
       headers: [Content-Type]
-    policy:
+    guardrails:
       rules:
         - name: risky-payloads
           type: ai_analysis
@@ -470,7 +555,9 @@ requirement, and accept that a provider outage then stops traffic.
 **`send: redacted` uses the in-process detector** to name entities instead of
 transmitting their values. A relay whose job is keeping taxpayer ids out of a
 database's query log should not post them to a model vendor. `send: refuse`
-denies locally instead of transmitting, and both need a `pii` section.
+denies locally instead of transmitting. Neither one needs a `pii` section any
+more: a detector always exists once the plugin is linked, and the section only
+narrows which entity types it scans for.
 
 **Handing the decision to OPA.** `high: block` is a level→action table with
 three rows, and it sees only the level. Set the action to `defer` where the
@@ -479,11 +566,12 @@ analyzer classifies and records the level, and the block/allow choice moves
 into Rego.
 
 ```yaml
-policy:
-  opa:
-    url: http://opa:8181/v1/data/hoop/inspect/result
-    fail_open: false
-    gate: true
+opa:
+  url: http://opa:8181/v1/data/hoop/inspect/result
+  fail_open: false
+  gate: true
+
+guardrails:
   rules:
     - name: risky-writes
       type: ai_analysis
@@ -508,15 +596,19 @@ answer what the level means. Both calls hit the same URL and carry
 `input.phase`, so a policy that ignores the field answers both identically,
 and turning the gate on costs one round trip rather than a rewrite.
 
-Four configs are refused at startup. `defer` on a lane with no
-`policy.opa.url` defers to a decision that does not exist, which allows
-everything; `gate: true` on a lane with no `ai_analysis` rule is a round trip
-that buys nothing. An `ai_analysis` rule with no `trigger` is also refused,
-except under `gate: true`, where an empty trigger is how you say Rego decides.
-So is `action: defer` on an `ai_analysis` rule: that type defers per level
-through `high`/`medium`/`low`, and a rule saying both would leave two answers
-to one question. [Policy](#policy) covers what the two phases send and what
-the gate may answer.
+Three configs are refused at startup. `gate: true` on a lane with no
+`ai_analysis` rule is a round trip that buys nothing. An `ai_analysis` rule
+with no `trigger` is refused too, except under `gate: true`, where an empty
+trigger is how you say Rego decides. So is `action: defer` on an `ai_analysis`
+rule: that type defers per level through `high`/`medium`/`low`, and a rule
+saying both would leave two answers to one question.
+
+`defer` on a lane with no `opa.url` used to be the fourth refusal. It now
+loads, warns at startup, and DENIES on a match. Deferring to a decision that
+does not exist has to fail closed somewhere, and moving that from startup to
+runtime lets one file serve a deployment with OPA and a deployment without
+one. [Guardrails and OPA](#guardrails-and-opa) covers what the two phases send
+and what the gate may answer.
 
 **Writing your own prompt.** Risk depends on what you are protecting, so the
 risk guidance is replaceable at two levels.
@@ -536,7 +628,7 @@ analyzer:
 
 listeners:
   - name: appdb
-    policy:
+    guardrails:
       rules:
         - name: risky-writes
           type: ai_analysis
@@ -548,7 +640,7 @@ listeners:
             change.
 
   - name: api
-    policy:
+    guardrails:
       rules:
         - name: risky-payloads
           type: ai_analysis
@@ -919,18 +1011,34 @@ keeping segments, so a policy comes out too narrow rather than too broad.
 A policy engine's decision log is a copy of everything you send it, and
 `Options.Headers` is an allowlist with no "capture all" switch.
 
-## Policy
+## Guardrails and OPA
 
-Two evaluators, meant to be layered via `policy.Chain{local, opa}` so a
-statement the local rules already forbid costs no network round-trip.
-Anything that defers changes the order: OPA moves after the producers whose
-findings it reads, its call carries `phase: decide`, and `opa.gate: true`
-adds a second call before them. Both phases are below.
+Two evaluators under two config sections, layered via `policy.Chain{local,
+opa}` so a statement the local rules already forbid costs no network round
+trip. The Go package is still `policy`; the config keys are what split.
 
-**Local rules.** SQL: `deny_words_list`, `pattern_match` (RE2), `operation`,
-`table`. HTTP: `http_resource`, `http_status`. Cross-protocol: `pii` (see
-[Masking and PII](#masking-and-pii)). One ordered set can mix them, so a
-deployment fronting a database and an API needs one evaluator:
+**Guardrails are Hoop's own rules**, written under `guardrails` and evaluated
+in-process against a decoded statement. Eight rule types, all local except the
+`ai_analysis` one, and `guardrails.mode` decides whether a match denies or
+lands in the audit record as `guardrails.would_deny`. Nothing here needs a
+policy engine, a network hop or a second team.
+
+**OPA is someone else's Rego**, wired under `opa`. sidecar owns no policy
+there; it owns the *input document* it posts and the two phases it may post
+on. Anything that defers changes the order: OPA moves after the producers
+whose findings it reads, its call carries `phase: decide`, and
+`opa.gate: true` adds a second call before them. Both phases are below.
+
+A lane can run either half alone. Guardrails with no `opa` block deny locally
+and never leave the process, and an `opa` block with no `guardrails.rules`
+hands every statement to Rego.
+
+**The local rule types.** SQL: `deny_words_list`, `pattern_match` (RE2),
+`operation`, `table`. HTTP: `http_resource`, `http_status`. Cross-protocol:
+`pii` (see [Masking and PII](#masking-and-pii)) and `ai_analysis` (see
+[Analyzing statements with a
+model](#analyzing-statements-with-a-model)). One ordered set can mix them, so
+a deployment fronting a database and an API needs one evaluator:
 
 ```go
 policy.NewRules([]policy.Rule{
@@ -1093,7 +1201,12 @@ result := {"allow": true, "request": {"ai_analysis": true}} if {
 `input.context` is whatever the caller attached. The relay fills it from the
 session: `principal`, `session_id`, `connection`, and `subject`, `email`,
 `groups`, `peer_addr`, `upstream`, `correlation_id` where the identity carries
-them. A library caller setting `OPAClient.Context` chooses its own keys.
+them. `context.connection` keeps its key and changes its source: the
+listener's `name` fills it now that `listeners[].connection` is gone. A
+deployment that set the two fields to different strings sees every Rego rule
+and every audit row key on the new value, so rename the listener before
+upgrading or the audit history splits in two. A library caller setting
+`OPAClient.Context` chooses its own keys.
 
 **Statement content never travels in a finding.** The analyzer's title and
 explanation are the model's own words about a statement it was shown, `pii`
@@ -1134,13 +1247,23 @@ rules:
     operations: [drop]
 ```
 
-First-match-wins applies to DENIALS only. A deferring rule never ends
-evaluation, so one statement can report several findings and still be denied
-by a hard rule further down. `defer` is the only value `action` takes, and
-anything else is refused at startup rather than read as "deny": a rule whose
-action was mistyped would otherwise enforce the opposite of what it says. So
-is `defer` on a lane with no `policy.opa.url`, which defers to a decision that
-does not exist and therefore allows everything.
+First-match-wins applies to DENIALS only. On a lane with OPA a deferring rule
+never ends evaluation, so one statement can report several findings and still
+be denied by a hard rule further down. `defer` is the only value `action`
+takes, and anything else is refused at startup rather than read as "deny": a
+rule whose action was mistyped would otherwise enforce the opposite of what it
+says.
+
+**`defer` on a lane with no `opa.url` denies.** The keyword hands a match to a
+decision-maker, and with no decision-maker the only reading that is not "allow
+everything" is refusal. The lane loads and warns at startup rather than
+refusing the config, so one file serves a deployment with OPA and a deployment
+without one. A denying `defer` also ends the set, so the first deferring rule
+wins there while the same config against OPA records every match and lets a
+later hard rule deny. The same statement can therefore name a different rule
+in the audit record depending on whether OPA is wired up. "No consumer" means
+no OPA and never "no analyzer": the analyzer produces findings and never reads
+them.
 
 **Findings key by rule TYPE, not by rule name.** A policy asks what the PII
 scanner found, not what the rule named `no-cpf` found, so every deferring
@@ -1187,12 +1310,14 @@ rather than by consulting a list of protocol names:
   Substituting bytes there desynchronizes the client, and `psql` reports "lost
   synchronization with server".
 
-A codec offering neither gets its `mask` section refused at startup, because
-accepting a masking config that can never fire is the failure that ends with an
-unmasked SSN in a screenshot.
+A codec offering neither gets its `mask.rules` refused at startup, because
+accepting a masking config that can never fire is the failure that ends with
+an unmasked SSN in a screenshot. That check is unconditional now that
+`mask.enabled` is gone, so a lane that used to load by omitting the flag
+refuses to start.
 
 Detection and rewriting both come from
-[alcatraz](https://github.com/hoophq/alcatraz): 45 entity types across 12
+[alcatraz](https://github.com/hoophq/alcatraz): 51 entity types across 12
 countries, 25 of them checksum-verified with Luhn on cards, ISO 7064 mod-97 on
 IBAN, Verhoeff on Aadhaar, mod-11 on the Brazilian schemes. It lives in the
 nested `pii/alcatraz` module, so the root library never links it.
@@ -1202,8 +1327,8 @@ det, _ := alcatraz.NewDetector(alcatraz.Options{
     Entities: []string{entities.USSSN, entities.CreditCard, entities.BRCPF},
 })
 m, _ := alcatraz.NewMasker(det, []alcatraz.Rule{
-    {Entity: entities.USSSN,      Strategy: alcatraz.StrategyRedact},
-    {Entity: entities.CreditCard, Strategy: alcatraz.StrategyPartial, KeepLast: 4},
+    {Entities: []string{entities.USSSN},      Strategy: alcatraz.StrategyRedact},
+    {Entities: []string{entities.CreditCard}, Strategy: alcatraz.StrategyPartial, KeepLast: 4},
 })
 out, res := m.Mask(responseBytes)   // res names WHAT was masked, never values
 
@@ -1211,6 +1336,10 @@ p, _ := policy.NewRulesWithScanner(rules, det)   // the same det, request side
 ```
 
 Four strategies: `redact`, `mask`, `partial`, `hash`.
+
+`alcatraz.NewDetector` with an empty `Options.Entities` builds over every
+supported type, which is the Go-level shape of an omitted `pii` section.
+`Options.Ignored` subtracts from that set.
 
 **Credentials too.** Alcatraz is a PII engine and carries no recognizer for a
 secret, so `pii/alcatraz/secrets.go` registers three into the same engine:
@@ -1220,7 +1349,7 @@ them in config like any other entity.
 
 ### The guardrail half
 
-One `Detector` drives both paths. The `pii` policy rule answers a different
+One `Detector` drives both paths. The `pii` guardrail rule answers a different
 question than masking: a national ID in a `WHERE` clause lands in the
 database's own query log, slow-query log and `EXPLAIN` output, and response
 masking never undoes that.
@@ -1230,10 +1359,28 @@ masking never undoes that.
  "message": "do not put a taxpayer id in a query"}
 ```
 
-### Name the entity types you want
+### Narrow the entity types
 
-There is no all-entities default, on purpose. Enabling all 45 recognizers
-rewrites ordinary numeric columns:
+Omit `pii` and the detector holds every type it has, 54 counting the three
+credential recognizers. The section subtracts, and `pii.ignored` is the knob
+built for it:
+
+```yaml
+pii:
+  # The seven recognizers that fire on ordinary business data. US_SSN stays
+  # active here because this deployment holds real ones.
+  ignored: [URL, DATE_TIME, ABA_ROUTING, AU_TFN, AU_ACN, US_ITIN]
+```
+
+A wide detector costs a wider scan and nothing else. `NewMasker` narrows the
+engine to exactly the entities its own rules name, and a `pii` guardrail rule
+intersects the scan with its own `entities` list before publishing anything.
+Both paths see the classes their config asked about, so a permissive detector
+widens the scan and never widens the result.
+
+What corrupts data is a MASK RULE naming a noisy entity. Write
+`{name: ssn, entities: [US_SSN], strategy: redact}` and ordinary numeric
+columns get rewritten on the way back:
 
 ```
 {"order_id":457555462,"customer_id":123456781}
@@ -1242,22 +1389,29 @@ rewrites ordinary numeric columns:
 
 Nine digits in a legal range *is* a valid SSN as far as any detector can tell:
 SSNs carry no checksum, so nothing rejects them. Measured over random
-nine-digit business ids, `US_SSN` fires on about a third. `alcatraz.Noisy`
-records the offenders with their rates, and `AllEntities()` is there once you
-have read it.
+nine-digit business ids, `US_SSN` fires on about a third, `ABA_ROUTING` on
+2.5%, `AU_TFN` on 2.1%, `AU_ACN` on 2.0% and `US_ITIN` on 1.7%. `URL` matches
+every HTTP response body and `DATE_TIME` every row with a timestamp.
+`alcatraz.Noisy` records those seven with their rates, and it is the list
+`pii.ignored` was written against. Reach for a `columns:` rule where the
+protocol names the value, because a column rule masks what is in the column
+whatever it looks like.
 
 The same validation cuts the other way, which will bite you in a demo:
 alcatraz **declines** `123-45-6789` and `987-65-4321`, rejecting sequential
 and descending runs as test fixtures. If you must mask placeholder SSNs, add
 a rule for that shape rather than widening the detector.
 
-A `pii` policy rule records the offending statement in the audit trail, raw
+A `pii` guardrail rule records the offending statement in the audit trail, raw
 literal included. Set `audit.redact_statements` where that is the wrong trade:
 the denial keeps working, and the record keeps a stable fingerprint instead of
 the text.
 
-**Masking requires the plugin.** The gate refuses `mask.enabled` with no
-detection wired in at startup rather than passing traffic through unmasked.
+**Masking needs the plugin linked, not a `pii` section.** A binary built
+without alcatraz refuses a `mask` block at startup rather than passing traffic
+through unmasked. A binary that links it always carries a detector, so
+`mask.rules` on its own is enough, and the config that used to be refused for
+omitting `pii` starts and masks.
 
 ## Transport
 

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -1389,6 +1389,16 @@ pii:
   ignored: [URL, DATE_TIME, ABA_ROUTING, AU_TFN, AU_ACN, US_ITIN]
 ```
 
+Every name in both lists is resolved at startup and an unknown one refuses the
+config, naming the key it sits under. `ignored` needs that more than `entities`
+does: a misspelled entry subtracts nothing, so the recognizer you wrote it to
+switch off keeps running and the detector boots looking exactly like one that
+obeyed you. Write `US_SSSN` and the process stops with
+
+```
+pii section: alcatraz: unknown entity type(s) in ignored: US_SSSN (PERSON, ...)
+```
+
 A wide detector costs a wider scan and nothing else. `NewMasker` narrows the
 engine to exactly the entities its own rules name, and a `pii` guardrail rule
 intersects the scan with its own `entities` list before publishing anything.

--- a/sidecar/cmd/main.go
+++ b/sidecar/cmd/main.go
@@ -25,15 +25,14 @@
 // the config file, so an operator adding a "pii" section does not also have to
 // swap the binary out:
 //
-//   - "pii" absent: detection is off. Masking is unavailable and a policy rule
-//     of type "pii" is a config error, both refused at startup rather than
-//     silently skipped.
-//   - "pii" present: 45 alcatraz entity types across 12 countries (25
-//     checksum-verified) plus three credential recognizers drive response
-//     masking, where a rule names an entity and a strategy, and policy rules
-//     of type "pii", which deny a statement that embeds a national identifier.
-//     No amount of response masking undoes that once the query is in the
-//     database's own log.
+//   - "pii" absent: the detector covers all 54 entity types it knows, and
+//     costs nothing until a rule asks it for one. A masker scans only for the
+//     entities its own rules name, and a "pii" guardrail intersects the scan
+//     with the entities its own rule names.
+//   - "pii" present: the section NARROWS that set. Name entities to restrict
+//     detection to them, or use "ignored" to drop the recognizers that fire on
+//     ordinary business data. See the pii/alcatraz package documentation for
+//     the measured rates.
 //
 // The config file may be YAML or JSON; the extension picks the parser.
 //
@@ -42,22 +41,26 @@
 //	    "entities": ["BR_CPF", "IBAN_CODE", "CREDIT_CARD"],
 //	    "allow_list": ["4111111111111111"]
 //	  },
-//	  "mask":   {"enabled": true, "rules": [{"entity": "BR_CPF", "strategy": "redact"}]},
-//	  "policy": {"enforce": true, "rules": [
+//	  "mask":       {"rules": [{"entities": ["BR_CPF"], "strategy": "redact"}]},
+//	  "guardrails": {"mode": "enforce", "rules": [
 //	    {"name": "no-cpf-in-query", "type": "pii", "entities": ["BR_CPF"],
 //	     "message": "do not put a national ID in a query"}
 //	  ]}
 //	}
 //
-// pii.entities is required whenever the section is present. There is no
-// all-entities default, because turning on all 45 recognizers rewrites
-// ordinary numeric columns as US_SSN. See the pii/alcatraz package
-// documentation for the measured rates.
+// # The pre-ADR-0011 spelling
+//
+// "policy" used to carry both Hoop's own rules and the OPA client. It split
+// into "guardrails" and "opa", "mask.enabled" and "listeners[].connection"
+// were dropped, and "mask.rules[].entity" became a list named "entities". Both
+// spellings load; the old one prints a warning naming its replacement, and
+// -strict turns that warning into a non-zero exit.
 //
 // Usage:
 //
 //	hoop-inspect -config /etc/hoop-inspect/config.yaml
 //	hoop-inspect -validate -config config.yaml
+//	hoop-inspect -validate -strict -config config.yaml
 //	hoop-inspect -version
 package main
 
@@ -87,9 +90,14 @@ var version = "0.1.0"
 
 func main() {
 	err := daemon.Main(version, configyaml.Load, func(raw json.RawMessage) (daemon.Plugin, error) {
-		// A nil alcatraz.Plugin converts to a nil daemon.Plugin, so "no pii
-		// section" stays nil rather than becoming a non-nil interface holding
-		// a nil pointer, which the sidecar would call through.
+		// An absent "pii" section no longer means no detector: the plugin
+		// builds one over every entity type it knows and the section
+		// narrows it. A nil Plugin now means only that a build linked no
+		// detector at all, which this one does not.
+		//
+		// The conversion still matters. A nil alcatraz.Plugin converts to a
+		// nil daemon.Plugin rather than to a non-nil interface holding a nil
+		// pointer, which the sidecar would call through.
 		return alcatraz.PluginFromConfig(raw)
 	})
 	if err == nil {

--- a/sidecar/daemon/analyzer.go
+++ b/sidecar/daemon/analyzer.go
@@ -345,6 +345,7 @@ func buildAnalyzerEvaluators(
 	cfg *AnalyzerConfig,
 	provider analyzer.Provider,
 	redact func(string) string,
+	hasOPA bool,
 ) ([]policy.Evaluator, error) {
 	if len(rules) == 0 {
 		return nil, nil
@@ -356,7 +357,7 @@ func buildAnalyzerEvaluators(
 
 	out := make([]policy.Evaluator, 0, len(rules))
 	for _, r := range rules {
-		actions, err := actionMap(r)
+		actions, err := actionMap(r, hasOPA)
 		if err != nil {
 			return nil, err
 		}
@@ -399,7 +400,16 @@ func triggerFrom(t *policy.AITrigger) analyzer.Trigger {
 	}
 }
 
-func actionMap(r policy.Rule) (analyzer.ActionMap, error) {
+// actionMap turns a rule's high/medium/low strings into the analyzer's
+// action vocabulary.
+//
+// hasOPA false degrades `defer` to `block`. Deferring names a decision-maker,
+// and the only evaluator that reads an ai_analysis finding is a decide-phase
+// OPA client. With no OPA the finding would be recorded and read by nobody,
+// which allows the statement: the opposite of what the operator asked for.
+// The lane keeps a startup note saying so, because a config that reads
+// `high: defer` and behaves as `high: block` has to say which one it did.
+func actionMap(r policy.Rule, hasOPA bool) (analyzer.ActionMap, error) {
 	m := analyzer.ActionMap{}
 	for level, raw := range map[analyzer.RiskLevel]string{
 		analyzer.RiskHigh:   r.HighRisk,
@@ -412,6 +422,9 @@ func actionMap(r policy.Rule) (analyzer.ActionMap, error) {
 		a := analyzer.Action(raw)
 		if !a.Valid() {
 			return nil, fmt.Errorf("rule %q: unknown action %q for %s risk", r.Name, raw, level)
+		}
+		if a == analyzer.ActionDefer && !hasOPA {
+			a = analyzer.ActionBlock
 		}
 		m[level] = a
 	}
@@ -538,8 +551,8 @@ func httpCodecFactory(proto inspect.Protocol, h *HTTPCodecConfig) func() inspect
 // Every refusal here is a control that would otherwise load, evaluate and do
 // nothing: the exact failure the pii-entity check exists to prevent, applied
 // to a feature that also costs money when it does fire.
-func validateAIRules(rules []policy.Rule, cfg *AnalyzerConfig, pc PolicyConfig, lane string) []string {
-	gated := pc.OPA.enabled() && pc.OPA.Gate
+func validateAIRules(rules []policy.Rule, cfg *AnalyzerConfig, opa *OPAConfig, lane string) []string {
+	gated := opa.enabled() && opa.Gate
 
 	if len(rules) == 0 {
 		if gated {
@@ -547,7 +560,7 @@ func validateAIRules(rules []policy.Rule, cfg *AnalyzerConfig, pc PolicyConfig, 
 			// analyzer that is not there. It would cost a round trip
 			// per statement and change nothing.
 			return []string{fmt.Sprintf(
-				"%s: policy.opa.gate is on but the lane has no ai_analysis rule, "+
+				"%s: opa.gate is on but the lane has no ai_analysis rule, "+
 					"so the extra decision would gate nothing", lane)}
 		}
 		return nil
@@ -569,7 +582,7 @@ func validateAIRules(rules []policy.Rule, cfg *AnalyzerConfig, pc PolicyConfig, 
 			// operator says so.
 			problems = append(problems, fmt.Sprintf(
 				"%s: ai_analysis rule %q has no trigger, so it would classify nothing; "+
-					"name operations, tables or resources, or turn on policy.opa.gate "+
+					"name operations, tables or resources, or turn on opa.gate "+
 					"and let the policy decide", lane, r.Name))
 		}
 
@@ -601,15 +614,10 @@ func validateAIRules(rules []policy.Rule, cfg *AnalyzerConfig, pc PolicyConfig, 
 						"(allow, warn, block or defer)", lane, r.Name, raw, level))
 				continue
 			}
-			if a == analyzer.ActionDefer && !pc.OPA.enabled() {
-				// Deferring to a decision that does not exist allows
-				// everything. The operator asked for the opposite.
-				problems = append(problems, fmt.Sprintf(
-					"%s: ai_analysis rule %q defers %s risk to a policy decision, "+
-						"and the lane has no policy.opa.url to defer to; "+
-						"set one or use block, warn or allow",
-					lane, r.Name, level))
-			}
+			// `defer` with no OPA is no longer a refusal. actionMap
+			// degrades it to block, so the statement is denied rather
+			// than allowed, and one config file can serve a deployment
+			// with OPA and a deployment without one.
 			if a == analyzer.ActionRequireReview {
 				// The action is declared in the enum so the schema is
 				// stable when review lands, and refused here so nobody

--- a/sidecar/daemon/analyzer_test.go
+++ b/sidecar/daemon/analyzer_test.go
@@ -23,10 +23,9 @@ func aiRule(name string) policy.Rule {
 
 func pgLane(rules ...policy.Rule) *Config {
 	return &Config{
-		Policy: PolicyConfig{Enforce: ptr(true)},
 		Listeners: []ListenerConfig{{
 			Name: "appdb", Protocol: "postgres", Listen: ":1", Upstream: "h:1",
-			Policy: &PolicyConfig{Rules: rules},
+			Guardrails: &GuardrailsConfig{Rules: rules},
 		}},
 	}
 }
@@ -241,7 +240,7 @@ func TestFailOpenDefaultsTrue(t *testing.T) {
 	if !(&AnalyzerConfig{}).failOpen() {
 		t.Error("fail_open defaulted to false")
 	}
-	if (&AnalyzerConfig{FailOpen: ptr(false)}).failOpen() {
+	if (&AnalyzerConfig{FailOpen: new(false)}).failOpen() {
 		t.Error("an explicit fail_open=false was ignored")
 	}
 }
@@ -292,7 +291,7 @@ func TestPromptPrecedence(t *testing.T) {
 			r.Prompt = tc.rulePrompt
 			cfg := &AnalyzerConfig{Provider: "stub", Model: "m", Prompt: tc.cfgPrompt}
 
-			evs, err := buildAnalyzerEvaluators([]policy.Rule{r}, cfg, stubAnalyzerProvider{}, nil)
+			evs, err := buildAnalyzerEvaluators([]policy.Rule{r}, cfg, stubAnalyzerProvider{}, nil, true)
 			if err != nil {
 				t.Fatalf("buildAnalyzerEvaluators: %v", err)
 			}
@@ -332,11 +331,10 @@ func TestHTTPAIRuleWithoutCaptureBodyIsRefused(t *testing.T) {
 	mk := func(h *HTTPCodecConfig) *Config {
 		return &Config{
 			Analyzer: &AnalyzerConfig{Provider: "stub", Model: "m"},
-			Policy:   PolicyConfig{Enforce: ptr(true)},
 			Listeners: []ListenerConfig{{
 				Name: "api", Protocol: "http", Listen: ":1", Upstream: "h:1",
 				HTTP:   h,
-				Policy: &PolicyConfig{Rules: []policy.Rule{aiRule("risky")}},
+				Guardrails: &GuardrailsConfig{Rules: []policy.Rule{aiRule("risky")}},
 			}},
 		}
 	}

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -450,6 +450,14 @@ type AuditConfig struct {
 // failOpen resolves the pointer default. Absent means fail closed.
 func (a AuditConfig) failOpen() bool { return a.FailOpen != nil && *a.FailOpen }
 
+// failOnAuditError is what the Gate is configured with.
+//
+// The inversion lives here rather than as a bare `!` at the call site because
+// this field changed polarity along with its name: `fail_closed: false` and
+// `fail_open: false` mean opposite things, and a flipped sign would hand every
+// lane the reverse of the operator's posture with nothing failing.
+func (a AuditConfig) failOnAuditError() bool { return !a.failOpen() }
+
 // AdminConfig configures the health/stats endpoint.
 type AdminConfig struct {
 	Listen string `json:"listen"`
@@ -692,7 +700,18 @@ func (c *Config) resolve(lc ListenerConfig) (GuardrailsConfig, *OPAConfig, MaskC
 	opa := c.OPA
 
 	if o := lc.Guardrails; o != nil {
-		if len(o.Rules) > 0 {
+		// Presence rather than length, because an explicitly empty list is
+		// how a lane runs no guardrails at all against a top-level set.
+		// Reading `rules: []` as "adds nothing" would be defensible for a
+		// field that concatenates, and it would also leave the lane with no
+		// way to say it. `opa: {}` and `mask: {rules: []}` spell the same
+		// intent for the other two sections; a decoder distinguishes the
+		// empty list from an absent key, so all three can mean it.
+		switch {
+		case o.Rules == nil:
+		case len(o.Rules) == 0:
+			gc.Rules = nil
+		default:
 			// A fresh slice: appending onto the default would let one
 			// listener's rules land in another's through a shared backing
 			// array.

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hoophq/hoop/sidecar/inspect"
 	"github.com/hoophq/hoop/sidecar/analyzer"
 	"github.com/hoophq/hoop/sidecar/gate"
+	"github.com/hoophq/hoop/sidecar/inspect"
 	"github.com/hoophq/hoop/sidecar/policy"
 )
 
@@ -23,19 +23,46 @@ import (
 // github.com/hoophq/hoop/sidecar/config/yaml, which transcodes to JSON and
 // hands the bytes to LoadConfigBytes. One schema, two syntaxes, and the
 // dependency stays out of anything that does not ask for it.
+//
+// # Two spellings, one meaning
+//
+// ADR-0011 split the old `policy` section into `guardrails` (Hoop's own rule
+// set) and `opa` (the client for someone else's Rego), renamed two fields and
+// dropped three. The old keys are still declared here and still work, because
+// LoadConfigBytes decodes with DisallowUnknownFields: a key that is not a Go
+// struct field fails the whole file, so removing one would break every
+// deployed config on upgrade rather than warning about it.
+//
+// normalize folds the deprecated spellings onto the canonical ones before
+// anything else reads the struct. Every field marked DEPRECATED below is
+// therefore empty by the time resolve, Validate or buildPolicy sees it.
 type Config struct {
 	// Listeners is the set of protocol endpoints to serve. A sidecar usually
 	// runs one; a per-user pod fronting both a database and an API runs two
 	// in one process instead of two containers.
 	Listeners []ListenerConfig `json:"listeners"`
 
-	// Policy is the DEFAULT rule set and OPA client, applied to every
-	// listener that does not override it. See ListenerConfig.Policy.
-	Policy PolicyConfig `json:"policy"`
+	// Guardrails is the DEFAULT rule set and enforcement mode, applied to
+	// every listener that does not override it. See
+	// ListenerConfig.Guardrails.
+	//
+	// A pointer so normalize can tell "the operator wrote a guardrails
+	// block" from "the operator wrote nothing", which decides whether the
+	// deprecated `policy` block conflicts with it or folds into it.
+	Guardrails *GuardrailsConfig `json:"guardrails,omitempty"`
+
+	// OPA is the DEFAULT decision endpoint, consulted after the local rules
+	// pass on every listener that does not override it.
+	//
+	// It sits beside Guardrails rather than inside it because the two
+	// configure different products. A reader of `guardrails.rules` is
+	// reading Hoop's matcher; a reader of `opa.url` is reading a client for
+	// a Rego policy someone else maintains, on a service they run.
+	OPA *OPAConfig `json:"opa,omitempty"`
 
 	// Mask is the DEFAULT response rewriting, applied to every listener that
 	// does not override it. See ListenerConfig.Mask.
-	Mask MaskConfig `json:"mask"`
+	Mask *MaskConfig `json:"mask,omitempty"`
 
 	// Audit configures where events go.
 	Audit AuditConfig `json:"audit"`
@@ -50,6 +77,14 @@ type Config struct {
 	// The field is declared so DisallowUnknownFields does not reject it, and
 	// so a build wired without a detector can say "this section needs one"
 	// instead of "unknown field pii".
+	//
+	// Omitting it no longer disables detection. The plugin builds a detector
+	// over every entity type it supports, and the section narrows that set
+	// rather than creating it. Enabling a recognizer is not the same as
+	// scanning for it: a masker scans only for the entities its own rules
+	// name, and a pii guardrail intersects the scan with the entities its
+	// own rule names, so a permissive detector costs nothing until a rule
+	// asks it for something.
 	PII json.RawMessage `json:"pii,omitempty"`
 
 	// Analyzer configures the optional AI risk analyzer.
@@ -63,12 +98,30 @@ type Config struct {
 
 	// LogLevel is debug, info, warn or error. Default info.
 	LogLevel string `json:"log_level"`
+
+	// Policy is the DEPRECATED pre-ADR-0011 spelling of Guardrails and OPA
+	// combined. normalize empties it.
+	Policy *PolicyConfig `json:"policy,omitempty"`
+
+	// Deprecations names every deprecated field this config used, phrased
+	// for an operator. It is not a config key: normalize fills it, Main and
+	// the CLI print it to stderr, and -strict turns it into a non-zero exit.
+	//
+	// It lives on the Config rather than travelling as a second return value
+	// from LoadConfigBytes because three entry points load a config and all
+	// three have to report the same thing.
+	Deprecations []string `json:"-"`
 }
 
 // ListenerConfig is one protocol endpoint: one Envoy cluster's worth of
 // traffic, with its own enforcement stack.
 type ListenerConfig struct {
-	// Name identifies the listener in logs. Defaults to Connection.
+	// Name identifies the listener in logs, in the audit trail and in the
+	// OPA input document as input.context.connection.
+	//
+	// It is the operator-facing resource name: audit queries key on it and
+	// the physical Upstream may change under it. Defaults to listener[i],
+	// which is a fallback rather than a name anyone should rely on.
 	Name string `json:"name"`
 
 	// Protocol selects the codec: postgres, mssql or http.
@@ -85,11 +138,6 @@ type ListenerConfig struct {
 
 	// Upstream is the real backend.
 	Upstream string `json:"upstream"`
-
-	// Connection is the operator-facing resource name recorded in audit and
-	// exposed to policy. Rules and audit queries key on it; the physical
-	// Upstream may change under it.
-	Connection string `json:"connection"`
 
 	// UpstreamTLS enables TLS to the backend.
 	UpstreamTLS *TLSConfig `json:"upstream_tls"`
@@ -126,7 +174,7 @@ type ListenerConfig struct {
 	// MaxConns bounds concurrency. Zero is unlimited.
 	MaxConns int `json:"max_conns"`
 
-	// Policy overrides the top-level default for this listener.
+	// Guardrails overrides the top-level default for this listener.
 	//
 	// Rules CONCATENATE, this listener's first: every rule type denies and
 	// evaluation is first-match-wins, so concatenating is monotonic in the
@@ -134,20 +182,39 @@ type ListenerConfig struct {
 	// reported. Listener-first lets a lane's specific message beat a generic
 	// default for the same statement.
 	//
-	// OPA and Enforce REPLACE when set. Two decision endpoints cannot merge
-	// into one, and a lane that says enforce:false means it.
-	Policy *PolicyConfig `json:"policy,omitempty"`
+	// Mode REPLACES when set. A lane rolling out behind an enforcing default
+	// means it when it says observe.
+	Guardrails *GuardrailsConfig `json:"guardrails,omitempty"`
+
+	// OPA overrides the top-level default for this listener, and REPLACES
+	// rather than merging: two decision endpoints cannot become one.
+	//
+	// An empty block, `opa: {}`, means this lane consults no OPA even when
+	// the top level configures one. Without that spelling a top-level
+	// endpoint reaches every lane with no way to opt out, which `mask` has
+	// through `rules: []` and `guardrails` has through `mode: observe`.
+	OPA *OPAConfig `json:"opa,omitempty"`
 
 	// Mask overrides the top-level default for this listener.
 	//
 	// Rules REPLACE rather than concatenate: a rule owns an entity type, and
 	// concatenating two lists produces two rewrites competing for one entity
-	// with slice order picking the winner. Enabled replaces when set.
+	// with slice order picking the winner. An empty list, `rules: []`, is how
+	// a lane switches inherited masking off.
 	Mask *MaskConfig `json:"mask,omitempty"`
 
 	// HTTP configures what this lane's HTTP codec captures. Only valid on
 	// an http lane.
 	HTTP *HTTPCodecConfig `json:"http,omitempty"`
+
+	// Connection is the DEPRECATED second name for this lane. normalize
+	// folds it onto Name, which now fills the audit key and
+	// input.context.connection on its own.
+	Connection string `json:"connection,omitempty"`
+
+	// Policy is the DEPRECATED pre-ADR-0011 spelling of Guardrails and OPA
+	// combined. normalize empties it.
+	Policy *PolicyConfig `json:"policy,omitempty"`
 }
 
 // TLSConfig configures an upstream TLS connection.
@@ -170,25 +237,48 @@ type TLSConfig struct {
 	InsecureSkipVerify bool `json:"insecure_skip_verify"`
 }
 
-// PolicyConfig configures enforcement.
-type PolicyConfig struct {
+// Enforcement modes for GuardrailsConfig.Mode.
+const (
+	// ModeEnforce denies a statement a rule matched. It is the default,
+	// because a relay whose rules are configured and inert is a relay
+	// nobody notices is broken.
+	ModeEnforce = "enforce"
+
+	// ModeObserve evaluates every rule, denies nothing, and records what
+	// each match WOULD have denied on the audit line as
+	// policy.AnnotationWouldDeny.
+	//
+	// It is the rollout mode: run it for a week, count the annotations, fix
+	// the rules that fire on legitimate traffic, then switch to enforce. It
+	// costs what enforcing costs, because nothing can report what would have
+	// been denied without evaluating it: a lane with ai_analysis rules makes
+	// model calls in this mode, and one with OPA makes round trips. A lane
+	// that wants to cost nothing sets `guardrails: {rules: []}` instead.
+	ModeObserve = "observe"
+)
+
+// GuardrailsConfig configures Hoop's own rule set.
+type GuardrailsConfig struct {
+	// Mode is enforce or observe. Empty inherits, and an empty resolved
+	// mode enforces.
+	//
+	// A string rather than the *bool this replaced: "" already expresses
+	// "inherit", which a zero bool could not, so the pointer that existed to
+	// carry three states is no longer needed. A third mode also has
+	// somewhere to go.
+	Mode string `json:"mode,omitempty"`
+
 	// Rules is the local rule set, evaluated first so a statement the
 	// local rules already forbid costs no network round trip.
-	Rules []policy.Rule `json:"rules"`
-
-	// OPA, when URL is set, is consulted after the local rules pass.
-	OPA *OPAConfig `json:"opa"`
-
-	// Enforce false runs in observe-only mode: the gate inspects and audits
-	// everything and denies nothing. Teams run this way for a week before
-	// turning enforcement on, and it is the default so a misconfigured rule
-	// cannot take production down on first deploy.
-	//
-	// A pointer, so a listener can distinguish "inherit" from an explicit
-	// false: a lane rolling out behind an enforcing default needs to say
-	// observe-only, and a zero bool cannot express that.
-	Enforce *bool `json:"enforce,omitempty"`
+	Rules []policy.Rule `json:"rules,omitempty"`
 }
+
+// enforcing reports whether a resolved lane denies what its rules match.
+// An unset mode enforces.
+func (g GuardrailsConfig) enforcing() bool { return g.Mode != ModeObserve }
+
+// observing reports whether a resolved lane runs as a dry run.
+func (g GuardrailsConfig) observing() bool { return g.Mode == ModeObserve }
 
 // OPAConfig configures the OPA client.
 type OPAConfig struct {
@@ -201,8 +291,8 @@ type OPAConfig struct {
 	FailOpen bool `json:"fail_open"`
 
 	// Gate adds a decision BEFORE the AI analyzer runs, letting the policy
-	// answer "is this statement worth a model call" by returning
-	// `analyze: true|false` beside its allow/deny.
+	// answer "is this statement worth a model call" by returning a
+	// `request` map beside its allow/deny.
 	//
 	// It exists to keep the cost control where the policy is. Without it, a
 	// lane whose rules defer to OPA calls the model first and OPA second,
@@ -239,23 +329,64 @@ func (o *OPAConfig) client(phase policy.Phase) *policy.OPAClient {
 // enabled reports whether this lane consults OPA at all.
 func (o *OPAConfig) enabled() bool { return o != nil && o.URL != "" }
 
+// off reports whether a block is the empty `opa: {}` that switches an
+// inherited endpoint off for one lane.
+//
+// Every field zero is the only reading available: a block naming a timeout or
+// a fail_open with no url configures a client that cannot be built, which
+// validateLane refuses separately.
+func (o *OPAConfig) off() bool {
+	return o != nil && o.URL == "" && o.TimeoutSec == 0 && !o.FailOpen && !o.Gate
+}
+
 // MaskConfig configures response rewriting.
 //
 // Rules stay raw JSON for the same reason as Config.PII: the shape belongs to
 // whichever detector plugin is wired in, and this package must not link one.
 // The plugin decodes them.
 type MaskConfig struct {
-	// Enabled is a pointer for the same reason as PolicyConfig.Enforce: a
-	// listener must be able to say "off" against an enabled default, and a
-	// zero bool reads as "inherit".
-	Enabled *bool           `json:"enabled,omitempty"`
-	Rules   json.RawMessage `json:"rules,omitempty"`
+	// Rules is the plugin-owned rule list. A non-empty list switches masking
+	// on; there is no separate enable flag, because a list that is present
+	// already says whether it is empty.
+	//
+	// An empty list is meaningful and distinct from an absent one: `rules:
+	// []` on a listener replaces an inherited set with nothing, which is how
+	// a lane opts out. json.RawMessage preserves that distinction, since the
+	// two bytes of `[]` are not the nil slice.
+	Rules json.RawMessage `json:"rules,omitempty"`
+
+	// Enabled is the DEPRECATED masking switch. normalize empties it, and
+	// an explicit false empties Rules with it so the lane keeps behaving as
+	// its author wrote it.
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
-// on reports whether masking is switched on, treating an absent Enabled as
-// off. Rules alone do not enable it: a config listing rules without enabling
-// them wants them dormant.
-func (m MaskConfig) on() bool { return m.Enabled != nil && *m.Enabled }
+// hasRules reports whether this resolved mask section asks for any rewriting.
+func (m MaskConfig) hasRules() bool { return len(m.Rules) > 0 && !isEmptyJSONList(m.Rules) }
+
+// isEmptyJSONList reports whether raw is an empty JSON array, ignoring
+// whitespace. `rules: []` has to read as "no rules" everywhere the resolved
+// config is consumed, while still counting as an override where the merge
+// happens.
+func isEmptyJSONList(raw json.RawMessage) bool {
+	return string(bytes.TrimSpace(raw)) == "[]"
+}
+
+// PolicyConfig is the DEPRECATED pre-ADR-0011 enforcement section.
+//
+// It stays declared, and only declared: normalize maps Rules onto
+// guardrails.rules, OPA onto the top-level or per-lane opa block, and Enforce
+// onto guardrails.mode, then empties the struct. Nothing downstream reads it.
+type PolicyConfig struct {
+	Rules   []policy.Rule `json:"rules,omitempty"`
+	OPA     *OPAConfig    `json:"opa,omitempty"`
+	Enforce *bool         `json:"enforce,omitempty"`
+}
+
+// set reports whether an operator wrote anything in this block.
+func (p *PolicyConfig) set() bool {
+	return p != nil && (len(p.Rules) > 0 || p.OPA != nil || p.Enforce != nil)
+}
 
 // AuditConfig configures the event sink.
 type AuditConfig struct {
@@ -296,14 +427,28 @@ type AuditConfig struct {
 	// either way.
 	QuerySessions int `json:"query_sessions"`
 
-	// FailClosed denies a statement when its audit record cannot be written.
+	// FailOpen allows a statement whose audit record could not be written.
 	//
-	// Default false, which is the uncomfortable default. Turn this on where
-	// the audit trail is a compliance requirement rather than an operational
-	// convenience: a sink outage then stops traffic, which is correct for a
-	// system that exists to prove who did what.
-	FailClosed bool `json:"fail_closed"`
+	// Default FALSE, so a sink outage stops traffic. A system that exists to
+	// prove who did what should not keep serving once it stopped being able
+	// to prove it.
+	//
+	// The spelling matters as much as the default. This field replaced
+	// `fail_closed`, which meant the opposite of the identically named
+	// fields on `opa` and `analyzer`: three sections used one word for one
+	// idea and one of them was negated, so `false` meant opposite things a
+	// few lines apart. A pointer, so normalize can tell an explicit value
+	// from silence and preserve the behaviour of a config that wrote the old
+	// field down.
+	FailOpen *bool `json:"fail_open,omitempty"`
+
+	// FailClosed is the DEPRECATED inverse of FailOpen. normalize empties it,
+	// inverting the value rather than copying it.
+	FailClosed *bool `json:"fail_closed,omitempty"`
 }
+
+// failOpen resolves the pointer default. Absent means fail closed.
+func (a AuditConfig) failOpen() bool { return a.FailOpen != nil && *a.FailOpen }
 
 // AdminConfig configures the health/stats endpoint.
 type AdminConfig struct {
@@ -326,8 +471,8 @@ func LoadConfig(path string) (*Config, error) {
 //
 // It is exported so config from somewhere other than a file (a ConfigMap, a
 // secret manager, or the YAML transcoder in the nested module
-// github.com/hoophq/hoop/sidecar/config/yaml) gets the same strict decode and
-// the same validation as the file path.
+// github.com/hoophq/hoop/sidecar/config/yaml) gets the same strict decode, the
+// same deprecation folding and the same validation as the file path.
 func LoadConfigBytes(data []byte) (*Config, error) {
 	var cfg Config
 	dec := json.NewDecoder(bytes.NewReader(data))
@@ -335,59 +480,253 @@ func LoadConfigBytes(data []byte) (*Config, error) {
 	if err := dec.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
+	// Before Validate, so every check below reads canonical fields and no
+	// downstream function has to know a deprecated spelling exists.
+	if err := cfg.normalize(); err != nil {
+		return nil, err
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 	return &cfg, nil
 }
 
+// normalize folds every deprecated field onto its replacement, filling
+// Deprecations as it goes, and returns an error naming every field written in
+// both spellings.
+//
+// One funnel, run once, immediately after the decode. The alternative is a
+// compat branch in resolve, in validateLane, in buildPolicy and in
+// buildMasker, which is four places to forget when the deprecated fields are
+// finally removed.
+//
+// A field written twice is refused rather than resolved by precedence. This
+// decoder already refuses a misspelled key on the grounds that a typo must not
+// silently disable a control; picking a winner between two spellings of one
+// setting fails the same test, and no operator can predict which one wins.
+func (c *Config) normalize() error {
+	var conflicts []string
+	warn := func(format string, args ...any) {
+		c.Deprecations = append(c.Deprecations, fmt.Sprintf(format, args...))
+	}
+	conflict := func(format string, args ...any) {
+		conflicts = append(conflicts, fmt.Sprintf(format, args...))
+	}
+
+	// audit.fail_closed -> audit.fail_open, INVERTED.
+	//
+	// The only polarity flip in the migration, and the reason FailClosed is
+	// read rather than pattern-matched: an operator who renamed the key
+	// without inverting the value would get the opposite of what they had.
+	// Reading the old field means a config that wrote it down keeps its
+	// behaviour exactly, and only a config that omitted it picks up the new
+	// fail-closed default.
+	if c.Audit.FailClosed != nil {
+		if c.Audit.FailOpen != nil {
+			conflict("audit: set audit.fail_open, not both it and the deprecated audit.fail_closed " +
+				"(they are inverses, so writing both cannot be resolved)")
+		} else {
+			inverted := !*c.Audit.FailClosed
+			c.Audit.FailOpen = &inverted
+			warn("audit.fail_closed: %t is deprecated; write audit.fail_open: %t "+
+				"(the sense is inverted, and omitting it now fails closed)",
+				*c.Audit.FailClosed, inverted)
+		}
+		c.Audit.FailClosed = nil
+	}
+
+	// policy -> guardrails + opa, at the top level.
+	if c.Policy.set() {
+		c.Guardrails, c.OPA = c.foldPolicy("policy", c.Policy, c.Guardrails, c.OPA, warn, conflict)
+	}
+	c.Policy = nil
+
+	// mask.enabled -> the presence of mask.rules.
+	c.Mask = normalizeMask("mask", c.Mask, warn)
+
+	for i := range c.Listeners {
+		lc := &c.Listeners[i]
+		where := lc.Name
+		if where == "" {
+			where = lc.Connection
+		}
+		if where == "" {
+			where = fmt.Sprintf("listener[%d]", i)
+		}
+
+		// connection -> name.
+		if lc.Connection != "" {
+			switch {
+			case lc.Name == "":
+				lc.Name = lc.Connection
+				warn("%s: listeners[].connection is deprecated; it now travels as "+
+					"listeners[].name, which fills the audit key and "+
+					"input.context.connection", where)
+			case lc.Name == lc.Connection:
+				warn("%s: listeners[].connection is deprecated and duplicates name; drop it", where)
+			default:
+				warn("%s: listeners[].connection %q is deprecated and differs from name %q; "+
+					"audit rows and input.context.connection will carry %q. Rename the "+
+					"listener to %q to keep the old value",
+					where, lc.Connection, lc.Name, lc.Name, lc.Connection)
+			}
+			lc.Connection = ""
+		}
+
+		if lc.Policy.set() {
+			lc.Guardrails, lc.OPA = c.foldPolicy(where+": policy", lc.Policy,
+				lc.Guardrails, lc.OPA, warn, conflict)
+		}
+		lc.Policy = nil
+
+		lc.Mask = normalizeMask(where+": mask", lc.Mask, warn)
+	}
+
+	if len(conflicts) > 0 {
+		return fmt.Errorf("invalid config:\n  - %s", strings.Join(conflicts, "\n  - "))
+	}
+	return nil
+}
+
+// foldPolicy maps one deprecated policy block onto a guardrails block and an
+// opa block, reporting a conflict for every field written in both spellings.
+//
+// Shared by the top level and each listener because the three fields fold the
+// same way at both scopes, and two copies would drift the moment one grows a
+// case the other does not.
+func (c *Config) foldPolicy(
+	where string,
+	old *PolicyConfig,
+	gc *GuardrailsConfig,
+	opa *OPAConfig,
+	warn, conflict func(string, ...any),
+) (*GuardrailsConfig, *OPAConfig) {
+	if gc == nil {
+		gc = &GuardrailsConfig{}
+	}
+
+	if len(old.Rules) > 0 {
+		if len(gc.Rules) > 0 {
+			conflict("%s.rules is deprecated and guardrails.rules is also set at this scope; "+
+				"keep guardrails.rules", where)
+		} else {
+			gc.Rules = old.Rules
+			warn("%s.rules is deprecated; rename it to guardrails.rules", where)
+		}
+	}
+
+	if old.Enforce != nil {
+		mode := ModeEnforce
+		if !*old.Enforce {
+			mode = ModeObserve
+		}
+		switch {
+		case gc.Mode != "":
+			conflict("%s.enforce is deprecated and guardrails.mode is also set at this scope; "+
+				"keep guardrails.mode", where)
+		default:
+			gc.Mode = mode
+			warn("%s.enforce: %t is deprecated; write guardrails.mode: %s",
+				where, *old.Enforce, mode)
+		}
+	}
+
+	if old.OPA != nil {
+		if opa != nil {
+			conflict("%s.opa is deprecated and a sibling opa block is also set at this scope; "+
+				"keep the opa block", where)
+		} else {
+			opa = old.OPA
+			warn("%s.opa is deprecated; move it to a sibling opa block", where)
+		}
+	}
+
+	if gc.Mode == "" && len(gc.Rules) == 0 {
+		return nil, opa
+	}
+	return gc, opa
+}
+
+// normalizeMask folds mask.enabled onto the presence of mask.rules.
+//
+// An explicit false stays authoritative rather than becoming a warning alone:
+// a lane written as `enabled: false` with rules listed is masking nothing
+// today, and a migration that switched masking ON for it would change what
+// leaves the process. Emptying the rule list preserves the behaviour and the
+// warning tells the operator how to write it.
+func normalizeMask(where string, mc *MaskConfig, warn func(string, ...any)) *MaskConfig {
+	if mc == nil || mc.Enabled == nil {
+		return mc
+	}
+	switch {
+	case *mc.Enabled:
+		warn("%s.enabled: true is deprecated; a non-empty mask.rules is what switches "+
+			"masking on, so drop the field", where)
+		if len(mc.Rules) == 0 {
+			warn("%s.enabled was true with no rules at this scope, which now masks nothing; "+
+				"add rules or drop the section", where)
+		}
+	default:
+		warn("%s.enabled: false is deprecated; masking stays off for this scope, and the "+
+			"equivalent spelling is mask: {rules: []}", where)
+		mc.Rules = json.RawMessage("[]")
+	}
+	mc.Enabled = nil
+	return mc
+}
+
 // resolve merges a listener's overrides onto the top-level defaults.
 //
-// Policy rules concatenate with the listener's first; OPA and Enforce replace
-// when the listener sets them. Mask replaces wholesale. See the field
-// documentation on ListenerConfig for why each field merges the way it does.
+// Guardrail rules concatenate with the listener's first; mode, OPA and mask
+// replace when the listener sets them. See the field documentation on
+// ListenerConfig for why each field merges the way it does.
 //
 // Pure: it reads config and returns config, so a test can assert the merge
 // without building an evaluator, and /config can render it without side
 // effects.
-func (c *Config) resolve(lc ListenerConfig) (PolicyConfig, MaskConfig) {
-	pc := PolicyConfig{
-		Rules:   c.Policy.Rules,
-		OPA:     c.Policy.OPA,
-		Enforce: c.Policy.Enforce,
+func (c *Config) resolve(lc ListenerConfig) (GuardrailsConfig, *OPAConfig, MaskConfig) {
+	var gc GuardrailsConfig
+	if c.Guardrails != nil {
+		gc = *c.Guardrails
 	}
-	if o := lc.Policy; o != nil {
+	opa := c.OPA
+
+	if o := lc.Guardrails; o != nil {
 		if len(o.Rules) > 0 {
-			// A fresh slice: appending onto c.Policy.Rules would let one
+			// A fresh slice: appending onto the default would let one
 			// listener's rules land in another's through a shared backing
 			// array.
-			merged := make([]policy.Rule, 0, len(o.Rules)+len(c.Policy.Rules))
+			merged := make([]policy.Rule, 0, len(o.Rules)+len(gc.Rules))
 			merged = append(merged, o.Rules...)
-			merged = append(merged, c.Policy.Rules...)
-			pc.Rules = merged
+			merged = append(merged, gc.Rules...)
+			gc.Rules = merged
 		}
-		if o.OPA != nil {
-			pc.OPA = o.OPA
+		if o.Mode != "" {
+			gc.Mode = o.Mode
 		}
-		if o.Enforce != nil {
-			pc.Enforce = o.Enforce
+	}
+	if o := lc.OPA; o != nil {
+		// An empty block switches an inherited endpoint off rather than
+		// replacing it with an unbuildable one.
+		if o.off() {
+			opa = nil
+		} else {
+			opa = o
 		}
 	}
 
-	mc := c.Mask
-	if o := lc.Mask; o != nil {
-		if o.Enabled != nil {
-			mc.Enabled = o.Enabled
-		}
-		if len(o.Rules) > 0 {
-			mc.Rules = o.Rules
-		}
+	var mc MaskConfig
+	if c.Mask != nil {
+		mc = *c.Mask
 	}
-	return pc, mc
+	if o := lc.Mask; o != nil && len(o.Rules) > 0 {
+		// Length rather than emptiness: `rules: []` is an override that
+		// resolves to nothing, and treating it as silence would leave a lane
+		// unable to switch inherited masking off.
+		mc.Rules = o.Rules
+	}
+	return gc, opa, mc
 }
-
-// enforcing reports whether a resolved policy denies anything.
-func (p PolicyConfig) enforcing() bool { return p.Enforce != nil && *p.Enforce }
 
 // Validate checks the config, returning every problem found.
 func (c *Config) Validate() error {
@@ -402,7 +741,10 @@ func (c *Config) Validate() error {
 	// Splitting them across phases is the "one error per restart" this
 	// package refuses everywhere else. setupAnalyzer keeps its own call for
 	// a caller that builds a Config by hand and never passes through here.
-	problems = append(problems, c.Analyzer.validate(len(c.PII) > 0)...)
+	//
+	// Detection is always available now, so the analyzer's redacting send
+	// modes always have a scanner to use.
+	problems = append(problems, c.Analyzer.validate(true)...)
 	seen := map[string]bool{}
 	for i, l := range c.Listeners {
 		name := l.displayName(i)
@@ -461,31 +803,22 @@ func (c *Config) Validate() error {
 // conflicts with something you set".
 func (c *Config) validateLane(lc ListenerConfig, name string) []string {
 	var problems []string
-	pc, mc := c.resolve(lc)
+	gc, opa, mc := c.resolve(lc)
 
-	// Compile the rules so a bad regex fails at startup rather than on the
-	// first request that hits it. With a pii section present, Main runs the
-	// real check against the detector; a pii rule has no scanner yet here and
-	// would fail for the wrong reason.
-	localRules, aiRules := splitAnalyzerRules(pc.Rules)
-	if len(localRules) > 0 && len(c.PII) == 0 {
-		if _, err := policy.NewRules(localRules); err != nil {
-			problems = append(problems, name+": "+err.Error())
-		}
+	switch gc.Mode {
+	case "", ModeEnforce, ModeObserve:
+	default:
+		problems = append(problems, fmt.Sprintf(
+			"%s: unknown guardrails.mode %q (%s or %s)", name, gc.Mode, ModeEnforce, ModeObserve))
 	}
-	problems = append(problems, validateAIRules(aiRules, c.Analyzer, pc, name)...)
-	for _, r := range localRules {
-		if r.Action == policy.ActionDefer && !pc.OPA.enabled() {
-			// A finding nobody reads is a rule that matches and then
-			// allows, which looks like enforcement and is not.
-			problems = append(problems, fmt.Sprintf(
-				"%s: rule %q defers its match to a policy decision, and the lane has "+
-					"no policy.opa.url to defer to; set one or drop the action",
-				name, r.Name))
-		}
-	}
-	if pc.OPA != nil && pc.OPA.URL == "" {
-		problems = append(problems, name+": policy.opa set but url is empty")
+
+	localRules, aiRules := splitAnalyzerRules(gc.Rules)
+	problems = append(problems, validateAIRules(aiRules, c.Analyzer, opa, name)...)
+
+	if opa != nil && opa.URL == "" && !opa.off() {
+		problems = append(problems, name+
+			": opa is set but url is empty; write an url, or an empty opa: {} to switch "+
+			"an inherited endpoint off for this lane")
 	}
 
 	// An http block on a lane with no HTTP codec would load and do nothing,
@@ -502,8 +835,9 @@ func (c *Config) validateLane(lc ListenerConfig, name string) []string {
 	// An ai_analysis rule on an HTTP lane with no body capture classifies
 	// nothing: HTTPBuilder.Build returns ok=false on an empty body, and the
 	// codec leaves Body empty unless the lane asked for it. The rule would
-	// load, evaluate and never fire: the same silent failure the pii-entity
-	// check refuses, on a control that also costs money when it does work.
+	// load, evaluate and never fire: the same silent failure the config
+	// refuses everywhere else, on a control that also costs money when it
+	// does work.
 	//
 	// This asserts only that the proxy COULD capture a body. A request that
 	// carries no body is still skipped at runtime, deliberately: paying for
@@ -531,22 +865,43 @@ func (c *Config) validateLane(lc ListenerConfig, name string) []string {
 		}
 	}
 
+	// Local rule compilation is checked at build time against the real
+	// scanner, not here: a pii rule needs one, and NewRules without it fails
+	// for the wrong reason. Rules with no pii type can still be compiled
+	// early, which catches a bad regex before a port is bound.
+	if len(localRules) > 0 && !anyPII(localRules) {
+		if _, err := policy.NewRules(localRules); err != nil {
+			problems = append(problems, name+": "+err.Error())
+		}
+	}
+
 	// Mask rule SHAPE belongs to the plugin, which checks it when building
 	// the masker. This check covers the one thing knowable here: whether
 	// masking can work on this protocol.
-	if mc.on() {
-		if len(mc.Rules) == 0 {
-			problems = append(problems, name+": mask.enabled is true but mask.rules is empty")
-		}
+	//
+	// It runs whenever rules are present, with no enable flag gating it. The
+	// flag used to skip this block entirely, so a lane could carry rules for
+	// a protocol that cannot mask and still load clean.
+	if mc.hasRules() {
 		if p := inspect.Protocol(lc.Protocol); p != "" && !gate.MaskSupported(p) {
 			problems = append(problems, fmt.Sprintf(
-				"%s: mask.enabled is true but masking is not supported on %s "+
-					"(its rows are length-prefixed binary frames; rewriting bytes in place "+
-					"desynchronizes the client). Set mask.enabled false on this listener.",
+				"%s: masking is not supported on %s (its rows are length-prefixed binary "+
+					"frames; rewriting bytes in place desynchronizes the client). Remove "+
+					"the rules from this lane, or set mask: {rules: []} on it.",
 				name, lc.Protocol))
 		}
 	}
 	return problems
+}
+
+// anyPII reports whether a rule set needs a scanner to compile.
+func anyPII(rules []policy.Rule) bool {
+	for _, r := range rules {
+		if r.Type == policy.MatchPII {
+			return true
+		}
+	}
+	return false
 }
 
 // Plugin is the optional detection engine: it scans statements for the PII
@@ -559,23 +914,22 @@ func (c *Config) validateLane(lc ListenerConfig, name string) []string {
 // AuditConfig.QuerySessions). The nested module
 // github.com/hoophq/hoop/sidecar/pii/alcatraz supplies an implementation.
 //
-// Nil means no detection: pii policy rules are a config error and masking is
+// Nil means this BUILD linked no detector, which is a different thing from an
+// absent "pii" config section: the section now narrows a detector that always
+// exists. A nil Plugin still makes pii policy rules a config error and masking
 // unavailable. Both are refusals, never silent downgrades.
 type Plugin interface {
-	// ScanText implements policy.Scanner for the pii rule type.
+	// ScanText names the entity classes present in a statement. Values never
+	// leave the detector: a denial quoting the identifier it denied has
+	// published it into the audit trail.
 	ScanText(text string) []string
 
-	// Entities lists the entity types this engine looks for. buildLanes uses
-	// it to reject a pii rule naming an entity the engine was not configured
-	// to detect: that rule would load, evaluate, and never match, silently
-	// allowing everything it was written to stop.
+	// Entities lists what this detector was configured to find, for the
+	// startup log and for a config error that has to say what is available.
 	Entities() []string
 
-	// BuildMasker decodes the "mask" config section and returns something
-	// the gate can call. rawRules is the JSON array from MaskConfig.Rules;
-	// its shape belongs to the plugin.
-	//
-	// Returning a nil Masker with a nil error means the rules were empty.
+	// BuildMasker compiles the raw "mask.rules" JSON into a response
+	// rewriter. The rule shape belongs to the plugin.
 	BuildMasker(rawRules []byte) (gate.Masker, error)
 }
 
@@ -592,18 +946,20 @@ type Plugin interface {
 // both sides: once to decide whether to spend, once to decide what the
 // answer means.
 //
-// Returns nil in observe-only mode. det may be nil, and a lane with pii rules
-// then fails to build by design: a guardrail that cannot see must not
+// A lane with NO OPA cannot consume a finding at all, so deferring rules deny
+// instead of reporting. `defer` means "hand this to a decision-maker"; with no
+// decision-maker the safe reading is refusal, and the alternative of refusing
+// the config at startup stopped one file from serving a deployment with OPA
+// and a deployment without one.
+//
+// Returns nil when nothing would evaluate. det may be nil, and a lane with pii
+// rules then fails to build by design: a guardrail that cannot see must not
 // start.
-func buildPolicy(pc PolicyConfig, det Plugin, ac *analyzerDeps) (policy.Evaluator, error) {
-	if !pc.enforcing() {
-		return nil, nil
-	}
-
+func buildPolicy(gc GuardrailsConfig, opa *OPAConfig, det Plugin, ac *analyzerDeps) (policy.Evaluator, error) {
 	// ai_analysis rules are lifted out before Rules sees them: they need a
 	// provider and a deadline, which a local matcher has no business
 	// holding, and Rules refuses one that reaches it.
-	localRules, aiRules := splitAnalyzerRules(pc.Rules)
+	localRules, aiRules := splitAnalyzerRules(gc.Rules)
 
 	var chain policy.Chain
 	if len(localRules) > 0 {
@@ -617,6 +973,9 @@ func buildPolicy(pc PolicyConfig, det Plugin, ac *analyzerDeps) (policy.Evaluato
 		if err != nil {
 			return nil, err
 		}
+		// With no OPA there is no evaluator that reads a Finding, so a
+		// deferring rule would match, record, and allow.
+		rules.DenyDeferred = !opa.enabled()
 		chain = append(chain, rules)
 	}
 
@@ -624,18 +983,17 @@ func buildPolicy(pc PolicyConfig, det Plugin, ac *analyzerDeps) (policy.Evaluato
 	// ai_analysis risk level or a local rule reporting a match. Both need a
 	// decision placed AFTER them, because a policy reading input.findings
 	// has to run after the thing that fills it.
-	twoPhase := pc.OPA.enabled() &&
-		(pc.OPA.Gate || anyDeferred(pc.Rules))
+	twoPhase := opa.enabled() && (opa.Gate || anyDeferred(gc.Rules))
 
 	switch {
-	case !pc.OPA.enabled():
+	case !opa.enabled():
 	case !twoPhase:
 		// One decision, no input.findings, exactly as before producers
 		// reported. Phase is empty so the input document a single-call
 		// lane produces is byte-identical to the old one.
-		chain = append(chain, pc.OPA.client(""))
-	case pc.OPA.Gate:
-		chain = append(chain, pc.OPA.client(policy.PhaseGate))
+		chain = append(chain, opa.client(""))
+	case opa.Gate:
+		chain = append(chain, opa.client(policy.PhaseGate))
 	}
 
 	if len(aiRules) > 0 {
@@ -645,7 +1003,7 @@ func buildPolicy(pc PolicyConfig, det Plugin, ac *analyzerDeps) (policy.Evaluato
 		if ac != nil {
 			cfg, provider, redact = ac.cfg, ac.provider, ac.redact
 		}
-		evs, err := buildAnalyzerEvaluators(aiRules, cfg, provider, redact)
+		evs, err := buildAnalyzerEvaluators(aiRules, cfg, provider, redact, opa.enabled())
 		if err != nil {
 			return nil, err
 		}
@@ -655,11 +1013,17 @@ func buildPolicy(pc PolicyConfig, det Plugin, ac *analyzerDeps) (policy.Evaluato
 	}
 
 	if twoPhase {
-		chain = append(chain, pc.OPA.client(policy.PhaseDecide))
+		chain = append(chain, opa.client(policy.PhaseDecide))
 	}
 
 	if len(chain) == 0 {
 		return nil, nil
+	}
+	if gc.observing() {
+		// Wrapping rather than skipping is what makes observe a dry run.
+		// Returning nil here, which is what the mode used to do, left the
+		// audit trail unable to say which rule would have refused.
+		return policy.Observe{Evaluator: chain}, nil
 	}
 	return chain, nil
 }

--- a/sidecar/daemon/config_test.go
+++ b/sidecar/daemon/config_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,13 +20,17 @@ func writeConfig(t *testing.T, body string) string {
 	return p
 }
 
-// ptr is the three-state-field literal helper: Enforce and Enabled are
-// pointers so a listener can say "off" against an enabled default.
-//
-// Go 1.26's new(expr) would replace this, but the module's go directive is
-// 1.24 and this package compiles under that toolchain by design. Revisit when
-// the directive moves.
-func ptr[T any](v T) *T { return &v }
+// hasDeprecation reports whether any notice mentions substr, so a test can
+// assert the operator was told which field to change without pinning the
+// whole sentence.
+func hasDeprecation(cfg *Config, substr string) bool {
+	for _, d := range cfg.Deprecations {
+		if strings.Contains(d, substr) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestLoadValidConfig(t *testing.T) {
 	p := writeConfig(t, `{
@@ -33,11 +38,10 @@ func TestLoadValidConfig(t *testing.T) {
         "name": "appdb",
         "protocol": "postgres",
         "listen": "127.0.0.1:15432",
-        "upstream": "db:5432",
-        "connection": "appdb"
+        "upstream": "db:5432"
       }],
-      "policy": {
-        "enforce": true,
+      "guardrails": {
+        "mode": "enforce",
         "rules": [{
           "name": "no-drop",
           "type": "operation",
@@ -58,6 +62,9 @@ func TestLoadValidConfig(t *testing.T) {
 	if cfg.Listeners[0].Protocol != "postgres" {
 		t.Errorf("protocol = %q", cfg.Listeners[0].Protocol)
 	}
+	if len(cfg.Deprecations) != 0 {
+		t.Errorf("a config in the current spelling warned: %v", cfg.Deprecations)
+	}
 }
 
 // A typo in a key must not silently disable a control. `enfroce: true`
@@ -65,63 +72,68 @@ func TestLoadValidConfig(t *testing.T) {
 func TestUnknownFieldIsRejected(t *testing.T) {
 	p := writeConfig(t, `{
       "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
-      "policy": {"enfroce": true}
+      "guardrails": {"mode": "enforce", "rulez": []}
     }`)
 
-	if _, err := LoadConfig(p); err == nil {
-		t.Fatal("a misspelled key was accepted")
-	} else if !strings.Contains(err.Error(), "enfroce") {
-		t.Errorf("error does not name the offending key: %v", err)
+	_, err := LoadConfig(p)
+	if err == nil {
+		t.Fatal("an unknown field was accepted")
+	}
+	if !strings.Contains(err.Error(), "rulez") {
+		t.Errorf("error does not name the bad key: %v", err)
 	}
 }
 
 // A bad config reports every problem at once, so nobody fixes one error per
 // restart.
 func TestValidationReportsEveryProblem(t *testing.T) {
-	cfg := &Config{
-		Listeners: []ListenerConfig{
-			{Name: "a"}, // no protocol, listen, upstream
-			{Name: "b", Protocol: "oracle", Listen: ":1"}, // bad protocol, no upstream
-		},
-	}
-	err := cfg.Validate()
+	p := writeConfig(t, `{
+      "listeners": [
+        {"name":"a","listen":":1","upstream":"h:1"},
+        {"name":"b","protocol":"nope","upstream":"h:2","listen":":2"},
+        {"name":"c","protocol":"postgres","listen":":3"}
+      ]
+    }`)
+
+	_, err := LoadConfig(p)
 	if err == nil {
-		t.Fatal("invalid config accepted")
+		t.Fatal("an invalid config was accepted")
 	}
-	msg := err.Error()
-	for _, want := range []string{"a: no protocol", "a: no listen", "a: no upstream",
-		`unsupported protocol "oracle"`, "b: no upstream"} {
-		if !strings.Contains(msg, want) {
-			t.Errorf("error missing %q:\n%s", want, msg)
+	for _, want := range []string{"a: no protocol", "unsupported protocol", "c: no upstream"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q:\n%v", want, err)
 		}
 	}
 }
 
 func TestValidationRejectsDuplicateListenAddress(t *testing.T) {
-	cfg := &Config{Listeners: []ListenerConfig{
-		{Name: "a", Protocol: "postgres", Listen: ":5432", Upstream: "h:1"},
-		{Name: "b", Protocol: "mysql", Listen: ":5432", Upstream: "h:2"},
-	}}
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "duplicate listen address") {
-		t.Errorf("duplicate bind accepted: %v", err)
+	p := writeConfig(t, `{
+      "listeners": [
+        {"name":"a","protocol":"postgres","listen":":1","upstream":"h:1"},
+        {"name":"b","protocol":"postgres","listen":":1","upstream":"h:2"}
+      ]
+    }`)
+
+	if _, err := LoadConfig(p); err == nil {
+		t.Error("two listeners on one address were accepted")
 	}
 }
 
 func TestValidationRejectsBadNetwork(t *testing.T) {
-	cfg := &Config{Listeners: []ListenerConfig{
-		{Protocol: "postgres", Listen: ":1", Upstream: "h:1", Network: "udp"},
-	}}
-	if err := cfg.Validate(); err == nil {
-		t.Error("network=udp accepted")
+	p := writeConfig(t, `{
+      "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1","network":"udp"}]
+    }`)
+
+	if _, err := LoadConfig(p); err == nil {
+		t.Error("an unsupported network was accepted")
 	}
 }
 
 // A bad regex must fail at startup, not on the first request that trips it.
-func TestBadPolicyRuleFailsAtLoad(t *testing.T) {
+func TestBadGuardrailRuleFailsAtLoad(t *testing.T) {
 	p := writeConfig(t, `{
       "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
-      "policy": {"rules":[{"name":"r","type":"pattern_match","pattern_regex":"([unclosed"}]}
+      "guardrails": {"rules":[{"name":"r","type":"pattern_match","pattern_regex":"([unclosed"}]}
     }`)
 
 	if _, err := LoadConfig(p); err == nil {
@@ -129,29 +141,83 @@ func TestBadPolicyRuleFailsAtLoad(t *testing.T) {
 	}
 }
 
-// Mask rule SHAPES are no longer validated here, since only the plugin knows
-// which entity names it detects. This package must still catch masking
-// switched on with nothing to do, which would look enabled in the config and
-// mask nothing at runtime.
-func TestMaskEnabledWithNoRulesFailsAtLoad(t *testing.T) {
+func TestUnknownGuardrailModeIsRejected(t *testing.T) {
 	p := writeConfig(t, `{
       "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
-      "mask": {"enabled": true}
+      "guardrails": {"mode": "audit"}
     }`)
 
-	if _, err := LoadConfig(p); err == nil {
-		t.Fatal("mask.enabled with no rules was accepted at load")
+	_, err := LoadConfig(p)
+	if err == nil {
+		t.Fatal("an unknown mode was accepted")
+	}
+	if !strings.Contains(err.Error(), "enforce") || !strings.Contains(err.Error(), "observe") {
+		t.Errorf("error does not name the valid modes: %v", err)
 	}
 }
 
-// An unknown entity is the plugin's error and must still be fatal, raised
-// where the knowledge lives. Masking enabled with no plugin at all is a
-// refusal, never a silent pass-through.
-func TestMaskWithoutPluginIsRefused(t *testing.T) {
-	mc := MaskConfig{
-		Enabled: ptr(true),
-		Rules:   []byte(`[{"name":"r","entity":"US_SSN","strategy":"redact"}]`),
+// Masking on a protocol that cannot mask is refused whenever rules are
+// present. Under the old mask.enabled flag this check was skipped for a lane
+// with the flag off, so a config could carry rules that could never fire and
+// still load clean.
+//
+// Every protocol this build ships masks: gate.MaskSupported asks the codec for
+// a Reframer rather than listing names, and postgres, mssql and http all have
+// one. So the refusal is exercised at the buildMasker seam, which is where a
+// future non-reframing codec would hit it.
+func TestMaskRulesOnUnmaskableProtocolAreRefused(t *testing.T) {
+	mc := MaskConfig{Rules: []byte(`[{"entities":["US_SSN"],"strategy":"redact"}]`)}
+	det := stubPlugin{entities: []string{"US_SSN"}}
+
+	for _, p := range []inspect.Protocol{inspect.Postgres, inspect.MSSQL, inspect.HTTP} {
+		if _, err := buildMasker(mc, det, p); err != nil {
+			t.Errorf("buildMasker refused %s, which can re-frame or re-tag: %v", p, err)
+		}
 	}
+	if _, err := buildMasker(mc, det, inspect.Protocol("mysql")); err == nil {
+		t.Error("buildMasker accepted a protocol with neither masking mechanism")
+	}
+}
+
+// An empty rule list is how a lane opts out of an inherited set, and it has to
+// survive the merge: json.RawMessage keeps `[]` distinct from absent, which a
+// nil slice could not.
+func TestEmptyMaskRulesOptOutOfAnInheritedSet(t *testing.T) {
+	cfg := &Config{
+		Mask: &MaskConfig{Rules: []byte(`[{"entities":["US_SSN"],"strategy":"redact"}]`)},
+		Listeners: []ListenerConfig{
+			{Name: "inherits", Protocol: "postgres", Listen: ":1", Upstream: "h:1"},
+			{Name: "opts-out", Protocol: "postgres", Listen: ":2", Upstream: "h:2",
+				Mask: &MaskConfig{Rules: []byte(`[]`)}},
+			{Name: "silent", Protocol: "postgres", Listen: ":3", Upstream: "h:3",
+				Mask: &MaskConfig{}},
+		},
+	}
+	if _, _, mc := cfg.resolve(cfg.Listeners[0]); !mc.hasRules() {
+		t.Error("the inheriting lane lost the default rule set")
+	}
+	if _, _, mc := cfg.resolve(cfg.Listeners[1]); mc.hasRules() {
+		t.Error("an empty rule list did not switch inherited masking off")
+	}
+	if _, _, mc := cfg.resolve(cfg.Listeners[2]); !mc.hasRules() {
+		t.Error("an empty mask block was read as an opt-out; only rules: [] is")
+	}
+
+	lanes, err := buildLanes(cfg, stubPlugin{entities: []string{"US_SSN"}}, nil)
+	if err != nil {
+		t.Fatalf("buildLanes: %v", err)
+	}
+	if lanes[0].masker == nil {
+		t.Error("the inheriting lane got no masker")
+	}
+	if lanes[1].masker != nil {
+		t.Error("the opted-out lane got a masker")
+	}
+}
+
+// Masking with no plugin at all is a refusal, never a silent pass-through.
+func TestMaskWithoutPluginIsRefused(t *testing.T) {
+	mc := MaskConfig{Rules: []byte(`[{"name":"r","entities":["US_SSN"],"strategy":"redact"}]`)}
 
 	m, err := buildMasker(mc, nil, inspect.HTTP)
 	if err == nil {
@@ -162,38 +228,103 @@ func TestMaskWithoutPluginIsRefused(t *testing.T) {
 	}
 }
 
-// Observe-only is the default so a misconfigured rule cannot take production
-// down on first deploy.
-func TestEnforceDefaultsOff(t *testing.T) {
+// Enforcement is the default. A relay whose rules are configured and inert is
+// a relay nobody notices is broken.
+func TestEnforceIsTheDefault(t *testing.T) {
 	cfg := &Config{
 		Listeners: []ListenerConfig{{Protocol: "postgres", Listen: ":1", Upstream: "h:1"}},
-		Policy: PolicyConfig{
+		Guardrails: &GuardrailsConfig{
 			Rules: []policy.Rule{{
 				Name: "no-drop", Type: policy.MatchOperation,
 				Operations: []inspect.Operation{inspect.OpDrop},
 			}},
 		},
 	}
-	pc, _ := cfg.resolve(cfg.Listeners[0])
-	pol, err := buildPolicy(pc, nil, nil)
+	gc, opa, _ := cfg.resolve(cfg.Listeners[0])
+	if !gc.enforcing() {
+		t.Fatal("an unset mode did not enforce")
+	}
+	pol, err := buildPolicy(gc, opa, nil, nil)
+	if err != nil {
+		t.Fatalf("buildPolicy: %v", err)
+	}
+	if pol == nil {
+		t.Fatal("rules were inert with no mode set; enforce is the default")
+	}
+	if _, wrapped := pol.(policy.Observe); wrapped {
+		t.Error("an enforcing lane was wrapped in the observe dry run")
+	}
+}
+
+// Observe evaluates every rule and denies nothing, which is the whole
+// difference from a lane with no rules: the audit line still names what would
+// have been refused.
+func TestObserveModeWrapsTheChainInsteadOfSkippingIt(t *testing.T) {
+	cfg := &Config{
+		Listeners: []ListenerConfig{{Protocol: "postgres", Listen: ":1", Upstream: "h:1"}},
+		Guardrails: &GuardrailsConfig{
+			Mode: ModeObserve,
+			Rules: []policy.Rule{{
+				Name: "no-drop", Type: policy.MatchOperation,
+				Operations: []inspect.Operation{inspect.OpDrop},
+			}},
+		},
+	}
+	gc, opa, _ := cfg.resolve(cfg.Listeners[0])
+	pol, err := buildPolicy(gc, opa, nil, nil)
+	if err != nil {
+		t.Fatalf("buildPolicy: %v", err)
+	}
+	obs, ok := pol.(policy.Observe)
+	if !ok {
+		t.Fatalf("buildPolicy returned %T, want policy.Observe", pol)
+	}
+
+	v := obs.Evaluate(inspect.Statement{
+		Protocol: inspect.Postgres, Operation: inspect.OpDrop, Text: "DROP TABLE t",
+	})
+	if v.Denied {
+		t.Error("observe mode denied a statement")
+	}
+	if v.Rule != "no-drop" {
+		t.Errorf("verdict rule = %q, want the rule that would have denied", v.Rule)
+	}
+	if v.Annotations[policy.AnnotationWouldDeny] != "no-drop" {
+		t.Errorf("annotations = %v, want %s", v.Annotations, policy.AnnotationWouldDeny)
+	}
+}
+
+// A lane with nothing to enforce relays normally rather than failing.
+func TestEnforceWithNoRulesIsAPassThrough(t *testing.T) {
+	pol, err := buildPolicy(GuardrailsConfig{Mode: ModeEnforce}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
 	if pol != nil {
-		t.Error("rules were active with enforce=false; observe-only must not deny")
+		t.Error("an empty rule set produced an evaluator")
+	}
+}
+
+// Observe over an empty chain must stay nil too, or the gate loses its
+// short-circuit and every statement walks a wrapper that does nothing.
+func TestObserveWithNoRulesStaysNil(t *testing.T) {
+	pol, err := buildPolicy(GuardrailsConfig{Mode: ModeObserve}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildPolicy: %v", err)
+	}
+	if pol != nil {
+		t.Errorf("an empty observe lane produced %T, want nil", pol)
 	}
 }
 
 func TestBuildPolicyChainsLocalRulesThenOPA(t *testing.T) {
-	pc := PolicyConfig{
-		Enforce: ptr(true),
+	gc := GuardrailsConfig{
 		Rules: []policy.Rule{{
 			Name: "no-drop", Type: policy.MatchOperation,
 			Operations: []inspect.Operation{inspect.OpDrop},
 		}},
-		OPA: &OPAConfig{URL: "http://opa:8181/v1/data/hoop"},
 	}
-	pol, err := buildPolicy(pc, nil, nil)
+	pol, err := buildPolicy(gc, &OPAConfig{URL: "http://opa:8181/v1/data/hoop"}, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -214,13 +345,87 @@ func TestBuildPolicyChainsLocalRulesThenOPA(t *testing.T) {
 	}
 }
 
+// `defer` names a decision-maker. With no OPA there is none, so the match
+// denies rather than recording a finding nobody reads.
+func TestDeferDeniesOnALaneWithNoOPA(t *testing.T) {
+	gc := GuardrailsConfig{
+		Rules: []policy.Rule{{
+			Name: "no-drop", Type: policy.MatchOperation,
+			Operations: []inspect.Operation{inspect.OpDrop},
+			Action:     policy.ActionDefer,
+			Message:    "no drops",
+		}},
+	}
+	pol, err := buildPolicy(gc, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("a deferring rule with no OPA was refused: %v", err)
+	}
+	v := pol.Evaluate(inspect.Statement{
+		Protocol: inspect.Postgres, Operation: inspect.OpDrop, Text: "DROP TABLE t",
+	})
+	if !v.Denied {
+		t.Fatal("a deferring rule allowed on a lane with nothing to defer to")
+	}
+	if v.Rule != "no-drop" {
+		t.Errorf("verdict rule = %q", v.Rule)
+	}
+}
+
+// The same rule with an OPA endpoint reports instead of denying, which is
+// what makes one config file portable across both deployments.
+func TestDeferReportsOnALaneWithOPA(t *testing.T) {
+	gc := GuardrailsConfig{
+		Rules: []policy.Rule{{
+			Name: "no-drop", Type: policy.MatchOperation,
+			Operations: []inspect.Operation{inspect.OpDrop},
+			Action:     policy.ActionDefer,
+		}},
+	}
+	pol, err := buildPolicy(gc, &OPAConfig{URL: "http://opa:8181/v1/data/hoop"}, nil, nil)
+	if err != nil {
+		t.Fatalf("buildPolicy: %v", err)
+	}
+	chain := pol.(policy.Chain)
+	rules, ok := chain[0].(*policy.Rules)
+	if !ok {
+		t.Fatalf("chain[0] = %T", chain[0])
+	}
+	if rules.DenyDeferred {
+		t.Error("DenyDeferred was set on a lane that has an OPA consumer")
+	}
+}
+
 func TestOPAWithoutURLIsRejected(t *testing.T) {
 	cfg := &Config{
 		Listeners: []ListenerConfig{{Protocol: "postgres", Listen: ":1", Upstream: "h:1"}},
-		Policy:    PolicyConfig{OPA: &OPAConfig{}},
+		// A timeout with no url configures a client that cannot be built.
+		// An entirely empty block means something else; see below.
+		OPA: &OPAConfig{TimeoutSec: 5},
 	}
 	if err := cfg.Validate(); err == nil {
 		t.Error("an OPA block with no URL was accepted")
+	}
+}
+
+// An empty block is how one lane opts out of an inherited endpoint. Without
+// it a top-level OPA reaches every lane with no way to say otherwise.
+func TestEmptyOPABlockDisablesAnInheritedEndpoint(t *testing.T) {
+	cfg := &Config{
+		OPA: &OPAConfig{URL: "http://opa:8181/v1/data/hoop"},
+		Listeners: []ListenerConfig{
+			{Name: "inherits", Protocol: "postgres", Listen: ":1", Upstream: "h:1"},
+			{Name: "opts-out", Protocol: "postgres", Listen: ":2", Upstream: "h:2",
+				OPA: &OPAConfig{}},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if _, opa, _ := cfg.resolve(cfg.Listeners[0]); !opa.enabled() {
+		t.Error("the inheriting lane lost the top-level endpoint")
+	}
+	if _, opa, _ := cfg.resolve(cfg.Listeners[1]); opa.enabled() {
+		t.Error("an empty opa block did not switch the inherited endpoint off")
 	}
 }
 
@@ -229,47 +434,42 @@ func TestBuildTLS(t *testing.T) {
 		var c *TLSConfig
 		got, err := c.BuildTLS()
 		if err != nil || got != nil {
-			t.Errorf("BuildTLS() = (%v, %v), want (nil, nil)", got, err)
+			t.Errorf("BuildTLS() = %v, %v; want nil, nil", got, err)
 		}
 	})
 
-	t.Run("minimum version is pinned", func(t *testing.T) {
-		got, err := (&TLSConfig{}).BuildTLS()
+	t.Run("cert without key is refused", func(t *testing.T) {
+		c := &TLSConfig{CertFile: "/tmp/nope.crt"}
+		if _, err := c.BuildTLS(); err == nil {
+			t.Error("a certificate with no key was accepted")
+		}
+	})
+
+	t.Run("insecure_skip_verify survives", func(t *testing.T) {
+		c := &TLSConfig{InsecureSkipVerify: true, ServerName: "db.internal"}
+		got, err := c.BuildTLS()
 		if err != nil {
 			t.Fatalf("BuildTLS: %v", err)
 		}
-		if got.MinVersion < 0x0303 { // TLS 1.2
-			t.Errorf("MinVersion = %#x, want at least TLS 1.2", got.MinVersion)
+		if !got.InsecureSkipVerify {
+			t.Error("insecure_skip_verify was dropped")
+		}
+		if got.ServerName != "db.internal" {
+			t.Errorf("ServerName = %q", got.ServerName)
 		}
 	})
 
-	t.Run("cert without key is rejected", func(t *testing.T) {
-		if _, err := (&TLSConfig{CertFile: "c.pem"}).BuildTLS(); err == nil {
-			t.Error("cert_file without key_file accepted")
-		}
-	})
-
-	t.Run("unreadable ca fails", func(t *testing.T) {
-		if _, err := (&TLSConfig{CAFile: "/nonexistent/ca.pem"}).BuildTLS(); err == nil {
+	t.Run("missing ca_file is an error", func(t *testing.T) {
+		c := &TLSConfig{CAFile: "/nonexistent/ca.pem"}
+		if _, err := c.BuildTLS(); err == nil {
 			t.Error("a missing ca_file was accepted")
-		}
-	})
-
-	t.Run("garbage ca fails", func(t *testing.T) {
-		p := filepath.Join(t.TempDir(), "ca.pem")
-		os.WriteFile(p, []byte("not a certificate"), 0o600)
-		if _, err := (&TLSConfig{CAFile: p}).BuildTLS(); err == nil {
-			t.Error("a ca_file with no certificate was accepted")
 		}
 	})
 }
 
 func TestDisplayNameFallback(t *testing.T) {
-	if got := (ListenerConfig{Name: "n", Connection: "c"}).displayName(0); got != "n" {
+	if got := (ListenerConfig{Name: "n"}).displayName(0); got != "n" {
 		t.Errorf("displayName = %q, want n", got)
-	}
-	if got := (ListenerConfig{Connection: "c"}).displayName(0); got != "c" {
-		t.Errorf("displayName = %q, want c", got)
 	}
 	if got := (ListenerConfig{}).displayName(3); got != "listener[3]" {
 		t.Errorf("displayName = %q", got)
@@ -286,5 +486,233 @@ func TestEmptyListenersRejected(t *testing.T) {
 	p := writeConfig(t, `{"listeners": []}`)
 	if _, err := LoadConfig(p); err == nil {
 		t.Error("a config with no listeners was accepted")
+	}
+}
+
+// ── the deprecation window ────────────────────────────────────────────────
+//
+// Every test below feeds a pre-ADR-0011 config. They exist because the
+// promise is that a deployed config keeps working, and a promise nothing
+// checks is a promise until the first upgrade.
+
+func TestDeprecatedPolicyBlockStillLoads(t *testing.T) {
+	p := writeConfig(t, `{
+      "listeners": [{
+        "name": "appdb", "protocol": "postgres",
+        "listen": ":1", "upstream": "h:1", "connection": "appdb"
+      }],
+      "policy": {
+        "enforce": true,
+        "rules": [{"name":"no-drop","type":"operation","operations":["drop"]}],
+        "opa": {"url": "http://opa:8181/v1/data/hoop"}
+      },
+      "mask": {"enabled": true, "rules": [{"entity":"US_SSN","strategy":"redact"}]}
+    }`)
+
+	cfg, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("a pre-0011 config was refused: %v", err)
+	}
+	if cfg.Policy != nil {
+		t.Error("normalize left the deprecated policy block populated")
+	}
+	if cfg.Guardrails == nil || cfg.Guardrails.Mode != ModeEnforce {
+		t.Errorf("guardrails = %+v, want mode enforce", cfg.Guardrails)
+	}
+	if len(cfg.Guardrails.Rules) != 1 {
+		t.Errorf("rules = %d, want the policy rule folded across", len(cfg.Guardrails.Rules))
+	}
+	if !cfg.OPA.enabled() {
+		t.Error("policy.opa did not fold onto the top-level opa block")
+	}
+	if cfg.Listeners[0].Connection != "" {
+		t.Error("normalize left the deprecated connection field populated")
+	}
+	if cfg.Mask == nil || cfg.Mask.Enabled != nil {
+		t.Errorf("mask = %+v, want enabled folded away", cfg.Mask)
+	}
+	for _, want := range []string{"policy.rules", "policy.enforce", "policy.opa",
+		"connection", "mask.enabled"} {
+		if !hasDeprecation(cfg, want) {
+			t.Errorf("no deprecation notice mentions %q; got %v", want, cfg.Deprecations)
+		}
+	}
+}
+
+// enforce: false is what observe-only used to be spelled.
+func TestDeprecatedEnforceFalseBecomesObserve(t *testing.T) {
+	p := writeConfig(t, `{
+      "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
+      "policy": {"enforce": false, "rules":[{"name":"r","type":"operation","operations":["drop"]}]}
+    }`)
+
+	cfg, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Guardrails.Mode != ModeObserve {
+		t.Errorf("mode = %q, want %q", cfg.Guardrails.Mode, ModeObserve)
+	}
+}
+
+// A lane that named only `connection` must keep that name, or its audit
+// history splits across two keys on upgrade.
+func TestDeprecatedConnectionBecomesTheName(t *testing.T) {
+	p := writeConfig(t, `{
+      "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1","connection":"metabase"}]
+    }`)
+
+	cfg, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Listeners[0].Name != "metabase" {
+		t.Errorf("name = %q, want the old connection value", cfg.Listeners[0].Name)
+	}
+}
+
+// A lane written as enabled:false with rules listed masks nothing today. The
+// migration must not switch masking ON for it.
+func TestDeprecatedMaskEnabledFalseKeepsMaskingOff(t *testing.T) {
+	p := writeConfig(t, `{
+      "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
+      "mask": {"enabled": false, "rules": [{"entity":"US_SSN","strategy":"redact"}]}
+    }`)
+
+	cfg, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	_, _, mc := cfg.resolve(cfg.Listeners[0])
+	if mc.hasRules() {
+		t.Error("mask.enabled:false was dropped and masking turned itself on")
+	}
+}
+
+// The polarity inversion. A config that wrote the old field down keeps its
+// behaviour exactly; only a config that omitted it picks up the new default.
+func TestDeprecatedAuditFailClosedInverts(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		body       string
+		wantOpen   bool
+		wantNotice bool
+	}{
+		{"explicit false stays open", `"audit":{"fail_closed":false}`, true, true},
+		{"explicit true stays closed", `"audit":{"fail_closed":true}`, false, true},
+		{"new spelling is honoured", `"audit":{"fail_open":true}`, true, false},
+		{"omitted fails closed", `"audit":{"file":"-"}`, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := writeConfig(t, `{
+              "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
+              `+tc.body+`}`)
+			cfg, err := LoadConfig(p)
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if got := cfg.Audit.failOpen(); got != tc.wantOpen {
+				t.Errorf("failOpen() = %t, want %t", got, tc.wantOpen)
+			}
+			if cfg.Audit.FailClosed != nil {
+				t.Error("normalize left the deprecated field populated")
+			}
+			if got := hasDeprecation(cfg, "fail_closed"); got != tc.wantNotice {
+				t.Errorf("deprecation notice = %t, want %t (%v)", got, tc.wantNotice, cfg.Deprecations)
+			}
+		})
+	}
+}
+
+// Picking a winner between two spellings of one setting fails the same test a
+// misspelled key fails: no operator can predict the answer.
+func TestBothSpellingsIsRefused(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"rules", `"guardrails":{"rules":[{"name":"a","type":"operation","operations":["drop"]}]},
+                   "policy":{"rules":[{"name":"b","type":"operation","operations":["drop"]}]}`},
+		{"mode", `"guardrails":{"mode":"observe"},"policy":{"enforce":true}`},
+		{"opa", `"opa":{"url":"http://a"},"policy":{"opa":{"url":"http://b"}}`},
+		{"audit", `"audit":{"fail_open":true,"fail_closed":true}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := writeConfig(t, `{
+              "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
+              `+tc.body+`}`)
+			if _, err := LoadConfig(p); err == nil {
+				t.Fatal("a config written in both spellings was accepted")
+			}
+		})
+	}
+}
+
+// Every conflict in one run, matching the rule the rest of validation follows.
+func TestEveryConflictIsReportedAtOnce(t *testing.T) {
+	p := writeConfig(t, `{
+      "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
+      "guardrails": {"mode":"observe","rules":[{"name":"a","type":"operation","operations":["drop"]}]},
+      "opa": {"url":"http://a"},
+      "policy": {"enforce":true,"opa":{"url":"http://b"},
+                 "rules":[{"name":"b","type":"operation","operations":["drop"]}]}
+    }`)
+
+	_, err := LoadConfig(p)
+	if err == nil {
+		t.Fatal("a conflicting config was accepted")
+	}
+	for _, want := range []string{"policy.rules", "policy.enforce", "policy.opa"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q:\n%v", want, err)
+		}
+	}
+}
+
+// The deprecated fields fold at listener scope too, and a listener block is
+// where a real migration is most likely to be half-finished.
+func TestDeprecatedListenerPolicyFolds(t *testing.T) {
+	p := writeConfig(t, `{
+      "listeners": [{
+        "name":"appdb","protocol":"postgres","listen":":1","upstream":"h:1",
+        "policy": {"enforce": false, "opa": {"url":"http://opa:8181/x"},
+                   "rules":[{"name":"lane","type":"operation","operations":["drop"]}]}
+      }]
+    }`)
+
+	cfg, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	lc := cfg.Listeners[0]
+	if lc.Policy != nil {
+		t.Error("normalize left the listener's policy block populated")
+	}
+	if lc.Guardrails == nil || lc.Guardrails.Mode != ModeObserve || len(lc.Guardrails.Rules) != 1 {
+		t.Errorf("listener guardrails = %+v", lc.Guardrails)
+	}
+	if !lc.OPA.enabled() {
+		t.Error("the listener's policy.opa did not fold onto its opa block")
+	}
+	if !hasDeprecation(cfg, "appdb") {
+		t.Errorf("the notice does not name the lane: %v", cfg.Deprecations)
+	}
+}
+
+// The mask rule shape belongs to the plugin, so the daemon must pass `entity`
+// through untouched for the plugin to warn about.
+func TestDeprecatedMaskEntityIsLeftToThePlugin(t *testing.T) {
+	p := writeConfig(t, `{
+      "listeners": [{"protocol":"postgres","listen":":1","upstream":"h:1"}],
+      "mask": {"rules": [{"entity":"US_SSN","strategy":"redact"}]}
+    }`)
+
+	cfg, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(cfg.Mask.Rules, &got); err != nil {
+		t.Fatalf("mask rules: %v", err)
+	}
+	if got[0]["entity"] != "US_SSN" {
+		t.Errorf("the daemon rewrote a plugin-owned rule: %v", got[0])
 	}
 }

--- a/sidecar/daemon/config_test.go
+++ b/sidecar/daemon/config_test.go
@@ -489,6 +489,91 @@ func TestEmptyListenersRejected(t *testing.T) {
 	}
 }
 
+// A lane that wants to cost nothing needs a way to say so. Observe still
+// evaluates, and evaluating is what costs money on a lane with ai_analysis
+// rules, so an explicit empty list is the only spelling left.
+func TestEmptyGuardrailRulesOptOutOfAnInheritedSet(t *testing.T) {
+	cfg := &Config{
+		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{{
+			Name: "no-drop", Type: policy.MatchOperation,
+			Operations: []inspect.Operation{inspect.OpDrop},
+		}}},
+		Listeners: []ListenerConfig{
+			{Name: "inherits", Protocol: "postgres", Listen: ":1", Upstream: "h:1"},
+			{Name: "opts-out", Protocol: "postgres", Listen: ":2", Upstream: "h:2",
+				Guardrails: &GuardrailsConfig{Rules: []policy.Rule{}}},
+			{Name: "silent", Protocol: "postgres", Listen: ":3", Upstream: "h:3",
+				Guardrails: &GuardrailsConfig{Mode: ModeEnforce}},
+		},
+	}
+	if gc, _, _ := cfg.resolve(cfg.Listeners[0]); len(gc.Rules) != 1 {
+		t.Errorf("the inheriting lane resolved %d rules, want 1", len(gc.Rules))
+	}
+	if gc, _, _ := cfg.resolve(cfg.Listeners[1]); len(gc.Rules) != 0 {
+		t.Errorf("an empty rule list did not opt out: %d rules", len(gc.Rules))
+	}
+	if gc, _, _ := cfg.resolve(cfg.Listeners[2]); len(gc.Rules) != 1 {
+		t.Errorf("a guardrails block with no rules key opted out; only rules: [] does")
+	}
+
+	lanes, err := buildLanes(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildLanes: %v", err)
+	}
+	if lanes[0].policy == nil {
+		t.Error("the inheriting lane got no evaluator")
+	}
+	if lanes[1].policy != nil {
+		t.Error("the opted-out lane still evaluates, so it still costs what it costs")
+	}
+}
+
+// The empty list has to survive a real decode, which is the only path an
+// operator uses. A nil slice and an empty one are the same length and the
+// merge reads presence, so this is the assertion that keeps them apart.
+func TestEmptyGuardrailRulesSurviveDecoding(t *testing.T) {
+	p := writeConfig(t, `{
+      "guardrails": {"rules":[{"name":"g","type":"operation","operations":["drop"]}]},
+      "listeners": [
+        {"name":"a","protocol":"postgres","listen":":1","upstream":"h:1",
+         "guardrails":{"rules":[]}},
+        {"name":"b","protocol":"postgres","listen":":2","upstream":"h:2",
+         "guardrails":{"mode":"enforce"}}
+      ]
+    }`)
+	cfg, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if gc, _, _ := cfg.resolve(cfg.Listeners[0]); len(gc.Rules) != 0 {
+		t.Errorf("rules: [] decoded as absent; lane resolved %d rules", len(gc.Rules))
+	}
+	if gc, _, _ := cfg.resolve(cfg.Listeners[1]); len(gc.Rules) != 1 {
+		t.Errorf("an absent rules key opted the lane out: %d rules", len(gc.Rules))
+	}
+}
+
+// The audit posture reaches the Gate through one inversion, and the field it
+// inverts changed polarity along with its name. A flipped sign here hands
+// every lane the reverse of what its operator asked for.
+func TestAuditFailOnErrorIsTheInverseOfFailOpen(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  AuditConfig
+		want bool
+	}{
+		{"omitted denies", AuditConfig{}, true},
+		{"fail_open false denies", AuditConfig{FailOpen: new(false)}, true},
+		{"fail_open true allows", AuditConfig{FailOpen: new(true)}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.failOnAuditError(); got != tc.want {
+				t.Errorf("failOnAuditError() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
 // ── the deprecation window ────────────────────────────────────────────────
 //
 // Every test below feeds a pre-ADR-0011 config. They exist because the

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -648,7 +648,7 @@ func buildServer(
 		Policy:           ln.policy,
 		Audit:            sink,
 		Masker:           ln.masker,
-		FailOnAuditError: !ac.failOpen(),
+		FailOnAuditError: ac.failOnAuditError(),
 		DenyWriter:       proxy.ProtocolDenyWriter{},
 		IdentityFn:       identityFn,
 		CodecFactory:     ln.codecFactory,

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -30,6 +30,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -130,6 +131,7 @@ func Main(version string, load Loader, build PluginBuilder) error {
 	var (
 		configPath = fs.String("config", "", "path to the config file ("+syntax+")")
 		validate   = fs.Bool("validate", false, "validate the config and exit")
+		strict     = fs.Bool("strict", false, "treat a deprecated config field as an error")
 		showVer    = fs.Bool("version", false, "print the version and exit")
 	)
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -154,20 +156,53 @@ func Main(version string, load Loader, build PluginBuilder) error {
 	if err != nil {
 		return err
 	}
+	ReportDeprecations(os.Stderr, cfg.Deprecations)
+	if *strict && len(cfg.Deprecations) > 0 {
+		return fmt.Errorf("%d deprecated config field(s) in use and -strict is set",
+			len(cfg.Deprecations))
+	}
 
 	if *validate {
 		lanes, err := Validate(cfg, det)
 		if err != nil {
 			return err
 		}
-		fmt.Println("config OK:", len(lanes), "listener(s)")
-		for _, ln := range lanes {
-			fmt.Printf("  %-16s %-9s %s\n", ln.Name, ln.Protocol, ln.Summary())
-		}
+		PrintLanes(os.Stdout, lanes)
 		return nil
 	}
 
 	return Run(cfg, det)
+}
+
+// ReportDeprecations writes each deprecation notice to w, one per line.
+//
+// It goes to STDERR at every call site. -validate writes a report to stdout
+// that an operator may parse, and a warning must not land in it. Same rule the
+// CLI's rename notice follows.
+func ReportDeprecations(w io.Writer, notes []string) {
+	for _, n := range notes {
+		fmt.Fprintln(w, "warn: deprecated config:", n)
+	}
+	if len(notes) > 0 {
+		fmt.Fprintln(w, "warn: these fields keep working for now and are removed in a "+
+			"future release. See docs/adr/0011-sidecar-config-schema.md")
+	}
+}
+
+// PrintLanes renders what -validate concluded, one line per lane plus any
+// notes the resolved stack produced.
+//
+// Shared by both entry points so `hoop start sidecar --validate` and
+// `hoop-inspect -validate` cannot drift into reporting different things about
+// one config.
+func PrintLanes(w io.Writer, lanes []LaneInfo) {
+	fmt.Fprintln(w, "config OK:", len(lanes), "listener(s)")
+	for _, ln := range lanes {
+		fmt.Fprintf(w, "  %-16s %-9s %s\n", ln.Name, ln.Protocol, ln.Summary())
+		for _, n := range ln.Notes {
+			fmt.Fprintf(w, "  %-16s %-9s   note: %s\n", "", "", n)
+		}
+	}
 }
 
 // LaneInfo is one resolved listener, as Validate reports it.
@@ -183,6 +218,16 @@ type LaneInfo struct {
 	OPA       bool
 	Masking   bool
 
+	// Observing is true when the lane evaluates every rule and denies
+	// nothing. Distinct from Enforcing being false, which now means the lane
+	// resolved no rules at all: a dry run runs its rules, and an operator
+	// reading this has to be able to tell the two apart.
+	Observing bool
+
+	// Notes are the facts about the resolved stack that no config file
+	// shows. See lane.notes.
+	Notes []string
+
 	// Analyzed counts the ai_analysis rules on this lane. They are
 	// reported apart from Rules because they behave differently in the way
 	// that matters to whoever is reading a validate output: they leave the
@@ -193,9 +238,14 @@ type LaneInfo struct {
 // Summary renders a LaneInfo as the one-line mode description the -validate
 // output and the CLI both print.
 func (l LaneInfo) Summary() string {
-	mode := "observe-only"
-	if l.Enforcing {
+	var mode string
+	switch {
+	case l.Observing:
+		mode = fmt.Sprintf("observing %d rule(s), denying none", l.Rules)
+	case l.Enforcing:
 		mode = fmt.Sprintf("enforcing %d rule(s)", l.Rules)
+	default:
+		mode = "no rules to enforce"
 	}
 	if l.OPA {
 		mode += " + opa"
@@ -238,11 +288,13 @@ func Validate(cfg *Config, det Plugin) ([]LaneInfo, error) {
 		out = append(out, LaneInfo{
 			Name:      ln.name,
 			Protocol:  ln.cfg.Protocol,
-			Enforcing: ln.policy != nil,
+			Enforcing: ln.policy != nil && !ln.observing,
+			Observing: ln.observing,
 			Rules:     len(ln.rules),
 			OPA:       ln.opaURL != "",
 			Masking:   ln.masker != nil,
 			Analyzed:  len(ln.analyzed),
+			Notes:     ln.notes,
 		})
 	}
 	return out, nil
@@ -329,13 +381,21 @@ func Run(cfg *Config, det Plugin) error {
 			"listener", ln.name,
 			"protocol", ln.cfg.Protocol,
 			"upstream", ln.cfg.Upstream,
-			"enforcing", ln.policy != nil,
+			"enforcing", ln.policy != nil && !ln.observing,
+			"observing", ln.observing,
 			"rules", len(ln.rules),
 			"opa", ln.opaURL,
 			"masking", ln.masker != nil)
+		for _, n := range ln.notes {
+			log.Warn(n, "listener", ln.name)
+		}
 		if ln.policy == nil {
-			log.Warn("lane is observe-only; no statement will be denied",
-				"listener", ln.name, "hint", "set policy.enforce=true on this listener or at the top level")
+			// Not a misconfiguration on its own: a lane may exist to audit
+			// and mask. It is worth one line, because a lane that resolved
+			// no rules looks identical to one whose rules failed to reach it.
+			log.Warn("lane resolved no rules and consults no policy; nothing will be denied",
+				"listener", ln.name,
+				"hint", "add guardrails.rules at the top level or on this listener")
 		}
 	}
 
@@ -374,12 +434,14 @@ func Run(cfg *Config, det Plugin) error {
 	return nil
 }
 
+// displayName is the lane's operator-facing name: what logs, audit rows,
+// validation errors and input.context.connection all key on.
+//
+// normalize folds the deprecated `connection` field onto Name before anything
+// calls this, so there is one name per lane rather than two that can disagree.
 func (l ListenerConfig) displayName(i int) string {
-	switch {
-	case l.Name != "":
+	if l.Name != "" {
 		return l.Name
-	case l.Connection != "":
-		return l.Connection
 	}
 	return fmt.Sprintf("listener[%d]", i)
 }
@@ -414,6 +476,18 @@ type lane struct {
 	// captureBody reports whether this lane's codec exposes request bodies,
 	// which decides whether HTTP analysis has anything to read.
 	captureBody bool
+
+	// observing is true when the lane evaluates everything and denies
+	// nothing. Reported apart from policy != nil because a dry-run lane HAS
+	// an evaluator: it is the one case where rules run and no denial can
+	// reach the client.
+	observing bool
+
+	// notes are per-lane facts an operator has to know at startup and that
+	// no config file shows, because they are consequences of the resolved
+	// stack rather than of anything written down. A rule that defers on a
+	// lane with no OPA is the case this exists for.
+	notes []string
 }
 
 // buildLanes resolves and builds every listener's stack.
@@ -427,16 +501,16 @@ func buildLanes(cfg *Config, det Plugin, ac *analyzerDeps) ([]lane, error) {
 
 	for i, lc := range cfg.Listeners {
 		name := lc.displayName(i)
-		pc, mc := cfg.resolve(lc)
+		gc, opa, mc := cfg.resolve(lc)
 
-		if errs := checkPIIEntities(pc, det); len(errs) > 0 {
+		if errs := checkPIIEntities(gc.Rules, det); len(errs) > 0 {
 			for _, e := range errs {
 				problems = append(problems, name+": "+e)
 			}
 			continue
 		}
 
-		pol, err := buildPolicy(pc, det, ac)
+		pol, err := buildPolicy(gc, opa, det, ac)
 		if err != nil {
 			problems = append(problems, name+": "+err.Error())
 			continue
@@ -455,19 +529,31 @@ func buildLanes(cfg *Config, det Plugin, ac *analyzerDeps) ([]lane, error) {
 			masker:       masker,
 			codecFactory: httpCodecFactory(proto, lc.HTTP),
 			captureBody:  lc.HTTP != nil && lc.HTTP.CaptureBody,
+			observing:    gc.observing(),
 		}
-		if pol != nil {
-			ln.rules = make([]string, 0, len(pc.Rules))
-			for _, r := range pc.Rules {
-				if r.Type == policy.MatchAIAnalysis {
-					ln.analyzed = append(ln.analyzed, r.Name)
-					continue
-				}
-				ln.rules = append(ln.rules, r.Name)
+		// Reported whether or not the lane enforces. An observing lane runs
+		// every one of these, and a reader of the startup log needs to see
+		// which rules a dry run is exercising.
+		ln.rules = make([]string, 0, len(gc.Rules))
+		for _, r := range gc.Rules {
+			if r.Type == policy.MatchAIAnalysis {
+				ln.analyzed = append(ln.analyzed, r.Name)
+				continue
 			}
-			if pc.OPA != nil {
-				ln.opaURL = pc.OPA.URL
-			}
+			ln.rules = append(ln.rules, r.Name)
+		}
+		if opa.enabled() {
+			ln.opaURL = opa.URL
+		}
+		if gc.observing() {
+			ln.notes = append(ln.notes,
+				"observe mode: every rule is evaluated and nothing is denied. "+
+					"Matches are recorded on the audit line as "+policy.AnnotationWouldDeny)
+		}
+		if !opa.enabled() && anyDeferred(gc.Rules) {
+			ln.notes = append(ln.notes,
+				"rule(s) defer to a decision this lane has no opa.url for, so a match "+
+					"denies instead of reporting a finding")
 		}
 		out = append(out, ln)
 	}
@@ -486,14 +572,14 @@ func buildLanes(cfg *Config, det Plugin, ac *analyzerDeps) ([]lane, error) {
 // engine never looks for never appears, and the rule silently allows every
 // statement it was written to deny. The operator sees a guardrail that is
 // doing nothing.
-func checkPIIEntities(pc PolicyConfig, det Plugin) []string {
+func checkPIIEntities(rules []policy.Rule, det Plugin) []string {
 	if det == nil {
 		return nil // buildPolicy already refuses pii rules with no scanner
 	}
 	var known map[string]bool
 	var problems []string
 
-	for _, r := range pc.Rules {
+	for _, r := range rules {
 		if r.Type != policy.MatchPII {
 			continue
 		}
@@ -508,7 +594,8 @@ func checkPIIEntities(pc PolicyConfig, det Plugin) []string {
 			if !known[want] {
 				problems = append(problems, fmt.Sprintf(
 					"rule %q names entity %q, which the detector is not configured to find; "+
-						"add it to pii.entities or the rule will never match",
+						"drop it from pii.ignored, or fix the spelling, or the rule will "+
+						"never match",
 					r.Name, want))
 			}
 		}
@@ -557,11 +644,11 @@ func buildServer(
 		UpstreamTLS:      upstreamTLS,
 		DownstreamTLS:    downstreamTLS,
 		Protocol:         inspect.Protocol(lc.Protocol),
-		Connection:       lc.Connection,
+		Connection:       ln.name,
 		Policy:           ln.policy,
 		Audit:            sink,
 		Masker:           ln.masker,
-		FailOnAuditError: ac.FailClosed,
+		FailOnAuditError: !ac.failOpen(),
 		DenyWriter:       proxy.ProtocolDenyWriter{},
 		IdentityFn:       identityFn,
 		CodecFactory:     ln.codecFactory,
@@ -577,21 +664,28 @@ func buildServer(
 // failures the same way: by finding an unmasked SSN in a screenshot.
 //
 //   - No plugin. Masking needs a detection engine and this package links
-//     none, so an enabled mask section without one cannot work.
+//     none, so a mask section without one cannot work.
 //   - A protocol whose framing cannot survive substitution. The rules would
 //     load, validate, and never fire.
+//
+// A non-empty rule list is the whole of the switch. The separate `enabled`
+// flag it replaced used to skip these checks along with the masking, so a
+// lane could carry rules for a protocol that cannot mask and still load
+// clean.
 //
 // Validate reports both at startup; these checks cover a caller reaching Run
 // without going through LoadConfig.
 func buildMasker(mc MaskConfig, det Plugin, proto inspect.Protocol) (gate.Masker, error) {
-	if !mc.on() {
+	if !mc.hasRules() {
 		return nil, nil
 	}
 	if det == nil {
-		return nil, fmt.Errorf("mask.enabled is true but this build has no detection plugin")
+		return nil, fmt.Errorf("mask.rules is set but this build has no detection plugin")
 	}
 	if !gate.MaskSupported(proto) {
-		return nil, fmt.Errorf("mask.enabled is true but masking is not supported on %s", proto)
+		return nil, fmt.Errorf(
+			"mask.rules is set but masking is not supported on %s; remove the rules from "+
+				"this lane, or set mask: {rules: []} on it", proto)
 	}
 	return det.BuildMasker(mc.Rules)
 }
@@ -742,6 +836,17 @@ func serveAdmin(
 			Masking   bool     `json:"masking"`
 			MaskNote  string   `json:"mask_note,omitempty"`
 
+			// Observing, Guardrails and OPAURL are the ADR-0011
+			// vocabulary. They sit BESIDE the four fields above rather
+			// than replacing them, so a control plane reading
+			// "enforcing" keeps working while it migrates. The
+			// response names the old set in deprecated_fields.
+			Observing  bool     `json:"observing"`
+			Guardrails string   `json:"guardrails"`
+			OPAURL     string   `json:"opa_url,omitempty"`
+			OPAGate    bool     `json:"opa_gate,omitempty"`
+			Notes      []string `json:"notes,omitempty"`
+
 			// AIRules names the ai_analysis rules and CaptureBody says
 			// whether this lane's codec exposes request bodies. Both
 			// are here because they answer "what leaves this process",
@@ -752,17 +857,25 @@ func serveAdmin(
 		}
 		out := make([]laneView, 0, len(lanes))
 		for _, ln := range lanes {
+			mode := ModeEnforce
+			if ln.observing {
+				mode = ModeObserve
+			}
 			v := laneView{
 				Name:        ln.name,
 				Protocol:    ln.cfg.Protocol,
 				Listen:      ln.cfg.Listen,
 				Upstream:    ln.cfg.Upstream,
-				Enforcing:   ln.policy != nil,
+				Enforcing:   ln.policy != nil && !ln.observing,
 				Rules:       ln.rules,
 				OPA:         ln.opaURL,
 				Masking:     ln.masker != nil,
 				AIRules:     ln.analyzed,
 				CaptureBody: ln.captureBody,
+				Observing:   ln.observing,
+				Guardrails:  mode,
+				OPAURL:      ln.opaURL,
+				Notes:       ln.notes,
 			}
 			if v.Rules == nil {
 				v.Rules = []string{} // render [] rather than null
@@ -775,6 +888,10 @@ func serveAdmin(
 		resp := map[string]any{
 			"version": Version,
 			"lanes":   out,
+			// Named in the payload rather than only in the README, so a
+			// control plane can warn its own developers without reading
+			// prose. These keys still carry correct values.
+			"deprecated_fields": []string{"enforcing", "rules", "opa", "masking"},
 		}
 		// The analyzer view names the provider, the model and the HOST it
 		// talks to — never the path, never a query string, and never the

--- a/sidecar/daemon/lane_test.go
+++ b/sidecar/daemon/lane_test.go
@@ -35,14 +35,19 @@ func (s stubPlugin) BuildMasker(raw []byte) (gate.Masker, error) {
 		return nil, nil
 	}
 	var rules []struct {
-		Entity string `json:"entity"`
+		Entity   string   `json:"entity"`
+		Entities []string `json:"entities"`
 	}
 	if err := json.Unmarshal(raw, &rules); err != nil {
 		return nil, err
 	}
 	for _, r := range rules {
-		if r.Entity != "" && !slices.Contains(s.entities, r.Entity) {
-			return nil, fmt.Errorf("entity %q is not detected", r.Entity)
+		// Both spellings, because the daemon passes plugin-owned rules
+		// through untouched and a deployed config may still use either.
+		for _, e := range append(r.Entities, r.Entity) {
+			if e != "" && !slices.Contains(s.entities, e) {
+				return nil, fmt.Errorf("entity %q is not detected", e)
+			}
 		}
 	}
 	return noopMasker{}, nil
@@ -75,15 +80,15 @@ func names(rules []policy.Rule) []string {
 // only which rule gets reported.
 func TestResolveConcatenatesRulesListenerFirst(t *testing.T) {
 	cfg := &Config{
-		Policy: PolicyConfig{Rules: []policy.Rule{rule("global-a"), rule("global-b")}},
+		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("global-a"), rule("global-b")}},
 		Listeners: []ListenerConfig{{
 			Name: "lane", Protocol: "postgres", Listen: ":1", Upstream: "h:1",
-			Policy: &PolicyConfig{Rules: []policy.Rule{rule("lane-a")}},
+			Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("lane-a")}},
 		}},
 	}
 
-	pc, _ := cfg.resolve(cfg.Listeners[0])
-	got := names(pc.Rules)
+	gc, _, _ := cfg.resolve(cfg.Listeners[0])
+	got := names(gc.Rules)
 	want := []string{"lane-a", "global-a", "global-b"}
 
 	if len(got) != len(want) {
@@ -101,26 +106,26 @@ func TestResolveConcatenatesRulesListenerFirst(t *testing.T) {
 func TestResolveDoesNotAliasAcrossListeners(t *testing.T) {
 	cfg := &Config{
 		// Capacity beyond length makes append reuse the array.
-		Policy: PolicyConfig{Rules: append(make([]policy.Rule, 0, 8), rule("global"))},
+		Guardrails: &GuardrailsConfig{Rules: append(make([]policy.Rule, 0, 8), rule("global"))},
 		Listeners: []ListenerConfig{
 			{Name: "a", Protocol: "postgres", Listen: ":1", Upstream: "h:1",
-				Policy: &PolicyConfig{Rules: []policy.Rule{rule("only-a")}}},
+				Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("only-a")}}},
 			{Name: "b", Protocol: "postgres", Listen: ":2", Upstream: "h:2",
-				Policy: &PolicyConfig{Rules: []policy.Rule{rule("only-b")}}},
+				Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("only-b")}}},
 		},
 	}
 
-	pcA, _ := cfg.resolve(cfg.Listeners[0])
-	pcB, _ := cfg.resolve(cfg.Listeners[1])
+	gcA, _, _ := cfg.resolve(cfg.Listeners[0])
+	gcB, _, _ := cfg.resolve(cfg.Listeners[1])
 
-	for _, n := range names(pcA.Rules) {
+	for _, n := range names(gcA.Rules) {
 		if n == "only-b" {
-			t.Fatalf("lane a saw lane b's rule: %v", names(pcA.Rules))
+			t.Fatalf("lane a saw lane b's rule: %v", names(gcA.Rules))
 		}
 	}
-	for _, n := range names(pcB.Rules) {
+	for _, n := range names(gcB.Rules) {
 		if n == "only-a" {
-			t.Fatalf("lane b saw lane a's rule: %v", names(pcB.Rules))
+			t.Fatalf("lane b saw lane a's rule: %v", names(gcB.Rules))
 		}
 	}
 }
@@ -130,32 +135,34 @@ func TestResolveDoesNotAliasAcrossListeners(t *testing.T) {
 // operator thought they had overridden.
 func TestResolveReplacesOPA(t *testing.T) {
 	cfg := &Config{
-		Policy: PolicyConfig{OPA: &OPAConfig{URL: "http://default/v1/data/x"}},
+		OPA: &OPAConfig{URL: "http://default/v1/data/x"},
 		Listeners: []ListenerConfig{
 			{Name: "override", Protocol: "http", Listen: ":1", Upstream: "h:1",
-				Policy: &PolicyConfig{OPA: &OPAConfig{URL: "http://lane/v1/data/y"}}},
+				OPA: &OPAConfig{URL: "http://lane/v1/data/y"}},
 			{Name: "inherit", Protocol: "http", Listen: ":2", Upstream: "h:2"},
 		},
 	}
 
-	pc, _ := cfg.resolve(cfg.Listeners[0])
-	if pc.OPA.URL != "http://lane/v1/data/y" {
-		t.Errorf("override lane opa = %q, want the listener's", pc.OPA.URL)
+	_, opa, _ := cfg.resolve(cfg.Listeners[0])
+	if opa.URL != "http://lane/v1/data/y" {
+		t.Errorf("override lane opa = %q, want the listener's", opa.URL)
 	}
-	pc, _ = cfg.resolve(cfg.Listeners[1])
-	if pc.OPA.URL != "http://default/v1/data/x" {
-		t.Errorf("inherit lane opa = %q, want the default", pc.OPA.URL)
+	_, opa, _ = cfg.resolve(cfg.Listeners[1])
+	if opa.URL != "http://default/v1/data/x" {
+		t.Errorf("inherit lane opa = %q, want the default", opa.URL)
 	}
 }
 
 // A lane rolling out behind an enforcing default must be able to say
-// observe-only. A plain bool cannot express that, so Enforce is a pointer.
-func TestResolveListenerCanDisableEnforcementAgainstEnabledDefault(t *testing.T) {
+// observe. It still gets an evaluator: the difference from a lane with no
+// rules is that a dry run RUNS them and records what each match would have
+// denied.
+func TestResolveListenerCanObserveAgainstAnEnforcingDefault(t *testing.T) {
 	cfg := &Config{
-		Policy: PolicyConfig{Enforce: ptr(true), Rules: []policy.Rule{rule("global")}},
+		Guardrails: &GuardrailsConfig{Mode: ModeEnforce, Rules: []policy.Rule{rule("global")}},
 		Listeners: []ListenerConfig{
 			{Name: "observing", Protocol: "postgres", Listen: ":1", Upstream: "h:1",
-				Policy: &PolicyConfig{Enforce: ptr(false)}},
+				Guardrails: &GuardrailsConfig{Mode: ModeObserve}},
 			{Name: "enforcing", Protocol: "postgres", Listen: ":2", Upstream: "h:2"},
 		},
 	}
@@ -164,11 +171,25 @@ func TestResolveListenerCanDisableEnforcementAgainstEnabledDefault(t *testing.T)
 	if err != nil {
 		t.Fatalf("buildLanes: %v", err)
 	}
-	if lanes[0].policy != nil {
-		t.Error("listener said enforce:false but got an evaluator")
+	if !lanes[0].observing {
+		t.Error("the listener said observe and the lane did not")
 	}
-	if lanes[1].policy == nil {
-		t.Error("listener inheriting enforce:true got no evaluator")
+	if _, ok := lanes[0].policy.(policy.Observe); !ok {
+		t.Errorf("observing lane policy = %T, want policy.Observe", lanes[0].policy)
+	}
+	drop := inspect.Statement{
+		Protocol: inspect.Postgres, Text: "DROP TABLE t", Operation: inspect.OpDrop,
+	}
+	if v := lanes[0].policy.Evaluate(drop); v.Denied {
+		t.Error("an observing lane denied a statement")
+	} else if v.Annotations[policy.AnnotationWouldDeny] == "" {
+		t.Error("an observing lane recorded nothing about the match")
+	}
+	if lanes[1].observing {
+		t.Error("the inheriting lane picked up observe mode")
+	}
+	if v := lanes[1].policy.Evaluate(drop); !v.Denied {
+		t.Error("the enforcing lane did not deny")
 	}
 }
 
@@ -176,19 +197,19 @@ func TestResolveListenerCanDisableEnforcementAgainstEnabledDefault(t *testing.T)
 // two rules claiming one entity leave slice order to decide the winner.
 func TestResolveReplacesMaskRules(t *testing.T) {
 	cfg := &Config{
-		Mask: MaskConfig{Enabled: ptr(true), Rules: []byte(`[{"entity":"EMAIL_ADDRESS"}]`)},
+		Mask: &MaskConfig{Rules: []byte(`[{"entities":["EMAIL_ADDRESS"]}]`)},
 		Listeners: []ListenerConfig{{
 			Name: "lane", Protocol: "http", Listen: ":1", Upstream: "h:1",
-			Mask: &MaskConfig{Rules: []byte(`[{"entity":"US_SSN"}]`)},
+			Mask: &MaskConfig{Rules: []byte(`[{"entities":["US_SSN"]}]`)},
 		}},
 	}
 
-	_, mc := cfg.resolve(cfg.Listeners[0])
-	if got := string(mc.Rules); got != `[{"entity":"US_SSN"}]` {
+	_, _, mc := cfg.resolve(cfg.Listeners[0])
+	if got := string(mc.Rules); got != `[{"entities":["US_SSN"]}]` {
 		t.Errorf("mask rules = %s, want the listener's list alone", got)
 	}
-	if !mc.on() {
-		t.Error("enabled should be inherited when the listener does not set it")
+	if !mc.hasRules() {
+		t.Error("a non-empty rule list did not switch masking on")
 	}
 }
 
@@ -196,10 +217,10 @@ func TestResolveReplacesMaskRules(t *testing.T) {
 // rules to every lane, the bug this change fixes.
 func TestBuildLanesGivesEachListenerItsOwnEvaluator(t *testing.T) {
 	cfg := &Config{
-		Policy: PolicyConfig{Enforce: ptr(true)},
+		
 		Listeners: []ListenerConfig{
 			{Name: "a", Protocol: "postgres", Listen: ":1", Upstream: "h:1",
-				Policy: &PolicyConfig{Rules: []policy.Rule{rule("deny-on-a")}}},
+				Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("deny-on-a")}}},
 			{Name: "b", Protocol: "postgres", Listen: ":2", Upstream: "h:2"},
 		},
 	}
@@ -218,6 +239,9 @@ func TestBuildLanesGivesEachListenerItsOwnEvaluator(t *testing.T) {
 	if lanes[1].policy != nil {
 		t.Error("lane b inherited a rule set it never configured")
 	}
+	if !lanes[1].observing && len(lanes[1].rules) != 0 {
+		t.Errorf("lane b resolved rules = %v, want none", lanes[1].rules)
+	}
 }
 
 // Postgres masking used to be refused because the gate could not re-frame a
@@ -228,12 +252,12 @@ func TestMaskOnPostgresIsAccepted(t *testing.T) {
 	cfg := &Config{
 		Listeners: []ListenerConfig{{
 			Name: "appdb", Protocol: "postgres", Listen: ":1", Upstream: "h:1",
-			Mask: &MaskConfig{Enabled: ptr(true), Rules: []byte(`[{"entity":"US_SSN"}]`)},
+			Mask: &MaskConfig{Rules: []byte(`[{"entities":["US_SSN"]}]`)},
 		}},
 	}
 
 	if err := cfg.Validate(); err != nil {
-		t.Fatalf("mask.enabled on a postgres listener was refused: %v", err)
+		t.Fatalf("mask rules on a postgres listener were refused: %v", err)
 	}
 
 	det := stubPlugin{entities: []string{"US_SSN"}}
@@ -246,7 +270,7 @@ func TestMaskOnPostgresIsAccepted(t *testing.T) {
 // against config that looks active and can never fire.
 func TestMaskOnUnmaskableProtocolIsRefused(t *testing.T) {
 	det := stubPlugin{entities: []string{"US_SSN"}}
-	mc := MaskConfig{Enabled: ptr(true), Rules: []byte(`[{"entity":"US_SSN"}]`)}
+	mc := MaskConfig{Rules: []byte(`[{"entities":["US_SSN"]}]`)}
 
 	if _, err := buildMasker(mc, det, inspect.Protocol("mysql")); err == nil {
 		t.Error("buildMasker accepted a protocol with no codec and no masking path")
@@ -258,7 +282,7 @@ func TestMaskOnHTTPIsAccepted(t *testing.T) {
 	cfg := &Config{
 		Listeners: []ListenerConfig{{
 			Name: "api", Protocol: "http", Listen: ":1", Upstream: "h:1",
-			Mask: &MaskConfig{Enabled: ptr(true), Rules: []byte(`[{"entity":"US_SSN"}]`)},
+			Mask: &MaskConfig{Rules: []byte(`[{"entities":["US_SSN"]}]`)},
 		}},
 	}
 	if err := cfg.Validate(); err != nil {
@@ -279,10 +303,10 @@ func TestMaskOnHTTPIsAccepted(t *testing.T) {
 // was written to deny.
 func TestPIIRuleNamingUndetectedEntityIsRefused(t *testing.T) {
 	cfg := &Config{
-		Policy: PolicyConfig{Enforce: ptr(true)},
+		
 		Listeners: []ListenerConfig{{
 			Name: "appdb", Protocol: "postgres", Listen: ":1", Upstream: "h:1",
-			Policy: &PolicyConfig{Rules: []policy.Rule{{
+			Guardrails: &GuardrailsConfig{Rules: []policy.Rule{{
 				Name: "no-cpf", Type: policy.MatchPII, Entities: []string{"BR_CPF"},
 			}}},
 		}},
@@ -307,16 +331,16 @@ func TestPIIRuleNamingUndetectedEntityIsRefused(t *testing.T) {
 // error per restart.
 func TestBuildLanesReportsEveryBrokenLane(t *testing.T) {
 	cfg := &Config{
-		Policy: PolicyConfig{Enforce: ptr(true)},
+		
 		Listeners: []ListenerConfig{
 			{Name: "bad-regex", Protocol: "postgres", Listen: ":1", Upstream: "h:1",
-				Policy: &PolicyConfig{Rules: []policy.Rule{{
+				Guardrails: &GuardrailsConfig{Rules: []policy.Rule{{
 					Name: "r", Type: policy.MatchPattern, Pattern: "([unclosed",
 				}}}},
 			// An entity the plugin does not detect: still a config error now
 			// that postgres masking itself is valid.
 			{Name: "bad-mask", Protocol: "postgres", Listen: ":2", Upstream: "h:2",
-				Mask: &MaskConfig{Enabled: ptr(true), Rules: []byte(`[{"entity":"NOT_A_THING"}]`)}},
+				Mask: &MaskConfig{Rules: []byte(`[{"entities":["NOT_A_THING"]}]`)}},
 		},
 	}
 
@@ -335,7 +359,7 @@ func TestBuildLanesReportsEveryBrokenLane(t *testing.T) {
 // existed: the top-level policy applies everywhere.
 func TestGlobalOnlyConfigStillAppliesToEveryLane(t *testing.T) {
 	cfg := &Config{
-		Policy: PolicyConfig{Enforce: ptr(true), Rules: []policy.Rule{rule("no-drop")}},
+		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("no-drop")}},
 		Listeners: []ListenerConfig{
 			{Name: "a", Protocol: "postgres", Listen: ":1", Upstream: "h:1"},
 			{Name: "b", Protocol: "http", Listen: ":2", Upstream: "h:2"},

--- a/sidecar/daemon/twophase_test.go
+++ b/sidecar/daemon/twophase_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hoophq/hoop/sidecar/analyzer"
+	"github.com/hoophq/hoop/sidecar/inspect"
 	"github.com/hoophq/hoop/sidecar/policy"
 )
 
@@ -51,8 +53,20 @@ func denyWordsRule(name, action string) policy.Rule {
 }
 
 // lanePolicy is an enforcing lane policy, whatever produces on it.
-func lanePolicy(opa *OPAConfig, rules ...policy.Rule) PolicyConfig {
-	return PolicyConfig{Enforce: new(true), OPA: opa, Rules: rules}
+// laneStack is the pair buildPolicy takes now that the old policy block is
+// two config sections. Bundling them keeps each test below a single call.
+type laneStack struct {
+	gc  GuardrailsConfig
+	opa *OPAConfig
+}
+
+// lanePolicy is an enforcing lane stack, whatever produces on it.
+func lanePolicy(opa *OPAConfig, rules ...policy.Rule) laneStack {
+	return laneStack{gc: GuardrailsConfig{Rules: rules}, opa: opa}
+}
+
+func buildLane(s laneStack, det Plugin, ac *analyzerDeps) (policy.Evaluator, error) {
+	return buildPolicy(s.gc, s.opa, det, ac)
 }
 
 // A lane with no defer and no gate must build exactly the chain it built
@@ -60,7 +74,7 @@ func lanePolicy(opa *OPAConfig, rules ...policy.Rule) PolicyConfig {
 func TestSinglePhaseChainIsUnchanged(t *testing.T) {
 	pc := lanePolicy(&OPAConfig{URL: "http://opa:8181/v1/data/hoop"}, aiRule("risky"))
 
-	pol, err := buildPolicy(pc, nil, stubDeps())
+	pol, err := buildLane(pc, nil, stubDeps())
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -78,7 +92,7 @@ func TestSinglePhaseChainIsUnchanged(t *testing.T) {
 func TestDeferPutsOPAAfterTheAnalyzer(t *testing.T) {
 	pc := lanePolicy(&OPAConfig{URL: "http://opa:8181/v1/data/hoop"}, deferRule("risky"))
 
-	pol, err := buildPolicy(pc, nil, stubDeps())
+	pol, err := buildLane(pc, nil, stubDeps())
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -96,7 +110,7 @@ func TestDeferPutsOPAAfterTheAnalyzer(t *testing.T) {
 func TestGateWrapsTheAnalyzer(t *testing.T) {
 	pc := lanePolicy(&OPAConfig{URL: "http://opa:8181/v1/data/hoop", Gate: true}, aiRule("risky"))
 
-	pol, err := buildPolicy(pc, nil, stubDeps())
+	pol, err := buildLane(pc, nil, stubDeps())
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -113,18 +127,34 @@ func TestGateWrapsTheAnalyzer(t *testing.T) {
 	}
 }
 
-// Deferring to a decision that does not exist allows everything, which is the
-// opposite of what the operator asked for.
-func TestDeferWithoutOPAIsRefused(t *testing.T) {
+// Deferring to a decision that does not exist would allow everything, which is
+// the opposite of what the operator asked for. The lane loads anyway and
+// blocks instead, so one config file serves a deployment with OPA and a
+// deployment without one.
+func TestAIDeferWithoutOPABlocks(t *testing.T) {
 	cfg := pgLane(deferRule("risky"))
 	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
 
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("a rule deferring to nothing was accepted")
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("a rule deferring on a lane with no opa was refused: %v", err)
 	}
-	if !strings.Contains(err.Error(), "defer") {
-		t.Errorf("the error does not name the action: %v", err)
+
+	m, err := actionMap(deferRule("risky"), false)
+	if err != nil {
+		t.Fatalf("actionMap: %v", err)
+	}
+	if got := m[analyzer.RiskHigh]; got != analyzer.ActionBlock {
+		t.Errorf("high risk = %q, want %q with no consumer for the finding",
+			got, analyzer.ActionBlock)
+	}
+
+	// With a consumer, the same rule defers as written.
+	m, err = actionMap(deferRule("risky"), true)
+	if err != nil {
+		t.Fatalf("actionMap: %v", err)
+	}
+	if got := m[analyzer.RiskHigh]; got != analyzer.ActionDefer {
+		t.Errorf("high risk = %q, want %q when OPA can rule on it", got, analyzer.ActionDefer)
 	}
 }
 
@@ -132,7 +162,7 @@ func TestDeferWithoutOPAIsRefused(t *testing.T) {
 // there. It would cost a round trip per statement and change nothing.
 func TestGateWithoutAIRulesIsRefused(t *testing.T) {
 	cfg := pgLane()
-	cfg.Listeners[0].Policy.OPA = &OPAConfig{URL: "http://opa:8181/v1/data/hoop", Gate: true}
+	cfg.Listeners[0].OPA = &OPAConfig{URL: "http://opa:8181/v1/data/hoop", Gate: true}
 
 	err := cfg.Validate()
 	if err == nil {
@@ -151,7 +181,7 @@ func TestEmptyTriggerIsAllowedOnlyWhenGated(t *testing.T) {
 		r.Trigger = nil
 		cfg := pgLane(r)
 		cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
-		cfg.Listeners[0].Policy.OPA = &OPAConfig{
+		cfg.Listeners[0].OPA = &OPAConfig{
 			URL: "http://opa:8181/v1/data/hoop", Gate: gate,
 		}
 		return cfg.Validate()
@@ -192,7 +222,7 @@ func TestLocalDeferMakesTheLaneTwoPhase(t *testing.T) {
 		denyWordsRule("no-destructive", policy.ActionDefer),
 	)
 
-	pol, err := buildPolicy(pc, nil, stubDeps())
+	pol, err := buildLane(pc, nil, stubDeps())
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -212,8 +242,8 @@ func TestLocalDeferMakesTheLaneTwoPhase(t *testing.T) {
 
 	// The same lane with the action dropped is the old single-call shape.
 	// Without this arm the assertions above pass on any two-element chain.
-	pc.Rules = []policy.Rule{denyWordsRule("no-destructive", "")}
-	pol, err = buildPolicy(pc, nil, stubDeps())
+	pc.gc.Rules = []policy.Rule{denyWordsRule("no-destructive", "")}
+	pol, err = buildLane(pc, nil, stubDeps())
 	if err != nil {
 		t.Fatalf("buildPolicy without the action: %v", err)
 	}
@@ -222,16 +252,40 @@ func TestLocalDeferMakesTheLaneTwoPhase(t *testing.T) {
 	}
 }
 
-// Deferring a local match to a lane with no policy.opa.url writes a finding
-// nobody reads: the rule matches, allows, and looks like enforcement.
-func TestLocalDeferWithoutOPAIsRefused(t *testing.T) {
-	err := pgLane(denyWordsRule("no-destructive", policy.ActionDefer)).Validate()
-	if err == nil {
-		t.Fatal("a local rule deferring to nothing was accepted")
+// Deferring a local match on a lane with no opa.url would write a finding
+// nobody reads: the rule matches, allows, and looks like enforcement. The lane
+// loads and the rule denies instead, so one config file serves a deployment
+// with OPA and a deployment without one.
+func TestLocalDeferWithoutOPADenies(t *testing.T) {
+	cfg := pgLane(denyWordsRule("no-destructive", policy.ActionDefer))
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("a local rule deferring on a lane with no opa was refused: %v", err)
 	}
-	if !strings.Contains(err.Error(), "no-destructive") ||
-		!strings.Contains(err.Error(), "policy.opa.url") {
-		t.Errorf("the error does not name the rule and what it lacks: %v", err)
+
+	lanes, err := buildLanes(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildLanes: %v", err)
+	}
+	v := lanes[0].policy.Evaluate(inspect.Statement{
+		Protocol: inspect.Postgres, Text: "DELETE FROM t", Operation: inspect.OpDelete,
+	})
+	if !v.Denied {
+		t.Fatal("a deferring rule allowed on a lane with nothing to defer to")
+	}
+	if v.Rule != "no-destructive" {
+		t.Errorf("verdict rule = %q", v.Rule)
+	}
+
+	// The operator is told, because a config that reads `defer` and denies
+	// has to say which one it did.
+	var found bool
+	for _, n := range lanes[0].notes {
+		if strings.Contains(n, "defer") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no lane note explains the degradation: %v", lanes[0].notes)
 	}
 }
 
@@ -257,7 +311,7 @@ func TestActionOnAIRuleIsRefused(t *testing.T) {
 	r.Action = policy.ActionDefer
 	cfg := pgLane(r)
 	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
-	cfg.Listeners[0].Policy.OPA = &OPAConfig{URL: "http://opa:8181/v1/data/x"}
+	cfg.Listeners[0].OPA = &OPAConfig{URL: "http://opa:8181/v1/data/x"}
 
 	err := cfg.Validate()
 	if err == nil {

--- a/sidecar/gate/gate_test.go
+++ b/sidecar/gate/gate_test.go
@@ -136,6 +136,56 @@ func TestAllowedStatementIsForwardedAndAudited(t *testing.T) {
 	}
 }
 
+// Observe mode is the rollout path, and it is only worth anything if the
+// audit trail says what WOULD have been refused. The verdict carries
+// Denied:false with the rule that matched, and audit.StatementEvent takes
+// allowed, rule and message as independent arguments, so a dry run produces a
+// statement row naming its rule without polluting the violation stream a
+// security team selects on.
+func TestObserveModeForwardsAndRecordsWhatWouldHaveDenied(t *testing.T) {
+	sink := &recordingSink{}
+	g, err := gate.New(newSession(), gate.Config{
+		Protocol: inspect.Postgres,
+		Policy:   policy.Observe{Evaluator: denyDrops(t)},
+		Audit:    sink,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	in := pgQuery("DROP TABLE customers")
+	d := g.Request(context.Background(), in)
+
+	if !d.Allowed {
+		t.Fatalf("observe mode denied a statement: %+v", d)
+	}
+	if !bytes.Equal(d.Payload, in) {
+		t.Error("payload was altered on an observed request")
+	}
+
+	ev := sink.find(audit.KindStatement)
+	if ev == nil {
+		t.Fatal("no statement event recorded")
+	}
+	if !ev.Allowed {
+		t.Error("Allowed = false; a dry run runs the statement")
+	}
+	if ev.Rule != "no-destructive" {
+		t.Errorf("Rule = %q, want the rule that would have denied", ev.Rule)
+	}
+	if ev.Message == "" {
+		t.Error("the operator's message was dropped, so the trail cannot say why")
+	}
+	if got := ev.Metadata[policy.AnnotationWouldDeny]; got != "no-destructive" {
+		t.Errorf("metadata[%s] = %q, want the rule name", policy.AnnotationWouldDeny, got)
+	}
+
+	// The violation stream stays clean, which is what makes it selectable.
+	if v := sink.find(audit.KindViolation); v != nil {
+		t.Errorf("a dry run wrote a violation record: %+v", v)
+	}
+}
+
 // A denial must both block the bytes and produce a violation record a
 // security team can select without scanning every statement.
 func TestDeniedStatementBlocksAndRecordsViolation(t *testing.T) {

--- a/sidecar/pii/alcatraz/alcatraz.go
+++ b/sidecar/pii/alcatraz/alcatraz.go
@@ -7,20 +7,21 @@
 // without a supply-chain review and drop it into a caller without touching
 // their dependency tree. Alcatraz is itself dependency-free, but importing it
 // from the root would add a module edge to every consumer of the library,
-// including the ones with no use for 45 national-ID recognizers. So it lives
+// including the ones with no use for 51 national-ID recognizers. So it lives
 // here, behind the two interfaces the root already declares, the same shape
 // as store/sqlite.
 //
 // # Coverage
 //
-// Alcatraz brings 45 entity types across 12 countries, and 25 of them carry a
+// Alcatraz brings 51 entity types across 12 countries, and 25 of them carry a
 // real checksum validator: Luhn, ISO 7064 mod-97 for IBAN, Verhoeff for
 // Aadhaar, the Brazilian mod-11 schemes. For a deployment whose data is not
 // US-shaped, that decides whether masking works at all.
 //
 // It is a PII engine, so it has no recognizer for a credential. secrets.go
 // adds three (AWS_ACCESS_KEY, JWT, PRIVATE_KEY) into the same engine, so a
-// config names them exactly like a built-in alcatraz type.
+// config names them exactly like a built-in alcatraz type. AllEntities()
+// therefore reports 54.
 //
 //	det, err := alcatraz.NewDetector(alcatraz.Options{
 //	    Entities: []string{entities.BRCPF, entities.IBANCode},
@@ -30,15 +31,26 @@
 //
 // One Detector drives both, so a deployment configures its entity list once.
 //
-// # Name the entities you want
+// # An empty entity list means all of them
 //
-// Options.Entities is required and there is no all-entities default. Turning
-// on all 45 recognizers rewrites ordinary numeric columns: nine digits in a
-// legal range is a valid US_SSN as far as any detector can tell, so a row of
-// order ids comes back redacted. Measured on synthetic business ids, US_SSN
-// alone fires on about a third of them. The Noisy map records the worst
-// offenders with their measured rates, and AllEntities() exists for a caller
-// who has read it and still wants everything.
+// Options.Entities is optional, and leaving it empty activates all 54
+// recognizers. That is safe because enabling a recognizer is not the same as
+// scanning for it. Two layers below, somebody names entities, and that name
+// is what decides the scan:
+//
+//   - NewMasker narrows the engine to exactly the entity types its own rules
+//     name (masker.go, opts.Entities = entities). A permissive Detector
+//     driving a two-rule Masker scans a response for two entities.
+//   - A pii guardrail hands its own entity list to ScanTextFor, which
+//     intersects it with the active set. A permissive Detector under a rule
+//     naming CREDIT_CARD scans a statement for CREDIT_CARD.
+//
+// Naming a noisy entity in a MASK RULE is still the mistake the Noisy map
+// warns about, because that IS the act that puts the recognizer on a data
+// path: a US_SSN mask rule redacts about a third of a column of nine-digit
+// order ids no matter how the Detector was built. Options.Ignored is the
+// pairing for the permissive form, subtracting the recognizers this
+// deployment's ordinary data trips.
 //
 // # Pattern core only
 //
@@ -73,8 +85,8 @@ import (
 // nine-digit business ids, US_SSN fires on about a third of them at any
 // threshold.
 //
-// So Options.Entities is required rather than defaulted. See its
-// documentation.
+// The threshold is therefore not what keeps a noisy recognizer off a data
+// path. The rule that names the entity is. See Noisy and Options.Entities.
 const DefaultThreshold = 0.4
 
 // Noisy names the recognizers that fire often on ordinary business data, so a
@@ -110,23 +122,29 @@ type Options struct {
 	// Entities selects the alcatraz entity types to detect, named as the
 	// constants in github.com/hoophq/alcatraz/entities ("US_SSN", "BR_CPF").
 	//
-	// REQUIRED. There is no "all entities" default. Enabling all 45
-	// recognizers on a response path corrupts ordinary data: a row like
+	// Empty means every supported type, all 54 of them. The package
+	// documentation carries the argument for why that is not the trap it
+	// reads as: NewMasker and ScanTextFor both narrow the scan to the
+	// entities their own caller named, so an active recognizer nobody
+	// names costs nothing on either data path.
+	//
+	// The row that the "all entities" default is accused of corrupting,
 	//
 	//	{"order_id":457555462,"customer_id":123456781}
 	//
-	// has both integers rewritten as US_SSN, because nine digits in a legal
-	// range IS a valid SSN as far as any detector can tell. An operator
-	// switches off a masker that mangles a third of the numeric columns
-	// within a day, and then nothing is masked at all.
+	// loses both integers to a US_SSN MASK RULE, because nine digits in a
+	// legal range IS a valid SSN as far as any detector can tell. Writing
+	// that rule is the mistake. Leaving this field empty is not.
 	//
-	// So you name the entity types your data contains. See Noisy for the
-	// ones that cost the most when guessed at, and AllEntities if you want
-	// the full set.
+	// Name the types your data contains when you know them: it documents
+	// the deployment, and it keeps ScanText, the one path that does run
+	// the whole active set, narrow. Use Ignored when you do not.
 	Entities []string
 
 	// Ignored removes types from the active set, applied after Entities.
-	// Chiefly useful with AllEntities.
+	// It is the knob for a permissive Detector: name the seven recognizers
+	// in Noisy that fire on this deployment's ordinary data rather than
+	// enumerating the 47 that do not.
 	Ignored []string
 
 	// Threshold drops detections scoring below it. Zero means
@@ -160,6 +178,11 @@ type Detector struct {
 var (
 	_ policy.Scanner = (*Detector)(nil)
 	_ Plugin         = (*Detector)(nil)
+
+	// The optional narrowing interface. It is optional to implement and
+	// only ever reached through a type assertion, so nothing would fail to
+	// compile if the method drifted out of shape. This line would.
+	_ policy.ScopedScanner = (*Detector)(nil)
 )
 
 // newEngine builds the alcatraz engine this package uses: the full built-in
@@ -175,33 +198,31 @@ func newEngine(lang string) *alcatraz.Engine {
 	return analyzer.NewEngine(reg, []string{lang})
 }
 
-// AllEntities returns every entity type this package detects: alcatraz's
-// built-in set plus AWS_ACCESS_KEY, JWT and PRIVATE_KEY.
+// AllEntities returns every entity type this package detects: alcatraz's 51
+// built-ins plus AWS_ACCESS_KEY, JWT and PRIVATE_KEY, 54 in all.
 //
-// Prefer naming the types your data contains. This exists so "everything" is
-// an explicit, greppable decision rather than the consequence of leaving a
-// config field blank.
+// NewDetector activates the same set for an empty Options.Entities, so this
+// exists for a caller that wants the list itself: to print it at startup, to
+// diff a config against it, or to write "everything" somewhere an empty
+// slice would read as an oversight.
 func AllEntities() []string {
 	return newEngine("en").SupportedEntities("en")
 }
 
-// NewDetector builds a Detector over the named entity types.
+// NewDetector builds a Detector over the named entity types. An empty
+// Options.Entities means every supported type; see that field for why the
+// permissive form is safe.
 //
-// It returns an error when Entities is empty or names a type alcatraz cannot
-// detect. Both are config mistakes that would otherwise surface as "masking
-// silently does nothing", which is the failure mode this package exists to
-// avoid.
+// It returns an error when Entities names a type alcatraz cannot detect, and
+// when Ignored subtracts the last remaining one. Both are config mistakes
+// that would otherwise surface as "masking silently does nothing", which is
+// the failure mode this package exists to avoid.
 func NewDetector(o Options) (*Detector, error) {
 	lang := o.Language
 	if lang == "" {
 		lang = "en"
 	}
 	eng := newEngine(lang)
-
-	if len(o.Entities) == 0 {
-		return nil, fmt.Errorf("alcatraz: Options.Entities is required " +
-			"(there is no safe all-entities default; use AllEntities() to opt in explicitly)")
-	}
 
 	known := make(map[string]bool)
 	for _, e := range eng.SupportedEntities(lang) {
@@ -220,7 +241,14 @@ func NewDetector(o Options) (*Detector, error) {
 			strings.Join(unknown, ", "))
 	}
 
+	// An empty list is the permissive form: every recognizer the engine
+	// registered. The scan is narrowed by whoever names entities, in
+	// NewMasker for a response and in ScanTextFor for a statement, so the
+	// only path that pays for the full set is ScanText.
 	active := o.Entities
+	if len(active) == 0 {
+		active = eng.SupportedEntities(lang)
+	}
 	if len(o.Ignored) > 0 {
 		ignored := o.Ignored
 		skip := make(map[string]bool, len(ignored))
@@ -272,7 +300,7 @@ func (d *Detector) Entities() []string {
 // Find returns the byte spans of one entity type in data.
 //
 // It restricts the engine to the single entity asked for rather than running
-// all 45 recognizers and discarding the rest. The Masker calls this once per
+// the whole active set and discarding the rest. The Masker calls this once per
 // rule, so a three-rule config costs three narrow scans instead of three full
 // ones. Nothing is cached between calls either, which matters because a cache
 // keyed on payloads is a map holding the PII it just found.
@@ -323,6 +351,58 @@ func (d *Detector) ScanText(text string) []string {
 		return nil
 	}
 
+	seen := make(map[string]bool, len(results))
+	out := make([]string, 0, len(results))
+	for _, r := range results {
+		if seen[r.EntityType] {
+			continue
+		}
+		seen[r.EntityType] = true
+		out = append(out, r.EntityType)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ScanTextFor is ScanText restricted to the entity classes the caller can act
+// on, implementing the root module's optional policy.ScopedScanner.
+//
+// A guardrail rule names its own entity list and throws away every finding
+// outside it, so the recognizers for the rest run for nothing. That is a
+// rounding error when a config names five entities and real work when it
+// names none: a permissive Detector has all 54 active, and paying for 54
+// recognizer passes per statement to keep two answers is the one genuine
+// cost of the permissive default. This is how a caller declines to pay it.
+//
+// entities is intersected with the active set rather than trusted, for the
+// reason Find calls claims: a rule naming a class this Detector does not
+// carry must narrow the scan to nothing, never widen it. An empty argument
+// asks for no narrowing at all and scans the active set, which is what the
+// ScopedScanner contract says it means.
+func (d *Detector) ScanTextFor(entities []string, text string) []string {
+	if text == "" {
+		return nil
+	}
+	opts := d.opts
+	if len(entities) > 0 {
+		scan := make([]string, 0, len(entities))
+		for _, e := range entities {
+			if d.claims(e) {
+				scan = append(scan, e)
+			}
+		}
+		if len(scan) == 0 {
+			// Nothing this Detector could find would survive the caller's
+			// own filter, so the engine call is pure cost.
+			return nil
+		}
+		opts.Entities = scan
+	}
+
+	results := d.eng.Analyze(text, opts)
+	if len(results) == 0 {
+		return nil
+	}
 	seen := make(map[string]bool, len(results))
 	out := make([]string, 0, len(results))
 	for _, r := range results {

--- a/sidecar/pii/alcatraz/alcatraz.go
+++ b/sidecar/pii/alcatraz/alcatraz.go
@@ -64,6 +64,7 @@ package alcatraz
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -145,6 +146,11 @@ type Options struct {
 	// It is the knob for a permissive Detector: name the seven recognizers
 	// in Noisy that fire on this deployment's ordinary data rather than
 	// enumerating the 47 that do not.
+	//
+	// A name alcatraz does not know is refused here exactly as it is in
+	// Entities. Subtraction fails silent: a misspelled entry removes
+	// nothing, leaves the recognizer it was written to disable running,
+	// and the deployment learns about it from a masked production column.
 	Ignored []string
 
 	// Threshold drops detections scoring below it. Zero means
@@ -213,10 +219,12 @@ func AllEntities() []string {
 // Options.Entities means every supported type; see that field for why the
 // permissive form is safe.
 //
-// It returns an error when Entities names a type alcatraz cannot detect, and
-// when Ignored subtracts the last remaining one. Both are config mistakes
-// that would otherwise surface as "masking silently does nothing", which is
-// the failure mode this package exists to avoid.
+// It returns an error when Entities or Ignored names a type alcatraz cannot
+// detect, and when Ignored subtracts the last remaining one. All three are
+// config mistakes that would otherwise surface as masking doing something
+// other than what the config says, which is the failure mode this package
+// exists to avoid. The two spelling checks report together, so an operator
+// who mistyped in both lists fixes both on one restart.
 func NewDetector(o Options) (*Detector, error) {
 	lang := o.Language
 	if lang == "" {
@@ -228,17 +236,27 @@ func NewDetector(o Options) (*Detector, error) {
 	for _, e := range eng.SupportedEntities(lang) {
 		known[e] = true
 	}
-	var unknown []string
-	for _, e := range o.Entities {
-		if !known[e] {
-			unknown = append(unknown, e)
-		}
+	// Both lists are checked, and Ignored is the one that needs it more.
+	// A bad name in Entities narrows the set to something the operator did
+	// not ask for; a bad name in Ignored subtracts NOTHING and leaves the
+	// recognizer it was written to disable running over every response.
+	// Neither failure is visible from the outside, and the permissive
+	// default makes the second the likelier of the two: the whole reason
+	// to write the section is to take a recognizer away.
+	//
+	// Both are reported at once, and each names the list it came from, so
+	// the operator edits the right key rather than grepping for the name.
+	var problems []string
+	if bad := unknownIn(known, o.Entities); len(bad) > 0 {
+		problems = append(problems, "entities: "+strings.Join(bad, ", "))
 	}
-	if len(unknown) > 0 {
-		sort.Strings(unknown)
-		return nil, fmt.Errorf("alcatraz: unknown entity type(s) %s "+
+	if bad := unknownIn(known, o.Ignored); len(bad) > 0 {
+		problems = append(problems, "ignored: "+strings.Join(bad, ", "))
+	}
+	if len(problems) > 0 {
+		return nil, fmt.Errorf("alcatraz: unknown entity type(s) in %s "+
 			"(PERSON, LOCATION and NRP need the alcatraz/ner module, which this package does not wire)",
-			strings.Join(unknown, ", "))
+			strings.Join(problems, "; "))
 	}
 
 	// An empty list is the permissive form: every recognizer the engine
@@ -289,6 +307,23 @@ func NewDetector(o Options) (*Detector, error) {
 		d.opts.Threshold = &threshold
 	}
 	return d, nil
+}
+
+// unknownIn returns the names in want that the engine does not recognize,
+// sorted and deduplicated so one typo written twice reads as one mistake.
+// Nil when every name resolves, which is the case it is called in.
+func unknownIn(known map[string]bool, want []string) []string {
+	var bad []string
+	for _, e := range want {
+		if !known[e] {
+			bad = append(bad, e)
+		}
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	sort.Strings(bad)
+	return slices.Compact(bad)
 }
 
 // Entities returns the active entity types. The returned slice is a copy: a caller

--- a/sidecar/pii/alcatraz/alcatraz_test.go
+++ b/sidecar/pii/alcatraz/alcatraz_test.go
@@ -118,6 +118,60 @@ func TestIgnoredSubtractsFromThePermissiveSet(t *testing.T) {
 	}
 }
 
+// A misspelled Ignored entry is refused. It subtracts nothing, so the
+// recognizer the operator wrote it to disable keeps running: the permissive
+// default hands back a detector that looks correct and behaves as though the
+// section were never written. This is the one config mistake that gets LOUDER
+// the more careful the operator was, because writing the section at all means
+// they wanted something switched off.
+func TestUnknownIgnoredEntityRejected(t *testing.T) {
+	// No Entities: the permissive form, where the typo is invisible.
+	_, err := alcatraz.NewDetector(alcatraz.Options{Ignored: []string{"US_SSSN"}})
+	if err == nil {
+		t.Fatal("want an error: US_SSSN ignores nothing and US_SSN stays active")
+	}
+	if !strings.Contains(err.Error(), "US_SSSN") {
+		t.Errorf("error should name the unresolved entry: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ignored") {
+		t.Errorf("error should name the list holding it: %v", err)
+	}
+}
+
+// One restart per typo is how a rollout takes three rounds. Both lists are
+// checked before either is applied, and each unresolved name is attributed to
+// the key it was written under.
+func TestUnknownEntitiesAndIgnoredReportedTogether(t *testing.T) {
+	_, err := alcatraz.NewDetector(alcatraz.Options{
+		Entities: []string{alcz.USSSN, "BR_CPFF"},
+		Ignored:  []string{"URLL"},
+	})
+	if err == nil {
+		t.Fatal("want an error for both unresolved names")
+	}
+	for _, want := range []string{"entities: BR_CPFF", "ignored: URLL"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+// A name that resolves is not reported just because it appears in both lists.
+// Naming a type in Entities and Ignored is how "everything is subtracted"
+// gets written, and that already has its own error.
+func TestKnownEntityInBothListsIsNotAnUnknownName(t *testing.T) {
+	_, err := alcatraz.NewDetector(alcatraz.Options{
+		Entities: []string{alcz.USSSN},
+		Ignored:  []string{alcz.USSSN},
+	})
+	if err == nil {
+		t.Fatal("want an error: nothing is left to detect")
+	}
+	if strings.Contains(err.Error(), "unknown") {
+		t.Errorf("US_SSN resolves in both lists; the error should be the empty set: %v", err)
+	}
+}
+
 // Ignoring everything leaves a detector that detects nothing, which is a
 // config mistake wearing the costume of a working one.
 func TestIgnoringEveryEntityRejected(t *testing.T) {

--- a/sidecar/pii/alcatraz/alcatraz_test.go
+++ b/sidecar/pii/alcatraz/alcatraz_test.go
@@ -37,6 +37,9 @@ func newMask(t *testing.T, d *alcatraz.Detector, rules ...alcatraz.Rule) *alcatr
 func TestSatisfiesPolicyScanner(t *testing.T) {
 	d := newDet(t, alcatraz.Options{Entities: []string{alcz.USSSN}})
 	var _ policy.Scanner = d
+	// The optional narrowing interface, reached through a type assertion in
+	// matchesPII, so only a compile-time check catches a drifted signature.
+	var _ policy.ScopedScanner = d
 }
 
 // Checksum-verified national identifiers, the reason this module exists.
@@ -84,17 +87,51 @@ func TestChecksumRejectsLookalikes(t *testing.T) {
 
 // --- entity set resolution -------------------------------------------------
 
-func TestEntitiesIsRequired(t *testing.T) {
-	_, err := alcatraz.NewDetector(alcatraz.Options{})
-	if err == nil {
-		t.Fatal("want an error: an all-entities default rewrites ordinary numeric columns")
-	}
-	if !strings.Contains(err.Error(), "Entities") {
-		t.Errorf("error should name the missing field: %v", err)
+// An empty Entities is the permissive form rather than a mistake. Enabling a
+// recognizer is not the same as scanning for it: NewMasker narrows a response
+// scan to the entities its rules name, and ScanTextFor narrows a statement
+// scan to the entities a guardrail rule names.
+func TestEmptyEntitiesMeansEveryEntity(t *testing.T) {
+	d := newDet(t, alcatraz.Options{})
+
+	want := alcatraz.AllEntities()
+	slices.Sort(want)
+	if got := d.Entities(); !slices.Equal(got, want) {
+		t.Errorf("Entities() = %v, want the full set %v", got, want)
 	}
 }
 
-// The full set is available, but only by asking for it by name.
+// Ignored is the knob that pairs with the permissive form: subtract the
+// recognizers this deployment's ordinary data trips instead of enumerating
+// the several dozen it does not.
+func TestIgnoredSubtractsFromThePermissiveSet(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Ignored: []string{alcz.USSSN, alcz.URL}})
+
+	got := d.Entities()
+	if len(got) != len(alcatraz.AllEntities())-2 {
+		t.Errorf("Entities() has %d types, want the full set less two", len(got))
+	}
+	for _, gone := range []string{alcz.USSSN, alcz.URL} {
+		if slices.Contains(got, gone) {
+			t.Errorf("%s was ignored and must not be active", gone)
+		}
+	}
+}
+
+// Ignoring everything leaves a detector that detects nothing, which is a
+// config mistake wearing the costume of a working one.
+func TestIgnoringEveryEntityRejected(t *testing.T) {
+	_, err := alcatraz.NewDetector(alcatraz.Options{
+		Entities: []string{alcz.USSSN},
+		Ignored:  []string{alcz.USSSN},
+	})
+	if err == nil {
+		t.Fatal("want an error: nothing is left to detect")
+	}
+}
+
+// AllEntities is the same set an empty Options.Entities activates, and it
+// must exclude the NER classes this package does not wire.
 func TestAllEntitiesOptIn(t *testing.T) {
 	all := alcatraz.AllEntities()
 	if len(all) < 40 {
@@ -262,6 +299,49 @@ func TestScanTextCleanAndEmpty(t *testing.T) {
 	}
 	if got := d.ScanText("SELECT name FROM customers WHERE id = 1"); len(got) != 0 {
 		t.Errorf("clean SQL reported entities: %v", got)
+	}
+}
+
+// ScanTextFor is the cheap path under a permissive detector: the scan itself
+// narrows to the classes the caller can act on, instead of running every
+// recognizer and throwing all but two answers away in the caller's filter.
+func TestScanTextForRestrictsTheScan(t *testing.T) {
+	d := newDet(t, alcatraz.Options{}) // permissive: every class active
+	const text = "mail ada@example.com card 4111111111111111"
+
+	all := d.ScanText(text)
+	if !slices.Contains(all, alcz.EmailAddress) || !slices.Contains(all, alcz.CreditCard) {
+		t.Fatalf("ScanText = %v, want both classes present to make the narrowing visible", all)
+	}
+
+	want := []string{alcz.CreditCard}
+	if got := d.ScanTextFor(want, text); !slices.Equal(got, want) {
+		t.Errorf("ScanTextFor = %v, want %v: the email must not be scanned for", got, want)
+	}
+}
+
+// A rule naming a class the detector does not carry narrows the scan to
+// nothing. Widening it back to the active set would report classes the caller
+// never asked about, which is the intersection ScanTextFor exists to skip.
+func TestScanTextForOutsideTheActiveSetFindsNothing(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.CreditCard}})
+
+	got := d.ScanTextFor([]string{alcz.EmailAddress}, "mail ada@example.com card 4111111111111111")
+	if got != nil {
+		t.Errorf("ScanTextFor = %v, want nil", got)
+	}
+}
+
+// The ScopedScanner contract: an empty list asks for no narrowing at all.
+func TestScanTextForEmptyListMatchesScanText(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.CreditCard, alcz.EmailAddress}})
+	const text = "mail ada@example.com card 4111111111111111"
+
+	if got, want := d.ScanTextFor(nil, text), d.ScanText(text); !slices.Equal(got, want) {
+		t.Errorf("ScanTextFor(nil) = %v, want ScanText's answer %v", got, want)
+	}
+	if got := d.ScanTextFor([]string{alcz.CreditCard}, ""); got != nil {
+		t.Errorf("ScanTextFor over empty text = %v", got)
 	}
 }
 

--- a/sidecar/pii/alcatraz/config.go
+++ b/sidecar/pii/alcatraz/config.go
@@ -26,7 +26,10 @@ type Plugin interface {
 // has to know what an Options looks like: knowing would drag this module's
 // dependency back into the one place the split exists to keep clean.
 type piiSection struct {
-	Entities  []string `json:"entities"`
+	// Entities is optional, and an empty one selects every supported type.
+	// The zero piiSection therefore describes the permissive detector,
+	// which is what an absent section builds.
+	Entities  []string `json:"entities,omitempty"`
 	Ignored   []string `json:"ignored,omitempty"`
 	Threshold float64  `json:"threshold,omitempty"`
 	AllowList []string `json:"allow_list,omitempty"`
@@ -36,18 +39,27 @@ type piiSection struct {
 // PluginFromConfig builds the detector described by a sidecar config's "pii"
 // section. Pass Config.PII straight in.
 //
-// An absent section returns a nil Plugin and no error: the relay then runs
-// with detection disabled, which is the right answer for a config written
-// before the section existed. A present but invalid section IS an error, so
-// an operator who wrote entity names hears that they do not resolve rather
-// than watching masking quietly do nothing.
+// An absent section is not "detection off". It builds the permissive
+// detector, with every supported entity type active, because the section's
+// job is to subtract: a deployment whose ordinary data trips a recognizer
+// names it in "ignored", and a deployment that knows its schema names the
+// types it holds in "entities". Neither is a precondition for detecting
+// anything, and requiring the section made masking and the analyzer's
+// redaction refuse to start on a config that had simply not heard of it.
+//
+// A present but invalid section IS an error, so an operator who wrote entity
+// names hears that they do not resolve rather than watching masking quietly
+// do nothing.
+//
+// A nil Plugin remains possible and now means one thing only: this build
+// linked no detector at all. The sidecar reports that case separately
+// (checkPIIPlugin), and it can no longer be reached through configuration.
 func PluginFromConfig(raw json.RawMessage) (Plugin, error) {
-	if len(raw) == 0 {
-		return nil, nil
-	}
 	var s piiSection
-	if err := json.Unmarshal(raw, &s); err != nil {
-		return nil, fmt.Errorf("pii section: %w", err)
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, fmt.Errorf("pii section: %w", err)
+		}
 	}
 	det, err := NewDetector(Options{
 		Entities:  s.Entities,

--- a/sidecar/pii/alcatraz/config_test.go
+++ b/sidecar/pii/alcatraz/config_test.go
@@ -1,0 +1,135 @@
+package alcatraz_test
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	alcz "github.com/hoophq/alcatraz/entities"
+	"github.com/hoophq/hoop/sidecar/pii/alcatraz"
+)
+
+// --- the pii section -------------------------------------------------------
+
+// An omitted section is not "detection off". It used to be, and a lane that
+// wanted masking had to hand-write an entity list first, so six shipped
+// configs carried the same copied list under the same copied comment. The
+// section's job is to subtract, not to switch the product on.
+func TestPluginFromConfigAbsentSectionIsPermissive(t *testing.T) {
+	p, err := alcatraz.PluginFromConfig(nil)
+	if err != nil {
+		t.Fatalf("PluginFromConfig(nil): %v", err)
+	}
+	if p == nil {
+		t.Fatal("want a working plugin: a nil one now means this build linked no detector")
+	}
+
+	// 51 alcatraz built-ins plus AWS_ACCESS_KEY, JWT and PRIVATE_KEY from
+	// secrets.go. The number is quoted in this package's documentation and
+	// in the sidecar's, so pin it: an alcatraz upgrade that moves it is
+	// exactly when those sentences need rewriting.
+	if got := len(p.Entities()); got != 54 {
+		t.Errorf("Entities() = %d, want 54 (51 built-ins plus the three in secrets.go)", got)
+	}
+}
+
+// The two things an absent section used to refuse: detecting, and building a
+// masker to rewrite what was detected.
+func TestPermissivePluginDetectsAndMasks(t *testing.T) {
+	p, err := alcatraz.PluginFromConfig(nil)
+	if err != nil {
+		t.Fatalf("PluginFromConfig(nil): %v", err)
+	}
+
+	if found := p.ScanText("card 4111111111111111"); !slices.Contains(found, alcz.CreditCard) {
+		t.Errorf("ScanText = %v, want CREDIT_CARD", found)
+	}
+
+	m, err := p.BuildMasker([]byte(`[{"entities":["CREDIT_CARD"],"strategy":"redact"}]`))
+	if err != nil {
+		t.Fatalf("BuildMasker: %v", err)
+	}
+	out, _, n := m.Mask([]byte("card 4111111111111111 order 457555462"))
+	if strings.Contains(string(out), "4111111111111111") {
+		t.Errorf("the card survived masking: %q", out)
+	}
+	// The permissive detector has US_SSN active, and a bare nine-digit order
+	// id IS a valid SSN to any detector. It survives anyway, because the
+	// masker scans for the entities its own rules name and nothing else.
+	// This is the whole argument for the permissive default.
+	if !strings.Contains(string(out), "457555462") {
+		t.Errorf("an entity no rule named was rewritten: %q", out)
+	}
+	if n != 1 {
+		t.Errorf("masked %d spans, want 1", n)
+	}
+}
+
+// An empty JSON object is the same as no section at all: the operator wrote
+// the key and subtracted nothing.
+func TestPluginFromConfigEmptySectionIsPermissive(t *testing.T) {
+	p, err := alcatraz.PluginFromConfig(json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("PluginFromConfig: %v", err)
+	}
+	if got, want := len(p.Entities()), len(alcatraz.AllEntities()); got != want {
+		t.Errorf("Entities() = %d, want the full set of %d", got, want)
+	}
+}
+
+// A section that names entities still restricts, which is what a deployment
+// that knows its schema should write.
+func TestPluginFromConfigNamedEntitiesRestrict(t *testing.T) {
+	p, err := alcatraz.PluginFromConfig(json.RawMessage(`{"entities":["BR_CPF","IBAN_CODE"]}`))
+	if err != nil {
+		t.Fatalf("PluginFromConfig: %v", err)
+	}
+	want := []string{alcz.BRCPF, alcz.IBANCode} // sorted
+	if got := p.Entities(); !slices.Equal(got, want) {
+		t.Errorf("Entities() = %v, want %v", got, want)
+	}
+}
+
+// The recommended knob for the permissive form: name the recognizers this
+// deployment's ordinary data trips.
+func TestPluginFromConfigIgnoredSubtracts(t *testing.T) {
+	p, err := alcatraz.PluginFromConfig(json.RawMessage(`{"ignored":["US_SSN","DATE_TIME","URL"]}`))
+	if err != nil {
+		t.Fatalf("PluginFromConfig: %v", err)
+	}
+	if got, want := len(p.Entities()), len(alcatraz.AllEntities())-3; got != want {
+		t.Errorf("Entities() = %d types, want %d", got, want)
+	}
+	if slices.Contains(p.Entities(), alcz.USSSN) {
+		t.Error("US_SSN was ignored and must not be active")
+	}
+}
+
+// A present but invalid section is an error, so an operator who wrote entity
+// names hears that they do not resolve instead of watching masking quietly do
+// nothing. Both failures wear the section's name.
+func TestPluginFromConfigInvalidSection(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{"malformed json", `{"entities":`},
+		{"wrong type", `{"entities":"US_SSN"}`},
+		{"unknown entity", `{"entities":["US_SSSN"]}`},
+		{"ignored everything", `{"entities":["US_SSN"],"ignored":["US_SSN"]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := alcatraz.PluginFromConfig(json.RawMessage(tc.raw))
+			if err == nil {
+				t.Fatalf("want an error for %s", tc.raw)
+			}
+			if p != nil {
+				t.Error("a failed section must not yield a plugin")
+			}
+			if !strings.Contains(err.Error(), "pii section") {
+				t.Errorf("error should name the section: %v", err)
+			}
+		})
+	}
+}

--- a/sidecar/pii/alcatraz/config_test.go
+++ b/sidecar/pii/alcatraz/config_test.go
@@ -117,6 +117,9 @@ func TestPluginFromConfigInvalidSection(t *testing.T) {
 		{"malformed json", `{"entities":`},
 		{"wrong type", `{"entities":"US_SSN"}`},
 		{"unknown entity", `{"entities":["US_SSSN"]}`},
+		// The permissive form: without this check the section decodes,
+		// the detector starts, and US_SSN keeps firing.
+		{"unknown ignored entity", `{"ignored":["US_SSSN"]}`},
 		{"ignored everything", `{"entities":["US_SSN"],"ignored":["US_SSN"]}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/sidecar/pii/alcatraz/masker.go
+++ b/sidecar/pii/alcatraz/masker.go
@@ -62,8 +62,8 @@ const DefaultMaskChar = '*'
 // A rule matches EITHER by detected entity type or by column name. Both are
 // useful and they answer different questions:
 //
-//	{"entity": "US_SSN", "strategy": "partial"}   // wherever an SSN appears
-//	{"columns": ["ssn"], "strategy": "redact"}    // whatever is in that column
+//	{"entities": ["US_SSN"], "strategy": "partial"}   // wherever an SSN appears
+//	{"columns": ["ssn"], "strategy": "redact"}        // whatever is in that column
 //
 // The column form is available only where the protocol names its values (a
 // database result set) and it is stronger there. It is deterministic rather
@@ -75,13 +75,26 @@ type Rule struct {
 	// "rule[<index>]".
 	Name string `json:"name,omitempty"`
 
-	// Entity is the alcatraz entity type this rule rewrites, named as the
-	// constants in github.com/hoophq/alcatraz/entities ("US_SSN", "BR_CPF")
-	// or one of AWSAccessKey / JWT / PrivateKey.
+	// Entities lists the alcatraz entity types this rule rewrites, named as
+	// the constants in github.com/hoophq/alcatraz/entities ("US_SSN",
+	// "BR_CPF") or one of AWSAccessKey / JWT / PrivateKey. Three entities
+	// in one rule compile to three rewrites sharing one strategy, which is
+	// the whole reason the plural exists: a contact-details rule covers an
+	// email and a phone number without saying "redact" twice.
 	//
-	// Required unless Columns is set. When both are set the rule masks the
-	// named columns and reports them under this entity name, which is how a
-	// column rule gets a meaningful label in the audit trail.
+	// Required unless Columns is set, and it cannot be combined with
+	// Columns. An entity named beside columns is only a label for the
+	// audit trail, and a list of labels names nothing.
+	Entities []string `json:"entities,omitempty"`
+
+	// Entity is the one-entity spelling of Entities.
+	//
+	// Deprecated: use Entities. The field stays declared because
+	// BuildMasker decodes with DisallowUnknownFields, so deleting it would
+	// refuse every config already deployed instead of migrating it.
+	// Setting both spellings on one rule is an error rather than a silent
+	// winner. Unlike Entities it may still be combined with Columns, where
+	// it supplies the audit label for the masked cells.
 	Entity string `json:"entity,omitempty"`
 
 	// Columns names result-set columns to mask outright, compared
@@ -107,7 +120,9 @@ type Rule struct {
 	MaskChar rune `json:"mask_char,omitempty"`
 }
 
-// entityName is the label a rule's matches are reported under.
+// entityName is the label a column rule's masked cells are reported under.
+// Only the deprecated singular reaches it, because Entities and Columns
+// cannot appear on one rule, so there is never a list to choose from here.
 func (r Rule) entityName() string {
 	if r.Entity != "" {
 		return r.Entity
@@ -192,9 +207,33 @@ func NewMasker(d *Detector, rules []Rule) (*Masker, error) {
 			continue
 		}
 
+		// One spelling from here down. The deprecated singular survives so
+		// a config written before the rename still loads, and setting both
+		// is refused rather than resolved: picking a winner silently is
+		// how a rename disables the control an operator thought they kept.
+		ents := r.Entities
+		if r.Entity != "" {
+			if len(ents) > 0 {
+				problems = append(problems, name+
+					": set entities, not both entity and entities")
+				continue
+			}
+			ents = []string{r.Entity}
+		}
+
 		// A column rule needs no detector: the operator has already decided
 		// the column is sensitive, so there is nothing to detect.
 		if len(r.Columns) > 0 {
+			// An entity named beside columns is a LABEL for the masked
+			// cells and nothing else, so a LIST of them says nothing: two
+			// labels for one cell has no meaning to pick between. The
+			// singular keeps working here for the configs that already
+			// pair the two.
+			if len(r.Entities) > 0 {
+				problems = append(problems, name+
+					": entities cannot be combined with columns (entity names the audit label for a column rule)")
+				continue
+			}
 			label := r.entityName()
 			for _, col := range r.Columns {
 				key := strings.ToLower(strings.TrimSpace(col))
@@ -214,31 +253,38 @@ func NewMasker(d *Detector, rules []Rule) (*Masker, error) {
 			continue
 		}
 
-		switch {
-		case r.Entity == "":
+		if len(ents) == 0 {
 			// Without either, the rule matches nothing and the audit event
 			// could not say what was masked.
 			problems = append(problems, name+": no entity or columns")
 			continue
-		case !claims[r.Entity]:
-			problems = append(problems, fmt.Sprintf(
-				"%s: entity %q is not in the detector's set (configured: %s)",
-				name, r.Entity, strings.Join(d.active, ", ")))
-			continue
 		}
 
-		// Two rules for one entity is ambiguous: the anonymizer keys
-		// operators by entity type, so the second would silently replace the
-		// first.
-		if prev, dup := seen[r.Entity]; dup {
-			problems = append(problems, fmt.Sprintf(
-				"%s: entity %q already rewritten by %s", name, r.Entity, prev))
-			continue
-		}
+		// One rule over three entities is three rewrites sharing one
+		// operator. Every check below runs per entity and against the maps
+		// the whole set shares, so a rule that names an entity another rule
+		// already claimed still collides, and a rule that repeats an entity
+		// collides with itself.
+		for _, e := range ents {
+			if !claims[e] {
+				problems = append(problems, fmt.Sprintf(
+					"%s: entity %q is not in the detector's set (configured: %s)",
+					name, e, strings.Join(d.active, ", ")))
+				continue
+			}
+			// Two rules for one entity is ambiguous: the anonymizer keys
+			// operators by entity type, so the second would silently replace
+			// the first.
+			if prev, dup := seen[e]; dup {
+				problems = append(problems, fmt.Sprintf(
+					"%s: entity %q already rewritten by %s", name, e, prev))
+				continue
+			}
 
-		seen[r.Entity] = name
-		perEntity[r.Entity] = op
-		entities = append(entities, r.Entity)
+			seen[e] = name
+			perEntity[e] = op
+			entities = append(entities, e)
+		}
 	}
 
 	if len(problems) > 0 {

--- a/sidecar/pii/alcatraz/masker.go
+++ b/sidecar/pii/alcatraz/masker.go
@@ -65,6 +65,13 @@ const DefaultMaskChar = '*'
 //	{"entities": ["US_SSN"], "strategy": "partial"}   // wherever an SSN appears
 //	{"columns": ["ssn"], "strategy": "redact"}        // whatever is in that column
 //
+// Naming both is the third shape, and it is still a column rule:
+//
+//	{"entities": ["US_SSN"], "columns": ["ssn"]}      // that column, audited as US_SSN
+//
+// Columns decide what is rewritten; the one entity beside them decides only
+// what the audit trail calls the masked cells.
+//
 // The column form is available only where the protocol names its values (a
 // database result set) and it is stronger there. It is deterministic rather
 // than probabilistic, it protects a column whose contents no detector
@@ -82,9 +89,12 @@ type Rule struct {
 	// the whole reason the plural exists: a contact-details rule covers an
 	// email and a phone number without saying "redact" twice.
 	//
-	// Required unless Columns is set, and it cannot be combined with
-	// Columns. An entity named beside columns is only a label for the
-	// audit trail, and a list of labels names nothing.
+	// Required unless Columns is set. Beside Columns it takes at most ONE
+	// entity, and that entity is a label for the audit trail rather than
+	// something to detect: a masked cell is reported under one name, and a
+	// second name gives the reader nothing to pick between. That
+	// one-element form is the canonical spelling of the deprecated Entity
+	// beside Columns.
 	Entities []string `json:"entities,omitempty"`
 
 	// Entity is the one-entity spelling of Entities.
@@ -93,8 +103,10 @@ type Rule struct {
 	// BuildMasker decodes with DisallowUnknownFields, so deleting it would
 	// refuse every config already deployed instead of migrating it.
 	// Setting both spellings on one rule is an error rather than a silent
-	// winner. Unlike Entities it may still be combined with Columns, where
-	// it supplies the audit label for the masked cells.
+	// winner. Every use of it renames to a one-element Entities without
+	// changing what the rule does, Columns included: {"entity": "US_SSN",
+	// "columns": ["ssn"]} becomes {"entities": ["US_SSN"], "columns":
+	// ["ssn"]} and keeps the same audit label.
 	Entity string `json:"entity,omitempty"`
 
 	// Columns names result-set columns to mask outright, compared
@@ -120,17 +132,19 @@ type Rule struct {
 	MaskChar rune `json:"mask_char,omitempty"`
 }
 
-// entityName is the label a column rule's masked cells are reported under.
-// Only the deprecated singular reaches it, because Entities and Columns
-// cannot appear on one rule, so there is never a list to choose from here.
-func (r Rule) entityName() string {
-	if r.Entity != "" {
-		return r.Entity
+// columnLabel is the label a column rule's masked cells are reported under.
+//
+// ents is the rule's entities after both spellings have been folded into one
+// list, and it holds at most one entry here: NewMasker refuses a longer one
+// before calling this, because two labels for one cell cannot be resolved.
+func columnLabel(ents, columns []string) string {
+	if len(ents) > 0 {
+		return ents[0]
 	}
 	// A column-only rule still needs a name in the audit trail. "column:ssn"
 	// says both what happened and why, without inventing an entity type that
 	// no detector produces.
-	return "column:" + strings.ToLower(strings.Join(r.Columns, ","))
+	return "column:" + strings.ToLower(strings.Join(columns, ","))
 }
 
 // Result reports what a Mask call rewrote.
@@ -225,16 +239,22 @@ func NewMasker(d *Detector, rules []Rule) (*Masker, error) {
 		// the column is sensitive, so there is nothing to detect.
 		if len(r.Columns) > 0 {
 			// An entity named beside columns is a LABEL for the masked
-			// cells and nothing else, so a LIST of them says nothing: two
-			// labels for one cell has no meaning to pick between. The
-			// singular keeps working here for the configs that already
-			// pair the two.
-			if len(r.Entities) > 0 {
-				problems = append(problems, name+
-					": entities cannot be combined with columns (entity names the audit label for a column rule)")
+			// cells and nothing else: the columns already decided what
+			// gets rewritten. One label, because a cell is reported under
+			// one name and a second has no meaning to pick between. Both
+			// spellings reach here through ents, so the deprecated
+			// singular renames to a one-element list and behaves the same.
+			//
+			// The label is not checked against the detector's set. No
+			// detector runs on a column rule, so the name is free text in
+			// an audit row rather than a class anything has to recognize.
+			if len(ents) > 1 {
+				problems = append(problems, fmt.Sprintf(
+					"%s: %d entities beside columns; a column rule labels its cells "+
+						"with ONE entity, so name one or none", name, len(ents)))
 				continue
 			}
-			label := r.entityName()
+			label := columnLabel(ents, r.Columns)
 			for _, col := range r.Columns {
 				key := strings.ToLower(strings.TrimSpace(col))
 				if key == "" {

--- a/sidecar/pii/alcatraz/masker_test.go
+++ b/sidecar/pii/alcatraz/masker_test.go
@@ -1,6 +1,7 @@
 package alcatraz_test
 
 import (
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -165,6 +166,135 @@ func TestDuplicateEntityRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "first") {
 		t.Errorf("error should name the rule already holding the entity: %v", err)
+	}
+}
+
+// The plural spelling fans out: one rule over two entities compiles to two
+// rewrites sharing one strategy, which is the whole reason it exists.
+func TestEntitiesFanOutToOneRewriteEach(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.EmailAddress, alcz.CreditCard}})
+	m := newMask(t, d, alcatraz.Rule{
+		Name:     "contact-details",
+		Entities: []string{alcz.EmailAddress, alcz.CreditCard},
+		Strategy: alcatraz.StrategyHash,
+	})
+
+	want := []string{alcz.CreditCard, alcz.EmailAddress} // sorted
+	if got := m.Entities(); !slices.Equal(got, want) {
+		t.Fatalf("Entities() = %v, want %v", got, want)
+	}
+
+	out, res := m.MaskString("mail ada@example.com card 4111111111111111")
+	if strings.Contains(out, "ada@example.com") || strings.Contains(out, "4111111111111111") {
+		t.Errorf("a listed entity survived masking: %q", out)
+	}
+	if n := strings.Count(out, "sha256:"); n != 2 {
+		t.Errorf("%d hashed spans, want 2: both entities carry the rule's one strategy (%q)", n, out)
+	}
+	if res.Count != 2 {
+		t.Errorf("Count = %d, want 2", res.Count)
+	}
+}
+
+// Both spellings on one rule is refused rather than resolved. Picking a
+// winner silently is how a rename switches off a control the operator
+// believed they had written down.
+func TestEntityAndEntitiesTogetherRefused(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.USSSN, alcz.CreditCard}})
+
+	_, err := alcatraz.NewMasker(d, []alcatraz.Rule{{
+		Name:     "r",
+		Entity:   alcz.USSSN,
+		Entities: []string{alcz.CreditCard},
+	}})
+	if err == nil {
+		t.Fatal("want an error for a rule setting both entity and entities")
+	}
+	if !strings.Contains(err.Error(), "entities") {
+		t.Errorf("error should name the spelling to keep: %v", err)
+	}
+}
+
+// An entity beside columns is only the audit label for the masked cells, so a
+// LIST of them names nothing a reader could pick between.
+func TestEntitiesWithColumnsRefused(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.USSSN, alcz.CreditCard}})
+
+	_, err := alcatraz.NewMasker(d, []alcatraz.Rule{{
+		Name:     "r",
+		Entities: []string{alcz.USSSN, alcz.CreditCard},
+		Columns:  []string{"ssn"},
+	}})
+	if err == nil {
+		t.Fatal("want an error for entities combined with columns")
+	}
+	if !strings.Contains(err.Error(), "columns") {
+		t.Errorf("error should name the conflict: %v", err)
+	}
+}
+
+// The singular keeps working beside Columns, which is the one thing it can do
+// that the plural cannot: label the masked cells in the audit trail.
+func TestEntityLabelsAColumnRule(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.USSSN}})
+	m := newMask(t, d, alcatraz.Rule{
+		Name:     "taxpayer",
+		Entity:   alcz.USSSN,
+		Columns:  []string{"Taxpayer_ID"},
+		Strategy: alcatraz.StrategyRedact,
+	})
+
+	// Contents no detector would flag: the operator named the column, so the
+	// cell goes whatever it holds.
+	out, names, n := m.MaskCell("taxpayer_id", []byte("not-an-ssn-at-all"))
+	if string(out) == "not-an-ssn-at-all" {
+		t.Errorf("the column rule did not fire: %q", out)
+	}
+	if n != 1 || !slices.Equal(names, []string{alcz.USSSN}) {
+		t.Errorf("MaskCell reported %v/%d, want the entity as the audit label", names, n)
+	}
+	if got := m.Entities(); len(got) != 0 {
+		t.Errorf("Entities() = %v, want none: a column rule enables no content detection", got)
+	}
+}
+
+// The duplicate check spans the whole rule set, not one rule, so an entity
+// claimed through the plural still collides with one claimed through the
+// singular. The anonymizer keys operators by entity type and the second would
+// silently replace the first.
+func TestDuplicateEntityAcrossSpellingsRejected(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.USSSN, alcz.CreditCard}})
+
+	_, err := alcatraz.NewMasker(d, []alcatraz.Rule{
+		{Name: "first", Entity: alcz.USSSN, Strategy: alcatraz.StrategyRedact},
+		{Name: "second", Entities: []string{alcz.CreditCard, alcz.USSSN}, Strategy: alcatraz.StrategyHash},
+	})
+	if err == nil {
+		t.Fatal("want an error for two rules claiming one entity")
+	}
+	if !strings.Contains(err.Error(), "first") {
+		t.Errorf("error should name the rule already holding the entity: %v", err)
+	}
+}
+
+// An unknown entity inside a list is reported for that entry alone, naming
+// it, so a five-entity rule with one typo does not read as five mistakes.
+func TestEntitiesReportsTheOffendingMemberOnly(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.USSSN}})
+
+	_, err := alcatraz.NewMasker(d, []alcatraz.Rule{{
+		Name:     "r",
+		Entities: []string{alcz.USSSN, alcz.BRCPF},
+	}})
+	if err == nil {
+		t.Fatal("want an error for an entity outside the detector's set")
+	}
+	if !strings.Contains(err.Error(), alcz.BRCPF) {
+		t.Errorf("error should name the entity that failed: %v", err)
+	}
+	if strings.Count(err.Error(), alcz.USSSN) != 1 {
+		// US_SSN appears once, in the "configured:" list, never as a problem.
+		t.Errorf("the valid entity was reported as a problem: %v", err)
 	}
 }
 
@@ -360,6 +490,29 @@ func TestBuildMaskerEmptyRules(t *testing.T) {
 		}
 		if m != nil {
 			t.Errorf("%q: want a nil masker for empty rules", raw)
+		}
+	}
+}
+
+// Both spellings decode. The deprecated key stays declared because decoding
+// is strict, so dropping it would refuse every config already deployed.
+func TestBuildMaskerAcceptsBothEntitySpellings(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.BRCPF, alcz.EmailAddress}})
+
+	for _, raw := range []string{
+		`[{"entities":["BR_CPF","EMAIL_ADDRESS"],"strategy":"redact"}]`,
+		`[{"entity":"BR_CPF","strategy":"redact"},{"entity":"EMAIL_ADDRESS","strategy":"redact"}]`,
+	} {
+		m, err := d.BuildMasker([]byte(raw))
+		if err != nil {
+			t.Fatalf("%s: BuildMasker: %v", raw, err)
+		}
+		out, names, n := m.Mask([]byte("cpf 111.444.777-35 mail ada@example.com"))
+		if strings.Contains(string(out), "111.444.777-35") || strings.Contains(string(out), "ada@example.com") {
+			t.Errorf("%s: masked output still carries a value: %q", raw, out)
+		}
+		if n != 2 {
+			t.Errorf("%s: masked %d spans, want 2 (%v)", raw, n, names)
 		}
 	}
 }

--- a/sidecar/pii/alcatraz/masker_test.go
+++ b/sidecar/pii/alcatraz/masker_test.go
@@ -215,9 +215,9 @@ func TestEntityAndEntitiesTogetherRefused(t *testing.T) {
 	}
 }
 
-// An entity beside columns is only the audit label for the masked cells, so a
-// LIST of them names nothing a reader could pick between.
-func TestEntitiesWithColumnsRefused(t *testing.T) {
+// An entity beside columns is the audit label for the masked cells, so TWO of
+// them name nothing a reader could pick between. One is the whole point.
+func TestTwoEntitiesWithColumnsRefused(t *testing.T) {
 	d := newDet(t, alcatraz.Options{Entities: []string{alcz.USSSN, alcz.CreditCard}})
 
 	_, err := alcatraz.NewMasker(d, []alcatraz.Rule{{
@@ -226,35 +226,67 @@ func TestEntitiesWithColumnsRefused(t *testing.T) {
 		Columns:  []string{"ssn"},
 	}})
 	if err == nil {
-		t.Fatal("want an error for entities combined with columns")
+		t.Fatal("want an error for two entity labels on one column rule")
 	}
 	if !strings.Contains(err.Error(), "columns") {
 		t.Errorf("error should name the conflict: %v", err)
 	}
 }
 
-// The singular keeps working beside Columns, which is the one thing it can do
-// that the plural cannot: label the masked cells in the audit trail.
-func TestEntityLabelsAColumnRule(t *testing.T) {
+// Both spellings label a column rule identically, which is what makes the
+// documented rename mechanical: a deployed {entity: X, columns: [...]} becomes
+// {entities: [X], columns: [...]} and masks the same cells under the same
+// audit label. Without this the singular would have no canonical replacement
+// and could never be removed.
+func TestEitherSpellingLabelsAColumnRule(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rule alcatraz.Rule
+	}{
+		{"deprecated singular", alcatraz.Rule{
+			Name: "taxpayer", Entity: alcz.USSSN,
+			Columns: []string{"Taxpayer_ID"}, Strategy: alcatraz.StrategyRedact,
+		}},
+		{"canonical one-element list", alcatraz.Rule{
+			Name: "taxpayer", Entities: []string{alcz.USSSN},
+			Columns: []string{"Taxpayer_ID"}, Strategy: alcatraz.StrategyRedact,
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDet(t, alcatraz.Options{Entities: []string{alcz.USSSN}})
+			m := newMask(t, d, tc.rule)
+
+			// Contents no detector would flag: the operator named the
+			// column, so the cell goes whatever it holds.
+			out, names, n := m.MaskCell("taxpayer_id", []byte("not-an-ssn-at-all"))
+			if string(out) != "[REDACTED:"+alcz.USSSN+"]" {
+				t.Errorf("MaskCell = %q, want the cell redacted under the entity", out)
+			}
+			if n != 1 || !slices.Equal(names, []string{alcz.USSSN}) {
+				t.Errorf("MaskCell reported %v/%d, want the entity as the audit label", names, n)
+			}
+			if got := m.Entities(); len(got) != 0 {
+				t.Errorf("Entities() = %v, want none: a column rule enables no content detection", got)
+			}
+		})
+	}
+}
+
+// A column rule runs no detector, so its label is a name for an audit row
+// rather than a class anything has to recognize. Checking it against the
+// detector's set would refuse configs the deprecated singular accepts and
+// break the rename this package promises.
+func TestColumnLabelNeedsNoRecognizer(t *testing.T) {
 	d := newDet(t, alcatraz.Options{Entities: []string{alcz.USSSN}})
 	m := newMask(t, d, alcatraz.Rule{
-		Name:     "taxpayer",
-		Entity:   alcz.USSSN,
-		Columns:  []string{"Taxpayer_ID"},
-		Strategy: alcatraz.StrategyRedact,
+		Name:     "risk",
+		Entities: []string{"INTERNAL_RISK_SCORE"},
+		Columns:  []string{"risk_score"},
 	})
 
-	// Contents no detector would flag: the operator named the column, so the
-	// cell goes whatever it holds.
-	out, names, n := m.MaskCell("taxpayer_id", []byte("not-an-ssn-at-all"))
-	if string(out) == "not-an-ssn-at-all" {
-		t.Errorf("the column rule did not fire: %q", out)
-	}
-	if n != 1 || !slices.Equal(names, []string{alcz.USSSN}) {
-		t.Errorf("MaskCell reported %v/%d, want the entity as the audit label", names, n)
-	}
-	if got := m.Entities(); len(got) != 0 {
-		t.Errorf("Entities() = %v, want none: a column rule enables no content detection", got)
+	_, names, n := m.MaskCell("risk_score", []byte("0.97"))
+	if n != 1 || !slices.Equal(names, []string{"INTERNAL_RISK_SCORE"}) {
+		t.Errorf("MaskCell reported %v/%d, want the rule's own label", names, n)
 	}
 }
 

--- a/sidecar/pii/alcatraz/secrets.go
+++ b/sidecar/pii/alcatraz/secrets.go
@@ -10,7 +10,7 @@ import (
 
 // Entity names for the credential recognizers this package adds.
 //
-// Alcatraz is a PII engine: it detects who someone is, across 45 identifier
+// Alcatraz is a PII engine: it detects who someone is, across 51 identifier
 // formats and 12 countries. It has no recognizer for a credential, and that
 // gap is correct, because an AWS key is not personal data. But a response
 // body carrying one is a worse leak than the same body carrying a phone

--- a/sidecar/policy/findings_test.go
+++ b/sidecar/policy/findings_test.go
@@ -455,6 +455,138 @@ func TestADenialStopsRulesBelowItFromReporting(t *testing.T) {
 	}
 }
 
+// --- deferring with nothing to defer to ----------------------------------
+
+// `action: defer` means "hand this match to a decision-maker". The only
+// evaluator that reads a Finding is a decide-phase OPA client, so on a lane
+// with no OPA the match is recorded, read by nobody, and the statement runs.
+// An operator who wrote defer on a rule asked for the opposite of that, and
+// DenyDeferred is how the daemon says the lane has no consumer.
+func TestDenyDeferredDeniesInsteadOfRecording(t *testing.T) {
+	build := func(denyDeferred bool) *policy.Rules {
+		t.Helper()
+		r, err := policy.NewRules([]policy.Rule{{
+			Name: "watch-deletes", Type: policy.MatchDenyWords,
+			Words: []string{"DELETE"}, Action: policy.ActionDefer,
+			Message: "deletes go through the migration job",
+		}})
+		if err != nil {
+			t.Fatalf("NewRules: %v", err)
+		}
+		r.DenyDeferred = denyDeferred
+		return r
+	}
+
+	s := stmt("DELETE FROM customers", inspect.OpDelete, "customers")
+
+	// With a consumer, the documented behaviour: report and continue.
+	ec := &policy.EvalContext{}
+	if v := build(false).EvaluateWith(s, ec); v.Denied {
+		t.Fatalf("a deferring rule denied on a lane that can consume it: %+v", v)
+	}
+	if _, ok := ec.Finding(string(policy.MatchDenyWords)); !ok {
+		t.Fatalf("the match was not reported: %v", ec.Findings)
+	}
+
+	// Without one, the same rule denies and keeps its own message.
+	ec = &policy.EvalContext{}
+	v := build(true).EvaluateWith(s, ec)
+	if !v.Denied {
+		t.Fatalf("a deferring rule with nothing to defer to allowed the statement: %+v", v)
+	}
+	if v.Rule != "watch-deletes" {
+		t.Errorf("Rule = %q, want the deferring rule", v.Rule)
+	}
+	if v.Message != "deletes go through the migration job" {
+		t.Errorf("Message = %q, want the operator's message", v.Message)
+	}
+	if _, ok := ec.Finding(string(policy.MatchDenyWords)); ok {
+		t.Error("the rule denied AND reported; nothing on this lane reads the finding")
+	}
+}
+
+// The PII branch dispatches separately from every other rule type, so it
+// needs its own proof. The denial must name the entity CLASS and never the
+// value, because a denial message travels into the audit trail.
+func TestDenyDeferredDeniesADeferringPIIRule(t *testing.T) {
+	const cpf = "111.222.333-44"
+	rules, err := policy.NewRulesWithScanner([]policy.Rule{{
+		Name: "no-cpf", Type: policy.MatchPII,
+		Entities: []string{"BR_CPF"}, Action: policy.ActionDefer,
+	}}, fakeScanner{"BR_CPF": cpf})
+	if err != nil {
+		t.Fatalf("NewRulesWithScanner: %v", err)
+	}
+	rules.DenyDeferred = true
+
+	ec := &policy.EvalContext{}
+	v := rules.EvaluateWith(piiStmt("SELECT * FROM t WHERE cpf = '"+cpf+"'"), ec)
+
+	if !v.Denied {
+		t.Fatalf("a deferring pii rule with nothing to defer to allowed the statement: %+v", v)
+	}
+	if v.Rule != "no-cpf" {
+		t.Errorf("Rule = %q, want the deferring rule", v.Rule)
+	}
+	if !strings.Contains(v.Message, "BR_CPF") {
+		t.Errorf("Message = %q, want it to name the entity class", v.Message)
+	}
+	if strings.Contains(v.Message, cpf) {
+		t.Errorf("Message = %q quotes the identifier the rule objected to", v.Message)
+	}
+	if _, ok := ec.Finding("pii"); ok {
+		t.Error("the rule denied AND reported; nothing on this lane reads the finding")
+	}
+}
+
+// A denial stops the rule set, so with DenyDeferred the FIRST deferring rule
+// wins rather than the hard rule below it. The same config run with and
+// without OPA therefore names a different rule in the audit record, which is
+// confusing enough in a trail to be worth pinning.
+func TestDenyDeferredShortCircuitsALaterHardRule(t *testing.T) {
+	build := func(denyDeferred bool) *policy.Rules {
+		t.Helper()
+		r, err := policy.NewRules([]policy.Rule{
+			{Name: "watch-deletes", Type: policy.MatchDenyWords,
+				Words: []string{"DELETE"}, Action: policy.ActionDefer},
+			{Name: "no-writes", Type: policy.MatchOperation,
+				Operations: []inspect.Operation{inspect.OpDelete},
+				Message:    "this credential is read-only"},
+		})
+		if err != nil {
+			t.Fatalf("NewRules: %v", err)
+		}
+		r.DenyDeferred = denyDeferred
+		return r
+	}
+
+	s := stmt("DELETE FROM customers", inspect.OpDelete, "customers")
+
+	if v := build(false).Evaluate(s); v.Rule != "no-writes" {
+		t.Errorf("with a consumer, Rule = %q, want the hard rule below", v.Rule)
+	}
+	if v := build(true).Evaluate(s); v.Rule != "watch-deletes" {
+		t.Errorf("without one, Rule = %q, want the first deferring rule", v.Rule)
+	}
+}
+
+// DenyDeferred changes what a MATCH does, never what matches. A rule nothing
+// hits still allows, or the flag would be a lane-wide kill switch.
+func TestDenyDeferredDoesNotDenyWithoutAMatch(t *testing.T) {
+	rules, err := policy.NewRules([]policy.Rule{{
+		Name: "watch-drops", Type: policy.MatchDenyWords,
+		Words: []string{"DROP"}, Action: policy.ActionDefer,
+	}})
+	if err != nil {
+		t.Fatalf("NewRules: %v", err)
+	}
+	rules.DenyDeferred = true
+
+	if v := rules.Evaluate(stmt("SELECT 1", inspect.OpSelect)); v.Denied {
+		t.Errorf("a statement nothing matched was denied: %+v", v)
+	}
+}
+
 // A table rule meaning "nothing WRITES customers" must not fire on a
 // statement that only reads it. Before the access split the only expressible
 // rule was "nothing mentions customers", which fires on both, and operators

--- a/sidecar/policy/observe_test.go
+++ b/sidecar/policy/observe_test.go
@@ -1,0 +1,205 @@
+package policy_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/inspect"
+	"github.com/hoophq/hoop/sidecar/policy"
+)
+
+// The whole point of observe mode. Before it existed, the off-switch built no
+// evaluator at all and the audit record carried an empty rule and an empty
+// message, so a week of running that way answered nothing. A dry run has to
+// let the statement through AND say which rule objected.
+func TestObserveTurnsADenialIntoAnAllowThatNamesTheRule(t *testing.T) {
+	inner := &stubEvaluator{verdict: policy.Deny("no-drop", "schema changes go through migrations")}
+	obs := policy.Observe{Evaluator: inner}
+
+	v := obs.Evaluate(stmt("DROP TABLE customers", inspect.OpDrop, "customers"))
+
+	if v.Denied {
+		t.Fatal("observe mode denied")
+	}
+	if v.Rule != "no-drop" {
+		t.Errorf("Rule = %q, want the rule that would have denied", v.Rule)
+	}
+	if v.Message != "schema changes go through migrations" {
+		t.Errorf("Message = %q, want the operator's message preserved", v.Message)
+	}
+	if got := v.Annotations[policy.AnnotationWouldDeny]; got != "no-drop" {
+		t.Errorf("%s = %q, want the rule name", policy.AnnotationWouldDeny, got)
+	}
+}
+
+// Err records why an evaluation broke, and a degraded evaluator is worth the
+// same audit line in a dry run as in enforcement. Losing it here would make
+// observe mode the one place an OPA outage goes unrecorded.
+func TestObserveKeepsTheEvaluationError(t *testing.T) {
+	boom := errors.New("opa unreachable")
+	inner := &stubEvaluator{verdict: policy.Verdict{
+		Denied: true, Rule: "opa", Message: "policy engine unreachable; denying", Err: boom,
+	}}
+
+	v := policy.Observe{Evaluator: inner}.Evaluate(stmt("SELECT 1", inspect.OpSelect))
+
+	if v.Denied {
+		t.Fatal("observe mode denied")
+	}
+	if !errors.Is(v.Err, boom) {
+		t.Errorf("Err = %v, want the inner failure", v.Err)
+	}
+}
+
+// An allowed statement must look untouched. Stamping would_deny on everything
+// would make the annotation useless for counting what enforcement will cost.
+func TestObservePassesAnAllowThrough(t *testing.T) {
+	inner := &stubEvaluator{verdict: policy.Verdict{
+		Annotations: map[string]string{policy.AnnotationRiskLevel: "low"},
+	}}
+
+	v := policy.Observe{Evaluator: inner}.Evaluate(stmt("SELECT 1", inspect.OpSelect))
+
+	if v.Denied {
+		t.Fatal("observe mode denied an allow")
+	}
+	if _, ok := v.Annotations[policy.AnnotationWouldDeny]; ok {
+		t.Errorf("an allowed statement carried %s", policy.AnnotationWouldDeny)
+	}
+	if v.Annotations[policy.AnnotationRiskLevel] != "low" {
+		t.Errorf("Annotations = %v, want the inner annotations untouched", v.Annotations)
+	}
+}
+
+// The inner evaluator's annotation map may outlive its verdict: Chain returns
+// the EvalContext's own map, and that context is reused for the rest of the
+// statement's evaluation. Writing into it would leak one statement's
+// would_deny onto the audit record of the statements after it.
+func TestObserveDoesNotWriteIntoTheInnerAnnotationMap(t *testing.T) {
+	shared := map[string]string{policy.AnnotationRiskLevel: "high"}
+	inner := &stubEvaluator{verdict: policy.Verdict{
+		Denied: true, Rule: "no-drop", Annotations: shared,
+	}}
+
+	v := policy.Observe{Evaluator: inner}.Evaluate(stmt("DROP TABLE t", inspect.OpDrop, "t"))
+
+	if _, ok := shared[policy.AnnotationWouldDeny]; ok {
+		t.Error("observe mutated the inner evaluator's annotation map")
+	}
+	if v.Annotations[policy.AnnotationRiskLevel] != "high" {
+		t.Errorf("Annotations = %v, want the inner annotations copied through", v.Annotations)
+	}
+}
+
+// recordingContextual is a ContextualEvaluator that reports which of its two
+// methods the caller reached, and what context arrived with it.
+type recordingContextual struct {
+	verdict policy.Verdict
+
+	withCalled  bool
+	plainCalled bool
+	seenContext map[string]string
+}
+
+func (r *recordingContextual) Evaluate(inspect.Statement) policy.Verdict {
+	r.plainCalled = true
+	return r.verdict
+}
+
+func (r *recordingContextual) EvaluateWith(_ inspect.Statement, ec *policy.EvalContext) policy.Verdict {
+	r.withCalled = true
+	if ec != nil {
+		r.seenContext = ec.Context
+	}
+	return r.verdict
+}
+
+// Observe has to implement ContextualEvaluator, not just Evaluator.
+// Gate.evaluate type-asserts for the interface before seeding the session
+// facts, and Chain does the same for every evaluator it holds. A wrapper that
+// only carried Evaluate would pass this test's sibling above and still empty
+// input.context on every OPA call the lane makes.
+func TestObserveForwardsTheEvalContextToAContextualInner(t *testing.T) {
+	inner := &recordingContextual{verdict: policy.Deny("no-drop", "no drops")}
+
+	var obs policy.Evaluator = policy.Observe{Evaluator: inner}
+	ce, ok := obs.(policy.ContextualEvaluator)
+	if !ok {
+		t.Fatal("Observe does not implement ContextualEvaluator; the gate would drop the session facts")
+	}
+
+	ec := &policy.EvalContext{Context: map[string]string{"principal": "ana@corp"}}
+	v := ce.EvaluateWith(stmt("DROP TABLE t", inspect.OpDrop, "t"), ec)
+
+	if !inner.withCalled {
+		t.Error("Observe did not call the inner evaluator's EvaluateWith")
+	}
+	if inner.plainCalled {
+		t.Error("Observe called Evaluate on an evaluator that has EvaluateWith")
+	}
+	if inner.seenContext["principal"] != "ana@corp" {
+		t.Errorf("inner saw context %v, want the session facts", inner.seenContext)
+	}
+	if v.Denied || v.Annotations[policy.AnnotationWouldDeny] != "no-drop" {
+		t.Errorf("EvaluateWith did not observe the denial: %+v", v)
+	}
+}
+
+// An evaluator with no EvaluateWith still has to run. Observe falls back
+// rather than refusing, exactly as Chain does.
+func TestObserveFallsBackToEvaluateOnAPlainInner(t *testing.T) {
+	inner := &stubEvaluator{verdict: policy.Deny("no-drop", "no drops")}
+
+	v := policy.Observe{Evaluator: inner}.EvaluateWith(
+		stmt("DROP TABLE t", inspect.OpDrop, "t"), &policy.EvalContext{})
+
+	if !inner.ran {
+		t.Error("the inner evaluator did not run")
+	}
+	if v.Denied || v.Rule != "no-drop" {
+		t.Errorf("verdict = %+v, want an allow naming the rule", v)
+	}
+}
+
+// A lane whose chain resolved to nothing gets a nil evaluator, and observe is
+// the mode most likely to be set on a lane with no rules yet. Panicking on it
+// would take the lane's traffic down.
+func TestObserveWithNoInnerAllows(t *testing.T) {
+	var obs policy.Observe
+	if obs.Evaluate(stmt("DROP TABLE t", inspect.OpDrop, "t")).Denied {
+		t.Error("an empty Observe denied")
+	}
+	if obs.EvaluateWith(stmt("DROP TABLE t", inspect.OpDrop, "t"), &policy.EvalContext{}).Denied {
+		t.Error("an empty Observe denied through EvaluateWith")
+	}
+}
+
+// Observe wraps a chain in practice, so the composition has to hold: the
+// chain's own annotations survive and the denial it produced is reported
+// rather than enforced.
+func TestObserveOverAChain(t *testing.T) {
+	rules, err := policy.NewRules([]policy.Rule{{
+		Name: "no-drop", Type: policy.MatchOperation,
+		Operations: []inspect.Operation{inspect.OpDrop},
+		Message:    "schema changes go through migrations",
+	}})
+	if err != nil {
+		t.Fatalf("NewRules: %v", err)
+	}
+	classifier := &stubEvaluator{verdict: policy.Verdict{
+		Annotations: map[string]string{policy.AnnotationRiskLevel: "high"},
+	}}
+
+	obs := policy.Observe{Evaluator: policy.Chain{classifier, rules}}
+	v := obs.Evaluate(stmt("DROP TABLE customers", inspect.OpDrop, "customers"))
+
+	if v.Denied {
+		t.Fatal("observe mode denied")
+	}
+	if v.Annotations[policy.AnnotationWouldDeny] != "no-drop" {
+		t.Errorf("%s = %q, want no-drop", policy.AnnotationWouldDeny, v.Annotations[policy.AnnotationWouldDeny])
+	}
+	if v.Annotations[policy.AnnotationRiskLevel] != "high" {
+		t.Errorf("the chain's own annotations were lost: %v", v.Annotations)
+	}
+}

--- a/sidecar/policy/pii.go
+++ b/sidecar/policy/pii.go
@@ -42,6 +42,30 @@ type Scanner interface {
 	ScanText(text string) []string
 }
 
+// ScopedScanner is an optional Scanner that can narrow one scan to the entity
+// classes the caller can act on.
+//
+// It exists because a detector's active set and a rule's Entities stopped
+// being the same thing. A config that omits its pii section now gets a
+// detector with every supported entity class active, and ScanText runs the
+// detector's whole set: a rule naming two classes would pay for fifty-odd
+// recognizer passes per statement and then discard all but two in the
+// intersection below.
+//
+// It sits beside Scanner rather than inside it. Widening a one-method
+// interface breaks every implementor, and this buys throughput rather than a
+// capability the policy layer depends on. A scanner that does not implement
+// it stays correct and stays slower.
+type ScopedScanner interface {
+	// ScanTextFor returns the distinct entity names found in text,
+	// restricted to entities. The return contract matches ScanText: names
+	// only, never values or offsets, in any order.
+	//
+	// An implementation MAY over-report, so a caller still filters. An
+	// empty entities slice means the same as ScanText.
+	ScanTextFor(entities []string, text string) []string
+}
+
 // NewRulesWithScanner is NewRules with a Scanner available to MatchPII rules.
 // A nil Scanner behaves as NewRules, so any PII rule then fails validation.
 func NewRulesWithScanner(rules []Rule, s Scanner) (*Rules, error) {
@@ -75,7 +99,16 @@ func (r Rule) matchesPII(stmt inspect.Statement, s Scanner) (bool, []string) {
 	if s == nil || stmt.Text == "" {
 		return false, nil
 	}
-	found := s.ScanText(stmt.Text)
+	// Ask the detector for this rule's classes where it can be asked. The
+	// intersection below still runs and must stay: ScanTextFor is allowed
+	// to over-report, and a plain Scanner arrives here having scanned its
+	// whole active set.
+	var found []string
+	if ss, ok := s.(ScopedScanner); ok {
+		found = ss.ScanTextFor(r.Entities, stmt.Text)
+	} else {
+		found = s.ScanText(stmt.Text)
+	}
 	if len(found) == 0 {
 		return false, nil
 	}

--- a/sidecar/policy/pii_test.go
+++ b/sidecar/policy/pii_test.go
@@ -1,6 +1,7 @@
 package policy_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -208,5 +209,110 @@ func TestPIIMixesWithOtherRuleTypes(t *testing.T) {
 	}
 	if v := rules.Evaluate(piiStmt("SELECT 1")); v.Denied {
 		t.Errorf("clean statement denied in a mixed set: %+v", v)
+	}
+}
+
+// --- scoped scanning -----------------------------------------------------
+
+// scopedScanner answers like fakeScanner and records how it was asked, so a
+// test can tell a narrowed scan from a full one.
+type scopedScanner struct {
+	entities map[string]string // entity -> literal
+	askedFor []string
+	unscoped int
+}
+
+func (s *scopedScanner) ScanText(text string) []string {
+	s.unscoped++
+	return s.scan(nil, text)
+}
+
+func (s *scopedScanner) ScanTextFor(entities []string, text string) []string {
+	s.askedFor = entities
+	return s.scan(entities, text)
+}
+
+func (s *scopedScanner) scan(only []string, text string) []string {
+	var out []string
+	for entity, lit := range s.entities {
+		if len(only) > 0 && !slices.Contains(only, entity) {
+			continue
+		}
+		if strings.Contains(text, lit) {
+			out = append(out, entity)
+		}
+	}
+	return out
+}
+
+// A config that omits its pii section now gets a detector with every entity
+// class active, and ScanText runs the detector's whole set. A rule naming two
+// classes would pay for fifty-odd recognizer passes per statement and discard
+// all but two in the intersection. Where the scanner can be narrowed, it must
+// be asked for the rule's own classes and nothing else.
+func TestPIIRuleAsksAScopedScannerForItsOwnEntities(t *testing.T) {
+	s := &scopedScanner{entities: map[string]string{
+		"US_SSN":        "123-45-6789",
+		"EMAIL_ADDRESS": "ana@corp.example",
+	}}
+	rules, err := policy.NewRulesWithScanner([]policy.Rule{{
+		Name: "no-ssn", Type: policy.MatchPII,
+		Entities: []string{"US_SSN", "BR_CPF"},
+	}}, s)
+	if err != nil {
+		t.Fatalf("NewRulesWithScanner: %v", err)
+	}
+
+	if v := rules.Evaluate(piiStmt("SELECT * FROM t WHERE ssn = '123-45-6789'")); !v.Denied {
+		t.Fatalf("the scoped scan lost the match: %+v", v)
+	}
+	if s.unscoped != 0 {
+		t.Errorf("ScanText ran %d times on a scanner that can be narrowed", s.unscoped)
+	}
+	if want := []string{"US_SSN", "BR_CPF"}; !slices.Equal(s.askedFor, want) {
+		t.Errorf("scanner was asked for %v, want the rule's own entities %v", s.askedFor, want)
+	}
+}
+
+// The intersection after the scan must survive the optimisation. ScanTextFor
+// is allowed to over-report, and a rule that denied on a class it never named
+// would turn a permissive detector back into the false-positive machine the
+// pii section exists to avoid.
+func TestScopedScannerOverReportingIsStillFiltered(t *testing.T) {
+	rules, err := policy.NewRulesWithScanner([]policy.Rule{{
+		Name: "no-ssn", Type: policy.MatchPII, Entities: []string{"US_SSN"},
+	}}, overReportingScanner{})
+	if err != nil {
+		t.Fatalf("NewRulesWithScanner: %v", err)
+	}
+
+	if v := rules.Evaluate(piiStmt("SELECT 1")); v.Denied {
+		t.Errorf("denied on an entity class the rule never named: %+v", v)
+	}
+}
+
+// overReportingScanner ignores the requested entities and always reports one
+// the caller did not ask for.
+type overReportingScanner struct{}
+
+func (overReportingScanner) ScanText(string) []string { return []string{"EMAIL_ADDRESS"} }
+
+func (overReportingScanner) ScanTextFor([]string, string) []string {
+	return []string{"EMAIL_ADDRESS"}
+}
+
+// A scanner with no ScanTextFor stays correct. The optional interface buys
+// throughput, and dropping an implementor that does not have it would be a
+// silent loss of enforcement.
+func TestPlainScannerStillScansUnscoped(t *testing.T) {
+	rules, err := policy.NewRulesWithScanner([]policy.Rule{{
+		Name: "no-ssn", Type: policy.MatchPII, Entities: []string{"US_SSN"},
+	}}, fakeScanner{"US_SSN": "123-45-6789"})
+	if err != nil {
+		t.Fatalf("NewRulesWithScanner: %v", err)
+	}
+
+	if v := rules.Evaluate(piiStmt("SELECT '123-45-6789'")); !v.Denied {
+		t.Errorf("a plain Scanner stopped enforcing: %+v", v)
 	}
 }

--- a/sidecar/policy/policy.go
+++ b/sidecar/policy/policy.go
@@ -420,7 +420,9 @@ type Rule struct {
 	//
 	// Deferring does not stop the rule set. First match wins applies to
 	// DENIALS; a deferring rule records and evaluation continues, so a
-	// later hard rule still denies and a policy sees every match.
+	// later hard rule still denies and a policy sees every match. The
+	// exception is Rules.DenyDeferred, which turns a deferring match into
+	// a denial and therefore into a stop.
 	//
 	// Not valid on ai_analysis, which expresses the same thing per risk
 	// level through high/medium/low.
@@ -482,6 +484,29 @@ type Rules struct {
 	// FailOpen inverts the error behavior: when a rule cannot be evaluated
 	// (an invalid regex), allow instead of deny. Default false.
 	FailOpen bool
+
+	// DenyDeferred makes a deferring rule DENY instead of recording a
+	// Finding. Default false.
+	//
+	// ActionDefer means: hand this match to a decision-maker. The only
+	// evaluator that can rule on a Finding is a decide-phase OPA client,
+	// which is the one place ec.Findings is read (see
+	// OPAClient.findingsFor). A lane with no OPA therefore has no consumer
+	// for the finding: the rule matches, the match is recorded, nobody
+	// reads it, and the statement is allowed. An operator who wrote
+	// `action: defer` on a rule protecting national identifiers asked for
+	// the opposite of that.
+	//
+	// The sidecar sets this when the lane resolves to no OPA URL, which is
+	// what lets one config file serve a deployment with OPA and a
+	// deployment without it: the same rule defers where there is something
+	// to defer TO, and denies where there is not.
+	//
+	// It changes ordering as well as outcome. A denial stops the rule set,
+	// so with this set the FIRST deferring rule wins rather than the first
+	// hard rule below it, and the same config run with and without OPA can
+	// name a different rule in the audit record.
+	DenyDeferred bool
 }
 
 // NewRules compiles a rule set. It returns an error listing every rule that
@@ -619,7 +644,12 @@ func (r *Rules) EvaluateWith(stmt inspect.Statement, ec *EvalContext) Verdict {
 			if !hit {
 				continue
 			}
-			if rule.Action == ActionDefer {
+			// Fall through to the denial below when nothing will
+			// read the finding. Returning through the same path
+			// keeps the deferred flush above running, so whatever
+			// EARLIER deferring rules recorded still reaches the
+			// context.
+			if rule.Action == ActionDefer && !r.DenyDeferred {
 				deferred = recordMatch(deferred, rule, map[string]any{
 					"entities": entities,
 				})
@@ -643,7 +673,7 @@ func (r *Rules) EvaluateWith(stmt inspect.Statement, ec *EvalContext) Verdict {
 		if !matched {
 			continue
 		}
-		if rule.Action == ActionDefer {
+		if rule.Action == ActionDefer && !r.DenyDeferred {
 			deferred = recordMatch(deferred, rule, rule.findingValues(stmt))
 			continue
 		}
@@ -961,4 +991,90 @@ func (c Chain) EvaluateWith(stmt inspect.Statement, ec *EvalContext) Verdict {
 		errs = errors.Join(errs, v.Err)
 	}
 	return Verdict{Err: errs, Annotations: ec.Annotations}
+}
+
+// --- observe mode --------------------------------------------------------
+
+// AnnotationWouldDeny names the rule that would have refused a statement an
+// Observe wrapper let through.
+//
+// It is the entire output of a dry run. An operator counts a week of these
+// out of the audit trail and reads what enforcement is about to cost before
+// switching a lane to it.
+const AnnotationWouldDeny = "guardrails.would_deny"
+
+// Observe turns a denial from the wrapped Evaluator into an allow that still
+// names the rule that objected.
+//
+// It is what observe mode builds instead of skipping evaluation. The old
+// off-switch configured no evaluator at all, so the gate allowed on its first
+// line and wrote an audit record with an empty rule and an empty message: a
+// week of running that way told an operator nothing about what would have
+// been refused, which is the one question the mode exists to answer. Here the
+// chain runs in full and records the answer, and a dry run therefore costs
+// what enforcement costs.
+//
+// Only the DECISION is reversed. Message, Rule and Err travel through
+// untouched, because audit.StatementEvent takes allowed, rule and message as
+// independent arguments and the gate already passes all three off the
+// verdict. An allowed verdict that names a rule is a complete dry-run record
+// with no change anywhere downstream.
+//
+// Observe switches off nothing else: a stream the codec cannot parse safely
+// still denies, and a failed audit write still denies on a fail-closed sink.
+// Neither is a guardrail verdict, so neither passes through here.
+type Observe struct{ Evaluator Evaluator }
+
+// Evaluate implements Evaluator.
+func (o Observe) Evaluate(stmt inspect.Statement) Verdict {
+	if o.Evaluator == nil {
+		return Allow()
+	}
+	return o.observe(o.Evaluator.Evaluate(stmt))
+}
+
+// EvaluateWith implements ContextualEvaluator, delegating to the inner
+// evaluator's own EvaluateWith wherever it has one.
+//
+// Implementing BOTH methods is load-bearing rather than tidy. Gate.evaluate
+// type-asserts its configured evaluator for ContextualEvaluator and only then
+// seeds the session facts onto the context, and Chain does the same for every
+// evaluator it holds. A wrapper carrying only Evaluate fails that assertion,
+// so wrapping a chain in observe mode would silently empty input.context on
+// every OPA call and drop every Finding a deferring rule recorded. The lane
+// would keep denying nothing, correctly, while its Rego quietly stopped
+// seeing who asked.
+//
+// A nil inner evaluator allows. A lane whose chain resolved to nothing gets a
+// nil Evaluator, and observe is the mode most likely to be set on a lane that
+// has not been given rules yet.
+func (o Observe) EvaluateWith(stmt inspect.Statement, ec *EvalContext) Verdict {
+	if o.Evaluator == nil {
+		return Allow()
+	}
+	if ce, ok := o.Evaluator.(ContextualEvaluator); ok {
+		return o.observe(ce.EvaluateWith(stmt, ec))
+	}
+	return o.observe(o.Evaluator.Evaluate(stmt))
+}
+
+// observe flips a denial and records the rule behind it.
+func (o Observe) observe(v Verdict) Verdict {
+	if !v.Denied {
+		return v
+	}
+	v.Denied = false
+
+	// A fresh map on every denial. The inner evaluator hands back a map it
+	// may still own: Chain returns the EvalContext's own annotation map,
+	// and that map outlives the verdict. Writing the rule name into it
+	// would leak one statement's would_deny onto the audit record of every
+	// statement that followed it through the same context.
+	ann := make(map[string]string, len(v.Annotations)+1)
+	for k, val := range v.Annotations {
+		ann[k] = val
+	}
+	ann[AnnotationWouldDeny] = v.Rule
+	v.Annotations = ann
+	return v
 }

--- a/sidecar/scripts/dev/01-validate.sh
+++ b/sidecar/scripts/dev/01-validate.sh
@@ -59,16 +59,15 @@ ${cred_line}
   cache: {size: 1024, ttl_sec: 900}
   max_calls: 50             # a ceiling for a test run, not a production number
 
-policy:
-  enforce: true
+guardrails:
+  mode: enforce
 
 listeners:
   - name: appdb
     protocol: postgres
     listen: 127.0.0.1:${PG_RELAY_PORT}
     upstream: 127.0.0.1:${PG_UPSTREAM_PORT}
-    connection: appdb
-    policy:
+    guardrails:
       rules:
         # Free, deterministic, and first in the chain: a DROP never reaches a
         # model, because Chain short-circuits on the first denial.
@@ -94,7 +93,6 @@ listeners:
     protocol: http
     listen: 127.0.0.1:${HTTP_RELAY_PORT}
     upstream: 127.0.0.1:${HTTP_UPSTREAM_PORT}
-    connection: api
     # Required. Without it the codec captures no body, the analyzer sees
     # "POST /anything" and nothing else, and every request is skipped. The
     # relay refuses this config at startup when it is missing.
@@ -102,7 +100,7 @@ listeners:
       capture_body: true
       max_body_bytes: 8192
       headers: [Content-Type]
-    policy:
+    guardrails:
       rules:
         - name: risky-payloads
           type: ai_analysis

--- a/sidecar/scripts/dev/04-offline.sh
+++ b/sidecar/scripts/dev/04-offline.sh
@@ -118,14 +118,13 @@ analyzer:
   fail_open: true
   cache: {size: 512, ttl_sec: 300}
   max_calls: 100
-policy: {enforce: true}
+guardrails: {mode: enforce}
 listeners:
   - name: appdb
     protocol: postgres
     listen: "127.0.0.1:${PG_RELAY_PORT}"
     upstream: "127.0.0.1:${PG_UPSTREAM_PORT}"
-    connection: appdb
-    policy:
+    guardrails:
       rules:
         - {name: no-drops, type: operation, operations: [drop, truncate],
            message: schema changes are not permitted on appdb}
@@ -139,9 +138,8 @@ listeners:
     protocol: http
     listen: "127.0.0.1:${HTTP_RELAY_PORT}"
     upstream: "127.0.0.1:${HTTP_UPSTREAM_PORT}"
-    connection: api
     http: {capture_body: true, max_body_bytes: 8192, headers: [Content-Type]}
-    policy:
+    guardrails:
       rules:
         - name: risky-payloads
           type: ai_analysis


### PR DESCRIPTION
> [!IMPORTANT]
> Label: **`major`**. Nothing is removed and every deployed config still loads, but three
> defaults change behaviour on upgrade with no config edit (see "Breaking behaviour" below).
> Downgrade to `minor` if the team reads a default flip as non-breaking.

## 📝 Description

Implements [ADR-0011](docs/adr/0011-sidecar-config-schema.md) and
[ADR-0012](docs/adr/0012-sidecar-enforcement-defaults.md).

One word, `policy`, named two products in the sidecar's `config.yaml`: Hoop's own rule set
and a client for someone else's Rego. This splits it into `guardrails` and `opa`, drops
three fields that restate what a list already says, and fixes two defaults that pointed the
wrong way for a component whose job is refusing statements.

Every pre-ADR-0011 config still loads. A single `normalize()` step folds the old spellings
onto the new ones between the strict decode and validation, so nothing downstream carries
compat logic, and each deprecated field prints a warning naming its replacement. Writing
one setting in both spellings is refused rather than resolved by precedence.

**Breaking behaviour on upgrade, no config edit required:**

1. A config that omitted `policy.enforce` ran observe-only and denied nothing. It now
   enforces. A rule set nobody validated because it never fired will start firing.
2. A config that omitted `audit.fail_closed` allowed a statement whose audit record could
   not be written. It now refuses. Audit-sink availability becomes traffic availability.
3. A config that omitted `pii` had detection off, so `mask.enabled: true` refused to start.
   It now starts and masks.

Configs that wrote any of those fields down keep their exact behaviour, including
`audit.fail_closed`, which inverts in value as well as name.

## 📣 User-facing impact

The sidecar config is smaller and says what it means: `guardrails` for Hoop's rules, `opa`
for the OPA integration, one entity list instead of two spellings, and no separate on/off
switches for masking and enforcement. Guardrails now enforce by default, and `mode: observe`
became a real dry run that records which rule *would* have refused each statement, so you
can size a rule set against live traffic for a week before turning it on. Omitting the `pii`
section enables detection for all 54 entity types instead of disabling it. Existing config
files keep working and print a warning naming each field to rename.

## 🔗 Related Issue

Fixes #<!-- DEP-178 -->

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

**Schema**

- `policy.rules` → `guardrails.rules`; `policy.opa` → a sibling `opa` block, top level and
  per listener.
- `policy.enforce` (`*bool`) → `guardrails.mode: enforce|observe`, defaulting to `enforce`.
  The empty string already means "inherit", so the pointer that carried three states is gone.
- `mask.rules[].entity` → `entities`, a list. One rule fans out to one rewrite per entity.
- `mask.enabled` removed: a non-empty rule list is the switch. The flag used to skip the
  whole validation block, so a lane could carry rules that could never fire and load clean.
- `listeners[].connection` removed. `name` fills the audit key and `input.context.connection`.
- `audit.fail_closed` → `audit.fail_open`, matching `opa.fail_open` and `analyzer.fail_open`.
  All three now read the same direction; one of them used to be negated.
- Omitting `pii` builds a detector over all 54 entity types instead of disabling detection.
  The section narrows rather than creates.
- Each inheritable section gained an opt-out: `guardrails: {rules: []}`, `opa: {}`,
  `mask: {rules: []}`. Two of the three had no way to say it before.

**Behaviour**

- `mode: observe` evaluates every rule, denies nothing, and records the rule that would have
  denied as `guardrails.would_deny` on the audit line. It previously evaluated nothing, which
  `docs/adr/0010` already flagged as "not a dry run". It now costs what enforcing costs.
- `action: defer` on a lane with no `opa.url` denies instead of refusing the config at
  startup. `defer` names a decision-maker; with none, the safe reading is refusal. One config
  file now serves a deployment with OPA and one without.
- `analyzer.fail_open` keeps its `true` default, deliberately. It guards a third-party
  network call on the request path, and an Anthropic incident should not be a database outage.

**Tooling**

- `--strict` / `-strict` on both entry points, exiting non-zero when a deprecated field is in
  use, so a pipeline can fail before the release that fails for it.
- Deprecation warnings go to stderr; `--validate` keeps stdout parseable.
- `GET /config` gains `observing`, `guardrails`, `opa_url` and `notes` beside the existing
  `enforcing`/`rules`/`opa`/`masking`, plus a `deprecated_fields` array in the payload so a
  control plane can warn its own developers.

**Rollout**

- Six shipped configs and two dev-script heredocs migrated.
  `envoy-stack/mssql2019/config-mssql2019.yaml` is deliberately left on the old spelling as
  the regression fixture for the deprecation path.
- `metabase-stack` had `name: appdb` with `connection: metabase`; the listener is renamed to
  `metabase` so its audit key keeps its value.
- `sidecar/README.md`, `sidecar-binary.md` and two stack READMEs rewritten, with a
  `### Deprecated fields` migration table placed before the first example.
- ADR-0006 marked superseded; ADR-0009 and ADR-0010 amended in place where this reverses them.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: N/A
- **OS**: macOS 15 (darwin 25.5.0, arm64), go1.26.5

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

`make test-sidecar` at the repo root: **0 failures** across the root module and all five
nested ones. `go vet` clean everywhere. `go build ./client/...` clean.

`gofmt -l` reports nine files dirty; all nine were already dirty at `HEAD`
(`git show HEAD:<f> | gofmt -l /dev/stdin`), three of which this PR never opens. No new
drift, so they are left as the repo has them.

**Integration tests were not run.** The compose stacks
(`envoy-stack/`, `metabase-stack/demo.sh`) need Docker and were not exercised. Their configs
validate clean against a real binary, but the end-to-end masking assertion in
`metabase-stack/demo.sh` is worth running before merge.

**New tests, each failing without its change:**

| Area | Pins |
|---|---|
| `daemon/config_test.go` | enforce is the default; observe wraps rather than skips; observe over an empty chain stays nil; `defer` denies with no OPA and reports with one; the three opt-out spellings, before and after a real decode; `audit.failOnAuditError` is the inverse of `failOpen`; both-spellings-at-one-scope refused; every conflict reported in one run; the deprecated-window suite (policy block folds, `enforce: false` → observe, `connection` → name, `mask.enabled: false` keeps masking off, `fail_closed` inverts in four cases) |
| `gate/gate_test.go` | the dry run at the **audit row**: `allowed: true`, `kind: statement`, the rule name, `metadata["guardrails.would_deny"]`, and no violation record |
| `policy/` | `DenyDeferred` on both defer branches; `Observe` keeps `Rule`/`Message`/`Err`, forwards `EvalContext` to a contextual inner, and never writes into the inner annotation map; `ScopedScanner` receives the rule's entity list |
| `pii/alcatraz/` | empty `Entities` means every entity; `ignored` subtracts; `entities` fans out; `entity`+`entities` and `entities`+`columns` refused; `ScanTextFor` restricts the scan; `PluginFromConfig(nil)` returns a 54-entity plugin. `config.go` had no test file and now has one |

**Manual, against a real binary:**

```
$ hoop start sidecar --config <each of the 6 shipped configs> --validate
appdb      postgres  enforcing 2 rule(s) + masking
httpbin    http      enforcing 4 rule(s) + masking
metabase   postgres  enforcing 3 rule(s) + masking
mssqldb    mssql     enforcing 2 rule(s) + masking

$ hoop start sidecar --config <old spelling> --validate      # stderr, exit 0
warn: deprecated config: mssql2019: policy.rules is deprecated; rename it to guardrails.rules
warn: deprecated config: mssql2019: policy.enforce: true is deprecated; write guardrails.mode: enforce
warn: deprecated config: mssql2019: listeners[].connection is deprecated and duplicates name; drop it
warn: deprecated config: mssql2019: mask.enabled: true is deprecated; ...

$ hoop start sidecar --config <old spelling> --validate --strict     → exit 1

$ hoop-inspect -validate -config <both spellings of one field>
invalid config:
  - policy.enforce is deprecated and guardrails.mode is also set at this scope; keep guardrails.mode

$ hoop-inspect -validate -config observe.yaml
reporting  postgres  observing 1 rule(s), denying none
             note: observe mode: every rule is evaluated and nothing is denied.
                   Matches are recorded on the audit line as guardrails.would_deny

$ hoop-inspect -validate -config deferred.yaml       # action: defer, no opa block
appdb      postgres  enforcing 1 rule(s)
             note: rule(s) defer to a decision this lane has no opa.url for,
                   so a match denies instead of reporting a finding

$ hoop-inspect -validate -config optouts.yaml
inherits   postgres  enforcing 1 rule(s) + opa + masking
bare       postgres  no rules to enforce
```

## 📸 Screenshots (if applicable)

N/A.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**Worth a reviewer's attention:**

1. **The `major` label.** Three defaults change behaviour for configs that omitted the
   corresponding field. Nothing is removed, so a case for `minor` exists. Your call.
2. **`guardrails: {rules: []}` means "opt out", not "add nothing".** For a field that
   concatenates, "adds nothing" is the other defensible reading. ADR-0012 promised the
   opt-out and the alternative leaves a lane unable to express it at all, so presence beats
   length in the merge. One `switch` in `resolve` if you disagree.
3. **`audit.fail_closed` → `fail_open` inverts polarity as well as name.** `normalize` reads
   the old field rather than pattern-matching the new one, so a config that wrote it down
   keeps its behaviour. Four test cases cover the matrix. This is the single riskiest line in
   the PR.
4. **`Validate()` on a hand-built `Config` does not understand deprecated fields.** They fold
   in `normalize`, which only `LoadConfigBytes` runs. Three tests moved because of it. Worth
   confirming you want that boundary.

**Corrections made while implementing:** ADR-0011 claimed a lane with mask rules on MSSQL
"loads clean today and will refuse to start" and called it the dangerous migration
direction. False, and verified so against a real build: `gate.MaskSupported` asks the codec
for a `Reframer` rather than listing protocol names, and all three shipped codecs have one.
The ADR was corrected and the false release-note hazard removed. Its conflict count was also
wrong (four fields have two writable spellings, not seven).

**Deprecation timeline is unset.** ADR-0011 proposes two minor releases warning, one
refusing with instructions, then removal. The releases need naming before merge, or the
deprecated fields follow `hoop start inspect` into permanent residency.

Both ADRs ship as `Status: Proposed` and per `docs/adr/README.md` want their own review
window before this merges.
