### PR TITLE
fix: update dependencies and improve MCP server handler

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/gomlx/go-xla v0.4.1 // indirect
 	github.com/gomlx/gomlx v0.28.2 // indirect
 	github.com/gomlx/onnx-gomlx v0.5.2 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
@@ -167,7 +167,7 @@ require (
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/microsoft/go-mssqldb v1.10.0 // indirect
-	github.com/modelcontextprotocol/go-sdk v1.5.0 // indirect
+	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect

--- a/client/go.sum
+++ b/client/go.sum
@@ -309,8 +309,8 @@ github.com/gomlx/onnx-gomlx v0.5.2/go.mod h1:536SP4SN0H+iv3MjQzWqPZjqOOs6ga9ikv5
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
-github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -400,8 +400,8 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
-github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/gateway/api/mcpserver/mcpserver.go
+++ b/gateway/api/mcpserver/mcpserver.go
@@ -33,7 +33,7 @@ import (
 const mcpSessionTimeout = 30 * time.Minute
 
 type MCPServer struct {
-	handler *mcp.StreamableHTTPHandler
+	handler http.Handler
 }
 
 func New(releaseConnFn reviewapi.TransportReleaseConnectionFunc) *MCPServer {
@@ -58,10 +58,12 @@ func New(releaseConnFn reviewapi.TransportReleaseConnectionFunc) *MCPServer {
 	registerAttributeTools(server)
 	registerAccessControlTools(server)
 
-	handler := mcp.NewStreamableHTTPHandler(
+	mcpHandler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server { return server },
 		&mcp.StreamableHTTPOptions{SessionTimeout: mcpSessionTimeout},
 	)
+
+	handler := http.NewCrossOriginProtection().Handler(mcpHandler)
 
 	return &MCPServer{handler: handler}
 }

--- a/gateway/api/mcpserver/transport_test.go
+++ b/gateway/api/mcpserver/transport_test.go
@@ -1,0 +1,68 @@
+package mcpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const initializeBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}`
+
+func postInitialize(t *testing.T, url, contentType string, extraHeaders map[string]string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(initializeBody))
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+// TestContentTypeSpellings guards the fix for issue #1764: the gateway must
+// accept every legal spelling of the JSON Content-Type on POST /api/mcp.
+// go-sdk v1.5.0 did a literal string compare and returned 415 for the
+// charset-parameterized and case-variant forms that Java MCP clients
+// (Apache HttpClient, e.g. AWS Bedrock AgentCore) always send.
+func TestContentTypeSpellings(t *testing.T) {
+	srv := httptest.NewServer(New(nil).handler)
+	defer srv.Close()
+
+	for _, contentType := range []string{
+		"application/json",
+		"application/json; charset=utf-8",
+		"Application/JSON",
+	} {
+		t.Run(contentType, func(t *testing.T) {
+			resp := postInitialize(t, srv.URL, contentType, nil)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("Content-Type %q: got status %d, want 200", contentType, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestCrossOriginRejected guards the http.NewCrossOriginProtection wrapper in
+// New(): go-sdk v1.6.0 stopped enabling Origin verification by default, so
+// dropping the wrapper would silently disable CSRF protection. Cross-origin
+// non-safe requests must be rejected with 403.
+func TestCrossOriginRejected(t *testing.T) {
+	srv := httptest.NewServer(New(nil).handler)
+	defer srv.Close()
+
+	resp := postInitialize(t, srv.URL, "application/json", map[string]string{
+		"Sec-Fetch-Site": "cross-site",
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-site POST: got status %d, want 403", resp.StatusCode)
+	}
+}

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/hoophq/mcpproxy v0.1.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lib/pq v1.12.3
-	github.com/modelcontextprotocol/go-sdk v1.5.0
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/russellhaering/gosaml2 v0.11.0
 	github.com/russellhaering/goxmldsig v1.6.0
@@ -145,7 +145,7 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -274,8 +274,8 @@ github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
-github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -367,8 +367,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
-github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
## What & Why

`POST /api/mcp` returned **415 Unsupported Media Type** for legal Content-Type spellings like `application/json;
charset=utf-8` and `Application/JSON` (#1764). `go-sdk v1.5.0` did a literal string compare on the header; Java MCP clients (Apache HttpClient — e.g. AWS Bedrock AgentCore) always send the charset parameter, so registration against the gateway failed outright.

- Bump `github.com/modelcontextprotocol/go-sdk` v1.5.0 → **v1.7.0** (`gateway/go.mod`, indirect pin in `client/go.mod`).   Upstream fixed the check in v1.6.0 via `mime.ParseMediaType`, so parameters and case variants are now accepted.
- Preserve cross-origin (CSRF) protection in `gateway/api/mcpserver/mcpserver.go`: v1.6.0 flipped the default so a nil `StreamableHTTPOptions.CrossOriginProtection` no longer enables Origin verification. The MCP handler is now wrapped with `http.NewCrossOriginProtection().Handler(...)` — the SDK-recommended replacement for the deprecated options field (removed in v1.8.0) — keeping the same semantics as v1.5.0: cross-origin non-safe requests are rejected with 403, requests without an Origin/`Sec-Fetch-Site` header (curl, server-to-server clients) pass.
- Add `gateway/api/mcpserver/transport_test.go`: table test posting the issue's raw `initialize` body with all three Content-Type spellings (expect 200), plus a `Sec-Fetch-Site: cross-site` → 403 guard so silently dropping the wrapper fails CI.

## Notes for Reviewers

- **Stateful server unchanged**: v1.7.0's new `2026-07-28` stateless protocol only activates with `Stateless: true`, which we leave unset — existing clients keep negotiating the legacy protocol (`2025-06-18` from the issue repro included). No protocol migration here.
- **New SDK default accepted**: `MaxRequestBodyBytes` now defaults to 4 MiB (previously unlimited). Left unset intentionally;  MCP payloads near 4 MiB aren't a supported use case. If one ever surfaces, set it explicitly in `StreamableHTTPOptions`.
- `MCPServer.handler` type widened from `*mcp.StreamableHTTPHandler` to `http.Handler` to hold the wrapped handler; `GinHandler` is unchanged.
- Everything else hoop uses from the SDK survives with identical signatures/semantics (`SessionTimeout` idle-only behavior, `AddTool`, progress notifications, tool annotations). Existing session-lifecycle tests  (`TestKeepAlive_ReproducesSessionTermination`, `TestProductionConfig_SurvivesIdleGap`) pass unmodified on v1.7.0.
- Wire-only serialization change: `ToolAnnotations` now emits `readOnlyHint`/`idempotentHint: false` instead of omitting them — no code impact.
- This wrapper is CSRF protection (server-side 403 on cross-site requests), distinct from and complementary to the permissive CORS headers set by `CORSMiddleware()` in `gateway/api/middleware.go`.
