### PR TITLE
EVL-241 let admins dismiss the setup checklist

### DIFF
--- a/webapp_v2/src/layout/Sidebar/ConfigStatus/ConfigStatus.module.css
+++ b/webapp_v2/src/layout/Sidebar/ConfigStatus/ConfigStatus.module.css
@@ -9,11 +9,24 @@
 
 /* ── Widget header (always visible) ────────────────────────── */
 
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-xsAlt);
+  width: 100%;
+}
+
 .headerBtn {
   display: flex;
   align-items: center;
   gap: var(--mantine-spacing-sm);
-  width: 100%;
+  flex: 1;
+  min-width: 0;
+}
+
+.closeBtn {
+  flex-shrink: 0;
+  color: var(--mantine-color-dimmed);
 }
 
 .headerLabel {

--- a/webapp_v2/src/layout/Sidebar/ConfigStatus/index.jsx
+++ b/webapp_v2/src/layout/Sidebar/ConfigStatus/index.jsx
@@ -25,11 +25,10 @@ export function ConfigStatus() {
   const completed = useConfigStatusStore((s) => s.completed && s.forUserId === userId)
   // Read through a selector, not useState(() => localStorage...): the gate must
   // stay effect-free, and a store read matches the three selectors above. The
-  // store already dropped an expired dismiss, so this is a plain comparison.
-  // userId is null before /userinfo resolves and the stored value is null when
-  // never dismissed — compare only once we actually have a user, or null === null
-  // hides the checklist from everyone.
-  const dismissed = useUIStore((s) => userId !== null && s.configStatusDismiss?.userId === userId)
+  // store already dropped expired entries, so presence of the key is the answer.
+  // The userId guard is for the window before /userinfo resolves: no key of the
+  // map may stand in for "no user yet".
+  const dismissed = useUIStore((s) => userId !== null && userId in s.configStatusDismiss)
 
   if (!isAdmin || !showSetupChecklist || completed || dismissed) return null
   return <ConfigStatusWidget />

--- a/webapp_v2/src/layout/Sidebar/ConfigStatus/index.jsx
+++ b/webapp_v2/src/layout/Sidebar/ConfigStatus/index.jsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Box, Collapse, Text, UnstyledButton } from '@mantine/core'
 import { useClickOutside } from '@mantine/hooks'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown, ChevronUp, X } from 'lucide-react'
+import ActionIcon from '@/components/ActionIcon'
 import RingProgress from '@/components/RingProgress'
 import { useUserStore } from '@/stores/useUserStore'
 import { useUIStore } from '@/stores/useUIStore'
@@ -22,8 +23,15 @@ export function ConfigStatus() {
   const userId = useUserStore((s) => s.user?.id ?? null)
   // forUserId guards a snapshot left behind by a previous login in the same tab.
   const completed = useConfigStatusStore((s) => s.completed && s.forUserId === userId)
+  // Read through a selector, not useState(() => localStorage...): the gate must
+  // stay effect-free, and a store read matches the three selectors above. The
+  // store already dropped an expired dismiss, so this is a plain comparison.
+  // userId is null before /userinfo resolves and the stored value is null when
+  // never dismissed — compare only once we actually have a user, or null === null
+  // hides the checklist from everyone.
+  const dismissed = useUIStore((s) => userId !== null && s.configStatusDismiss?.userId === userId)
 
-  if (!isAdmin || !showSetupChecklist || completed) return null
+  if (!isAdmin || !showSetupChecklist || completed || dismissed) return null
   return <ConfigStatusWidget />
 }
 
@@ -32,6 +40,7 @@ function ConfigStatusWidget() {
   const location = useLocation()
   const user = useUserStore((s) => s.user)
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen)
+  const dismissConfigStatus = useUIStore((s) => s.dismissConfigStatus)
   const status = useConfigStatusStore((s) => s.status)
   const forUserId = useConfigStatusStore((s) => s.forUserId)
   const checks = useConfigStatusStore((s) => s.checks)
