### PR TITLE
docs(adr): ADR-0013 the control plane is a second boot path in the gateway

### DIFF
--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -69,8 +69,8 @@ keys, IdP integration and license management all work that way with no port.
 
 We will run the control plane as **the gateway binary started with
 `hoop start control-plane`**, split at two seams: the process boot path and the
-engine builder. The boot seam removes the data plane. The engine seam removes
-the web UI and nothing else.
+engine builder. The boot seam removes the data plane. The engine is the same
+in both modes; one handler, `/healthz`, differs.
 
 **The subcommand picks the mode, not the environment.** `gateway.Run` takes an
 `appconfig.AppMode` and hands it to `appconfig.Load`. There is no variable to
@@ -93,12 +93,13 @@ addition there is off in control-plane mode by construction, without anyone
 remembering this ADR.
 
 **The engine seam is in `BuildEngine()`.** Both modes build one engine from one
-route tree. Control-plane mode skips `serveWebUI`, the embedded web app and its
-SPA fallback, because the control plane has its own frontend. Everything else
-is registered in both modes: the `/api` tree, the MCP well-known handlers,
-`/ssm` and `/rdpproxy`. Both modes share one middleware chain through
-`newEngine` and `newAPIRouter`, so the control plane gets the same recovery,
-proxy policy, security headers, CORS and Sentry wiring the gateway gets.
+route tree: the `/api` tree, the MCP well-known handlers, `/ssm`, `/rdpproxy`,
+and the gateway's web app with its SPA fallback. Both modes share one middleware
+chain through `newEngine` and `newAPIRouter`, so the control plane gets the
+same recovery, proxy policy, security headers, CORS and Sentry wiring the
+gateway gets. The web app served at `/` is the gateway's; `controlplane/frontend`
+is a separate app that is not embedded in the binary, and which of the two a
+browser reaches is a deployment question this ADR does not settle.
 
 `buildRoutes` reads the mode for one route. The gateway's `/healthz` dials
 `127.0.0.1:8010` and returns 400 when the port is closed; control-plane mode
@@ -113,12 +114,11 @@ should not expose a gateway feature hides it in the UI, not in the handler.
 
 | | gateway (default) | control-plane |
 |---|---|---|
-| HTTP routes | 389 | 389, minus `index.html` and `js/app.js` when a web UI build resolves |
+| HTTP routes | 389 | 389 |
 | `/api/healthz` | probes the gRPC port | answers 200 without dialing |
 | gRPC `:8010` | open | closed |
 | Protocol proxies, transport plugins, agent controller | started | not started |
