### PR TITLE
DEP-188: Enforce mysql cmd when listing tables and schems in the Webapp

### DIFF
--- a/gateway/api/connections/helpers.go
+++ b/gateway/api/connections/helpers.go
@@ -684,6 +684,8 @@ func parseCloudWatchTables(output string) (openapi.TablesResponse, error) {
 func getConnectionCommandOverride(currentConnectionType pb.ConnectionType, connectionCmd []string) []string {
 	var cmd []string
 	switch currentConnectionType {
+	case pb.ConnectionTypeMySQL:
+		return []string{"mysql", "-h$HOST", "-u$USER", "--port=$PORT", "-D$DB"}
 	case pb.ConnectionTypeCloudWatch, pb.ConnectionTypeDynamoDB:
 		return []string{"bash"}
 	case pb.ConnectionTypeMongoDB:


### PR DESCRIPTION
## 📝 Description

It allows providing verbose output to mysql (-vv) in the connection and avoiding breaking the schema viewer in the Webapp

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