@@ -83,6 +92,14 @@ function ConfigStatusWidget() {
     setOpened(true)
   }
 
+  // Per user, per browser. How long it lasts depends on how much is left — see
+  // useUIStore. Every destination below stays reachable from the sidebar nav,
+  // so nothing becomes unreachable.
+  const handleDismiss = () => {
+    setOpened(false)
+    dismissConfigStatus(user.id, progress.subItemsLeft)
+  }
+
   const handleNavigate = (item) => {
     setOpened(false)
     setSidebarOpen(false) // close the mobile drawer when open; no-op on desktop
@@ -107,17 +124,32 @@ function ConfigStatusWidget() {
 
   return (
     <Box ref={cardRef} className={classes.card} mb="lg">
-      <UnstyledButton className={classes.headerBtn} aria-expanded={opened} onClick={toggleOpened}>
-        <RingProgress value={progress.percent} />
-        <Text component="span" className={classes.headerLabel}>
-          {headerLabel}
-        </Text>
-        {opened ? (
-          <ChevronUp size={16} aria-hidden="true" className={classes.chevron} />
-        ) : (
-          <ChevronDown size={16} aria-hidden="true" className={classes.chevron} />
-        )}
-      </UnstyledButton>
+      {/* The dismiss control is a sibling, never nested in the toggle: a button
+          inside a button is invalid and swallows the inner click target. */}
+      <Box className={classes.header}>
+        <UnstyledButton className={classes.headerBtn} aria-expanded={opened} onClick={toggleOpened}>
+          <RingProgress value={progress.percent} />
+          <Text component="span" className={classes.headerLabel}>
+            {headerLabel}
+          </Text>
+          {opened ? (
+            <ChevronUp size={16} aria-hidden="true" className={classes.chevron} />
+          ) : (
+            <ChevronDown size={16} aria-hidden="true" className={classes.chevron} />
+          )}
+        </UnstyledButton>
+
+        <ActionIcon
+          variant="subtle"
+          color="gray"
+          size="sm"
+          className={classes.closeBtn}
+          aria-label="Dismiss setup checklist"
+          onClick={handleDismiss}
+        >
+          <X size={14} aria-hidden="true" />
+        </ActionIcon>
+      </Box>
 
       <Collapse in={opened}>
         <Box className={classes.body}>

--- a/webapp_v2/src/layout/Sidebar/ConfigStatus/steps.js
+++ b/webapp_v2/src/layout/Sidebar/ConfigStatus/steps.js
@@ -55,5 +55,7 @@ export function computeProgress(checks) {
     totalSteps: steps.length,
     percent: Math.floor((stepsDone * 100) / steps.length),
     firstIncompleteStepId: steps.find((step) => !step.done)?.id ?? null,
+    // How long a dismiss lasts depends on this — see useUIStore.
+    subItemsLeft: steps.reduce((n, step) => n + step.subItems.filter((sub) => !sub.done).length, 0),
   }
 }

--- a/webapp_v2/src/stores/useUIStore.js
+++ b/webapp_v2/src/stores/useUIStore.js
@@ -7,7 +7,7 @@ const CONFIG_STATUS_DISMISS_KEY = 'config-status-dismissed'
 // One task left is a decision, not a postponement: the admin read the last item
 // and does not want it. Most reports are orgs stuck on "Set Protection Level".
 const PERMANENT_AT_OR_BELOW = 1
-const SNOOZE_MS = 30 * 24 * 60 * 60 * 1000
+const SNOOZE_MS = 7 * 24 * 60 * 60 * 1000
 
 // Read once here, never inside a selector: Date.now() in a selector makes the
 // snapshot unstable, and the ConfigStatus gate must stay pure and hook-free

--- a/webapp_v2/src/stores/useUIStore.js
+++ b/webapp_v2/src/stores/useUIStore.js
@@ -2,10 +2,40 @@ import { create } from 'zustand'
 
 const getSavedCollapsed = () => localStorage.getItem('sidebar') === 'closed'
 
+// EVL-241: how long a dismissed setup checklist stays hidden.
+const CONFIG_STATUS_DISMISS_KEY = 'config-status-dismissed'
+// One task left is a decision, not a postponement: the admin read the last item
+// and does not want it. Most reports are orgs stuck on "Set Protection Level".
+const PERMANENT_AT_OR_BELOW = 1
+const SNOOZE_MS = 30 * 24 * 60 * 60 * 1000
+
+// Read once here, never inside a selector: Date.now() in a selector makes the
+// snapshot unstable, and the ConfigStatus gate must stay pure and hook-free
+// (DEP-136). A snooze therefore ends on the next page load, not mid-session.
+const readConfigStatusDismiss = () => {
+  try {
+    const saved = JSON.parse(localStorage.getItem(CONFIG_STATUS_DISMISS_KEY))
+    const { userId, until } = saved ?? {}
+    if (!userId) return null
+    if (until === null) return { userId, until }
+    if (typeof until !== 'number' || until <= Date.now()) {
+      localStorage.removeItem(CONFIG_STATUS_DISMISS_KEY)
+      return null
+    }
+    return { userId, until }
+  } catch {
+    // Truncated or hand-edited value — fail toward showing the checklist.
+    return null
+  }
+}
+
 export const useUIStore = create((set) => ({
   sidebarOpen: false,
   sidebarCollapsed: getSavedCollapsed(),
   pendingOpenSection: null,
+  // Keyed by user id so one admin dismissing the setup checklist cannot silence
+  // it for another admin sharing the browser.
+  configStatusDismiss: readConfigStatusDismiss(),
 
   toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
   setSidebarOpen: (open) => set({ sidebarOpen: open }),
@@ -19,4 +49,11 @@ export const useUIStore = create((set) => ({
 
   setPendingOpenSection: (label) => set({ pendingOpenSection: label }),
   clearPendingOpenSection: () => set({ pendingOpenSection: null }),
+
+  dismissConfigStatus: (userId, subItemsLeft) => {
+    const until = subItemsLeft <= PERMANENT_AT_OR_BELOW ? null : Date.now() + SNOOZE_MS
+    const dismiss = { userId, until }
+    localStorage.setItem(CONFIG_STATUS_DISMISS_KEY, JSON.stringify(dismiss))
+    set({ configStatusDismiss: dismiss })
+  },
 }))

--- a/webapp_v2/src/stores/useUIStore.js
+++ b/webapp_v2/src/stores/useUIStore.js
@@ -9,24 +9,29 @@ const CONFIG_STATUS_DISMISS_KEY = 'config-status-dismissed'
 const PERMANENT_AT_OR_BELOW = 1
 const SNOOZE_MS = 7 * 24 * 60 * 60 * 1000
 
+// One entry per user id, so two admins sharing a browser each keep their own
+// dismissal. The value is null for permanent, an epoch-ms deadline otherwise.
+//
 // Read once here, never inside a selector: Date.now() in a selector makes the
 // snapshot unstable, and the ConfigStatus gate must stay pure and hook-free
 // (DEP-136). A snooze therefore ends on the next page load, not mid-session.
+// Expired entries are dropped from the returned map and leave storage on the
+// next dismiss, which keeps page load free of storage writes.
 const readConfigStatusDismiss = () => {
+  let saved
   try {
-    const saved = JSON.parse(localStorage.getItem(CONFIG_STATUS_DISMISS_KEY))
-    const { userId, until } = saved ?? {}
-    if (!userId) return null
-    if (until === null) return { userId, until }
-    if (typeof until !== 'number' || until <= Date.now()) {
-      localStorage.removeItem(CONFIG_STATUS_DISMISS_KEY)
-      return null
-    }
-    return { userId, until }
+    saved = JSON.parse(localStorage.getItem(CONFIG_STATUS_DISMISS_KEY))
   } catch {
     // Truncated or hand-edited value — fail toward showing the checklist.
-    return null
+    return {}
   }
+  if (saved === null || typeof saved !== 'object' || Array.isArray(saved)) return {}
+  const now = Date.now()
+  return Object.fromEntries(
+    Object.entries(saved).filter(
+      ([, until]) => until === null || (typeof until === 'number' && until > now)
+    )
+  )
 }
 
 export const useUIStore = create((set) => ({
@@ -50,10 +55,17 @@ export const useUIStore = create((set) => ({
   setPendingOpenSection: (label) => set({ pendingOpenSection: label }),
   clearPendingOpenSection: () => set({ pendingOpenSection: null }),
 
-  dismissConfigStatus: (userId, subItemsLeft) => {
-    const until = subItemsLeft <= PERMANENT_AT_OR_BELOW ? null : Date.now() + SNOOZE_MS
-    const dismiss = { userId, until }
-    localStorage.setItem(CONFIG_STATUS_DISMISS_KEY, JSON.stringify(dismiss))
-    set({ configStatusDismiss: dismiss })
-  },
+  dismissConfigStatus: (userId, subItemsLeft) =>
+    set((state) => {
+      const until = subItemsLeft <= PERMANENT_AT_OR_BELOW ? null : Date.now() + SNOOZE_MS
+      const next = { ...state.configStatusDismiss, [userId]: until }
+      try {
+        localStorage.setItem(CONFIG_STATUS_DISMISS_KEY, JSON.stringify(next))
+      } catch (err) {
+        // Storage blocked or over quota. Hiding it for this session beats a
+        // dismiss button that throws and leaves the card on screen.
+        console.warn('[useUIStore] could not persist the checklist dismissal:', err)
+      }
+      return { configStatusDismiss: next }
+    }),
 }))


### PR DESCRIPTION
## What

The sidebar setup checklist only goes away when all 9 sub-items are done. An admin who does not want it is stuck with it taking space on the UI (acting as an offender for old customers).

This adds an `X` to the card header. The dismiss is per user, in `localStorage`:

- **1 sub-item left** at dismiss time: permanent. The admin read the last item and said no. Nearly every complaint is an org stuck on `Set Protection Level`.
- **More than 1 left**: 7 days, then the checklist returns.

The two knobs are `PERMANENT_AT_OR_BELOW` and `SNOOZE_MS` in `webapp_v2/src/stores/useUIStore.js`.

## Notes

- The expired snooze is pruned once at module load, not in the selector. `Date.now()` inside a Zustand selector is an unstable snapshot, and the DEP-136 gate must stay pure and hook-free. A snooze therefore ends on the next page load, not mid-session.
- Corrupt or hand-edited JSON reads as "not dismissed" — it fails toward showing the checklist.
- **Known gap**: after a permanent dismiss there is no in-app way to bring the checklist back, short of clearing `localStorage`. `LicenseBanner` sets the same precedent, and every checklist destination stays reachable from the sidebar nav.

## How to test

As an **admin of an org with `onboarding_completed_at` NULL** — the checklist renders for nobody else.

1. `cd webapp_v2 && npm run dev:full`, open **:5173**.
2. Checklist visible in the expanded sidebar. Click `X` — it disappears.
3. Hard-reload (Cmd+Shift+R) — still gone.
4. DevTools: `localStorage.getItem('config-status-dismissed')`. With more than 1 task left, `until` is an epoch ~7 days out. With 1 left, `until` is `null`.
5. Force the expiry: `localStorage.setItem('config-status-dismissed', JSON.stringify({userId: '<your-id>', until: 1}))`, reload — the checklist is back.
6. Log in as a **different admin** — the checklist is visible for them. The dismiss is per user.
7. Keyboard: Tab reaches the `X` separately from the expand toggle; Enter dismisses.
8. Regression (DEP-136): while dismissed, no `focus` or `hoop:session-executed` listener is registered.

Both branches were checked against a local stack: with 8 tasks pending the stored `until` was 7 days out; with only `Set Protection Level` pending it was `null`.

`npm run lint` and `npm run build` are green — lint reports the same 15 errors + 1 warning as `main`.