-| Static UI, SPA fallback | served | absent |
-| `/.well-known/*`, `/ssm`, `/rdpproxy` | served | served |
+| Static UI, SPA fallback, `/.well-known/*`, `/ssm`, `/rdpproxy` | served | served |
 | Bootstrap: migrations, default org, auth | runs | runs |
 
 **What does not work, and how it fails.** 23 of the 271 distinct routes (389
@@ -156,8 +156,8 @@ accepted.
 
 **`gateway/api/controlplane_routes_test.go` asserts parity, not a list.** It
 builds both engines in one process and checks, in both directions, that the
-gateway's routes minus the web UI are the control plane's routes. A test that
-pins a hand-written list is what this replaces.
+two modes register the same routes. A test that pins a hand-written list is
+what this replaces.
 
 **Part of the control plane frontend still describes the allowlist.** PR #1785
 updates `controlplane/frontend`'s `README.md` and `CLAUDE.md`. Its `ModeBanner`
@@ -199,12 +199,13 @@ and diffs them; `make test-oss` passes with no failures.
 Both modes booted from one binary against embedded PGlite with
 `GIN_MODE=debug`, counting unique `METHOD /path` pairs from gin's registration
 log. Both register 389 (271 without the `HEAD` twins) and a `diff` of the two
-lists is empty. The dev binary embeds no web UI build, so the two UI routes
-appear in neither.
+lists is empty. The dev binary embeds no web UI build; with `STATIC_UI_PATH`
+pointing at a directory holding an `index.html`, both modes register
+`GET /index.html` and serve it at `/`.
 
 `hoop start control-plane`: `GET /api/healthz` → `200 {"liveness":"OK"}`;
 `/api/publicserverinfo` → 200; `/api/serverinfo` and `/api/users` → 401
-without a token; `/` and `/index.html` → 404; TCP `127.0.0.1:8010` closed.
+without a token; `/` → 404 without a UI build; TCP `127.0.0.1:8010` closed.
 After `POST /api/localauth/register` and a login, `GET /api/users`,
 `/api/serverinfo`, `/api/plugins` (every plugin, not only slack),
 `/api/api-keys`, `/api/audit/logs`, `/api/server-logs`, `/api/agents` and

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -159,10 +159,9 @@ builds both engines in one process and checks, in both directions, that the
 two modes register the same routes. A test that pins a hand-written list is
 what this replaces.
 
-**Part of the control plane frontend still describes the allowlist.** PR #1785
-updates `controlplane/frontend`'s `README.md`, `CLAUDE.md` and `ModeBanner`.
-Comments in its services and user store still say the group and attribute
-routes answer 404, which is no longer true; they are owed a follow-up.
+**The control plane frontend's docs follow.** PR #1785 updates
+`controlplane/frontend`'s `README.md`, `CLAUDE.md`, `ModeBanner` and the
+service and store comments that described the allowlist.
 
 **The served OpenAPI spec describes what is served.** It is generated from the
 handlers' swagger annotations, which know nothing about the mode; with one

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -159,10 +159,11 @@ builds both engines in one process and checks, in both directions, that the
 gateway's routes minus the web UI are the control plane's routes. A test that
 pins a hand-written list is what this replaces.
 
-**The control plane frontend's own docs are now wrong.** `controlplane/frontend`'s
-`README.md` and `CLAUDE.md` describe an allowlist and an `APP_MODE` variable,
-and its `ModeBanner` warns about routes the control plane blocks. None of that
-is true any more. Fixing them is out of EVL-245's scope and owed a follow-up.
+**Part of the control plane frontend still describes the allowlist.** PR #1785
+updates `controlplane/frontend`'s `README.md` and `CLAUDE.md`. Its `ModeBanner`
+still warns about routes the control plane blocks, and two service comments
+still say the group and attribute routes answer 404. Neither is true any more;
+both are owed a follow-up.
 
 **The served OpenAPI spec describes what is served.** It is generated from the
 handlers' swagger annotations, which know nothing about the mode; with one

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-09-01
 - **Author:** @p3rotto
 - **Linear:** EVL-237
-- **Code:** [`gateway/main.go`](../../gateway/main.go), [`gateway/api/server.go`](../../gateway/api/server.go), [`gateway/appconfig/appconfig.go`](../../gateway/appconfig/appconfig.go), [`gateway/api/healthz/healthz.go`](../../gateway/api/healthz/healthz.go)
-- **Related:** PR #1754 (the control plane frontend), PR #1773 (implements this ADR), PR #1772 (open draft proposing the route-allowlist mechanism this ADR's option 3 records)
+- **Code:** [`client/cmd/start.go`](../../client/cmd/start.go), [`gateway/main.go`](../../gateway/main.go), [`gateway/api/server.go`](../../gateway/api/server.go), [`gateway/appconfig/appconfig.go`](../../gateway/appconfig/appconfig.go), [`gateway/api/healthz/healthz.go`](../../gateway/api/healthz/healthz.go)
+- **Related:** PR #1754 (the control plane frontend), PR #1773 (implements the two boot paths), PR #1772 (open draft proposing the route-allowlist mechanism this ADR's option 3 records)
 - **Supersedes / Superseded by:** —
 
 ## Context
@@ -19,7 +19,7 @@ sidecar is a library that turns database wire bytes into verdicts; it opens no
 gRPC stream to a gateway and registers nothing. So a deployment that exists to
 manage sidecars needs none of the machinery the gateway exists to run.
 
-Booted today, it would get all of it: **264** HTTP routes, the gRPC transport on
+Booted today, it would get all of it: **389** HTTP routes, the gRPC transport on
 `:8010` accepting agent and client streams, the Postgres, SSH, RDP and HTTP
 protocol proxies, the six transport plugins, the agent controller and the
 connection-status conciliation loop. Runbook execution, agent registration, API
@@ -60,15 +60,21 @@ yet been reviewed against a deployment that has no agents and no sessions.
 
 ## Decision
 
-We will run the control plane as **the gateway binary booted with
-`APP_MODE=control-plane`**, split at two seams: the process boot path and the
+We will run the control plane as **the gateway binary started with
+`hoop start control-plane`**, split at two seams: the process boot path and the
 engine builder.
 
-**`APP_MODE` is typed and defaults to the gateway.** `appconfig` parses it into
-an `AppMode` case-insensitively; empty means `gateway`, and an unrecognised
-value stops startup rather than guessing. A zero-value `Config` reads as the
-gateway, so the mode is never the empty string and an existing deployment that
-never heard of the variable is unaffected.
+**The subcommand picks the mode, not the environment.** `gateway.Run` takes an
+`appconfig.AppMode` and hands it to `appconfig.Load`. There is no variable to
+set, so no environment and command line can disagree with each other, and a
+deployment picks a component the same way it already does: by picking a
+container command. An unrecognised mode stops startup rather than guessing, and
+the zero value reads as the gateway, so a caller that leaves it unset keeps the
+shipping behaviour.
+
+PR #1773 first shipped this as an `APP_MODE` environment variable. The
+follow-up removed it in favour of the subcommand, because a second way to say
+the same thing is a second way to get it wrong.
 
 **The boot seam is in `Run()`.** Shared bootstrap runs first — config, TLS,
 migrations, the default organization, auth, Sentry — then `Run` dispatches to
@@ -92,7 +98,7 @@ sessions.
 
 | | gateway (default) | control-plane |
 |---|---|---|
-| HTTP routes | 264 | 2 (`GET`/`HEAD /api/healthz`) |
+| HTTP routes | 389 | 2 (`GET`/`HEAD /api/healthz`) |
 | gRPC `:8010` | open | closed |
 | Protocol proxies, transport plugins, agent controller | started | not started |
 | Static UI, SPA fallback, `/.well-known/*`, `/ssm`, `/rdpproxy` | served | absent |
@@ -131,7 +137,7 @@ its routes exist.
 route added to `buildControlPlaneRoutes` without being listed in the test fails
 the build. The test is the review gate, not a description of one.
 
-**The served OpenAPI spec still describes all 264 routes in control-plane
+**The served OpenAPI spec still describes all 389 routes in control-plane
 mode.** It is generated from swagger annotations on the handlers, which know
 nothing about the mode. Filtering it needs its own change.
 
@@ -143,11 +149,13 @@ gateway side of the split. Left as-is because provisioning an unused key is
 harmless and moving it is a behaviour change; revisit when the first real
 control-plane route lands.
 
-**The helm chart now refuses one combination.** `defaultAgent.enabled=true` with
-`APP_MODE=control-plane` renders an agent pointed at `127.0.0.1:8010`, which
-this mode never opens, so the chart fails rendering unless
-`defaultAgent.grpcHost` names an external gateway. Two products in one chart
-means every value that assumes a data plane needs this question asked of it.
+**The control plane ships its own chart.** `deploy/helm-chart/chart/controlplane`
+is a skeleton: one Deployment whose container `args` are `hoop start
+control-plane`, and no Service, Ingress or config Secret, because the mode
+serves one route. The gateway chart is untouched, so no value on it can produce
+a control plane and no combination of its values needs a guard. Two products in
+one chart would have meant asking that question of every value that assumes a
+data plane; two charts do not.
 
 **No agent sees any of this.** No packet type, spec key or payload changed, so
 the gateway↔agent contract is untouched and an old agent is unaffected. This is
@@ -160,19 +168,21 @@ the second boot path.
 
 ### How this was verified
 
-Against `main` at `10f45d22`, both modes booted against embedded PGlite.
+Both modes booted against embedded PGlite with `GIN_MODE=debug`, counting
+unique `METHOD /path` pairs from gin's registration log.
 
-Control plane (`APP_MODE=control-plane POSTGRES_DB_URI=pglite:///tmp/cp`): gin
-registered 2 routes; `GET /api/healthz` → `200 {"liveness":"OK"}`;
-`/api/serverinfo`, `/` and `/.well-known/oauth-protected-resource` → 404; TCP
+`hoop start control-plane`: 2 routes, `GET` and `HEAD /api/healthz`. `GET
+/api/healthz` → `200 {"liveness":"OK"}`; `/api/serverinfo` and `/` → 404; TCP
 `127.0.0.1:8010` closed.
 
-Gateway regression (`POSTGRES_DB_URI=pglite:///tmp/gw`, `APP_MODE` unset): gin
-registered 264 routes; `/api/healthz` → 200; `/api/publicserverinfo` → 200;
-`/api/serverinfo` → 401; TCP `127.0.0.1:8010` open.
+`hoop start gateway`, with `APP_MODE=control-plane` deliberately still set in
+the environment to prove it is ignored: 389 routes; `/api/healthz` → 200;
+`/api/publicserverinfo` → 200; `/api/serverinfo` → 401; TCP `127.0.0.1:8010`
+open.
 
-`gateway/appconfig/appmode_test.go` covers the parse table, including that an
+`gateway/appconfig/appmode_test.go` covers the mode table, including that an
 unrecognised value errors and a zero-value `Config` reads as the gateway. The
-helm guard was checked with helm 3.16.2 across all four combinations of
-`APP_MODE` and `defaultAgent.enabled`: the three legal ones render, the broken
-one fails with the incompatibility message. `make test-oss` passes.
+gateway chart and `.env.sample` are byte-identical to their state before #1773
+(`git diff` against `10f45d22^` is empty). The control plane chart was rendered
+with helm 3.16.2: it produces the expected Deployment and refuses to render
+without `existingSecret`. `make test-oss` passes.

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -1,0 +1,178 @@
+# ADR-0013: The control plane is a second boot path in the gateway binary
+
+- **Status:** Proposed
+- **Date:** 2026-09-01
+- **Author:** @p3rotto
+- **Linear:** EVL-237
+- **Code:** [`gateway/main.go`](../../gateway/main.go), [`gateway/api/server.go`](../../gateway/api/server.go), [`gateway/appconfig/appconfig.go`](../../gateway/appconfig/appconfig.go), [`gateway/api/healthz/healthz.go`](../../gateway/api/healthz/healthz.go)
+- **Related:** PR #1754 (the control plane frontend), PR #1773 (implements this ADR), PR #1772 (open draft proposing the route-allowlist mechanism this ADR's option 3 records)
+- **Supersedes / Superseded by:** —
+
+## Context
+
+`controlplane/frontend` shipped in PR #1754. It is an admin-only React app for
+administering a fleet of sidecars, and its own `CLAUDE.md` is explicit that the
+control plane backend does not exist yet, so the API comes from the gateway.
+
+The control plane has no agents, no connections and no sessions of its own. A
+sidecar is a library that turns database wire bytes into verdicts; it opens no
+gRPC stream to a gateway and registers nothing. So a deployment that exists to
+manage sidecars needs none of the machinery the gateway exists to run.
+
+Booted today, it would get all of it: **264** HTTP routes, the gRPC transport on
+`:8010` accepting agent and client streams, the Postgres, SSH, RDP and HTTP
+protocol proxies, the six transport plugins, the agent controller and the
+connection-status conciliation loop. Runbook execution, agent registration, API
+keys and webhooks are all reachable with an admin token in a product that cannot
+use them.
+
+Three constraints shape the answer. The gateway ships to customers and its
+behaviour must not change. Agents run on customer infrastructure and stay old
+for a long time, so nothing here may touch the gateway↔agent contract. And the
+reason to stay inside the gateway binary at all is reuse: auth, users, reviews,
+guardrails, masking and the analyzer already exist here with their tables and
+migrations.
+
+One thing we do not know is which routes the control plane will need. The
+frontend's information architecture is new and still moving, and no route has
+yet been reviewed against a deployment that has no agents and no sessions.
+
+## Options considered
+
+1. **A separate `controlplane/backend` Go module.** Its own `go.mod`, port,
+   migrations and admin auth. The right end state, and the one `go.work` should
+   eventually list. It loses *for now* because reusing those six subsystems is
+   the entire point of an interim step, and a second module forks all of them
+   before anything ships. No such module exists in the repo today.
+2. **A per-org feature flag.** `common/featureflag` is already wired to
+   Settings → Experimental. It loses because the root `CLAUDE.md` defines a flag
+   as a kill switch an admin flips in a browser, and a deployment topology is
+   not something a browser toggles.
+3. **One route tree, narrowed by an allowlist.** A `"METHOD /path"` list
+   consulted at registration, with `apiroutes.Router` changed so the compiler
+   refuses a registration that skips the list — the design in the open draft
+   #1772. Its central property is real: one route tree, and a test can diff the
+   two surfaces in both directions. It loses as the *first* step for two
+   reasons. It presumes we know the control plane's route list, and we do not.
+   And it narrows only the HTTP surface, leaving the gRPC transport, the proxies
+   and the plugins running in a deployment that has no agents to serve.
+4. **Two boot paths, starting from a near-empty route set.** Chosen.
+
+## Decision
+
+We will run the control plane as **the gateway binary booted with
+`APP_MODE=control-plane`**, split at two seams: the process boot path and the
+engine builder.
+
+**`APP_MODE` is typed and defaults to the gateway.** `appconfig` parses it into
+an `AppMode` case-insensitively; empty means `gateway`, and an unrecognised
+value stops startup rather than guessing. A zero-value `Config` reads as the
+gateway, so the mode is never the empty string and an existing deployment that
+never heard of the variable is unaffected.
+
+**The boot seam is in `Run()`.** Shared bootstrap runs first — config, TLS,
+migrations, the default organization, auth, Sentry — then `Run` dispatches to
+`runControlPlane()` or `runGateway()`. Everything that carries agent or client
+traffic lives in `runGateway`: the transport plugin chain, the agent controller,
+the protocol proxies, connection-status conciliation, the gRPC server. A future
+addition there is off in control-plane mode by construction, without anyone
+remembering this ADR.
+
+**The engine seam is in `BuildEngine()`.** Control-plane mode returns early into
+`buildControlPlaneEngine` before the static UI, the SPA fallback, the MCP
+well-known handlers, `/ssm` and `/rdpproxy`. Both modes share one middleware
+chain through `newEngine` and `newAPIRouter`, so the control plane gets the same
+recovery, proxy policy, security headers, CORS and Sentry wiring the gateway
+gets.
+
+**The route surface starts near-empty and grows.** `buildControlPlaneRoutes`
+registers `/healthz` and nothing else. Each route is added only after it has
+been reviewed against a deployment with no agents, no connections and no
+sessions.
+
+| | gateway (default) | control-plane |
+|---|---|---|
+| HTTP routes | 264 | 2 (`GET`/`HEAD /api/healthz`) |
+| gRPC `:8010` | open | closed |
+| Protocol proxies, transport plugins, agent controller | started | not started |
+| Static UI, SPA fallback, `/.well-known/*`, `/ssm`, `/rdpproxy` | served | absent |
+| Bootstrap: migrations, default org, auth | runs | runs |
+
+`/healthz` gets its own handler rather than a shared one. The gateway's
+`LivenessHandler` dials `127.0.0.1:8010` and returns 400 when the port is
+closed; control-plane mode never opens it, so reusing that handler would fail
+every health check — and `/api/healthz` is what the helm service, the AWS load
+balancer template and the docker-compose healthcheck all probe.
+
+`/serverinfo` reports `application_mode`, so a client can tell which product it
+is talking to without inferring it from a 404.
+
+## Consequences
+
+**The default is now fail-closed, and that is the property worth keeping.** A
+new proxy, plugin or route added to `runGateway` or `buildRoutes` does not
+appear in control-plane mode unless someone puts it there. The alternative
+designs all default the other way: they start from everything and subtract.
+
+**The route set is a migration ledger that grows.** This is the inverse of
+#1772, whose list shrinks as domains leave the gateway. Both describe the same
+transition from opposite ends, and they are not compatible mechanisms — if the
+control plane ends up serving most of the gateway's routes, the allowlist
+becomes the better tool and this ADR should be amended rather than quietly
+worked around.
+
+**The control plane frontend has no backend until routes are ported.** PR #1754
+shipped a UI that calls the gateway; in control-plane mode it now reaches a
+process that answers `/api/healthz`. That is deliberate and it is a real gap,
+not a soft launch. Nothing should be pointed at this mode in production until
+its routes exist.
+
+**`gateway/api/controlplane_routes_test.go` asserts the exact route list.** A
+route added to `buildControlPlaneRoutes` without being listed in the test fails
+the build. The test is the review gate, not a description of one.
+
+**The served OpenAPI spec still describes all 264 routes in control-plane
+mode.** It is generated from swagger annotations on the handlers, which know
+nothing about the mode. Filtering it needs its own change.
+
+**The bootstrap/`runGateway` boundary is not obviously in the right place.**
+Migrations, the default organization, default runbooks and rulepack seeding all
+still run in control-plane mode. `ProvisionOrgAgentKey` and the default
+connection tags are agent- and connection-shaped and arguably belong on the
+gateway side of the split. Left as-is because provisioning an unused key is
+harmless and moving it is a behaviour change; revisit when the first real
+control-plane route lands.
+
+**The helm chart now refuses one combination.** `defaultAgent.enabled=true` with
+`APP_MODE=control-plane` renders an agent pointed at `127.0.0.1:8010`, which
+this mode never opens, so the chart fails rendering unless
+`defaultAgent.grpcHost` names an external gateway. Two products in one chart
+means every value that assumes a data plane needs this question asked of it.
+
+**No agent sees any of this.** No packet type, spec key or payload changed, so
+the gateway↔agent contract is untouched and an old agent is unaffected. This is
+a deployment-topology decision, not a wire one.
+
+**Revisit if the gateway is not retired.** Two products in one binary told apart
+by an env var is cheap for a transition and expensive as a permanent condition.
+If the transition stalls, the answer is to finish option 1, not to keep growing
+the second boot path.
+
+### How this was verified
+
+Against `main` at `10f45d22`, both modes booted against embedded PGlite.
+
+Control plane (`APP_MODE=control-plane POSTGRES_DB_URI=pglite:///tmp/cp`): gin
+registered 2 routes; `GET /api/healthz` → `200 {"liveness":"OK"}`;
+`/api/serverinfo`, `/` and `/.well-known/oauth-protected-resource` → 404; TCP
+`127.0.0.1:8010` closed.
+
+Gateway regression (`POSTGRES_DB_URI=pglite:///tmp/gw`, `APP_MODE` unset): gin
+registered 264 routes; `/api/healthz` → 200; `/api/publicserverinfo` → 200;
+`/api/serverinfo` → 401; TCP `127.0.0.1:8010` open.
+
+`gateway/appconfig/appmode_test.go` covers the parse table, including that an
+unrecognised value errors and a zero-value `Config` reads as the gateway. The
+helm guard was checked with helm 3.16.2 across all four combinations of
+`APP_MODE` and `defaultAgent.enabled`: the three legal ones render, the broken
+one fails with the incompatibility message. `make test-oss` passes.

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -1,6 +1,6 @@
 # ADR-0013: The control plane is a second boot path in the gateway binary
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-09-03
 - **Author:** @p3rotto
 - **Linear:** EVL-237, EVL-245

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -5,226 +5,135 @@
 - **Author:** @p3rotto
 - **Linear:** EVL-237, EVL-245
 - **Code:** [`client/cmd/start.go`](../../client/cmd/start.go), [`gateway/main.go`](../../gateway/main.go), [`gateway/api/server.go`](../../gateway/api/server.go), [`gateway/appconfig/appconfig.go`](../../gateway/appconfig/appconfig.go), [`gateway/api/healthz/healthz.go`](../../gateway/api/healthz/healthz.go), [`gateway/api/controlplane_routes_test.go`](../../gateway/api/controlplane_routes_test.go)
-- **Related:** PR #1754 (the control plane frontend), PR #1773 (the two boot paths), PR #1775 (`hoop start control-plane`), PR #1770 (the 66-route allowlist this ADR retires), PR #1772 (closed draft of a registration-time allowlist), PR #1785 (one route tree for both modes)
+- **Related:** PR #1754 (control plane frontend), PR #1773 and #1775 (boot paths, `hoop start control-plane`), PR #1770 (the route allowlist this ADR retires), PR #1772 (closed allowlist draft), PR #1785 (one route tree)
 - **Supersedes / Superseded by:** —
 
 ## Context
 
-`controlplane/frontend` shipped in PR #1754. It is an admin-only React app for
-administering a fleet of sidecars, and its own `CLAUDE.md` is explicit that the
-control plane backend does not exist yet, so the API comes from the gateway.
+`controlplane/frontend` (PR #1754) administers a fleet of sidecars and has no
+backend of its own; the API comes from the gateway. A sidecar opens no gRPC
+stream and registers nothing, so that deployment needs none of the gateway's
+data plane: the gRPC transport on `:8010`, the protocol proxies, the six
+transport plugins, the agent controller, the connection-status loop.
 
-The control plane has no agents, no connections and no sessions of its own. A
-sidecar is a library that turns database wire bytes into verdicts; it opens no
-gRPC stream to a gateway and registers nothing. So a deployment that exists to
-manage sidecars needs none of the machinery the gateway exists to run.
+Three constraints: the gateway's behaviour must not change, the gateway↔agent
+contract must not change, and the point of staying in one binary is reusing
+auth, users, reviews, guardrails, masking and the analyzer with their tables.
 
-Booted as a gateway, it would get all of it: the gRPC transport on `:8010`
-accepting agent and client streams, the Postgres, SSH, RDP and HTTP protocol
-proxies, the six transport plugins, the agent controller and the
-connection-status conciliation loop.
-
-Three constraints shape the answer. The gateway ships to customers and its
-behaviour must not change. Agents run on customer infrastructure and stay old
-for a long time, so nothing here may touch the gateway↔agent contract. And the
-reason to stay inside the gateway binary at all is reuse: auth, users, reviews,
-guardrails, masking and the analyzer already exist here with their tables and
-migrations.
-
-The HTTP surface was the open question. PR #1773 started it near-empty and
-PR #1770 grew it to the 66 routes the shipped frontend calls. The EVL-245
-discussion settled it the other way: a feature the gateway already has should
-work in the control plane from the first version, and the UI hides what the
-product does not expose. Users, audit logs, server logs, analytics mode, API
-keys, IdP integration and license management all work that way with no port.
+The open question was the HTTP surface. PR #1773 started it near-empty and
+PR #1770 grew it to 66 hand-picked routes. EVL-245 settled it: a feature the
+gateway has works in the control plane from day one, and the UI hides what the
+product does not expose.
 
 ## Options considered
 
-1. **A separate `controlplane/backend` Go module.** Its own `go.mod`, port,
-   migrations and admin auth. The right end state, and the one `go.work` should
-   eventually list. It loses *for now* because reusing those six subsystems is
-   the entire point of an interim step, and a second module forks all of them
-   before anything ships. No such module exists in the repo today.
-2. **A per-org feature flag.** `common/featureflag` is already wired to
-   Settings → Experimental. It loses because the root `CLAUDE.md` defines a flag
-   as a kill switch an admin flips in a browser, and a deployment topology is
-   not something a browser toggles.
-3. **One route tree, narrowed by an allowlist.** A `"METHOD /path"` list
-   consulted at registration, with `apiroutes.Router` changed so the compiler
-   refuses a registration that skips the list: the design in the closed draft
-   #1772. It loses because it presumes we know the control plane's route list,
-   and because it narrows only the HTTP surface, leaving the gRPC transport, the
-   proxies and the plugins running in a deployment that has no agents to serve.
-4. **Two boot paths, starting from a near-empty route set.** What PR #1773 and
-   PR #1770 shipped: `buildControlPlaneRoutes` listed each route by hand, a test
-   pinned the list, and `gateway/api/plugins` hid every plugin but Slack. It
-   loses under EVL-245. Every route was a decision to make, a test to edit and a
-   frontend change to coordinate, and what it prevented, a route answering in a
-   deployment that cannot use it, turned out cheaper to accept than to prevent:
-   23 of the gateway's 271 routes need the transport, and each of them fails
-   with an error rather than silently.
+1. **A separate `controlplane/backend` module.** The right end state. Loses for
+   now: a second module forks the six reused subsystems before anything ships.
+2. **A per-org feature flag.** Loses: a flag is a kill switch an admin flips in
+   a browser, and a deployment topology is not that.
+3. **One route tree narrowed by an allowlist** (closed draft #1772). Loses: it
+   presumes the route list is known, and it narrows only HTTP while the
+   transport, proxies and plugins keep running.
+4. **Two boot paths with a near-empty route set that grows** (what #1773 and
+   #1770 shipped). Loses under EVL-245: every route was a decision, a test edit
+   and a frontend change, to prevent something cheaper to accept. 21 of 271
+   routes need the transport, and each fails with an error, not silently.
 5. **Two boot paths, one route tree.** Chosen.
 
 ## Decision
 
-We will run the control plane as **the gateway binary started with
-`hoop start control-plane`**, split at two seams: the process boot path and the
-engine builder. The boot seam removes the data plane. The engine is the same
-in both modes; one handler, `/healthz`, differs.
+The control plane is **the gateway binary started with
+`hoop start control-plane`**. The boot path drops the data plane; the HTTP
+engine is the gateway's, with one handler that differs.
 
-**The subcommand picks the mode, not the environment.** `gateway.Run` takes an
-`appconfig.AppMode` and hands it to `appconfig.Load`. There is no variable to
-set, so no environment and command line can disagree with each other, and a
-deployment picks a component the same way it already does: by picking a
-container command. An unrecognised mode stops startup rather than guessing, and
-the zero value reads as the gateway, so a caller that leaves it unset keeps the
-shipping behaviour.
+**The subcommand picks the mode.** `gateway.Run` takes an `appconfig.AppMode`
+from the command that started the process. An unknown mode stops startup; the
+zero value is the gateway. PR #1773 used an `APP_MODE` variable and PR #1775
+removed it: a second way to say the same thing is a second way to get it wrong.
 
-PR #1773 first shipped this as an `APP_MODE` environment variable. PR #1775
-removed it in favour of the subcommand, because a second way to say the same
-thing is a second way to get it wrong.
+**The boot seam is `Run()`.** Shared bootstrap (config, TLS, migrations,
+default org, auth, Sentry) runs first, then `runControlPlane()` or
+`runGateway()`. Everything that carries traffic lives in `runGateway`, so a
+future addition there is off in control-plane mode by construction.
 
-**The boot seam is in `Run()`.** Shared bootstrap runs first: config, TLS,
-migrations, the default organization, auth, Sentry. Then `Run` dispatches to
-`runControlPlane()` or `runGateway()`. Everything that carries agent or client
-traffic lives in `runGateway`: the transport plugin chain, the agent controller,
-the protocol proxies, connection-status conciliation, the gRPC server. A future
-addition there is off in control-plane mode by construction, without anyone
-remembering this ADR.
+**The engine is shared.** `BuildEngine` builds one engine for both modes: the
+`/api` tree, the MCP well-known handlers, `/ssm`, `/rdpproxy`, the web app and
+its SPA fallback, behind one middleware chain. The web app is the gateway's;
+`controlplane/frontend` is a separate app, and which one a browser reaches is a
+deployment question.
 
-**The engine seam is in `BuildEngine()`.** Both modes build one engine from one
-route tree: the `/api` tree, the MCP well-known handlers, `/ssm`, `/rdpproxy`,
-and the gateway's web app with its SPA fallback. Both modes share one middleware
-chain through `newEngine` and `newAPIRouter`, so the control plane gets the
-same recovery, proxy policy, security headers, CORS and Sentry wiring the
-gateway gets. The web app served at `/` is the gateway's; `controlplane/frontend`
-is a separate app that is not embedded in the binary, and which of the two a
-browser reaches is a deployment question this ADR does not settle.
+**`/healthz` is the one mode-aware handler.** The gateway's probe dials
+`127.0.0.1:8010` and returns 400 when it is closed. The control plane never
+opens that port, so its probe answers without dialing; otherwise the helm, AWS
+and docker-compose health checks would never pass.
 
-`buildRoutes` reads the mode for one route. The gateway's `/healthz` dials
-`127.0.0.1:8010` and returns 400 when the port is closed; control-plane mode
-never opens it, so its handler answers without dialing. `/api/healthz` is what
-the helm service, the AWS load balancer template and the docker-compose
-healthcheck all probe, so a control plane with the gateway's handler would never
-become healthy.
+**No handler hides a feature by mode.** The Slack-only plugin filter from
+PR #1770 is gone. The UI hides what the product does not expose.
 
-**No handler hides a feature by mode.** PR #1770 answered 404 for every plugin
-but Slack inside `gateway/api/plugins`; that is gone. A control plane that
-should not expose a gateway feature hides it in the UI, not in the handler.
-
-| | gateway (default) | control-plane |
+| | gateway | control-plane |
 |---|---|---|
-| HTTP routes | 389 | 389 |
-| `/api/healthz` | probes the gRPC port | answers 200 without dialing |
+| HTTP routes, web UI, `/.well-known/*`, `/ssm`, `/rdpproxy` | 389, served | 389, served |
+| `/api/healthz` | probes the gRPC port | answers without dialing |
 | gRPC `:8010` | open | closed |
-| Protocol proxies, transport plugins, agent controller | started | not started |
-| Static UI, SPA fallback, `/.well-known/*`, `/ssm`, `/rdpproxy` | served | served |
+| Proxies, transport plugins, agent controller | started | not started |
 | Bootstrap: migrations, default org, auth | runs | runs |
 
-**What does not work, and how it fails.** 21 of the 271 distinct routes (389
-counting the `HEAD` twin gin registers for every `GET`) need the gRPC transport
-this mode never starts. Each fails per request with an HTTP error; none panics.
+**What fails, and how.** 21 of the 271 distinct routes (389 with gin's `HEAD`
+twins) need the gRPC transport and fail per request with an HTTP error:
 
-| Group | Routes | Failure |
-|---|---|---|
-| Exec and schema browsing | `POST /sessions`, `POST /sessions/:id/exec`, `POST /runbooks/exec`, `POST /plugins/runbooks/connections/:name/exec`, `GET /connections/:id/{test,databases,tables,columns}`, `POST /federation/test` | `clientexec` dials `127.0.0.1:8010`, which is closed |
-| Resource plan, apply and health; `POST /dbroles/jobs` | 7 | no agent stream is connected |
-| `POST /proxymanager/{connect,disconnect}` | 2 | no client stream is connected |
-| `/ssm/*` | 3 | dials `127.0.0.1:8010` per session |
+| Routes | Why |
+|---|---|
+| `POST /sessions`, `POST /sessions/:id/exec`, `POST /runbooks/exec`, `POST /plugins/runbooks/connections/:name/exec`, `GET /connections/:id/{test,databases,tables,columns}`, `POST /federation/test` | `clientexec` dials the closed port |
+| Resource plan, apply and health (6); `POST /dbroles/jobs` | no agent stream |
+| `POST /proxymanager/{connect,disconnect}` | no client stream |
+| `/ssm/*` (3) | dials the closed port per session |
 
-`/mcp` answers; three of its tools (exec, schema exec, review execute) fail the
-same way. `PUT /serverconfig/misc` succeeds and starts native proxy listeners
-inside the control plane process; any session through them fails at the gRPC
-dial. Connection and resource writes report `offline`, and a feature-flag update
-pushes to zero agents.
+`/mcp` answers; its exec, schema and review-execute tools fail the same way.
+`PUT /serverconfig/misc` starts native proxy listeners in the control plane
+process. Connection and resource writes report `offline`.
 
-**Two routes are a transport of their own and work without gRPC.**
-`GET /api/ws` authenticates an agent by its key, upgrades the connection and
-registers the agent in the in-process broker; `/rdpproxy/*` relays RDP through
-such an agent. Neither needs the gRPC port or a proxy listener, so an agent
-that connects over WebSocket turns a control plane into an RDP data plane.
-EVL-245 gates nothing, so this is recorded rather than prevented; a deployment
-that must carry no traffic must not expose `/api/ws`.
+**Two routes work without gRPC.** `GET /api/ws` registers a WebSocket agent in
+the in-process broker and `/rdpproxy/*` relays RDP through it, so such an agent
+turns a control plane into an RDP data plane. Recorded, not prevented: a
+deployment that must carry no traffic must not expose `/api/ws`.
 
-`PUT /reviews/:id` and `PUT /sessions/:id/review` run the gateway's code.
-Approving a review calls `ReleaseConnectionOnReview`, which `runControlPlane`
-wires from a transport server it builds and never starts; with no stream in
-this process the call only logs, so a session waiting on another gateway is
-not signalled by a verdict written here.
+**Reviews run the gateway's code.** `runControlPlane` wires
+`ReleaseConnectionOnReview` from a transport server it builds and never starts.
+With no stream in the process it only logs, so a verdict written here does not
+signal a session waiting on another gateway.
 
-`/serverinfo` reports `application_mode`, so a client can tell which product it
-is talking to.
+`/serverinfo` reports `application_mode`.
 
 ## Consequences
 
-**HTTP is fail-open and the process is fail-closed.** A route added to
-`buildRoutes` appears in the control plane without anyone deciding so; a
-subsystem added to `runGateway` does not. Whoever adds a route that needs the
-transport gets a control plane that answers it with an error, and that is
-accepted.
-
-**`gateway/api/controlplane_routes_test.go` asserts parity, not a list.** It
-builds both engines in one process and checks, in both directions, that the
-two modes register the same routes. A test that pins a hand-written list is
-what this replaces.
-
-**The control plane frontend's docs follow.** PR #1785 updates
-`controlplane/frontend`'s `README.md`, `CLAUDE.md`, `ModeBanner` and the
-service and store comments that described the allowlist.
-
-**The served OpenAPI spec describes what is served.** It is generated from the
-handlers' swagger annotations, which know nothing about the mode; with one
-route tree that is accurate, including the 23 routes that fail.
-
-**The bootstrap/`runGateway` boundary is not obviously in the right place.**
-Migrations, the default organization, default runbooks and rulepack seeding all
-still run in control-plane mode. `ProvisionOrgAgentKey` and the default
-connection tags are agent- and connection-shaped and arguably belong on the
-gateway side of the split. Left as-is because provisioning an unused key is
-harmless and moving it is a behaviour change.
-
-**The control plane has no chart.** PR #1775 added a skeleton chart and removed
-it in the same PR; `make run-dev-control-plane` runs the mode on the host
-against the dev database. A chart is owed before anything points at this mode
-in production. The gateway chart is untouched, so no value on it can produce a
-control plane.
-
-**No agent sees any of this.** No packet type, spec key or payload changed, so
-the gateway↔agent contract is untouched and an old agent is unaffected. This is
-a deployment-topology decision, not a wire one.
-
-**Revisit if the gateway is not retired.** Two products in one binary told apart
-by a subcommand is cheap for a transition and expensive as a permanent
-condition. If the transition stalls, the answer is to finish option 1, not to
-keep growing the second boot path.
+- **HTTP is fail-open, the process is fail-closed.** A route added to
+  `buildRoutes` reaches the control plane; a subsystem added to `runGateway`
+  does not.
+- **`controlplane_routes_test.go` asserts parity**, in both directions, and
+  replaces the pinned list.
+- **The OpenAPI spec is accurate**: one route tree, the 21 failing routes
+  included.
+- **The bootstrap boundary is debatable.** `ProvisionOrgAgentKey` and the
+  default connection tags still run in control-plane mode; an unused key is
+  harmless, and moving it is a behaviour change.
+- **No chart yet.** PR #1775 added and removed a skeleton chart;
+  `make run-dev-control-plane` runs the mode on the host. A chart is owed
+  before production use.
+- **No agent sees any of this.** No packet type, spec key or payload changed.
+- **Revisit if the gateway is not retired.** Two products in one binary is
+  cheap for a transition and expensive as a permanent condition; the answer is
+  option 1, not a longer second boot path.
 
 ### How this was verified
 
-`gateway/api/controlplane_routes_test.go` builds both engines in one process
-and diffs them; `make test-oss` passes with no failures.
+`controlplane_routes_test.go` diffs both engines; `make test-oss` passes.
 
-Both modes booted from one binary against embedded PGlite with
-`GIN_MODE=debug`, counting unique `METHOD /path` pairs from gin's registration
-log. Both register 389 (271 without the `HEAD` twins) and a `diff` of the two
-lists is empty. The dev binary embeds no web UI build; with `STATIC_UI_PATH`
-pointing at a directory holding an `index.html`, both modes register
-`GET /index.html` and serve it at `/`.
-
-`hoop start control-plane`: `GET /api/healthz` → `200 {"liveness":"OK"}`;
-`/api/publicserverinfo` → 200; `/api/serverinfo` and `/api/users` → 401
-without a token; `/` → 404 without a UI build; TCP `127.0.0.1:8010` closed.
-After `POST /api/localauth/register` and a login, `GET /api/users`,
-`/api/serverinfo`, `/api/plugins` (every plugin, not only slack),
-`/api/api-keys`, `/api/audit/logs`, `/api/server-logs`, `/api/agents` and
-`/api/serverconfig/auth` answer 200. With an agent and a connection created
-through the API, `POST /api/sessions` and `GET /api/connections/:name/databases`
-answer 500 from `clientexec` (on a macOS host it fails preparing `/opt/hoop`
-before the dial), `POST /api/proxymanager/connect` answers 400
-`proxy manager state ... not found`, `PUT /api/reviews/:id` answers
-`review not found`, and the process stays up with no panic logged.
-
-`hoop start gateway`, with `PLUGIN_AUDIT_PATH` pointed at a writable directory:
-389 routes; `/api/healthz` → 200; TCP `127.0.0.1:8010` open.
-
-`gateway/appconfig/appmode_test.go` covers the mode table, including that an
-unrecognised value errors and a zero-value `Config` reads as the gateway.
+Both modes booted from one binary on embedded PGlite with `GIN_MODE=debug`
+register the same 389 routes, and with `STATIC_UI_PATH` set both serve
+`index.html` at `/`. Control plane: `/api/healthz` 200, `/api/serverinfo` 401
+without a token, port 8010 closed; with an admin token, users, plugins (all of
+them), API keys, audit logs, server logs, agents and auth config answer 200,
+while `POST /api/sessions`, `GET /api/connections/:name/databases` and
+`POST /api/proxymanager/connect` return errors and the process stays up.
+Gateway (`PLUGIN_AUDIT_PATH` on a writable directory): 389 routes,
+`/api/healthz` 200, port 8010 open. `appmode_test.go` covers the mode table.

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -121,22 +121,30 @@ should not expose a gateway feature hides it in the UI, not in the handler.
 | Static UI, SPA fallback, `/.well-known/*`, `/ssm`, `/rdpproxy` | served | served |
 | Bootstrap: migrations, default org, auth | runs | runs |
 
-**What does not work, and how it fails.** 23 of the 271 distinct routes (389
-counting the `HEAD` twin gin registers for every `GET`) need the transport this
-mode never starts. Each fails per request with an HTTP error; none panics.
+**What does not work, and how it fails.** 21 of the 271 distinct routes (389
+counting the `HEAD` twin gin registers for every `GET`) need the gRPC transport
+this mode never starts. Each fails per request with an HTTP error; none panics.
 
 | Group | Routes | Failure |
 |---|---|---|
 | Exec and schema browsing | `POST /sessions`, `POST /sessions/:id/exec`, `POST /runbooks/exec`, `POST /plugins/runbooks/connections/:name/exec`, `GET /connections/:id/{test,databases,tables,columns}`, `POST /federation/test` | `clientexec` dials `127.0.0.1:8010`, which is closed |
 | Resource plan, apply and health; `POST /dbroles/jobs` | 7 | no agent stream is connected |
 | `POST /proxymanager/{connect,disconnect}` | 2 | no client stream is connected |
-| `/ssm/*`, `/rdpproxy/*` | 5 | proxy to the transport |
+| `/ssm/*` | 3 | dials `127.0.0.1:8010` per session |
 
 `/mcp` answers; three of its tools (exec, schema exec, review execute) fail the
 same way. `PUT /serverconfig/misc` succeeds and starts native proxy listeners
 inside the control plane process; any session through them fails at the gRPC
 dial. Connection and resource writes report `offline`, and a feature-flag update
 pushes to zero agents.
+
+**Two routes are a transport of their own and work without gRPC.**
+`GET /api/ws` authenticates an agent by its key, upgrades the connection and
+registers the agent in the in-process broker; `/rdpproxy/*` relays RDP through
+such an agent. Neither needs the gRPC port or a proxy listener, so an agent
+that connects over WebSocket turns a control plane into an RDP data plane.
+EVL-245 gates nothing, so this is recorded rather than prevented; a deployment
+that must carry no traffic must not expose `/api/ws`.
 
 `PUT /reviews/:id` and `PUT /sessions/:id/review` work. Approving a review
 releases the gRPC stream waiting on the verdict; `runControlPlane` passes a

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -146,10 +146,11 @@ that connects over WebSocket turns a control plane into an RDP data plane.
 EVL-245 gates nothing, so this is recorded rather than prevented; a deployment
 that must carry no traffic must not expose `/api/ws`.
 
-`PUT /reviews/:id` and `PUT /sessions/:id/review` work. Approving a review
-releases the gRPC stream waiting on the verdict; `runControlPlane` passes a
-no-op release callback because this mode holds no stream, so the verdict is
-complete once written.
+`PUT /reviews/:id` and `PUT /sessions/:id/review` run the gateway's code.
+Approving a review calls `ReleaseConnectionOnReview`, which `runControlPlane`
+wires from a transport server it builds and never starts; with no stream in
+this process the call only logs, so a session waiting on another gateway is
+not signalled by a verdict written here.
 
 `/serverinfo` reports `application_mode`, so a client can tell which product it
 is talking to.

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -160,10 +160,9 @@ two modes register the same routes. A test that pins a hand-written list is
 what this replaces.
 
 **Part of the control plane frontend still describes the allowlist.** PR #1785
-updates `controlplane/frontend`'s `README.md` and `CLAUDE.md`. Its `ModeBanner`
-still warns about routes the control plane blocks, and two service comments
-still say the group and attribute routes answer 404. Neither is true any more;
-both are owed a follow-up.
+updates `controlplane/frontend`'s `README.md`, `CLAUDE.md` and `ModeBanner`.
+Comments in its services and user store still say the group and attribute
+routes answer 404, which is no longer true; they are owed a follow-up.
 
 **The served OpenAPI spec describes what is served.** It is generated from the
 handlers' swagger annotations, which know nothing about the mode; with one

--- a/docs/adr/0013-gateway-control-plane-mode.md
+++ b/docs/adr/0013-gateway-control-plane-mode.md
@@ -1,11 +1,11 @@
 # ADR-0013: The control plane is a second boot path in the gateway binary
 
 - **Status:** Proposed
-- **Date:** 2026-09-01
+- **Date:** 2026-09-03
 - **Author:** @p3rotto
-- **Linear:** EVL-237
-- **Code:** [`client/cmd/start.go`](../../client/cmd/start.go), [`gateway/main.go`](../../gateway/main.go), [`gateway/api/server.go`](../../gateway/api/server.go), [`gateway/appconfig/appconfig.go`](../../gateway/appconfig/appconfig.go), [`gateway/api/healthz/healthz.go`](../../gateway/api/healthz/healthz.go)
-- **Related:** PR #1754 (the control plane frontend), PR #1773 (implements the two boot paths), PR #1772 (open draft proposing the route-allowlist mechanism this ADR's option 3 records)
+- **Linear:** EVL-237, EVL-245
+- **Code:** [`client/cmd/start.go`](../../client/cmd/start.go), [`gateway/main.go`](../../gateway/main.go), [`gateway/api/server.go`](../../gateway/api/server.go), [`gateway/appconfig/appconfig.go`](../../gateway/appconfig/appconfig.go), [`gateway/api/healthz/healthz.go`](../../gateway/api/healthz/healthz.go), [`gateway/api/controlplane_routes_test.go`](../../gateway/api/controlplane_routes_test.go)
+- **Related:** PR #1754 (the control plane frontend), PR #1773 (the two boot paths), PR #1775 (`hoop start control-plane`), PR #1770 (the 66-route allowlist this ADR retires), PR #1772 (closed draft of a registration-time allowlist), PR #1785 (one route tree for both modes)
 - **Supersedes / Superseded by:** —
 
 ## Context
@@ -19,12 +19,10 @@ sidecar is a library that turns database wire bytes into verdicts; it opens no
 gRPC stream to a gateway and registers nothing. So a deployment that exists to
 manage sidecars needs none of the machinery the gateway exists to run.
 
-Booted today, it would get all of it: **389** HTTP routes, the gRPC transport on
-`:8010` accepting agent and client streams, the Postgres, SSH, RDP and HTTP
-protocol proxies, the six transport plugins, the agent controller and the
-connection-status conciliation loop. Runbook execution, agent registration, API
-keys and webhooks are all reachable with an admin token in a product that cannot
-use them.
+Booted as a gateway, it would get all of it: the gRPC transport on `:8010`
+accepting agent and client streams, the Postgres, SSH, RDP and HTTP protocol
+proxies, the six transport plugins, the agent controller and the
+connection-status conciliation loop.
 
 Three constraints shape the answer. The gateway ships to customers and its
 behaviour must not change. Agents run on customer infrastructure and stay old
@@ -33,9 +31,12 @@ reason to stay inside the gateway binary at all is reuse: auth, users, reviews,
 guardrails, masking and the analyzer already exist here with their tables and
 migrations.
 
-One thing we do not know is which routes the control plane will need. The
-frontend's information architecture is new and still moving, and no route has
-yet been reviewed against a deployment that has no agents and no sessions.
+The HTTP surface was the open question. PR #1773 started it near-empty and
+PR #1770 grew it to the 66 routes the shipped frontend calls. The EVL-245
+discussion settled it the other way: a feature the gateway already has should
+work in the control plane from the first version, and the UI hides what the
+product does not expose. Users, audit logs, server logs, analytics mode, API
+keys, IdP integration and license management all work that way with no port.
 
 ## Options considered
 
@@ -50,19 +51,26 @@ yet been reviewed against a deployment that has no agents and no sessions.
    not something a browser toggles.
 3. **One route tree, narrowed by an allowlist.** A `"METHOD /path"` list
    consulted at registration, with `apiroutes.Router` changed so the compiler
-   refuses a registration that skips the list — the design in the open draft
-   #1772. Its central property is real: one route tree, and a test can diff the
-   two surfaces in both directions. It loses as the *first* step for two
-   reasons. It presumes we know the control plane's route list, and we do not.
-   And it narrows only the HTTP surface, leaving the gRPC transport, the proxies
-   and the plugins running in a deployment that has no agents to serve.
-4. **Two boot paths, starting from a near-empty route set.** Chosen.
+   refuses a registration that skips the list: the design in the closed draft
+   #1772. It loses because it presumes we know the control plane's route list,
+   and because it narrows only the HTTP surface, leaving the gRPC transport, the
+   proxies and the plugins running in a deployment that has no agents to serve.
+4. **Two boot paths, starting from a near-empty route set.** What PR #1773 and
+   PR #1770 shipped: `buildControlPlaneRoutes` listed each route by hand, a test
+   pinned the list, and `gateway/api/plugins` hid every plugin but Slack. It
+   loses under EVL-245. Every route was a decision to make, a test to edit and a
+   frontend change to coordinate, and what it prevented, a route answering in a
+   deployment that cannot use it, turned out cheaper to accept than to prevent:
+   23 of the gateway's 271 routes need the transport, and each of them fails
+   with an error rather than silently.
+5. **Two boot paths, one route tree.** Chosen.
 
 ## Decision
 
 We will run the control plane as **the gateway binary started with
 `hoop start control-plane`**, split at two seams: the process boot path and the
-engine builder.
+engine builder. The boot seam removes the data plane. The engine seam removes
+the web UI and nothing else.
 
 **The subcommand picks the mode, not the environment.** `gateway.Run` takes an
 `appconfig.AppMode` and hands it to `appconfig.Load`. There is no variable to
@@ -72,117 +80,142 @@ container command. An unrecognised mode stops startup rather than guessing, and
 the zero value reads as the gateway, so a caller that leaves it unset keeps the
 shipping behaviour.
 
-PR #1773 first shipped this as an `APP_MODE` environment variable. The
-follow-up removed it in favour of the subcommand, because a second way to say
-the same thing is a second way to get it wrong.
+PR #1773 first shipped this as an `APP_MODE` environment variable. PR #1775
+removed it in favour of the subcommand, because a second way to say the same
+thing is a second way to get it wrong.
 
-**The boot seam is in `Run()`.** Shared bootstrap runs first — config, TLS,
-migrations, the default organization, auth, Sentry — then `Run` dispatches to
+**The boot seam is in `Run()`.** Shared bootstrap runs first: config, TLS,
+migrations, the default organization, auth, Sentry. Then `Run` dispatches to
 `runControlPlane()` or `runGateway()`. Everything that carries agent or client
 traffic lives in `runGateway`: the transport plugin chain, the agent controller,
 the protocol proxies, connection-status conciliation, the gRPC server. A future
 addition there is off in control-plane mode by construction, without anyone
 remembering this ADR.
 
-**The engine seam is in `BuildEngine()`.** Control-plane mode returns early into
-`buildControlPlaneEngine` before the static UI, the SPA fallback, the MCP
-well-known handlers, `/ssm` and `/rdpproxy`. Both modes share one middleware
-chain through `newEngine` and `newAPIRouter`, so the control plane gets the same
-recovery, proxy policy, security headers, CORS and Sentry wiring the gateway
-gets.
+**The engine seam is in `BuildEngine()`.** Both modes build one engine from one
+route tree. Control-plane mode skips `serveWebUI`, the embedded web app and its
+SPA fallback, because the control plane has its own frontend. Everything else
+is registered in both modes: the `/api` tree, the MCP well-known handlers,
+`/ssm` and `/rdpproxy`. Both modes share one middleware chain through
+`newEngine` and `newAPIRouter`, so the control plane gets the same recovery,
+proxy policy, security headers, CORS and Sentry wiring the gateway gets.
 
-**The route surface starts near-empty and grows.** `buildControlPlaneRoutes`
-registers `/healthz` and nothing else. Each route is added only after it has
-been reviewed against a deployment with no agents, no connections and no
-sessions.
+`buildRoutes` reads the mode for one route. The gateway's `/healthz` dials
+`127.0.0.1:8010` and returns 400 when the port is closed; control-plane mode
+never opens it, so its handler answers without dialing. `/api/healthz` is what
+the helm service, the AWS load balancer template and the docker-compose
+healthcheck all probe, so a control plane with the gateway's handler would never
+become healthy.
+
+**No handler hides a feature by mode.** PR #1770 answered 404 for every plugin
+but Slack inside `gateway/api/plugins`; that is gone. A control plane that
+should not expose a gateway feature hides it in the UI, not in the handler.
 
 | | gateway (default) | control-plane |
 |---|---|---|
-| HTTP routes | 389 | 2 (`GET`/`HEAD /api/healthz`) |
+| HTTP routes | 389 | 389, minus `index.html` and `js/app.js` when a web UI build resolves |
+| `/api/healthz` | probes the gRPC port | answers 200 without dialing |
 | gRPC `:8010` | open | closed |
 | Protocol proxies, transport plugins, agent controller | started | not started |
-| Static UI, SPA fallback, `/.well-known/*`, `/ssm`, `/rdpproxy` | served | absent |
+| Static UI, SPA fallback | served | absent |
+| `/.well-known/*`, `/ssm`, `/rdpproxy` | served | served |
 | Bootstrap: migrations, default org, auth | runs | runs |
 
-`/healthz` gets its own handler rather than a shared one. The gateway's
-`LivenessHandler` dials `127.0.0.1:8010` and returns 400 when the port is
-closed; control-plane mode never opens it, so reusing that handler would fail
-every health check — and `/api/healthz` is what the helm service, the AWS load
-balancer template and the docker-compose healthcheck all probe.
+**What does not work, and how it fails.** 23 of the 271 distinct routes (389
+counting the `HEAD` twin gin registers for every `GET`) need the transport this
+mode never starts. Each fails per request with an HTTP error; none panics.
+
+| Group | Routes | Failure |
+|---|---|---|
+| Exec and schema browsing | `POST /sessions`, `POST /sessions/:id/exec`, `POST /runbooks/exec`, `POST /plugins/runbooks/connections/:name/exec`, `GET /connections/:id/{test,databases,tables,columns}`, `POST /federation/test` | `clientexec` dials `127.0.0.1:8010`, which is closed |
+| Resource plan, apply and health; `POST /dbroles/jobs` | 7 | no agent stream is connected |
+| `POST /proxymanager/{connect,disconnect}` | 2 | no client stream is connected |
+| `/ssm/*`, `/rdpproxy/*` | 5 | proxy to the transport |
+
+`/mcp` answers; three of its tools (exec, schema exec, review execute) fail the
+same way. `PUT /serverconfig/misc` succeeds and starts native proxy listeners
+inside the control plane process; any session through them fails at the gRPC
+dial. Connection and resource writes report `offline`, and a feature-flag update
+pushes to zero agents.
+
+`PUT /reviews/:id` and `PUT /sessions/:id/review` work. Approving a review
+releases the gRPC stream waiting on the verdict; `runControlPlane` passes a
+no-op release callback because this mode holds no stream, so the verdict is
+complete once written.
 
 `/serverinfo` reports `application_mode`, so a client can tell which product it
-is talking to without inferring it from a 404.
+is talking to.
 
 ## Consequences
 
-**The default is now fail-closed, and that is the property worth keeping.** A
-new proxy, plugin or route added to `runGateway` or `buildRoutes` does not
-appear in control-plane mode unless someone puts it there. The alternative
-designs all default the other way: they start from everything and subtract.
+**HTTP is fail-open and the process is fail-closed.** A route added to
+`buildRoutes` appears in the control plane without anyone deciding so; a
+subsystem added to `runGateway` does not. Whoever adds a route that needs the
+transport gets a control plane that answers it with an error, and that is
+accepted.
 
-**The route set is a migration ledger that grows.** This is the inverse of
-#1772, whose list shrinks as domains leave the gateway. Both describe the same
-transition from opposite ends, and they are not compatible mechanisms — if the
-control plane ends up serving most of the gateway's routes, the allowlist
-becomes the better tool and this ADR should be amended rather than quietly
-worked around.
+**`gateway/api/controlplane_routes_test.go` asserts parity, not a list.** It
+builds both engines in one process and checks, in both directions, that the
+gateway's routes minus the web UI are the control plane's routes. A test that
+pins a hand-written list is what this replaces.
 
-**The control plane frontend has no backend until routes are ported.** PR #1754
-shipped a UI that calls the gateway; in control-plane mode it now reaches a
-process that answers `/api/healthz`. That is deliberate and it is a real gap,
-not a soft launch. Nothing should be pointed at this mode in production until
-its routes exist.
+**The control plane frontend's own docs are now wrong.** `controlplane/frontend`'s
+`README.md` and `CLAUDE.md` describe an allowlist and an `APP_MODE` variable,
+and its `ModeBanner` warns about routes the control plane blocks. None of that
+is true any more. Fixing them is out of EVL-245's scope and owed a follow-up.
 
-**`gateway/api/controlplane_routes_test.go` asserts the exact route list.** A
-route added to `buildControlPlaneRoutes` without being listed in the test fails
-the build. The test is the review gate, not a description of one.
-
-**The served OpenAPI spec still describes all 389 routes in control-plane
-mode.** It is generated from swagger annotations on the handlers, which know
-nothing about the mode. Filtering it needs its own change.
+**The served OpenAPI spec describes what is served.** It is generated from the
+handlers' swagger annotations, which know nothing about the mode; with one
+route tree that is accurate, including the 23 routes that fail.
 
 **The bootstrap/`runGateway` boundary is not obviously in the right place.**
 Migrations, the default organization, default runbooks and rulepack seeding all
 still run in control-plane mode. `ProvisionOrgAgentKey` and the default
 connection tags are agent- and connection-shaped and arguably belong on the
 gateway side of the split. Left as-is because provisioning an unused key is
-harmless and moving it is a behaviour change; revisit when the first real
-control-plane route lands.
+harmless and moving it is a behaviour change.
 
-**The control plane ships its own chart.** `deploy/helm-chart/chart/controlplane`
-is a skeleton: one Deployment whose container `args` are `hoop start
-control-plane`, and no Service, Ingress or config Secret, because the mode
-serves one route. The gateway chart is untouched, so no value on it can produce
-a control plane and no combination of its values needs a guard. Two products in
-one chart would have meant asking that question of every value that assumes a
-data plane; two charts do not.
+**The control plane has no chart.** PR #1775 added a skeleton chart and removed
+it in the same PR; `make run-dev-control-plane` runs the mode on the host
+against the dev database. A chart is owed before anything points at this mode
+in production. The gateway chart is untouched, so no value on it can produce a
+control plane.
 
 **No agent sees any of this.** No packet type, spec key or payload changed, so
 the gateway↔agent contract is untouched and an old agent is unaffected. This is
 a deployment-topology decision, not a wire one.
 
 **Revisit if the gateway is not retired.** Two products in one binary told apart
-by an env var is cheap for a transition and expensive as a permanent condition.
-If the transition stalls, the answer is to finish option 1, not to keep growing
-the second boot path.
+by a subcommand is cheap for a transition and expensive as a permanent
+condition. If the transition stalls, the answer is to finish option 1, not to
+keep growing the second boot path.
 
 ### How this was verified
 
-Both modes booted against embedded PGlite with `GIN_MODE=debug`, counting
-unique `METHOD /path` pairs from gin's registration log.
+`gateway/api/controlplane_routes_test.go` builds both engines in one process
+and diffs them; `make test-oss` passes with no failures.
 
-`hoop start control-plane`: 2 routes, `GET` and `HEAD /api/healthz`. `GET
-/api/healthz` → `200 {"liveness":"OK"}`; `/api/serverinfo` and `/` → 404; TCP
-`127.0.0.1:8010` closed.
+Both modes booted from one binary against embedded PGlite with
+`GIN_MODE=debug`, counting unique `METHOD /path` pairs from gin's registration
+log. Both register 389 (271 without the `HEAD` twins) and a `diff` of the two
+lists is empty. The dev binary embeds no web UI build, so the two UI routes
+appear in neither.
 
-`hoop start gateway`, with `APP_MODE=control-plane` deliberately still set in
-the environment to prove it is ignored: 389 routes; `/api/healthz` → 200;
-`/api/publicserverinfo` → 200; `/api/serverinfo` → 401; TCP `127.0.0.1:8010`
-open.
+`hoop start control-plane`: `GET /api/healthz` → `200 {"liveness":"OK"}`;
+`/api/publicserverinfo` → 200; `/api/serverinfo` and `/api/users` → 401
+without a token; `/` and `/index.html` → 404; TCP `127.0.0.1:8010` closed.
+After `POST /api/localauth/register` and a login, `GET /api/users`,
+`/api/serverinfo`, `/api/plugins` (every plugin, not only slack),
+`/api/api-keys`, `/api/audit/logs`, `/api/server-logs`, `/api/agents` and
+`/api/serverconfig/auth` answer 200. With an agent and a connection created
+through the API, `POST /api/sessions` and `GET /api/connections/:name/databases`
+answer 500 from `clientexec` (on a macOS host it fails preparing `/opt/hoop`
+before the dial), `POST /api/proxymanager/connect` answers 400
+`proxy manager state ... not found`, `PUT /api/reviews/:id` answers
+`review not found`, and the process stays up with no panic logged.
+
+`hoop start gateway`, with `PLUGIN_AUDIT_PATH` pointed at a writable directory:
+389 routes; `/api/healthz` → 200; TCP `127.0.0.1:8010` open.
 
 `gateway/appconfig/appmode_test.go` covers the mode table, including that an
-unrecognised value errors and a zero-value `Config` reads as the gateway. The
-gateway chart and `.env.sample` are byte-identical to their state before #1773
-(`git diff` against `10f45d22^` is empty). The control plane chart was rendered
-with helm 3.16.2: it produces the expected Deployment and refuses to render
-without `existingSecret`. `make test-oss` passes.
+unrecognised value errors and a zero-value `Config` reads as the gateway.


### PR DESCRIPTION
## 📝 Description

Records the decision merged in #1773: the control plane runs as the gateway binary booted with `APP_MODE=control-plane`, split at two seams — the process boot path (`Run` → `runControlPlane` / `runGateway`) and the engine builder (`BuildEngine` → `buildControlPlaneEngine`). It starts no data plane and serves a near-empty route set that grows as routes are ported.

Documentation only. No code changes.

## 📣 User-facing impact

None.

## 🔗 Related Issue

EVL-237

## 🚀 Type of Change

- [x] 📚 Documentation update

## 📋 Changes Made

- Adds `docs/adr/0013-gateway-control-plane-mode.md`, `Status: Proposed`.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a
- **OS**: macOS 15 (darwin/arm64)

### Tests performed:
- [x] Manual testing completed

No code changed. Every relative link in the ADR was checked to resolve, and the claims about what runs in each mode were re-verified against `main` at `10f45d22` rather than carried over from the implementation PR.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

**This overlaps with #1772 and the two disagree.** @rogefm opened a draft ADR for the same ticket a few hours before #1773 merged. It proposes narrowing one route tree with a `"METHOD /path"` allowlist and a compiler-enforced `Router` seam, and it lists "a second `buildControlPlaneRoutes`" among its rejected options — which is what shipped. Its referenced code (`gateway/api/apiroutes/controlplane.go`, `Router.allow`) does not exist on `main`.

This ADR records what merged and names that allowlist as option 3, with the reason it lost as the *first* step: it presumes we know the control plane's route list, and it narrows only HTTP, leaving the gRPC transport, the proxies and the plugins running in a deployment with no agents. The two describe the same transition from opposite ends — one list grows, the other shrinks. Worth settling before either is accepted; #1772 also needs renumbering, since `0011` and `0012` are now taken on `main`.

**Reviewers:** the call worth pushing back on is the boundary between shared bootstrap and `runGateway`. `ProvisionOrgAgentKey` and the default connection tags still run in control-plane mode and are arguably agent-shaped. The ADR records this as accepted-for-now rather than settled.

**Process note:** per `docs/adr/README.md` this needs a post in the engineering Slack channel with an @engineering-team mention to start the review clock. I have not done that.
