### PR TITLE
EVL-237 add control plane mode to the gateway

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,9 @@
 # configuration gateway docs: https://hoop.dev/docs/configuring/gateway#gateway-configuration
 # configuration agent docs: https://hoop.dev/docs/configuring/agent
+# gateway | control-plane
+# 'control-plane' serves the HTTP API only: no gRPC transport, no protocol
+# proxies, no web UI.
+APP_MODE=gateway
 GIN_MODE=release
 ORG_MULTI_TENANT=false
 # api gateway port

--- a/deploy/helm-chart/chart/gateway/templates/deployment.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{- if and (eq (.Values.config.APP_MODE | default "gateway") "control-plane") .Values.defaultAgent.enabled -}}
+{{- if eq (.Values.defaultAgent.grpcHost | default "127.0.0.1:8010") "127.0.0.1:8010" -}}
+{{- fail "defaultAgent.enabled with config.APP_MODE=control-plane targets 127.0.0.1:8010, which control-plane mode never opens. Set defaultAgent.grpcHost to an external gateway, or set defaultAgent.enabled=false." -}}
+{{- end -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
+++ b/deploy/helm-chart/chart/gateway/templates/secret-configs.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hoop-config
 type: Opaque
 stringData:
+  APP_MODE: '{{ .Values.config.APP_MODE | default "gateway" }}'
   ORG_MULTI_TENANT: '{{ .Values.config.ORG_MULTI_TENANT | default "false" }}'
   MIGRATION_PATH_FILES: '{{ .Values.config.MIGRATION_PATH_FILES | default "" }}'
   STATIC_UI_PATH: '{{ .Values.config.STATIC_UI_PATH | default "/app/ui/public" }}'

--- a/deploy/helm-chart/chart/gateway/values.yaml
+++ b/deploy/helm-chart/chart/gateway/values.yaml
@@ -132,7 +132,7 @@ config:
   # Which component this deployment runs as: 'gateway' (default) serves
   # agents and clients; 'control-plane' administers a fleet of sidecars and
   # starts no gRPC transport and no protocol proxies.
-  # APP_MODE: 'gateway'
+  APP_MODE: 'gateway'
   # postgres://user:pass@host:5432/dbname — external PostgreSQL (recommended).
   # pglite:///path/to/data-dir — embedded PostgreSQL (single-node/standalone
   # only; requires a persistent volume mounted at the data directory).

--- a/deploy/helm-chart/chart/gateway/values.yaml
+++ b/deploy/helm-chart/chart/gateway/values.yaml
@@ -129,6 +129,10 @@ securityContext: {}
 
 # hoop gateway configuration. Please refer to https://hoop.dev/docs/self-hosting
 config:
+  # Which component this deployment runs as: 'gateway' (default) serves
+  # agents and clients; 'control-plane' administers a fleet of sidecars and
+  # starts no gRPC transport and no protocol proxies.
+  # APP_MODE: 'gateway'
   # postgres://user:pass@host:5432/dbname — external PostgreSQL (recommended).
   # pglite:///path/to/data-dir — embedded PostgreSQL (single-node/standalone
   # only; requires a persistent volume mounted at the data directory).

--- a/gateway/api/controlplane_routes_test.go
+++ b/gateway/api/controlplane_routes_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hoophq/hoop/gateway/api/apiroutes"
+)
+
+// The control plane answers only what this test lists. A route added to
+// buildControlPlaneRoutes without being added here fails the test, which is
+// the point: routes are ported one at a time and each one is a decision.
+func TestControlPlaneRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	a := &Api{}
+	a.buildControlPlaneRoutes(apiroutes.New(engine.Group("/api")))
+
+	var got []string
+	for _, r := range engine.Routes() {
+		got = append(got, r.Method+" "+r.Path)
+	}
+	sort.Strings(got)
+
+	// apiroutes.Router.GET registers HEAD alongside GET.
+	want := []string{"GET /api/healthz", "HEAD /api/healthz"}
+	if len(got) != len(want) {
+		t.Fatalf("registered routes\ngot:  %v\nwant: %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("route %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// Liveness must not depend on the gRPC transport: the control plane never
+// starts one, so probing it would fail every health check.
+func TestControlPlaneHealthzIsOKWithoutGRPC(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	a := &Api{}
+	a.buildControlPlaneRoutes(apiroutes.New(engine.Group("/api")))
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/healthz", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+}

--- a/gateway/api/healthz/healthz.go
+++ b/gateway/api/healthz/healthz.go
@@ -31,6 +31,19 @@ func LivenessHandler() func(_ *gin.Context) {
 	}
 }
 
+// ControlPlaneLivenessHandler answers the same /healthz route as
+// LivenessHandler when the process runs as the control plane. It carries no
+// swagger annotation because the route is already documented above.
+//
+// The control plane runs no gRPC server, so liveness cannot depend on the
+// transport port LivenessHandler probes — that check would fail every time
+// and the deployment would never become healthy.
+func ControlPlaneLivenessHandler() func(_ *gin.Context) {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, openapi.LivenessCheck{Liveness: "OK"})
+	}
+}
+
 func checkAddrLiveness(addr string) error {
 	timeout := time.Second * 3
 	conn, err := net.DialTimeout("tcp", addr, timeout)

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -17573,6 +17573,15 @@ const docTemplate = `{
                     "type": "string",
                     "example": "https://api.johnwick.org"
                 },
+                "application_mode": {
+                    "description": "Which component this process runs as",
+                    "type": "string",
+                    "enum": [
+                        "gateway",
+                        "control-plane"
+                    ],
+                    "example": "gateway"
+                },
                 "auth_method": {
                     "description": "Auth method used by the server",
                     "type": "string",

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -6956,6 +6956,15 @@
             "example": "https://api.johnwick.org",
             "type": "string"
           },
+          "application_mode": {
+            "description": "Which component this process runs as",
+            "enum": [
+              "gateway",
+              "control-plane"
+            ],
+            "example": "gateway",
+            "type": "string"
+          },
           "auth_method": {
             "description": "Auth method used by the server",
             "enum": [

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -1604,6 +1604,8 @@ type ServerInfo struct {
 	AnalyticsMode AnalyticsModeType `json:"analytics_mode" enums:"identified,anonymous,disabled" example:"identified"`
 	// Effective feature flags for the caller's organization
 	FeatureFlags map[string]bool `json:"feature_flags,omitempty"`
+	// Which component this process runs as
+	ApplicationMode string `json:"application_mode" enums:"gateway,control-plane" example:"gateway"`
 }
 
 // ServerLogEntry is one runtime log record from the gateway process or a

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -136,19 +136,16 @@ type Api struct {
 // It performs no network I/O, so StartAPI and the integration/smoke tests
 // share the exact same handler — tests exercise the production middleware
 // chain and validators rather than a stripped-down router.
+//
+// In control-plane mode it returns the much smaller engine described in
+// buildControlPlaneEngine.
 func (a *Api) BuildEngine() *gin.Engine {
-	zaplogger := log.NewDefaultLogger(nil)
-	route := gin.New()
-	route.Use(ginzap.RecoveryWithZap(zaplogger, false))
-	if os.Getenv("GIN_MODE") == "debug" {
-		route.Use(ginzap.Ginzap(zaplogger, time.RFC3339, true))
-	}
-	a.logger = zaplogger
-	// https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies
-	route.SetTrustedProxies(nil)
-	route.Use(SecurityHeaderMiddleware())
-	route.Use(CORSMiddleware())
+	route := a.newEngine()
 	baseURL := appconfig.Get().ApiURLPath()
+
+	if appconfig.Get().IsControlPlane() {
+		return a.buildControlPlaneEngine(route, baseURL)
+	}
 
 	// UI: assets resolved from STATIC_UI_PATH, the default disk path or the
 	// build embedded in the binary; index.html and js/app.js are
@@ -205,15 +202,46 @@ func (a *Api) BuildEngine() *gin.Engine {
 	ironRdpInstance := rdp.GetIronServerInstance()
 	ironRdpInstance.AttachHandlers(ironRdpGroup)
 
+	a.buildRoutes(a.newAPIRouter(route, baseURL))
+	openapi.RegisterGinValidators()
+
+	return route
+}
+
+// newEngine builds the gin engine with the middleware every mode needs:
+// panic recovery, the debug request log, the proxy policy, security headers
+// and CORS.
+func (a *Api) newEngine() *gin.Engine {
+	zaplogger := log.NewDefaultLogger(nil)
+	route := gin.New()
+	route.Use(ginzap.RecoveryWithZap(zaplogger, false))
+	if os.Getenv("GIN_MODE") == "debug" {
+		route.Use(ginzap.Ginzap(zaplogger, time.RFC3339, true))
+	}
+	a.logger = zaplogger
+	// https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies
+	route.SetTrustedProxies(nil)
+	route.Use(SecurityHeaderMiddleware())
+	route.Use(CORSMiddleware())
+	return route
+}
+
+// newAPIRouter creates the /api group with its Sentry middleware.
+func (a *Api) newAPIRouter(route *gin.Engine, baseURL string) *apiroutes.Router {
 	rg := route.Group(baseURL + "/api")
 	rg.Use(sentrygin.New(sentrygin.Options{Repanic: true}))
 	rg.Use(sentryCatchAll5xxMiddleware)
+	return apiroutes.New(rg)
+}
 
-	router := apiroutes.New(rg)
-
-	a.buildRoutes(router)
+// buildControlPlaneEngine wires the control plane's HTTP surface. It shares
+// the middleware chain with the gateway and stops there: no static UI and no
+// SPA fallback (the gateway's web app calls routes the control plane does not
+// serve), no MCP well-known handlers, no SSM and no RDP proxy group — those
+// belong to the traffic path the control plane does not have.
+func (a *Api) buildControlPlaneEngine(route *gin.Engine, baseURL string) *gin.Engine {
+	a.buildControlPlaneRoutes(a.newAPIRouter(route, baseURL))
 	openapi.RegisterGinValidators()
-
 	return route
 }
 
@@ -244,6 +272,18 @@ func (a *Api) StartAPI() {
 	if err := route.Run(); err != nil {
 		log.Fatalf("Failed to start HTTP server, err=%v", err)
 	}
+}
+
+// buildControlPlaneRoutes registers the control plane's API surface. It is
+// deliberately near-empty: the gateway's routes are being ported one at a
+// time, and a route answers here only after it has been reviewed for a
+// deployment that has no agents, no connections and no sessions of its own.
+//
+// /healthz is the exception, and not an optional one: the helm service, the
+// AWS load balancer template and the docker-compose healthcheck all probe
+// /api/healthz, so a control plane without it never passes its health check.
+func (api *Api) buildControlPlaneRoutes(r *apiroutes.Router) {
+	r.GET("/healthz", apihealthz.ControlPlaneLivenessHandler())
 }
 
 func (api *Api) buildRoutes(r *apiroutes.Router) {

--- a/gateway/api/serverinfo/serverinfo.go
+++ b/gateway/api/serverinfo/serverinfo.go
@@ -93,6 +93,7 @@ func Get(c *gin.Context) {
 		tenancyType = "multitenant"
 	}
 
+	serverInfoData.ApplicationMode = string(appc.AppMode())
 	serverInfoData.IdpProviderName = parseIdpProviderName(serverConfig)
 	serverInfoData.TenancyType = tenancyType
 	serverInfoData.AuthMethod = string(ctx.ProviderType)

--- a/gateway/appconfig/appconfig.go
+++ b/gateway/appconfig/appconfig.go
@@ -20,6 +20,31 @@ import (
 
 // TODO: it should include all runtime configuration
 
+// AppMode selects which component the gateway binary runs as.
+type AppMode string
+
+const (
+	// AppModeGateway is the default: the full gateway, serving agents over
+	// gRPC, protocol proxies and the complete HTTP API.
+	AppModeGateway AppMode = "gateway"
+	// AppModeControlPlane runs the HTTP API only, to administer a fleet of
+	// sidecars. It serves no agents and no clients.
+	AppModeControlPlane AppMode = "control-plane"
+)
+
+// parseAppMode resolves the APP_MODE value. An empty value keeps the gateway
+// behaviour, so an existing deployment that never heard of APP_MODE is
+// unaffected.
+func parseAppMode(v string) (AppMode, error) {
+	switch mode := AppMode(strings.ToLower(strings.TrimSpace(v))); mode {
+	case "":
+		return AppModeGateway, nil
+	case AppModeGateway, AppModeControlPlane:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid APP_MODE %q (want %s|%s)", v, AppModeGateway, AppModeControlPlane)
+	}
+}
 
 type pgCredentials struct {
 	connectionString string
@@ -31,6 +56,7 @@ type pgCredentials struct {
 	pgliteDataDir string
 }
 type Config struct {
+	appMode                         AppMode
 	apiKey                          string
 	askAICredentials                *url.URL
 	authMethod                      idptypes.ProviderType
@@ -91,6 +117,10 @@ var runtimeConfig Config
 func Load() error {
 	if runtimeConfig.isLoaded {
 		return nil
+	}
+	appMode, err := parseAppMode(os.Getenv("APP_MODE"))
+	if err != nil {
+		return err
 	}
 	apiURL := os.Getenv("API_URL")
 	if apiURL == "" {
@@ -262,6 +292,7 @@ func Load() error {
 	}
 
 	runtimeConfig = Config{
+		appMode:                         appMode,
 		apiKey:                          os.Getenv("API_KEY"),
 		apiURL:                          fmt.Sprintf("%s://%s", apiRawURL.Scheme, apiRawURL.Host),
 		grpcURL:                         grpcURL,
@@ -445,24 +476,37 @@ func (c Config) LicenseSigningKey() (string, *rsa.PrivateKey) {
 func (c Config) FullApiURL() string { return c.apiURL + c.apiURLPath }
 
 // ApiURL is the base URL without any path segment or query strings (scheme://host:port)
-func (c Config) ApiURL() string                        { return c.apiURL }
-func (c Config) GrpcURL() string                       { return c.grpcURL }
+func (c Config) ApiURL() string  { return c.apiURL }
+func (c Config) GrpcURL() string { return c.grpcURL }
+
+// AppMode reports which component this process runs as. An unloaded config
+// reads as the gateway, so the mode is never the empty string.
+func (c Config) AppMode() AppMode {
+	if c.appMode == "" {
+		return AppModeGateway
+	}
+	return c.appMode
+}
+
+// IsControlPlane reports whether this process runs as the control plane.
+func (c Config) IsControlPlane() bool { return c.AppMode() == AppModeControlPlane }
+
 // WebappStaticUiPath returns the explicitly configured STATIC_UI_PATH, or
 // empty when unset (the web UI source is then resolved by gateway/webappui).
-func (c Config) WebappStaticUiPath() string            { return c.webappStaticUIPath }
-func (c Config) ApiHostname() string                   { return c.apiHostname }
-func (c Config) ApiHost() string                       { return c.apiHost } // ApiHost host or host:port
-func (c Config) ApiScheme() string                     { return c.apiScheme }
-func (c Config) ApiURLPath() string                    { return c.apiURLPath }
-func (c Config) ApiKey() string                        { return c.apiKey }
-func (c Config) AuthMethod() idptypes.ProviderType     { return c.authMethod }
-func (c Config) ForceUrlTokenExchange() bool           { return c.forceUrlTokenExchange }
-func (c Config) WebhookAppKey() string                 { return c.webhookAppKey }
-func (c Config) WebhookAppURL() *url.URL               { return c.webhookAppURL }
-func (c Config) GcpDLPJsonCredentials() string         { return c.gcpDLPJsonCredentials }
-func (c Config) DlpProvider() string                   { return c.dlpProvider }
-func (c Config) DlpMode() string                       { return c.dlpMode }
-func (c Config) HasRedactCredentials() bool            { return c.hasRedactCredentials }
+func (c Config) WebappStaticUiPath() string        { return c.webappStaticUIPath }
+func (c Config) ApiHostname() string               { return c.apiHostname }
+func (c Config) ApiHost() string                   { return c.apiHost } // ApiHost host or host:port
+func (c Config) ApiScheme() string                 { return c.apiScheme }
+func (c Config) ApiURLPath() string                { return c.apiURLPath }
+func (c Config) ApiKey() string                    { return c.apiKey }
+func (c Config) AuthMethod() idptypes.ProviderType { return c.authMethod }
+func (c Config) ForceUrlTokenExchange() bool       { return c.forceUrlTokenExchange }
+func (c Config) WebhookAppKey() string             { return c.webhookAppKey }
+func (c Config) WebhookAppURL() *url.URL           { return c.webhookAppURL }
+func (c Config) GcpDLPJsonCredentials() string     { return c.gcpDLPJsonCredentials }
+func (c Config) DlpProvider() string               { return c.dlpProvider }
+func (c Config) DlpMode() string                   { return c.dlpMode }
+func (c Config) HasRedactCredentials() bool        { return c.hasRedactCredentials }
 
 // HasGuardrailProvider reports whether the mspresidio provider is fully
 // configured (both analyzer and anonymizer URLs).
@@ -474,10 +518,10 @@ func (c Config) HasRedactCredentials() bool            { return c.hasRedactCrede
 func (c Config) HasGuardrailProvider() bool {
 	return c.dlpProvider == "mspresidio" && c.msPresidioAnalyzerURL != "" && c.msPresidioAnonymizerURL != ""
 }
-func (c Config) MSPresidioAnalyzerURL() string         { return c.msPresidioAnalyzerURL }
-func (c Config) MSPresidioAnomymizerURL() string       { return c.msPresidioAnonymizerURL }
-func (c Config) PgUsername() string                    { return c.pgCred.username }
-func (c Config) PgURI() string                         { return c.pgCred.connectionString }
+func (c Config) MSPresidioAnalyzerURL() string   { return c.msPresidioAnalyzerURL }
+func (c Config) MSPresidioAnomymizerURL() string { return c.msPresidioAnonymizerURL }
+func (c Config) PgUsername() string              { return c.pgCred.username }
+func (c Config) PgURI() string                   { return c.pgCred.connectionString }
 
 // MigrationPathFiles returns the directory to load SQL migration files
 // from when MIGRATION_PATH_FILES is set. Empty means the migrations
@@ -490,7 +534,7 @@ func (c Config) PgliteDataDir() string { return c.pgCred.pgliteDataDir }
 
 // IsPgliteEnabled reports whether the gateway must boot the embedded PGlite
 // database instead of connecting to an external PostgreSQL.
-func (c Config) IsPgliteEnabled() bool { return c.pgCred.pgliteDataDir != "" }
+func (c Config) IsPgliteEnabled() bool                 { return c.pgCred.pgliteDataDir != "" }
 func (c Config) DisableSessionsDownload() bool         { return c.disableSessionsDownload }
 func (c Config) DisableClipboardCopyCut() bool         { return c.disableClipboardCopyCut }
 func (c Config) OrgMultitenant() bool                  { return c.orgMultitenant }

--- a/gateway/appconfig/appmode_test.go
+++ b/gateway/appconfig/appmode_test.go
@@ -1,0 +1,48 @@
+package appconfig
+
+import "testing"
+
+func TestParseAppMode(t *testing.T) {
+	for _, tt := range []struct {
+		env     string
+		want    AppMode
+		wantErr bool
+	}{
+		{env: "", want: AppModeGateway},
+		{env: "gateway", want: AppModeGateway},
+		{env: "control-plane", want: AppModeControlPlane},
+		{env: "CONTROL-PLANE", want: AppModeControlPlane},
+		{env: " control-plane ", want: AppModeControlPlane},
+		{env: "control_plane", wantErr: true},
+		{env: "controlplane", wantErr: true},
+		{env: "agent", wantErr: true},
+	} {
+		t.Run(tt.env, func(t *testing.T) {
+			got, err := parseAppMode(tt.env)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("APP_MODE=%q: want error, got mode %q", tt.env, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("APP_MODE=%q: unexpected error: %v", tt.env, err)
+			}
+			if got != tt.want {
+				t.Errorf("APP_MODE=%q: got %q, want %q", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+// An unloaded config must read as the gateway, so nothing that runs before
+// Load — or in a test that never calls it — sees an empty mode.
+func TestAppModeZeroValue(t *testing.T) {
+	var c Config
+	if got := c.AppMode(); got != AppModeGateway {
+		t.Errorf("got %q, want %q", got, AppModeGateway)
+	}
+	if c.IsControlPlane() {
+		t.Error("zero config reports control plane")
+	}
+}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 
@@ -175,6 +176,36 @@ func Run() {
 		log.Infof("failed adding default runbooks, reason=%v", err)
 	}
 
+	_, _ = monitoring.StartSentry(appconfig.Get().ApiHostname())
+
+	if appconfig.Get().IsControlPlane() {
+		runControlPlane(tlsConfig)
+		return
+	}
+	runGateway(tlsConfig, apiURL, defaultOrgID, isOrgMultiTenant)
+}
+
+// runControlPlane serves the control plane: the HTTP API and nothing else.
+// It administers a fleet of sidecars, so it accepts no agent or client
+// connection — the gRPC transport, the protocol proxies and the transport
+// plugins never start. The API surface is still being ported route by route
+// (see Api.buildControlPlaneRoutes), so today it answers /api/healthz only.
+func runControlPlane(tlsConfig *tls.Config) {
+	a := &api.Api{TLSConfig: tlsConfig}
+
+	bootstrap.Phase("Starting API")
+	apiStep := bootstrap.Step("HTTP API")
+	apiStep.OK(fmt.Sprintf("%s mode=%s", appconfig.Get().ApiURL(), appconfig.AppModeControlPlane))
+
+	bootstrap.Ready(map[string]string{"Control Plane": appconfig.Get().ApiURL()})
+
+	a.StartAPI()
+}
+
+// runGateway serves the gateway: everything that carries agent and client
+// traffic — the transport plugins, the protocol proxies, the gRPC server —
+// plus the full HTTP API.
+func runGateway(tlsConfig *tls.Config, apiURL, defaultOrgID string, isOrgMultiTenant bool) {
 	g := &transport.Server{
 		TLSConfig:   tlsConfig,
 		ApiHostname: appconfig.Get().ApiHostname(),
@@ -201,7 +232,6 @@ func Run() {
 		}
 	}
 
-	_, _ = monitoring.StartSentry(appconfig.Get().ApiHostname())
 	if isOrgMultiTenant {
 		// grpc url from env is used for multi tenant setups
 		if err := agentcontroller.Run(os.Getenv("GRPC_URL")); err != nil {


### PR DESCRIPTION
## 📝 Description

Adds a run mode to the gateway binary. `APP_MODE=control-plane` starts the HTTP API only; `APP_MODE=gateway` (the default, and the value when the variable is unset) changes nothing.

The control plane administers a fleet of sidecars, so it carries no agent or client traffic. This PR is the boot path only: the API surface is ported route by route in follow-ups, so today the control plane answers `/api/healthz` and nothing else.

|  | gateway (default) | control-plane |
|---|---|---|
| Routes registered | 264 | 2 (`GET`/`HEAD /api/healthz`) |
| gRPC `:8010` | open | closed |
| Protocol proxies, transport plugins, agent controller | started | not started |
| Static UI + SPA fallback, `/.well-known/*`, `/ssm`, `/rdpproxy` | served | absent |
| Bootstrap (migrations, default org, auth) | runs | runs |

Builds on `bf40f968` from `feat/modes`, which introduced `APP_MODE` and the `application_mode` field of `/serverinfo`.

## 📣 User-facing impact

None. The new mode is opt-in and serves no product surface yet.

## 🔗 Related Issue

EVL-237

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

- `gateway/appconfig`: `AppMode` type with `AppModeGateway` / `AppModeControlPlane`, `parseAppMode` (case-insensitive, empty means gateway), `AppMode()` and `IsControlPlane()` accessors.
- `gateway/main.go`: `Run()` keeps the shared bootstrap, then dispatches to `runControlPlane()` or `runGateway()`. Everything that carries agent and client traffic moved into `runGateway`, so a future addition there is off in control-plane mode by construction.
- `gateway/api/server.go`: `newEngine()` and `newAPIRouter()` extracted so both modes share one middleware chain; `buildControlPlaneEngine()` and `buildControlPlaneRoutes()` added.
- `gateway/api/healthz`: `ControlPlaneLivenessHandler()`.
- `/serverinfo` reports `application_mode`; OpenAPI regenerated.
- Gateway helm chart: `APP_MODE` pass-through and a documented default.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a
- **OS**: macOS 15 (darwin/arm64)

### Tests performed:
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

`make test-oss` green, zero failures.

New tests:
- `gateway/appconfig/appmode_test.go` — mode parsing, including that a zero-value config reads as the gateway.
- `gateway/api/controlplane_routes_test.go` — asserts the exact route list, so a route added to `buildControlPlaneRoutes` without being listed fails the test; and asserts `/api/healthz` answers 200 with no gRPC server running.

Manual, both modes booted against embedded PGlite:

```
# control plane
APP_MODE=control-plane POSTGRES_DB_URI=pglite:///tmp/cp hoop start gateway

GET /api/healthz     -> 200 {"liveness":"OK"}
GET /api/serverinfo  -> 404
GET /                -> 404
GET /.well-known/oauth-protected-resource -> 404
tcp 127.0.0.1:8010   -> closed
gin registered 2 routes

# gateway (regression)
POSTGRES_DB_URI=pglite:///tmp/gw hoop start gateway

GET /api/healthz          -> 200
GET /api/publicserverinfo -> 200
GET /api/serverinfo       -> 401 (unauthenticated)
tcp 127.0.0.1:8010        -> open
gin registered 264 routes
```

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**Why a separate liveness handler.** The gateway's `LivenessHandler` dials `127.0.0.1:8010` and returns 400 when the port is closed. The control plane never opens it, so reusing that handler would fail every health check — and `/api/healthz` is what the helm service, the AWS load balancer template and the docker-compose healthcheck all probe. `ControlPlaneLivenessHandler` carries no swagger annotation on purpose: a second `@Router /healthz [get]` made swag drop the documented 400 response from the spec.

**Sentry moved up.** `monitoring.StartSentry` is now part of the shared bootstrap, so in gateway mode it initialises before transport-plugin startup instead of after. Both modes get it.

**`appconfig.go` diff noise.** Adding an accessor to the aligned single-line block made gofmt realign the whole group. The behaviour change there is the six lines around `parseAppMode`, the struct field and the two accessors.

**Helm guard on the bundled default agent.** `defaultAgent.enabled=true` with `config.APP_MODE=control-plane` renders an agent pointed at `127.0.0.1:8010`, which this mode never opens. The chart now fails rendering for that combination, unless `defaultAgent.grpcHost` names an external gateway.

**Reviewers:** the decision worth pushing back on is the split between shared bootstrap and `runGateway`. Migrations, the default org, default runbooks and rulepack seeding all still run in control-plane mode; `ProvisionOrgAgentKey` and the default connection tags are agent- and connection-shaped and arguably belong on the gateway side of the split.

No ADR yet. This picks between real alternatives and sets how every future route is gated per mode, so it may deserve one before the route ports start.

