### PR TITLE
Add license validation with sidecar

### DIFF
--- a/client/cmd/startsidecar.go
+++ b/client/cmd/startsidecar.go
@@ -98,8 +98,7 @@ HOOP_LICENSE, which outranks the "license" key in the config file.`,
 			if err != nil {
 				return err
 			}
-			daemon.PrintLanes(os.Stdout, cfg.Licensing(), lanes)
-			return nil
+			return daemon.PrintLanes(os.Stdout, cfg.Licensing(), lanes)
 		}
 
 		// Run blocks until SIGINT or SIGTERM and installs its own handler.

--- a/client/cmd/startsidecar.go
+++ b/client/cmd/startsidecar.go
@@ -79,8 +79,8 @@ HOOP_LICENSE, which outranks the "license" key in the config file.`,
 			return fmt.Errorf("--config is required (or set HOOP_SIDECAR_CONFIG)")
 		}
 
-		cfg, det, err := daemon.Setup(sidecarConfigFlag, configyaml.Load, buildSidecarPlugin,
-			sidecarLicenseFlag)
+		cfg, det, err := daemon.SetupWith(sidecarConfigFlag, configyaml.Load, buildSidecarPlugin,
+			daemon.WithLicense(sidecarLicenseFlag))
 		if err != nil {
 			return err
 		}

--- a/client/cmd/startsidecar.go
+++ b/client/cmd/startsidecar.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/hoophq/hoop/sidecar/analyzer/vertex"
 	configyaml "github.com/hoophq/hoop/sidecar/config/yaml"
 	"github.com/hoophq/hoop/sidecar/daemon"
+	"github.com/hoophq/hoop/sidecar/license"
 	"github.com/hoophq/hoop/sidecar/pii/alcatraz"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,7 @@ const deprecatedSidecarAlias = "inspect"
 
 var (
 	sidecarConfigFlag   string
+	sidecarLicenseFlag  string
 	sidecarValidateFlag bool
 	sidecarStrictFlag   bool
 )
@@ -55,8 +57,14 @@ alias.
 
 The config schema changed in ADR-0011: "policy" split into "guardrails" and
 "opa", and three fields were dropped. Both spellings load, and the old one
-prints a warning naming its replacement. Use --strict to fail on one.`,
+prints a warning naming its replacement. Use --strict to fail on one.
+
+Without a license the process caps guardrail and data masking rules at one
+each and says so at startup. A license lifts the caps for the features it
+names. It may be a path or the document itself, and --license outranks
+HOOP_LICENSE, which outranks the "license" key in the config file.`,
 	Example: `  hoop start sidecar --config /etc/hoop-inspect/config.yaml
+  hoop start sidecar --config config.yaml --license /etc/hoop-inspect/license.json
   hoop start sidecar --config config.yaml --validate
   hoop start sidecar --config config.yaml --validate --strict`,
 	// A bad config is not a usage error, and dumping the flag list under one
@@ -71,7 +79,8 @@ prints a warning naming its replacement. Use --strict to fail on one.`,
 			return fmt.Errorf("--config is required (or set HOOP_SIDECAR_CONFIG)")
 		}
 
-		cfg, det, err := daemon.Setup(sidecarConfigFlag, configyaml.Load, buildSidecarPlugin)
+		cfg, det, err := daemon.Setup(sidecarConfigFlag, configyaml.Load, buildSidecarPlugin,
+			sidecarLicenseFlag)
 		if err != nil {
 			return err
 		}
@@ -89,7 +98,7 @@ prints a warning naming its replacement. Use --strict to fail on one.`,
 			if err != nil {
 				return err
 			}
-			daemon.PrintLanes(os.Stdout, lanes)
+			daemon.PrintLanes(os.Stdout, cfg.Licensing(), lanes)
 			return nil
 		}
 
@@ -147,6 +156,12 @@ func init() {
 
 	startSidecarCmd.Flags().StringVar(&sidecarConfigFlag, "config", sidecarConfigFromEnv(),
 		"Path to the inspection config file (YAML or JSON)")
+	// No default from the environment, unlike --config. daemon.Setup reads
+	// HOOP_LICENSE when this is empty, which holds the precedence in one
+	// place and keeps a customer's license out of --help.
+	startSidecarCmd.Flags().StringVar(&sidecarLicenseFlag, "license", "",
+		"Path to the license file, or the license document itself. Overrides "+
+			license.EnvVar+" and the config file's \"license\" key")
 	startSidecarCmd.Flags().BoolVar(&sidecarValidateFlag, "validate", false,
 		"Validate the config, report what each listener resolved to, and exit")
 	startSidecarCmd.Flags().BoolVar(&sidecarStrictFlag, "strict", false,

--- a/client/licensecompat/licensecompat_test.go
+++ b/client/licensecompat/licensecompat_test.go
@@ -1,0 +1,152 @@
+// Package licensecompat pins the sidecar's license verifier to the
+// gateway's, and client is the only module that can import both. Change the
+// key or the signed bytes on one side and every licensed sidecar drops to
+// the free tier at its next restart, with nothing in CI naming the commit.
+package licensecompat
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	gateway "github.com/hoophq/hoop/common/license"
+	sidecar "github.com/hoophq/hoop/sidecar/license"
+)
+
+// The two builds must trust the same signing key. Nothing else in either
+// package can detect a rotation applied to one copy and not the other: every
+// test on each side signs with a key it generated, so both keep passing while
+// no real license verifies in the sidecar.
+func TestTheTrustedKeysAreTheSame(t *testing.T) {
+	want, err := gateway.PublicKeyID()
+	if err != nil {
+		t.Fatalf("common/license: %v", err)
+	}
+	got, err := sidecar.PublicKeyID()
+	if err != nil {
+		t.Fatalf("sidecar/license: %v", err)
+	}
+	if got != want {
+		t.Errorf("the sidecar trusts a different license key\n gateway: %s\n sidecar: %s",
+			want, got)
+	}
+}
+
+// The two must sign over identical bytes, proved by cryptography rather than
+// string comparison: the gateway signs with a key generated here, and the
+// signature is checked against the SIDECAR's SigningData. PSS passes only if
+// the two byte strings match.
+func TestTheSignedBytesAreTheSame(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		features []string
+	}{
+		// A license signed before the features field existed. The
+		// segment is appended only when present, and the gateway still
+		// has customers holding one of these.
+		{"no features", nil},
+		{"one feature", []string{gateway.FeatureDataMasking}},
+		{"several features", []string{gateway.FeatureDataMasking, gateway.FeatureGuardrails}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			signed, err := gateway.Sign(key, gateway.EnterpriseType, "Acme Corp",
+				[]string{"*.acme.example", "acme.example"}, tc.features, 720*time.Hour)
+			if err != nil {
+				t.Fatalf("sign: %v", err)
+			}
+
+			sig, err := base64.StdEncoding.DecodeString(signed.Signature)
+			if err != nil {
+				t.Fatalf("decode signature: %v", err)
+			}
+			sum := sha256.Sum256(sidecarPayload(signed.Payload).SigningData())
+			if err := rsa.VerifyPSS(&key.PublicKey, crypto.SHA256, sum[:], sig, nil); err != nil {
+				t.Errorf("the sidecar signs different bytes than the gateway: %v\n"+
+					"sidecar: %q", err, sidecarPayload(signed.Payload).SigningData())
+			}
+		})
+	}
+}
+
+// The document has to survive the trip in JSON: a license the gateway issues
+// is pasted into a sidecar config unchanged, so every field the sidecar reads
+// has to carry the gateway's tag.
+func TestTheDocumentDecodesUnchanged(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	issued, err := gateway.Sign(key, gateway.EnterpriseType, "Acme Corp",
+		[]string{"acme.example"}, []string{gateway.FeatureGuardrails}, 720*time.Hour)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	raw, err := json.Marshal(issued)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got sidecar.License
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("the sidecar cannot decode a license the gateway issued: %v", err)
+	}
+
+	if got.KeyID != issued.KeyID || got.Signature != issued.Signature {
+		t.Error("key_id or signature did not survive the decode")
+	}
+	if got.Payload.Type != issued.Payload.Type ||
+		got.Payload.Description != issued.Payload.Description ||
+		got.Payload.IssuedAt != issued.Payload.IssuedAt ||
+		got.Payload.ExpireAt != issued.Payload.ExpireAt {
+		t.Errorf("payload fields did not survive the decode:\n gateway: %+v\n sidecar: %+v",
+			issued.Payload, got.Payload)
+	}
+	if len(got.Payload.AllowedHosts) != len(issued.Payload.AllowedHosts) {
+		t.Error("allowed_hosts did not survive the decode")
+	}
+	if !got.IsFeatureEnabled(gateway.FeatureGuardrails) {
+		t.Error("the feature the license names did not survive the decode")
+	}
+	if got.IsFeatureEnabled(gateway.FeatureDataMasking) {
+		t.Error("the sidecar granted a feature the license does not name")
+	}
+}
+
+// The feature keys the sidecar gates on have to be the ones the gateway
+// issues licenses for. A typo in either constant is a license that verifies
+// and unlocks nothing.
+func TestTheFeatureKeysMatch(t *testing.T) {
+	if sidecar.FeatureGuardrails != gateway.FeatureGuardrails {
+		t.Errorf("guardrails key: sidecar %q, gateway %q",
+			sidecar.FeatureGuardrails, gateway.FeatureGuardrails)
+	}
+	if sidecar.FeatureDataMasking != gateway.FeatureDataMasking {
+		t.Errorf("data masking key: sidecar %q, gateway %q",
+			sidecar.FeatureDataMasking, gateway.FeatureDataMasking)
+	}
+	if sidecar.EnterpriseType != gateway.EnterpriseType || sidecar.OSSType != gateway.OSSType {
+		t.Error("the license types do not match")
+	}
+}
+
+func sidecarPayload(p gateway.Payload) sidecar.Payload {
+	return sidecar.Payload{
+		Type:         p.Type,
+		IssuedAt:     p.IssuedAt,
+		ExpireAt:     p.ExpireAt,
+		AllowedHosts: p.AllowedHosts,
+		Description:  p.Description,
+		Features:     p.Features,
+	}
+}

--- a/common/license/license.go
+++ b/common/license/license.go
@@ -108,6 +108,18 @@ func validateFeatures(features []string) error {
 	return nil
 }
 
+// PublicKeyID is the sha256 of the public key this build trusts, hex
+// encoded. sidecar/license keeps its own copy of the key, and
+// client/licensecompat asserts the two ids match: rotate one and not the
+// other and every sidecar loses the features its customer pays for.
+func PublicKeyID() (string, error) {
+	pubkey, err := parsePublicKey()
+	if err != nil {
+		return "", err
+	}
+	return pubkeyChecksum(pubkey)
+}
+
 func Sign(privKey *rsa.PrivateKey, licenseType, description string, allowedHosts, features []string, expireAt time.Duration) (*License, error) {
 	clockTolerance := -time.Hour
 	issuedAt := time.Now().UTC().Add(clockTolerance)

--- a/deploy/docker-compose/envoy-stack/sidecar-binary.md
+++ b/deploy/docker-compose/envoy-stack/sidecar-binary.md
@@ -93,8 +93,13 @@ docker run --rm -v "$PWD/config.yaml:/etc/hoop-inspect/config.yaml:ro" \
 
 ```
 config OK: 1 listener(s)
+  license: missing, running the free tier. Add one with the license flag, the HOOP_LICENSE environment variable, or the "license" key in the config file
+  limits: 1 guardrail rule(s), 1 data masking rule(s)
   appdb            postgres  enforcing 1 rule(s) + masking
 ```
+
+Mount a license and pass `--license`, or set `HOOP_LICENSE`, to lift those
+caps for the features it names.
 
 That line is the **resolved** lane, so the rule count includes anything it
 inherited from the top-level defaults. Validation builds every lane, which
@@ -325,6 +330,8 @@ risky statement:
 
 ```
 config OK: 1 listener(s)
+  license: missing, running the free tier. Add one with the license flag, the HOOP_LICENSE environment variable, or the "license" key in the config file
+  limits: 1 guardrail rule(s), 1 data masking rule(s)
   appdb            postgres  enforcing 1 rule(s) + masking + 1 ai rule(s)
 ```
 

--- a/sidecar/CLAUDE.md
+++ b/sidecar/CLAUDE.md
@@ -155,6 +155,16 @@ done
   whose config the free tier would refuse, because re-applying the caps live
   would mean deleting guardrail and mask rules from a running proxy.
 
+- **A verdict cannot be assembled, only earned.** `Status.verified` is
+  unexported and `license.Load` is the only thing that sets it, after checking
+  the signature. Build a `Status` literal anywhere else and it reports invalid
+  and grants nothing. `Config.UseLicense` therefore takes a `license.Ref` and
+  never a `Status`: the control plane sends a document and the sidecar checks
+  it, rather than believing whoever is on the connection. NEVER add a
+  constructor that skips `Verify`, and NEVER export the trust root; a test that
+  needs a licensed process uses `license/licensetest`, which signs for real
+  under a key it installs for the duration of one `*testing.T`.
+
 ## Layout
 
 The module root holds no Go files: `go.mod`, this file and `README.md` only.
@@ -165,7 +175,7 @@ The module root holds no Go files: `go.mod`, this file and `README.md` only.
 | `lexer/` | SQL text to an effect and a relation list, without a grammar |
 | `codec/` | registration seam: wires libhoop's decoders to the classifier |
 | `policy/` | statement to verdict; local rules, then OPA |
-| `license/` | verifies the signed license that lifts the rule caps; a stdlib twin of `common/license` |
+| `license/` | verifies the signed license that lifts the rule caps; a stdlib twin of `common/license`. `internal/trust` owns the key, `licensetest` signs for tests |
 | `analyzer/` | the model-backed evaluator, third in the policy chain |
 | `gate/` | orders inspection, policy, audit and masking into one decision |
 | `proxy/` | TCP relay that pumps both directions through a Gate |

--- a/sidecar/CLAUDE.md
+++ b/sidecar/CLAUDE.md
@@ -147,6 +147,14 @@ done
   see it, so `client/licensecompat` pins the two. Touch the key or the
   signing data on one side and you MUST touch the other.
 
+- **The license verdict is a function of the clock.** `license.Status` stores
+  "the signature checked out" and derives everything else from the term, so a
+  relay that has been up for months loses the caps the second its license
+  lapses. Never cache `State()` in a field or a lane: that cache is the bug
+  this design exists to prevent. `Run` watches the term and stops a process
+  whose config the free tier would refuse, because re-applying the caps live
+  would mean deleting guardrail and mask rules from a running proxy.
+
 ## Layout
 
 The module root holds no Go files: `go.mod`, this file and `README.md` only.

--- a/sidecar/CLAUDE.md
+++ b/sidecar/CLAUDE.md
@@ -139,6 +139,14 @@ done
   with `OpUnknown`. That fails closed, but it means a policy naming `select`
   matches nothing.
 
+- **The license verifier exists twice, on purpose.** `sidecar/license`
+  reimplements `common/license` over the stdlib: same key, same RSA-PSS
+  signature over the same bytes, same JSON. Importing the gateway's module
+  would end the one-dependency invariant, so the copy is the price. Drift
+  locks paying customers out of features they bought and neither module can
+  see it, so `client/licensecompat` pins the two. Touch the key or the
+  signing data on one side and you MUST touch the other.
+
 ## Layout
 
 The module root holds no Go files: `go.mod`, this file and `README.md` only.
@@ -149,6 +157,7 @@ The module root holds no Go files: `go.mod`, this file and `README.md` only.
 | `lexer/` | SQL text to an effect and a relation list, without a grammar |
 | `codec/` | registration seam: wires libhoop's decoders to the classifier |
 | `policy/` | statement to verdict; local rules, then OPA |
+| `license/` | verifies the signed license that lifts the rule caps; a stdlib twin of `common/license` |
 | `analyzer/` | the model-backed evaluator, third in the policy chain |
 | `gate/` | orders inspection, policy, audit and masking into one decision |
 | `proxy/` | TCP relay that pumps both directions through a Gate |

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -291,6 +291,42 @@ a path is the silent downgrade this build refuses everywhere else.
 `/config` serves the same verdict under `license`, without the signature, and
 the caps under `limits`, where a `null` means the license lifted one.
 
+#### When a term ends under a running process
+
+The verdict is a function of the clock, not a flag set at startup. A relay
+that has been up for months re-reads its own term, so `/config` and the caps
+flip to the free tier the second the license lapses. Nothing has to reload.
+
+What happens next depends on whether the config needs the license:
+
+- **Inside the free tier**, nothing. The process keeps serving, reports
+  `expired`, and an operator renews whenever they get to it. Expiry took
+  nothing away, so taking the relay down would be an outage with no revenue
+  behind it.
+- **Over the free tier**, the relay stops. It logs the expiry, drains open
+  connections, flushes the audit trail and exits non-zero. The supervisor
+  restarts it, and startup then refuses the config by name until somebody
+  renews or removes rules.
+
+The stop is deliberate and the alternative is worse. Lanes are built once and
+hold their rules for the life of the process, so re-applying the caps to a
+running relay would mean deleting rules: dropping a guardrail lets through
+statements it was refusing, and dropping a mask rule leaks the values it was
+hiding. A billing event must never widen what a proxy allows.
+
+To keep it from being a surprise, the log counts down once a day through the
+last fortnight of a term:
+
+```
+WARN license expires soon, and this config needs it: the relay stops when the term ends days_left=6 expires=2026-05-01T00:00:00Z renew=https://help.hoop.dev
+WARN license: expired. "Acme Corp" expired on 2026-05-01, running the free tier. Renew it at https://help.hoop.dev
+WARN stopping: the license term ended and this config needs more rules than the free tier allows free_tier="1 guardrail rule(s), 1 data masking rule(s)"
+```
+
+The clock is polled once a minute rather than slept on with one long timer,
+so an NTP correction or a host that suspended through the expiry is still
+caught. Expect the stop within a minute of the term ending.
+
 The verifier is `sidecar/license`, a standard-library reimplementation of
 `common/license`: same key, same signature, same JSON, because this module
 cannot import the gateway's without inheriting its dependency tree. The two

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -204,6 +204,21 @@ To embed the relay in your own process, call `daemon.Setup` to load the config
 and build the detector, then `daemon.Run`. That is all `hoop start sidecar`
 does; read `client/cmd/startsidecar.go` for the whole of it.
 
+`Setup` takes the same three arguments it always has. It resolves a license
+from `HOOP_LICENSE` and from the config file's `license` key on its own, so an
+embedder that mounts one needs no code change. A caller with its own license
+flag reaches for `daemon.SetupWith`, which is the same function plus options:
+
+```go
+cfg, det, err := daemon.SetupWith(path, configyaml.Load, buildPlugin,
+    daemon.WithLicense(licenseFlag))
+```
+
+Startup facts arrive as new `Option` values rather than new arguments, so
+neither signature moves again. `daemon.Setup` briefly took the license as a
+fourth argument, which broke every embedder that upgraded; that is what the
+split is for.
+
 ## Configuring it: config.yaml
 
 One file is the whole configuration. The process reads it at startup, resolves

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -334,6 +334,21 @@ are pinned together by `client/licensecompat`, the only module that can see
 both. `allowed_hosts` is the one thing the sidecar does not check, since the
 address it could offer is a scheduler-generated pod name.
 
+A verdict cannot be handed to the daemon, only earned. The flag that says a
+license verified is unexported and `license.Load` is the only thing that sets
+it, after checking the signature, so a `license.Status` built by hand reports
+`invalid` and lifts nothing. `Config.UseLicense` takes a reference rather than
+a verdict for the same reason: when the control plane starts sending licenses,
+it will send the document Hoop signed and the sidecar will check that
+signature itself, instead of trusting whoever is on the connection.
+
+That leaves a test no way to run a licensed daemon, which
+`sidecar/license/licensetest` fixes honestly. It generates a keypair, points
+the trust root at it for the duration of one `*testing.T`, and signs documents
+that go through the same `Load`. Every function there takes a `*testing.T`,
+which is the guard: production code calling one would have to import
+`testing`.
+
 ### Deprecated fields
 
 0.1.0 renamed six keys, removed one, and reversed two defaults. Both

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -148,6 +148,7 @@ release pipeline already builds. Nothing extra to compile or ship:
 ```bash
 hoop start sidecar --config config.yaml --validate   # check the config and exit
 hoop start sidecar --config config.yaml              # run
+hoop start sidecar --config config.yaml --license /etc/hoop-inspect/license.json
 ```
 
 The command was named `inspect`. On 1.149.0 and newer that name still works as
@@ -176,6 +177,7 @@ go build -o hoop-inspect .
 
 ./hoop-inspect -validate -config config.yaml
 ./hoop-inspect -config config.yaml
+./hoop-inspect -config config.yaml -license /etc/hoop-inspect/license.json
 ./hoop-inspect -version
 ```
 
@@ -210,14 +212,15 @@ and the extension picks the parser: `.yaml` and `.yml` go through the nested
 `config/yaml` module, anything else is read as JSON. Decoding is strict, so a
 mistyped key fails the startup instead of silently disabling a control.
 
-### What this build limits
+### What this build limits, and the license that lifts it
 
-One guardrail rule and one data masking rule, for the whole process. The count
-is what the file AUTHORS, not what each lane resolves: a rule in the top-level
-`guardrails` block is one rule however many listeners inherit it, and a lane
-that overrides `mask.rules` with `[]` spends nothing. `ai_analysis` rules are
-counted apart and are not capped, because their controls are the trigger and
-`analyzer.max_calls` rather than a number of rules.
+Unlicensed, one guardrail rule and one data masking rule, for the whole
+process. The count is what the file AUTHORS, not what each lane resolves: a
+rule in the top-level `guardrails` block is one rule however many listeners
+inherit it, and a lane that overrides `mask.rules` with `[]` spends nothing.
+`ai_analysis` rules are counted apart and are not capped, because their
+controls are the trigger and `analyzer.max_calls` rather than a number of
+rules.
 
 A config over either cap is refused at startup, naming every block that
 authored rules and how many each holds, so the message reads as a map of what
@@ -225,17 +228,75 @@ to merge:
 
 ```
 hoop-inspect: invalid config:
-  - 2 guardrail rules are configured (guardrails: 1, appdb: 1) and this build
-    enforces at most 1; merge them into one rule, or contact our support at
+  - 2 guardrail rules are configured (guardrails: 1, appdb: 1) and this
+    process enforces at most 1; merge them into one rule. A license lifts this
+    cap: add one with the license flag, the HOOP_LICENSE environment variable,
+    or the "license" key in the config file. Contact our support at
     https://help.hoop.dev. ai_analysis rules are counted separately and are
     not limited
 ```
 
-The numbers are constants in `sidecar/daemon/limits.go` rather than config
-keys, because a cap the file it limits can raise is documentation. They mirror
-the control plane's free tier, which caps the same two things per
-organization. `-validate` prints them, `/config` serves them under `limits`,
-and lifting them is a build without that file.
+The free-tier numbers are constants in `sidecar/daemon/limits.go` rather than
+config keys, because a cap the file it limits can raise is documentation. They
+mirror the control plane's free tier, which caps the same two things per
+organization.
+
+A license Hoop signed lifts them, per feature. Three places carry one, and the
+first that holds anything decides:
+
+| Source | Spelling |
+|---|---|
+| Command line | `hoop-inspect -license …`, `hoop start sidecar --license …` |
+| Environment | `HOOP_LICENSE` |
+| Config file | `license: …` |
+
+The value is a path to the document Hoop issued, or the document itself: a
+value starting with `{` is read as the license, anything else as a filename.
+That is one field for a mounted secret and for a Helm value, so moving a
+license between the two is not also a rename.
+
+```yaml
+license: /etc/hoop-inspect/license.json
+```
+
+First wins, not first valid. A `HOOP_LICENSE` that points at nothing is an
+error rather than a reason to fall through to the config file, because a
+process that quietly ignored your environment variable will surprise you on
+the restart after the file changes. The control plane will be added above the
+flag when the sidecar starts receiving a license on connection, and it will
+outrank all three.
+
+The license names the features it covers, and each one lifts its own cap:
+`guardrails` and `data-masking` are the two this process reads. A license
+naming neither field covers everything; one naming only `data-masking` leaves
+the guardrail cap exactly where it was. An `oss` license verifies and grants
+nothing, which is what the control plane does with the same value.
+
+What the process concluded is the first line of its startup output, and
+`-validate` prints it too:
+
+```
+license: valid. enterprise "Acme Corp", expires 2027-01-30, features: all (from HOOP_LICENSE)
+license: expired. "Acme Corp" expired on 2026-05-01, running the free tier. Renew it at https://help.hoop.dev (from the license flag)
+license: missing, running the free tier. Add one with the license flag, the HOOP_LICENSE environment variable, or the "license" key in the config file
+```
+
+Missing and expired are states, not failures: the process starts, the caps
+stay in force, and an expired one logs at WARN so the reason a config that
+loaded last month stops loading is the first thing in the log. A license that
+cannot be READ is different and stops startup, naming the source and what a
+good value looks like: a process that drops to the free tier over a typo in
+a path is the silent downgrade this build refuses everywhere else.
+
+`/config` serves the same verdict under `license`, without the signature, and
+the caps under `limits`, where a `null` means the license lifted one.
+
+The verifier is `sidecar/license`, a standard-library reimplementation of
+`common/license`: same key, same signature, same JSON, because this module
+cannot import the gateway's without inheriting its dependency tree. The two
+are pinned together by `client/licensecompat`, the only module that can see
+both. `allowed_hosts` is the one thing the sidecar does not check, since the
+address it could offer is a scheduler-generated pod name.
 
 ### Deprecated fields
 
@@ -307,6 +368,10 @@ inherits those defaults unless it overrides them.
 ```yaml
 log_level: info
 
+# A path to the license Hoop issued, or the document itself. The license flag
+# and HOOP_LICENSE both outrank this. Omit it to run the free tier.
+license: /etc/hoop-inspect/license.json
+
 admin:
   listen: 127.0.0.1:19000   # /healthz /stats /config /events /api/*
 
@@ -374,7 +439,8 @@ whole because a config holding one rule per section cannot show a listener
 overriding a default at all, and inheritance is what the section is teaching.
 The stack config in `deploy/docker-compose/envoy-stack/sidecar/config.yaml` is
 the version that loads: same shape, the rest commented out and marked. See
-[What this build limits](#what-this-build-limits).
+[What this build limits, and the license that lifts
+it](#what-this-build-limits-and-the-license-that-lifts-it).
 
 Rule types and what each one matches are in [Guardrails and
 OPA](#guardrails-and-opa); masking strategies and the entity-versus-column
@@ -413,6 +479,7 @@ cd cmd && go build -o hoop-inspect . && \
 
 ```
 config OK: 2 listener(s)
+  license: missing, running the free tier. Add one with the license flag, the HOOP_LICENSE environment variable, or the "license" key in the config file
   limits: 1 guardrail rule(s), 1 data masking rule(s)
   appdb            postgres  enforcing 1 rule(s) + masking
   httpbin          http      enforcing 1 rule(s) + masking
@@ -434,9 +501,12 @@ Validation builds every lane, so it catches what a syntax check cannot, and it
 reports every problem in one run rather than one per restart. It refuses these
 outright:
 
-- More guardrail rules or more mask rules than this build allows, naming every
-  block that authored one. See [What this build
-  limits](#what-this-build-limits).
+- More guardrail rules or more mask rules than this process allows, naming
+  every block that authored one. See [What this build limits, and the license
+  that lifts it](#what-this-build-limits-and-the-license-that-lifts-it).
+- A license that cannot be read or was not issued by Hoop, naming the source
+  it came from. An expired one is a warning instead: the caps come back and
+  the process runs.
 - `mask.rules` on a protocol whose codec can carry neither masking mechanism,
   naming the lane. This check used to sit behind `mask.enabled`, so a lane
   omitting the flag skipped it and loaded rules that could never fire.
@@ -472,15 +542,19 @@ curl -s localhost:19000/config | python3 -m json.tool
   {"name": "httpbin", "protocol": "http", "enforcing": true,
    "rules": ["no-cpf-in-query"], "masking": true}
  ],
+ "license": {"state": "missing"},
  "limits": {"guardrail_rules": 1, "mask_rules": 1}}
 ```
 
 Both lanes resolved the same rule, because the process's one guardrail rule is
 a top-level default and neither lane authors its own. Rule names only: a
 `pattern_regex` can encode business logic, and this endpoint already sits
-beside a read interface to the audit trail. `limits` is what this build
+beside a read interface to the audit trail. `limits` is what this process
 refuses to exceed, served here so an operator asking why a second rule will
-not load reads the answer from the endpoint that told them what did.
+not load reads the answer from the endpoint that told them what did, and a
+`null` there means a license lifted that cap. `license` is the verdict behind
+those numbers: the type, the customer, the term, the features and the source,
+never the signature.
 
 ### Sharing a rule block between lanes
 

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -130,11 +130,22 @@ type Config struct {
 // missing license, so this always has something to say.
 func (c *Config) Licensing() license.Status { return c.lic }
 
-// UseLicense sets the license this config runs under, replacing whatever
-// Setup resolved. It is the seam a control-plane license arrives through:
-// the sidecar gets one on connection, calls this, and every cap moves with
-// it. Verify it first, since this stores a verdict and does not reach one.
-func (c *Config) UseLicense(s license.Status) { c.lic = s }
+// UseLicense verifies a license and adopts it, replacing whatever Setup
+// resolved. It is the seam a control-plane license arrives through: the plane
+// sends the document Hoop signed, the sidecar checks that signature itself
+// and every cap moves with the result.
+//
+// It takes a REFERENCE and not a Status, so no caller can hand the daemon a
+// verdict it reached on its own. Trusting the sender would make the caps a
+// matter of who is on the other end of a connection.
+func (c *Config) UseLicense(ref license.Ref) error {
+	s := license.Load(ref)
+	if s.State() == license.StateInvalid {
+		return s.Err
+	}
+	c.lic = s
+	return nil
+}
 
 // ListenerConfig is one protocol endpoint: one Envoy cluster's worth of
 // traffic, with its own enforcement stack.

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hoophq/hoop/sidecar/analyzer"
 	"github.com/hoophq/hoop/sidecar/gate"
 	"github.com/hoophq/hoop/sidecar/inspect"
+	"github.com/hoophq/hoop/sidecar/license"
 	"github.com/hoophq/hoop/sidecar/policy"
 )
 
@@ -99,6 +100,12 @@ type Config struct {
 	// LogLevel is debug, info, warn or error. Default info.
 	LogLevel string `json:"log_level"`
 
+	// License is a path to the document Hoop issued, or the document
+	// itself: a value starting with "{" is the document, so moving one
+	// between a mounted file and a secret is not also a rename. Lowest
+	// precedence of the three sources; ResolveLicense holds the order.
+	License string `json:"license,omitempty"`
+
 	// Policy is the DEPRECATED pre-ADR-0011 spelling of Guardrails and OPA
 	// combined. normalize empties it.
 	Policy *PolicyConfig `json:"policy,omitempty"`
@@ -111,7 +118,23 @@ type Config struct {
 	// from LoadConfigBytes because three entry points load a config and all
 	// three have to report the same thing.
 	Deprecations []string `json:"-"`
+
+	// lic is the VERIFIED license ResolveLicense reached. Setup fills it,
+	// UseLicense sets it for a caller assembling a Config in Go. Not a
+	// config key: the file names a license and does not carry a verdict.
+	// The zero value is missing, so an embedder who skips it keeps the caps.
+	lic license.Status
 }
+
+// Licensing reports the license this config runs under. The zero value is a
+// missing license, so this always has something to say.
+func (c *Config) Licensing() license.Status { return c.lic }
+
+// UseLicense sets the license this config runs under, replacing whatever
+// Setup resolved. It is the seam a control-plane license arrives through:
+// the sidecar gets one on connection, calls this, and every cap moves with
+// it. Verify it first, since this stores a verdict and does not reach one.
+func (c *Config) UseLicense(s license.Status) { c.lic = s }
 
 // ListenerConfig is one protocol endpoint: one Envoy cluster's worth of
 // traffic, with its own enforcement stack.
@@ -765,12 +788,10 @@ func (c *Config) Validate() error {
 	// modes always have a scanner to use.
 	problems = append(problems, c.Analyzer.validate(true)...)
 
-	// The feature caps are checked here and again in buildLanes, for a
-	// sharper version of the same reason: Run and the exported Validate
-	// never call this function at all, so a cap that lived only here would
-	// be skipped by every caller that builds a Config in Go rather than
-	// loading one from a file.
-	problems = append(problems, c.checkLimits()...)
+	// The feature caps are NOT checked here. This runs inside
+	// LoadConfigBytes, before Setup has seen the license flag or
+	// HOOP_LICENSE, so a cap here would refuse a licensed config for a
+	// limit its license lifts. buildLanes is the single site instead.
 
 	seen := map[string]bool{}
 	for i, l := range c.Listeners {

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -84,7 +84,7 @@ func Setup(path string, load Loader, build PluginBuilder, licenseFlag string) (*
 		return nil, nil, err
 	}
 	cfg.lic = ResolveLicense(licenseFlag, cfg.License)
-	if cfg.lic.State == license.StateInvalid {
+	if cfg.lic.State() == license.StateInvalid {
 		return nil, nil, cfg.lic.Err
 	}
 	if build == nil {
@@ -337,11 +337,82 @@ func checkPIIPlugin(cfg *Config, det Plugin) error {
 // caps and the operator has to see why a config that loaded last month now
 // refuses a rule. Missing is information. Invalid never reaches here.
 func reportLicense(log *slog.Logger, lic license.Status) {
-	if lic.State == license.StateExpired {
+	if lic.State() == license.StateExpired {
 		log.Warn(lic.Line())
 		return
 	}
 	log.Info(lic.Line())
+}
+
+// How often the run loop re-reads the clock against the license term, and how
+// long before the term ends the log starts asking for a renewal.
+//
+// Polling beats one long timer: a timer set for a year misses an NTP
+// correction and a host that slept through the expiry, and the cost here is
+// one comparison a minute.
+const (
+	licenseCheckEvery = time.Minute
+	licenseNotice     = 14 * 24 * time.Hour
+)
+
+// watchLicense stops the relay when the license term ends, and closes the
+// returned channel to say so.
+//
+// Lanes are built once and hold their rules for the process lifetime, so the
+// caps cannot be re-applied to a running relay. Dropping rules to fit the
+// free tier would be worse than the problem it solves: removing a guardrail
+// lets through statements it was refusing, and removing a mask rule leaks the
+// values it was hiding. A billing event must never widen what a proxy allows.
+//
+// So the transition is a controlled stop. Run drains, flushes the audit trail
+// and returns an error, the supervisor restarts, and buildLanes then refuses
+// the config by name until somebody renews or removes rules. Callers start
+// this only for a config that exceeds the free tier, because a process
+// already inside the caps has nothing to take away.
+func watchLicense(ctx context.Context, lic license.Status, every time.Duration, log *slog.Logger) <-chan struct{} {
+	expired := make(chan struct{})
+	go func() {
+		tick := time.NewTicker(every)
+		defer tick.Stop()
+		notified := -1
+		for {
+			if lic.StateAt(time.Now().UTC()) == license.StateExpired {
+				log.Warn(lic.Line())
+				close(expired)
+				return
+			}
+			notified = noticeLicenseExpiry(lic, notified, log)
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+			}
+		}
+	}()
+	return expired
+}
+
+// noticeLicenseExpiry warns once a day through the last fortnight of a term,
+// and returns the day count it last warned about.
+//
+// The stop at expiry is abrupt by design, so the notice is what keeps it from
+// being a surprise. An operator who reads one line a day for two weeks and
+// still lets the term lapse has made a decision.
+func noticeLicenseExpiry(lic license.Status, lastNotified int, log *slog.Logger) int {
+	left := time.Until(lic.ExpiresAt())
+	if left <= 0 || left > licenseNotice {
+		return lastNotified
+	}
+	days := int(left.Hours() / 24)
+	if days == lastNotified {
+		return lastNotified
+	}
+	log.Warn("license expires soon, and this config needs it: the relay stops when the "+
+		"term ends",
+		"days_left", days,
+		"expires", lic.ExpiresAt().Format(time.RFC3339),
+		"renew", license.Support)
+	return days
 }
 
 // Run starts the sidecar and blocks until the process is signalled.
@@ -404,6 +475,16 @@ func Run(cfg *Config, det Plugin) error {
 	ctx, stop := signal.NotifyContext(context.Background(),
 		os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Only a config the free tier would refuse is worth watching. One inside
+	// the caps keeps serving when its term ends, because expiry takes
+	// nothing away from it.
+	var licenseExpired <-chan struct{}
+	if cfg.dependsOnLicense() {
+		licenseExpired = watchLicense(ctx, cfg.lic, licenseCheckEvery, log)
+	}
 
 	servers := make([]*proxy.Server, 0, len(lanes))
 	for _, ln := range lanes {
@@ -456,8 +537,18 @@ func Run(cfg *Config, det Plugin) error {
 		}(srv, lanes[i].name)
 	}
 
-	<-ctx.Done()
-	log.Info("shutting down")
+	var stoppedByLicense bool
+	select {
+	case <-ctx.Done():
+		log.Info("shutting down")
+	case <-licenseExpired:
+		stoppedByLicense = true
+		log.Warn("stopping: the license term ended and this config needs more rules than "+
+			"the free tier allows",
+			"free_tier", limitsText(license.Status{}),
+			"renew", license.Support)
+		cancel()
+	}
 	for _, srv := range servers {
 		_ = srv.Close()
 	}
@@ -470,6 +561,15 @@ func Run(cfg *Config, det Plugin) error {
 		if e != nil {
 			return e
 		}
+	}
+	if stoppedByLicense {
+		// A non-nil error exits non-zero, so a supervisor restarts and
+		// buildLanes refuses the config by name. That loop is the point:
+		// the operator renews or removes rules, and nothing in between
+		// keeps serving licensed capacity for free.
+		return fmt.Errorf("the license term ended and the free tier allows %s. "+
+			"Renew at %s, or reduce the config and restart", limitsText(license.Status{}),
+			license.Support)
 	}
 	return nil
 }

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -186,8 +186,7 @@ func Main(version string, load Loader, build PluginBuilder) error {
 		if err != nil {
 			return err
 		}
-		PrintLanes(os.Stdout, cfg.lic, lanes)
-		return nil
+		return PrintLanes(os.Stdout, cfg.lic, lanes)
 	}
 
 	return Run(cfg, det)
@@ -198,6 +197,11 @@ func Main(version string, load Loader, build PluginBuilder) error {
 // It goes to STDERR at every call site. -validate writes a report to stdout
 // that an operator may parse, and a warning must not land in it. Same rule the
 // CLI's rename notice follows.
+//
+// The write errors are DROPPED, and that is the whole difference from
+// PrintLanes. A warning nobody could deliver must not turn a good config into
+// a non-zero exit: the config is still valid, and failing the run would
+// punish an operator for a broken stderr rather than for anything they wrote.
 func ReportDeprecations(w io.Writer, notes []string) {
 	for _, n := range notes {
 		fmt.Fprintln(w, "warn: deprecated config:", n)
@@ -212,16 +216,40 @@ func ReportDeprecations(w io.Writer, notes []string) {
 // leaves in force, one line per lane and the notes the resolved stack
 // produced. The license goes to stdout, since an expired one is the likeliest
 // reason a config stops loading and stdout is where "config OK" goes.
-func PrintLanes(w io.Writer, lic license.Status, lanes []LaneInfo) {
-	fmt.Fprintln(w, "config OK:", len(lanes), "listener(s)")
-	fmt.Fprintf(w, "  %s\n", lic.Line())
-	fmt.Fprintf(w, "  %s\n", LimitsSummary(lic))
+//
+// It returns the write error, and both entry points exit non-zero on it. This
+// report is what a pipeline reads to decide whether a config ships, so a run
+// that could not deliver it must not also claim success: `hoop-inspect
+// -validate > report.txt` on a full disk has produced no report, and an exit
+// code of zero would say it produced a clean one.
+//
+// The body renders into a strings.Builder first. Builder.Write never fails,
+// which is what makes the fmt calls below safe to ignore, and it leaves one
+// write to check instead of one per line.
+func PrintLanes(w io.Writer, lic license.Status, lanes []LaneInfo) error {
+	var b strings.Builder
+	fmt.Fprintln(&b, "config OK:", len(lanes), "listener(s)")
+	fmt.Fprintf(&b, "  %s\n", lic.Line())
+	fmt.Fprintf(&b, "  %s\n", LimitsSummary(lic))
 	for _, ln := range lanes {
-		fmt.Fprintf(w, "  %-16s %-9s %s\n", ln.Name, ln.Protocol, ln.Summary())
+		fmt.Fprintf(&b, "  %-16s %-9s %s\n", ln.Name, ln.Protocol, ln.Summary())
 		for _, n := range ln.Notes {
-			fmt.Fprintf(w, "  %-16s %-9s   note: %s\n", "", "", n)
+			fmt.Fprintf(&b, "  %-16s %-9s   note: %s\n", "", "", n)
 		}
 	}
+	// The length check is not paranoia: io.WriteString hands back whatever
+	// the Writer returned, so a Writer that reports a short count with a nil
+	// error truncates the report and nothing notices. Half a report is worse
+	// than none, because the half that arrived looks whole.
+	out := b.String()
+	n, err := io.WriteString(w, out)
+	if err == nil && n != len(out) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		return fmt.Errorf("writing the validation report: %w", err)
+	}
+	return nil
 }
 
 // LaneInfo is one resolved listener, as Validate reports it.

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -71,11 +71,51 @@ type Loader func(path string) (*Config, error)
 // a nil Plugin for an absent section. Pass nil to disable detection outright.
 type PluginBuilder func(rawPII json.RawMessage) (Plugin, error)
 
+// Option adjusts what Setup learns outside the config file.
+//
+// Variadic because the license arrived as a fourth PARAMETER once, and that
+// broke every embedder at compile time. This module's README tells people to
+// call Setup, so its signature is a contract: a new startup fact becomes a
+// new Option, never a new argument and never a second Setup.
+type Option func(*setupOptions)
+
+type setupOptions struct {
+	licenseFlag string
+}
+
+// WithLicense supplies a license from the command line, which outranks
+// HOOP_LICENSE and the config file's `license` key.
+//
+// Only a caller with such a flag needs it. Setup reads the other two sources
+// on its own, so an embedder that mounts a license file and names it in the
+// config gets it from a plain three-argument call.
+func WithLicense(ref string) Option {
+	return func(o *setupOptions) { o.licenseFlag = ref }
+}
+
 // Setup loads a config file, resolves the license and builds the detection
-// plugin. licenseFlag outranks the environment and the file; pass "" when
-// the caller has no flag. An UNREADABLE license stops startup and an expired
-// one does not, since killing a data-path proxy over billing is an outage.
-func Setup(path string, load Loader, build PluginBuilder, licenseFlag string) (*Config, Plugin, error) {
+// plugin.
+//
+// Three parameters, exactly as before licensing existed. This module's README
+// tells embedders to call it, so the signature is a contract: adding the
+// license as a fourth argument broke every one of them, and a variadic would
+// still break a caller holding it in a typed variable. SetupWith is the same
+// function with options.
+func Setup(path string, load Loader, build PluginBuilder) (*Config, Plugin, error) {
+	return SetupWith(path, load, build)
+}
+
+// SetupWith is Setup plus the facts an entry point learned outside the config
+// file. A new startup fact becomes a new Option, never another parameter and
+// never a third Setup.
+//
+// An UNREADABLE license stops startup and an expired one does not, since
+// killing a data-path proxy over billing is an outage.
+func SetupWith(path string, load Loader, build PluginBuilder, opts ...Option) (*Config, Plugin, error) {
+	var o setupOptions
+	for _, apply := range opts {
+		apply(&o)
+	}
 	if load == nil {
 		load = LoadConfig
 	}
@@ -83,7 +123,7 @@ func Setup(path string, load Loader, build PluginBuilder, licenseFlag string) (*
 	if err != nil {
 		return nil, nil, err
 	}
-	cfg.lic = ResolveLicense(licenseFlag, cfg.License)
+	cfg.lic = ResolveLicense(o.licenseFlag, cfg.License)
 	if cfg.lic.State() == license.StateInvalid {
 		return nil, nil, cfg.lic.Err
 	}
@@ -171,7 +211,7 @@ func Main(version string, load Loader, build PluginBuilder) error {
 		return fmt.Errorf("%w: -config is required", ErrUsage)
 	}
 
-	cfg, det, err := Setup(*configPath, load, build, *licenseRef)
+	cfg, det, err := SetupWith(*configPath, load, build, WithLicense(*licenseRef))
 	if err != nil {
 		return err
 	}

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -41,10 +41,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hoophq/hoop/sidecar/inspect"
 	"github.com/hoophq/hoop/sidecar/audit"
 	_ "github.com/hoophq/hoop/sidecar/codec/all"
 	"github.com/hoophq/hoop/sidecar/gate"
+	"github.com/hoophq/hoop/sidecar/inspect"
+	"github.com/hoophq/hoop/sidecar/license"
 	"github.com/hoophq/hoop/sidecar/policy"
 	"github.com/hoophq/hoop/sidecar/proxy"
 	"github.com/hoophq/hoop/sidecar/session"
@@ -70,19 +71,21 @@ type Loader func(path string) (*Config, error)
 // a nil Plugin for an absent section. Pass nil to disable detection outright.
 type PluginBuilder func(rawPII json.RawMessage) (Plugin, error)
 
-// Setup loads a config file and builds its detection plugin.
-//
-// This is the whole startup sequence short of binding a port, so a caller
-// embedding the relay reaches Validate or Run with two lines and no
-// opportunity to wire the two halves together differently than the shipped
-// binary does.
-func Setup(path string, load Loader, build PluginBuilder) (*Config, Plugin, error) {
+// Setup loads a config file, resolves the license and builds the detection
+// plugin. licenseFlag outranks the environment and the file; pass "" when
+// the caller has no flag. An UNREADABLE license stops startup and an expired
+// one does not, since killing a data-path proxy over billing is an outage.
+func Setup(path string, load Loader, build PluginBuilder, licenseFlag string) (*Config, Plugin, error) {
 	if load == nil {
 		load = LoadConfig
 	}
 	cfg, err := load(path)
 	if err != nil {
 		return nil, nil, err
+	}
+	cfg.lic = ResolveLicense(licenseFlag, cfg.License)
+	if cfg.lic.State == license.StateInvalid {
+		return nil, nil, cfg.lic.Err
 	}
 	if build == nil {
 		return cfg, nil, nil
@@ -92,6 +95,18 @@ func Setup(path string, load Loader, build PluginBuilder) (*Config, Plugin, erro
 		return nil, nil, err
 	}
 	return cfg, det, nil
+}
+
+// ResolveLicense picks the license a process runs under, highest precedence
+// first: the command line, then HOOP_LICENSE, then the config file's
+// `license` key. Licensing a fleet must not mean editing every file in it.
+// The control plane goes above all three once it sends one on connection.
+func ResolveLicense(flagValue, fileValue string) license.Status {
+	return license.Resolve(
+		license.Ref{Value: flagValue, Source: "the license flag"},
+		license.Ref{Value: os.Getenv(license.EnvVar), Source: license.EnvVar},
+		license.Ref{Value: fileValue, Source: `the "license" config key`},
+	)
 }
 
 // ErrUsage marks a command-line misuse: a missing or unparseable flag, as
@@ -114,6 +129,7 @@ var ErrUsage = errors.New("usage")
 // Usage:
 //
 //	hoop-inspect -config /etc/hoop-inspect/config.yaml
+//	hoop-inspect -config config.yaml -license /etc/hoop-inspect/license.json
 //	hoop-inspect -validate -config config.yaml   # check and exit
 //	hoop-inspect -version
 func Main(version string, load Loader, build PluginBuilder) error {
@@ -130,9 +146,12 @@ func Main(version string, load Loader, build PluginBuilder) error {
 	fs := flag.NewFlagSet("hoop-inspect", flag.ContinueOnError)
 	var (
 		configPath = fs.String("config", "", "path to the config file ("+syntax+")")
-		validate   = fs.Bool("validate", false, "validate the config and exit")
-		strict     = fs.Bool("strict", false, "treat a deprecated config field as an error")
-		showVer    = fs.Bool("version", false, "print the version and exit")
+		licenseRef = fs.String("license", "", "path to the license file, or the license "+
+			"document itself; overrides "+license.EnvVar+" and the config file's "+
+			`"license" key`)
+		validate = fs.Bool("validate", false, "validate the config and exit")
+		strict   = fs.Bool("strict", false, "treat a deprecated config field as an error")
+		showVer  = fs.Bool("version", false, "print the version and exit")
 	)
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		// -h is a request, not a mistake. ContinueOnError has already
@@ -152,7 +171,7 @@ func Main(version string, load Loader, build PluginBuilder) error {
 		return fmt.Errorf("%w: -config is required", ErrUsage)
 	}
 
-	cfg, det, err := Setup(*configPath, load, build)
+	cfg, det, err := Setup(*configPath, load, build, *licenseRef)
 	if err != nil {
 		return err
 	}
@@ -167,7 +186,7 @@ func Main(version string, load Loader, build PluginBuilder) error {
 		if err != nil {
 			return err
 		}
-		PrintLanes(os.Stdout, lanes)
+		PrintLanes(os.Stdout, cfg.lic, lanes)
 		return nil
 	}
 
@@ -189,15 +208,14 @@ func ReportDeprecations(w io.Writer, notes []string) {
 	}
 }
 
-// PrintLanes renders what -validate concluded, one line per lane plus any
-// notes the resolved stack produced.
-//
-// Shared by both entry points so `hoop start sidecar --validate` and
-// `hoop-inspect -validate` cannot drift into reporting different things about
-// one config.
-func PrintLanes(w io.Writer, lanes []LaneInfo) {
+// PrintLanes renders what -validate concluded: the license, the caps it
+// leaves in force, one line per lane and the notes the resolved stack
+// produced. The license goes to stdout, since an expired one is the likeliest
+// reason a config stops loading and stdout is where "config OK" goes.
+func PrintLanes(w io.Writer, lic license.Status, lanes []LaneInfo) {
 	fmt.Fprintln(w, "config OK:", len(lanes), "listener(s)")
-	fmt.Fprintf(w, "  %s\n", LimitsSummary())
+	fmt.Fprintf(w, "  %s\n", lic.Line())
+	fmt.Fprintf(w, "  %s\n", LimitsSummary(lic))
 	for _, ln := range lanes {
 		fmt.Fprintf(w, "  %-16s %-9s %s\n", ln.Name, ln.Protocol, ln.Summary())
 		for _, n := range ln.Notes {
@@ -314,19 +332,37 @@ func checkPIIPlugin(cfg *Config, det Plugin) error {
 	return nil
 }
 
+// reportLicense logs the state the process starts in, at the level it
+// deserves. Expired warns: the process keeps serving under the free-tier
+// caps and the operator has to see why a config that loaded last month now
+// refuses a rule. Missing is information. Invalid never reaches here.
+func reportLicense(log *slog.Logger, lic license.Status) {
+	if lic.State == license.StateExpired {
+		log.Warn(lic.Line())
+		return
+	}
+	log.Info(lic.Line())
+}
+
 // Run starts the sidecar and blocks until the process is signalled.
 //
 // det is the optional detection plugin. Passing nil disables masking and
 // rejects any pii policy rule. Call Run to embed the relay in your own
 // binary; the shipped one goes through Main.
+//
+// The license comes from the Config, where Setup left it. A Config assembled
+// in Go carries the zero Status, so an embedder who never calls UseLicense
+// gets the caps rather than a bypass.
 func Run(cfg *Config, det Plugin) error {
 	if err := checkPIIPlugin(cfg, det); err != nil {
 		return err
 	}
 	log := newLogger(cfg.LogLevel)
+	reportLicense(log, cfg.lic)
+	limit := capsFor(cfg.lic)
 	log.Info("rule limits",
-		"guardrail_rules", maxGuardrailRules,
-		"mask_rules", maxMaskRules)
+		"guardrail_rules", capText(limit.guardrails),
+		"mask_rules", capText(limit.mask))
 
 	ac, err := buildAudit(cfg.Audit)
 	if err != nil {
@@ -404,7 +440,7 @@ func Run(cfg *Config, det Plugin) error {
 	}
 
 	if cfg.Admin.Listen != "" {
-		go serveAdmin(ctx, cfg.Admin.Listen, servers, lanes, ac, cfg.Analyzer, log)
+		go serveAdmin(ctx, cfg.Admin.Listen, servers, lanes, ac, cfg.Analyzer, cfg.lic, log)
 	}
 
 	var wg sync.WaitGroup
@@ -503,11 +539,11 @@ func buildLanes(cfg *Config, det Plugin, ac *analyzerDeps) ([]lane, error) {
 	out := make([]lane, 0, len(cfg.Listeners))
 	var problems []string
 
-	// Here rather than only in (*Config).Validate because this is the one
-	// function Main, Run and the exported Validate all reach. An embedder
-	// assembling a Config in Go and calling Run never passes through the
-	// file validator, and a cap with a documented way around it is not one.
-	problems = append(problems, cfg.checkLimits()...)
+	// The one place the caps are enforced. (*Config).Validate cannot: it
+	// runs inside LoadConfigBytes, before Setup resolves the license flag
+	// or HOOP_LICENSE, so it would refuse a config for a limit its license
+	// lifts. Every caller that runs or validates a sidecar reaches this.
+	problems = append(problems, cfg.checkLimits(cfg.lic)...)
 
 	for i, lc := range cfg.Listeners {
 		name := lc.displayName(i)
@@ -786,6 +822,7 @@ func serveAdmin(
 	lanes []lane,
 	ac auditChain,
 	analyzerCfg *AnalyzerConfig,
+	lic license.Status,
 	log *slog.Logger,
 ) {
 	mux := http.NewServeMux()
@@ -895,6 +932,7 @@ func serveAdmin(
 			}
 			out = append(out, v)
 		}
+		limit := capsFor(lic)
 		resp := map[string]any{
 			"version": Version,
 			"lanes":   out,
@@ -902,13 +940,18 @@ func serveAdmin(
 			// control plane can warn its own developers without reading
 			// prose. These keys still carry correct values.
 			"deprecated_fields": []string{"enforcing", "rules", "opa", "masking"},
-			// What this build refuses to exceed. An operator asking why a
+			// What this process refuses to exceed. An operator asking why a
 			// second rule will not load gets the answer from the same
-			// endpoint that tells them what did load.
-			"limits": map[string]int{
-				"guardrail_rules": maxGuardrailRules,
-				"mask_rules":      maxMaskRules,
+			// endpoint that tells them what did load, and a null says the
+			// license lifted the cap rather than that the cap is zero.
+			"limits": map[string]any{
+				"guardrail_rules": capJSON(limit.guardrails),
+				"mask_rules":      capJSON(limit.mask),
 			},
+			// Beside the limits because it is the reason for them. Never
+			// the signature: an endpoint handing out a complete, reusable
+			// license is a licensing hole with an HTTP interface.
+			"license": lic.Report(),
 		}
 		// The analyzer view names the provider, the model and the HOST it
 		// talks to — never the path, never a query string, and never the

--- a/sidecar/daemon/expiry_test.go
+++ b/sidecar/daemon/expiry_test.go
@@ -1,0 +1,158 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/policy"
+)
+
+// expiredIn builds a licensed verdict whose term ends after d.
+func expiredIn(d time.Duration) license.Status {
+	return licenseStatus(license.EnterpriseType, nil, time.Now().Add(d))
+}
+
+// The caps read the license live, so the same Status that lifted them gives
+// them back when its term ends. Without this a process holds the caps it
+// bought for as long as it stays up.
+func TestTheCapsComeBackWhenTheTermEnds(t *testing.T) {
+	cfg := overCap()
+
+	cfg.UseLicense(expiredIn(time.Hour))
+	if problems := cfg.checkLimits(cfg.Licensing()); len(problems) != 0 {
+		t.Fatalf("a current license did not lift the caps: %v", problems)
+	}
+
+	cfg.UseLicense(expiredIn(-time.Hour))
+	problems := cfg.checkLimits(cfg.Licensing())
+	if len(problems) != 2 {
+		t.Fatalf("an expired license kept the caps lifted: %v", problems)
+	}
+	for _, p := range problems {
+		if !strings.Contains(p, "expired") {
+			t.Errorf("the message does not name the expiry: %v", p)
+		}
+	}
+}
+
+// The summary line and the admin endpoint both derive from the same verdict,
+// so an operator reading either after expiry sees the free tier rather than
+// the "unlimited" the process started with.
+func TestTheReportedCapsFollowTheTerm(t *testing.T) {
+	if got := LimitsSummary(expiredIn(time.Hour)); !strings.Contains(got, "unlimited") {
+		t.Errorf("a current license did not report unlimited: %q", got)
+	}
+	got := LimitsSummary(expiredIn(-time.Hour))
+	for _, want := range []string{"1 guardrail rule(s)", "1 data masking rule(s)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("an expired license did not report the free tier: %q", got)
+		}
+	}
+	if c := capsFor(expiredIn(-time.Hour)); capJSON(c.guardrails) == nil {
+		t.Error("/config would still serve null, meaning no cap, after expiry")
+	}
+}
+
+// Only a config the free tier would refuse is worth watching. Taking down a
+// process that never used its license is an outage with no revenue behind it.
+func TestOnlyAnOverCapConfigDependsOnTheLicense(t *testing.T) {
+	if !overCap().dependsOnLicense() {
+		t.Error("a config over both caps does not depend on its license")
+	}
+	within := &Config{
+		Guardrails: &GuardrailsConfig{Mode: ModeEnforce, Rules: []policy.Rule{rule("only-one")}},
+		Listeners:  []ListenerConfig{limitsLane("appdb", ":1")},
+	}
+	if within.dependsOnLicense() {
+		t.Error("a config inside the free tier depends on a license")
+	}
+}
+
+// The transition itself: the watchdog notices the term ending and closes its
+// channel, which is what makes Run drain and exit.
+func TestTheWatchdogFiresWhenTheTermEnds(t *testing.T) {
+	var buf bytes.Buffer
+	log := newTestLogger(&buf)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	expired := watchLicense(ctx, expiredIn(-time.Second), time.Millisecond, log)
+
+	select {
+	case <-expired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the watchdog did not notice an expired term")
+	}
+	if out := buf.String(); !strings.Contains(out, "level=WARN") ||
+		!strings.Contains(out, "expired") {
+		t.Errorf("the transition was not logged as a warning: %s", out)
+	}
+}
+
+// A term with time left keeps the relay up. A watchdog that fired early would
+// be an outage generator.
+func TestTheWatchdogWaitsWhileTheTermRuns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	expired := watchLicense(ctx, expiredIn(time.Hour), time.Millisecond, newTestLogger(&bytes.Buffer{}))
+
+	select {
+	case <-expired:
+		t.Fatal("the watchdog stopped a relay whose license is current")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// Shutdown must not read as an expiry. The channel stays open when the
+// context ends, so Run reports a signal as a signal and exits zero.
+func TestTheWatchdogIsSilentOnShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	expired := watchLicense(ctx, expiredIn(time.Hour), time.Hour, newTestLogger(&bytes.Buffer{}))
+	cancel()
+
+	select {
+	case <-expired:
+		t.Fatal("a signalled shutdown was reported as a license expiry")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// The stop is abrupt, so the notice is what keeps it from being a surprise.
+// It counts down in days and repeats only when the count changes.
+func TestExpiryIsAnnouncedBeforeItHappens(t *testing.T) {
+	var buf bytes.Buffer
+	log := newTestLogger(&buf)
+	lic := expiredIn(3 * 24 * time.Hour)
+
+	day := noticeLicenseExpiry(lic, -1, log)
+	if day != 2 && day != 3 {
+		t.Fatalf("days_left = %d, want 2 or 3", day)
+	}
+	first := buf.String()
+	if !strings.Contains(first, "expires soon") || !strings.Contains(first, "days_left") {
+		t.Errorf("no countdown was logged: %s", first)
+	}
+
+	buf.Reset()
+	if again := noticeLicenseExpiry(lic, day, log); again != day {
+		t.Errorf("the day count moved without time passing: %d then %d", day, again)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("the same day was announced twice: %s", buf.String())
+	}
+}
+
+// Outside the notice window there is nothing to say. A line a day for two
+// years is a line nobody reads.
+func TestALongTermIsNotAnnounced(t *testing.T) {
+	var buf bytes.Buffer
+	noticeLicenseExpiry(expiredIn(365*24*time.Hour), -1, newTestLogger(&buf))
+	if buf.Len() != 0 {
+		t.Errorf("a term with a year left was announced: %s", buf.String())
+	}
+}

--- a/sidecar/daemon/expiry_test.go
+++ b/sidecar/daemon/expiry_test.go
@@ -8,12 +8,15 @@ import (
 	"time"
 
 	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/license/licensetest"
 	"github.com/hoophq/hoop/sidecar/policy"
 )
 
-// expiredIn builds a licensed verdict whose term ends after d.
-func expiredIn(d time.Duration) license.Status {
-	return licenseStatus(license.EnterpriseType, nil, time.Now().Add(d))
+// expiredIn signs a license whose term ends after d and puts it through the
+// real verifier, so these tests age a verdict a customer could hold.
+func expiredIn(t *testing.T, d time.Duration) license.Status {
+	t.Helper()
+	return licensetest.Status(t, licensetest.Expiring(d))
 }
 
 // The caps read the license live, so the same Status that lifted them gives
@@ -22,12 +25,12 @@ func expiredIn(d time.Duration) license.Status {
 func TestTheCapsComeBackWhenTheTermEnds(t *testing.T) {
 	cfg := overCap()
 
-	cfg.UseLicense(expiredIn(time.Hour))
+	useLicense(t, cfg, licensetest.Expiring(time.Hour))
 	if problems := cfg.checkLimits(cfg.Licensing()); len(problems) != 0 {
 		t.Fatalf("a current license did not lift the caps: %v", problems)
 	}
 
-	cfg.UseLicense(expiredIn(-time.Hour))
+	useLicense(t, cfg, licensetest.Expiring(-time.Hour))
 	problems := cfg.checkLimits(cfg.Licensing())
 	if len(problems) != 2 {
 		t.Fatalf("an expired license kept the caps lifted: %v", problems)
@@ -43,16 +46,16 @@ func TestTheCapsComeBackWhenTheTermEnds(t *testing.T) {
 // so an operator reading either after expiry sees the free tier rather than
 // the "unlimited" the process started with.
 func TestTheReportedCapsFollowTheTerm(t *testing.T) {
-	if got := LimitsSummary(expiredIn(time.Hour)); !strings.Contains(got, "unlimited") {
+	if got := LimitsSummary(expiredIn(t, time.Hour)); !strings.Contains(got, "unlimited") {
 		t.Errorf("a current license did not report unlimited: %q", got)
 	}
-	got := LimitsSummary(expiredIn(-time.Hour))
+	got := LimitsSummary(expiredIn(t, -time.Hour))
 	for _, want := range []string{"1 guardrail rule(s)", "1 data masking rule(s)"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("an expired license did not report the free tier: %q", got)
 		}
 	}
-	if c := capsFor(expiredIn(-time.Hour)); capJSON(c.guardrails) == nil {
+	if c := capsFor(expiredIn(t, -time.Hour)); capJSON(c.guardrails) == nil {
 		t.Error("/config would still serve null, meaning no cap, after expiry")
 	}
 }
@@ -80,7 +83,7 @@ func TestTheWatchdogFiresWhenTheTermEnds(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	expired := watchLicense(ctx, expiredIn(-time.Second), time.Millisecond, log)
+	expired := watchLicense(ctx, expiredIn(t, -time.Second), time.Millisecond, log)
 
 	select {
 	case <-expired:
@@ -99,7 +102,7 @@ func TestTheWatchdogWaitsWhileTheTermRuns(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	expired := watchLicense(ctx, expiredIn(time.Hour), time.Millisecond, newTestLogger(&bytes.Buffer{}))
+	expired := watchLicense(ctx, expiredIn(t, time.Hour), time.Millisecond, newTestLogger(&bytes.Buffer{}))
 
 	select {
 	case <-expired:
@@ -112,7 +115,7 @@ func TestTheWatchdogWaitsWhileTheTermRuns(t *testing.T) {
 // context ends, so Run reports a signal as a signal and exits zero.
 func TestTheWatchdogIsSilentOnShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	expired := watchLicense(ctx, expiredIn(time.Hour), time.Hour, newTestLogger(&bytes.Buffer{}))
+	expired := watchLicense(ctx, expiredIn(t, time.Hour), time.Hour, newTestLogger(&bytes.Buffer{}))
 	cancel()
 
 	select {
@@ -127,7 +130,7 @@ func TestTheWatchdogIsSilentOnShutdown(t *testing.T) {
 func TestExpiryIsAnnouncedBeforeItHappens(t *testing.T) {
 	var buf bytes.Buffer
 	log := newTestLogger(&buf)
-	lic := expiredIn(3 * 24 * time.Hour)
+	lic := expiredIn(t, 3*24*time.Hour)
 
 	day := noticeLicenseExpiry(lic, -1, log)
 	if day != 2 && day != 3 {
@@ -151,7 +154,7 @@ func TestExpiryIsAnnouncedBeforeItHappens(t *testing.T) {
 // years is a line nobody reads.
 func TestALongTermIsNotAnnounced(t *testing.T) {
 	var buf bytes.Buffer
-	noticeLicenseExpiry(expiredIn(365*24*time.Hour), -1, newTestLogger(&buf))
+	noticeLicenseExpiry(expiredIn(t, 365*24*time.Hour), -1, newTestLogger(&buf))
 	if buf.Len() != 0 {
 		t.Errorf("a term with a year left was announced: %s", buf.String())
 	}

--- a/sidecar/daemon/forgery_test.go
+++ b/sidecar/daemon/forgery_test.go
@@ -1,0 +1,134 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/license/licensetest"
+)
+
+// The hole this file exists for. A Status assembled by a caller used to be
+// enough to lift the caps, because the daemon took a verdict and trusted it.
+// Now the fields that decide are unexported and only license.Load sets them,
+// so the best a caller can build grants nothing.
+func TestAHandBuiltStatusLiftsNothing(t *testing.T) {
+	forged := license.Status{
+		Source: "an attacker",
+		License: &license.License{
+			Payload: license.Payload{
+				Type:         license.EnterpriseType,
+				IssuedAt:     time.Now().Add(-time.Hour).Unix(),
+				ExpireAt:     time.Now().Add(10 * 365 * 24 * time.Hour).Unix(),
+				AllowedHosts: []string{"*"},
+				Description:  "Free Stuff Inc",
+			},
+			KeyID:     "whatever",
+			Signature: "whatever",
+		},
+	}
+
+	if forged.State() != license.StateInvalid {
+		t.Errorf("state = %q, want invalid", forged.State())
+	}
+	if forged.Allows(license.FeatureGuardrails) || forged.Allows(license.FeatureDataMasking) {
+		t.Fatal("a hand-built status granted a feature")
+	}
+	if c := capsFor(forged); c.guardrails != maxGuardrailRules || c.mask != maxMaskRules {
+		t.Errorf("caps moved for a hand-built status: %+v", c)
+	}
+	if problems := overCap().checkLimits(forged); len(problems) != 2 {
+		t.Errorf("a hand-built status lifted a cap: %v", problems)
+	}
+}
+
+// UseLicense takes a reference and verifies it, so the caller never gets to
+// decide. A document nobody signed is refused at the seam rather than stored
+// and quietly ignored.
+func TestUseLicenseRefusesAnUnsignedDocument(t *testing.T) {
+	doc, err := json.Marshal(license.License{
+		Payload: license.Payload{
+			Type:         license.EnterpriseType,
+			IssuedAt:     time.Now().Add(-time.Hour).Unix(),
+			ExpireAt:     time.Now().Add(time.Hour).Unix(),
+			AllowedHosts: []string{"*"},
+			Description:  "Free Stuff Inc",
+		},
+		KeyID:     "whatever",
+		Signature: "bm90LWEtc2lnbmF0dXJl",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	cfg := overCap()
+	uerr := cfg.UseLicense(license.Ref{Value: string(doc), Source: "the control plane"})
+
+	if uerr == nil {
+		t.Fatal("an unsigned document was adopted")
+	}
+	if !strings.Contains(uerr.Error(), "the control plane") {
+		t.Errorf("the error does not name the source: %v", uerr)
+	}
+	if cfg.Licensing().State() != license.StateMissing {
+		t.Errorf("a refused license was stored anyway: %q", cfg.Licensing().State())
+	}
+	if len(cfg.checkLimits(cfg.Licensing())) != 2 {
+		t.Error("a refused license lifted a cap")
+	}
+}
+
+// A license signed by a key this build does not trust is the same refusal.
+// This is the case a compromised control plane would produce.
+func TestUseLicenseRefusesAnotherKeysSignature(t *testing.T) {
+	// Sign inside a subtest so its cleanup puts the production key back
+	// before the assertion. What is left is a document carrying a real
+	// signature from a key this process no longer accepts.
+	var doc string
+	t.Run("issued under a trust root that goes away", func(t *testing.T) {
+		doc = licensetest.Document(t, licensetest.Enterprise())
+	})
+
+	cfg := overCap()
+	if err := cfg.UseLicense(license.Ref{Value: doc, Source: "the control plane"}); err == nil {
+		t.Fatal("a license from an untrusted key was adopted")
+	}
+	if len(cfg.checkLimits(cfg.Licensing())) != 2 {
+		t.Error("a license from an untrusted key lifted a cap")
+	}
+}
+
+// The seam still has to work for a real one, or the enforcement above is just
+// a broken feature.
+func TestUseLicenseAdoptsAVerifiedDocument(t *testing.T) {
+	cfg := overCap()
+
+	if err := cfg.UseLicense(licensetest.Ref(t, licensetest.Enterprise())); err != nil {
+		t.Fatalf("UseLicense refused a signed license: %v", err)
+	}
+	if cfg.Licensing().State() != license.StateValid {
+		t.Fatalf("state = %q, want valid", cfg.Licensing().State())
+	}
+	if problems := cfg.checkLimits(cfg.Licensing()); len(problems) != 0 {
+		t.Errorf("a verified license did not lift the caps: %v", problems)
+	}
+}
+
+// An expired document is adopted rather than refused: the caps stay in force
+// and the process reports the state. Refusing it would leave a control plane
+// unable to tell a sidecar that the customer stopped paying.
+func TestUseLicenseAdoptsAnExpiredDocument(t *testing.T) {
+	cfg := overCap()
+
+	if err := cfg.UseLicense(licensetest.Ref(t, licensetest.Expiring(-time.Hour))); err != nil {
+		t.Fatalf("UseLicense refused an expired license: %v", err)
+	}
+	if cfg.Licensing().State() != license.StateExpired {
+		t.Errorf("state = %q, want expired", cfg.Licensing().State())
+	}
+	if len(cfg.checkLimits(cfg.Licensing())) != 2 {
+		t.Error("an expired license lifted a cap")
+	}
+}

--- a/sidecar/daemon/license_test.go
+++ b/sidecar/daemon/license_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -122,7 +123,9 @@ func TestAnInlineDocumentIsReadAsADocument(t *testing.T) {
 // belongs in its report rather than only in the run log.
 func TestPrintLanesReportsTheLicenseAndTheCaps(t *testing.T) {
 	var buf bytes.Buffer
-	PrintLanes(&buf, licensed(t), []LaneInfo{{Name: "appdb", Protocol: "postgres"}})
+	if err := PrintLanes(&buf, licensed(t), []LaneInfo{{Name: "appdb", Protocol: "postgres"}}); err != nil {
+		t.Fatalf("PrintLanes: %v", err)
+	}
 
 	out := buf.String()
 	for _, want := range []string{"license: valid", "Acme Corp", "unlimited guardrail rule(s)", "appdb"} {
@@ -134,7 +137,9 @@ func TestPrintLanesReportsTheLicenseAndTheCaps(t *testing.T) {
 
 func TestPrintLanesSaysWhenThereIsNoLicense(t *testing.T) {
 	var buf bytes.Buffer
-	PrintLanes(&buf, license.Status{}, nil)
+	if err := PrintLanes(&buf, license.Status{}, nil); err != nil {
+		t.Fatalf("PrintLanes: %v", err)
+	}
 
 	out := buf.String()
 	for _, want := range []string{"license: missing", license.EnvVar, "1 guardrail rule(s)"} {
@@ -142,6 +147,51 @@ func TestPrintLanesSaysWhenThereIsNoLicense(t *testing.T) {
 			t.Errorf("the report is missing %q:\n%s", want, out)
 		}
 	}
+}
+
+// failingWriter is a stdout that has run out of disk.
+type failingWriter struct{ err error }
+
+func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }
+
+// A -validate run that could not write its report must not exit zero. The
+// report is what a pipeline reads to decide whether a config ships, and an
+// exit code claiming success over an empty file says the config was checked
+// when nobody ever saw the answer.
+func TestPrintLanesReturnsTheWriteError(t *testing.T) {
+	want := errors.New("no space left on device")
+
+	err := PrintLanes(failingWriter{want}, licensed(t), []LaneInfo{{Name: "appdb"}})
+
+	if err == nil {
+		t.Fatal("a failed write was reported as a clean report")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("the cause was dropped: %v", err)
+	}
+	if !strings.Contains(err.Error(), "validation report") {
+		t.Errorf("the error does not say what failed to write: %v", err)
+	}
+}
+
+// A short write is a failure even when the writer reports no error, which is
+// what io.WriteString turns into ErrShortWrite. Losing half a report is worse
+// than losing all of it: the half that arrived looks complete.
+func TestPrintLanesCatchesAShortWrite(t *testing.T) {
+	if err := PrintLanes(shortWriter{}, license.Status{}, nil); err == nil {
+		t.Fatal("a truncated report was reported as a clean one")
+	}
+}
+
+// shortWriter accepts one byte at a time and claims success, which is the
+// contract violation io.WriteString detects.
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return 1, nil
 }
 
 // An expired license reports as a warning and a valid one as information,

--- a/sidecar/daemon/license_test.go
+++ b/sidecar/daemon/license_test.go
@@ -25,7 +25,7 @@ const minimalConfig = `{"listeners":[{"protocol":"postgres","listen":":1","upstr
 
 func setupWith(t *testing.T, cfgJSON, licenseFlag string) (*Config, error) {
 	t.Helper()
-	cfg, _, err := Setup(writeConfig(t, cfgJSON), nil, nil, licenseFlag)
+	cfg, _, err := SetupWith(writeConfig(t, cfgJSON), nil, nil, WithLicense(licenseFlag))
 	return cfg, err
 }
 

--- a/sidecar/daemon/license_test.go
+++ b/sidecar/daemon/license_test.go
@@ -1,0 +1,204 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/sidecar/license"
+)
+
+// newTestLogger captures what Run would print, at a level that keeps both
+// info and warnings so a test can tell them apart.
+func newTestLogger(w *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: slog.LevelInfo}))
+}
+
+// minimalConfig is one valid lane and nothing else, so a license test fails
+// on the license. It is left unclosed: each case appends its own fields.
+const minimalConfig = `{"listeners":[{"protocol":"postgres","listen":":1","upstream":"h:5432"}]`
+
+func setupWith(t *testing.T, cfgJSON, licenseFlag string) (*Config, error) {
+	t.Helper()
+	cfg, _, err := Setup(writeConfig(t, cfgJSON), nil, nil, licenseFlag)
+	return cfg, err
+}
+
+func TestSetupWithoutALicenseRunsTheFreeTier(t *testing.T) {
+	t.Setenv(license.EnvVar, "")
+
+	cfg, err := setupWith(t, minimalConfig+`}`, "")
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if got := cfg.Licensing().State; got != license.StateMissing {
+		t.Errorf("state = %q, want missing", got)
+	}
+	if !strings.Contains(LimitsSummary(cfg.Licensing()), "1 guardrail rule(s)") {
+		t.Error("an unlicensed process did not report the free-tier caps")
+	}
+}
+
+// The three sources in the order the spec sets. Every candidate is a path
+// that does not resolve and the assertion is on which one the error names,
+// which tests precedence without a signature: sidecar/license owns whether a
+// document verifies, and this owns which document we picked.
+func TestSetupPrefersTheFlagThenTheEnvironmentThenTheFile(t *testing.T) {
+	cases := []struct {
+		name       string
+		flag, env  string
+		file       string
+		wantSource string
+	}{
+		{"flag wins", "/no/flag.json", "/no/env.json", "/no/file.json", "the license flag"},
+		{"env beats the file", "", "/no/env.json", "/no/file.json", license.EnvVar},
+		{"the file is the fallback", "", "", "/no/file.json", `the "license" config key`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(license.EnvVar, tc.env)
+			cfgJSON := minimalConfig + `,"license":` + quote(tc.file) + `}`
+
+			_, err := setupWith(t, cfgJSON, tc.flag)
+			if err == nil {
+				t.Fatal("a license that cannot be read was accepted")
+			}
+			if !strings.Contains(err.Error(), tc.wantSource) {
+				t.Errorf("error names the wrong source: %v", err)
+			}
+		})
+	}
+}
+
+// A license nobody can read stops startup, or the operator gets a process
+// that dropped to the free tier and said nothing. An EXPIRED one keeps
+// running capped, so Setup tests StateInvalid and nothing else.
+func TestSetupRefusesALicenseItCannotRead(t *testing.T) {
+	t.Setenv(license.EnvVar, "")
+	cfgJSON := minimalConfig + `,"license":"/etc/hoop/nope.json"}`
+
+	_, err := setupWith(t, cfgJSON, "")
+	if err == nil {
+		t.Fatal("an unreadable license was accepted")
+	}
+	msg := err.Error()
+	for _, want := range []string{"/etc/hoop/nope.json", "paste the document"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the message is missing %q: %s", want, msg)
+		}
+	}
+	// The "not a stack trace" requirement. A refusal an operator cannot act
+	// on costs a support ticket.
+	if strings.Contains(msg, "goroutine") || strings.Contains(msg, ".go:") {
+		t.Errorf("the message reads like a dump: %s", msg)
+	}
+}
+
+// A value starting with "{" is the document, not a filename. A deployment
+// that moves a license out of a mounted file and into a Helm value must not
+// get "no such file or directory" naming its own JSON.
+func TestAnInlineDocumentIsReadAsADocument(t *testing.T) {
+	t.Setenv(license.EnvVar, "")
+	doc := unsignedLicense(t)
+	cfgJSON := minimalConfig + `,"license":` + quote(doc) + `}`
+
+	_, err := setupWith(t, cfgJSON, "")
+	if err == nil {
+		t.Fatal("an unsigned license was accepted")
+	}
+	if strings.Contains(err.Error(), "cannot read the license file") {
+		t.Errorf("the document was treated as a path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not valid") {
+		t.Errorf("the document was not verified: %v", err)
+	}
+}
+
+// -validate is where an operator finds out what a config does, so the license
+// belongs in its report rather than only in the run log.
+func TestPrintLanesReportsTheLicenseAndTheCaps(t *testing.T) {
+	var buf bytes.Buffer
+	PrintLanes(&buf, licensed(), []LaneInfo{{Name: "appdb", Protocol: "postgres"}})
+
+	out := buf.String()
+	for _, want := range []string{"license: valid", "Acme Corp", "unlimited guardrail rule(s)", "appdb"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the report is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintLanesSaysWhenThereIsNoLicense(t *testing.T) {
+	var buf bytes.Buffer
+	PrintLanes(&buf, license.Status{}, nil)
+
+	out := buf.String()
+	for _, want := range []string{"license: missing", license.EnvVar, "1 guardrail rule(s)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the report is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// An expired license reports as a warning and a valid one as information,
+// because only one of them is something an operator has to act on.
+func TestReportLicenseWarnsOnlyWhenSomethingIsWrong(t *testing.T) {
+	expired := licenseStatus(license.StateExpired, license.EnterpriseType, nil,
+		time.Now().Add(-time.Hour))
+	cases := []struct {
+		name     string
+		lic      license.Status
+		wantWarn bool
+	}{
+		{"valid", licensed(), false},
+		{"missing", license.Status{}, false},
+		{"expired", expired, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			reportLicense(newTestLogger(&buf), tc.lic)
+			out := buf.String()
+			if got := strings.Contains(out, "level=WARN"); got != tc.wantWarn {
+				t.Errorf("warned = %v, want %v: %s", got, tc.wantWarn, out)
+			}
+			if !strings.Contains(out, "license:") {
+				t.Errorf("nothing was reported: %s", out)
+			}
+		})
+	}
+}
+
+// quote renders s as a JSON string, so a path or a document full of quotes
+// survives being embedded in a config.
+func quote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// unsignedLicense is a complete license document carrying a signature this
+// build does not trust. It cannot be signed for real here: the trusted key is
+// unexported in sidecar/license, whose own tests swap it and cover the
+// signature. These tests are about what the daemon does with the verdict.
+func unsignedLicense(t *testing.T) string {
+	t.Helper()
+	l := license.License{
+		Payload: license.Payload{
+			Type:         license.EnterpriseType,
+			IssuedAt:     time.Now().Add(-time.Hour).Unix(),
+			ExpireAt:     time.Now().Add(time.Hour).Unix(),
+			AllowedHosts: []string{"*"},
+			Description:  "Acme Corp",
+		},
+		KeyID:     "test-key",
+		Signature: "bm90LWEtc2lnbmF0dXJl",
+	}
+	b, err := json.Marshal(l)
+	if err != nil {
+		t.Fatalf("marshal license: %v", err)
+	}
+	return string(b)
+}

--- a/sidecar/daemon/license_test.go
+++ b/sidecar/daemon/license_test.go
@@ -34,7 +34,7 @@ func TestSetupWithoutALicenseRunsTheFreeTier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Setup: %v", err)
 	}
-	if got := cfg.Licensing().State; got != license.StateMissing {
+	if got := cfg.Licensing().State(); got != license.StateMissing {
 		t.Errorf("state = %q, want missing", got)
 	}
 	if !strings.Contains(LimitsSummary(cfg.Licensing()), "1 guardrail rule(s)") {
@@ -146,8 +146,7 @@ func TestPrintLanesSaysWhenThereIsNoLicense(t *testing.T) {
 // An expired license reports as a warning and a valid one as information,
 // because only one of them is something an operator has to act on.
 func TestReportLicenseWarnsOnlyWhenSomethingIsWrong(t *testing.T) {
-	expired := licenseStatus(license.StateExpired, license.EnterpriseType, nil,
-		time.Now().Add(-time.Hour))
+	expired := licenseStatus(license.EnterpriseType, nil, time.Now().Add(-time.Hour))
 	cases := []struct {
 		name     string
 		lic      license.Status

--- a/sidecar/daemon/license_test.go
+++ b/sidecar/daemon/license_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/license/licensetest"
 )
 
 // newTestLogger captures what Run would print, at a level that keeps both
@@ -121,7 +122,7 @@ func TestAnInlineDocumentIsReadAsADocument(t *testing.T) {
 // belongs in its report rather than only in the run log.
 func TestPrintLanesReportsTheLicenseAndTheCaps(t *testing.T) {
 	var buf bytes.Buffer
-	PrintLanes(&buf, licensed(), []LaneInfo{{Name: "appdb", Protocol: "postgres"}})
+	PrintLanes(&buf, licensed(t), []LaneInfo{{Name: "appdb", Protocol: "postgres"}})
 
 	out := buf.String()
 	for _, want := range []string{"license: valid", "Acme Corp", "unlimited guardrail rule(s)", "appdb"} {
@@ -146,13 +147,13 @@ func TestPrintLanesSaysWhenThereIsNoLicense(t *testing.T) {
 // An expired license reports as a warning and a valid one as information,
 // because only one of them is something an operator has to act on.
 func TestReportLicenseWarnsOnlyWhenSomethingIsWrong(t *testing.T) {
-	expired := licenseStatus(license.EnterpriseType, nil, time.Now().Add(-time.Hour))
+	expired := licensetest.Status(t, licensetest.Expiring(-time.Hour))
 	cases := []struct {
 		name     string
 		lic      license.Status
 		wantWarn bool
 	}{
-		{"valid", licensed(), false},
+		{"valid", licensed(t), false},
 		{"missing", license.Status{}, false},
 		{"expired", expired, true},
 	}

--- a/sidecar/daemon/limits.go
+++ b/sidecar/daemon/limits.go
@@ -48,6 +48,14 @@ func capsFor(lic license.Status) caps {
 	return c
 }
 
+// dependsOnLicense reports whether this config needs a license to run at all,
+// meaning the free-tier caps refuse it. Run watches the term only for these:
+// a config inside the caps loses nothing when a license expires, and taking
+// it down would be an outage with no revenue behind it.
+func (c *Config) dependsOnLicense() bool {
+	return len(c.checkLimits(license.Status{})) > 0
+}
+
 // exceeds reports whether n is over a cap. An unlimited cap is over nothing.
 func exceeds(n, limit int) bool { return limit != unlimited && n > limit }
 
@@ -73,9 +81,13 @@ func capJSON(n int) *int {
 // because both entry points report a validated config and neither should
 // learn the numbers by hand: sidecar/cmd through Main, the CLI through
 // `hoop start sidecar --validate`.
-func LimitsSummary(lic license.Status) string {
+func LimitsSummary(lic license.Status) string { return "limits: " + limitsText(lic) }
+
+// limitsText is the same pair without the label, for a sentence that supplies
+// its own. "needs more than limits: 1 guardrail rule(s)" reads like a bug.
+func limitsText(lic license.Status) string {
 	c := capsFor(lic)
-	return fmt.Sprintf("limits: %s guardrail rule(s), %s data masking rule(s)",
+	return fmt.Sprintf("%s guardrail rule(s), %s data masking rule(s)",
 		capText(c.guardrails), capText(c.mask))
 }
 
@@ -124,7 +136,7 @@ func (c *Config) checkLimits(lic license.Status) []string {
 // operator looks straight at the limit, and "contact our support" wastes it
 // when the reason is a license that expired last week.
 func licenseAdvice(lic license.Status) string {
-	switch lic.State {
+	switch lic.State() {
 	case license.StateExpired:
 		return " " + licenseName(lic) + " expired, so the free tier caps are back in " +
 			"force; renew it at " + license.Support + "."

--- a/sidecar/daemon/limits.go
+++ b/sidecar/daemon/limits.go
@@ -37,6 +37,11 @@ type caps struct {
 // bought data masking does not get unlimited guardrails with it. Status
 // grants nothing unless the license verified and is an enterprise one, so an
 // oss license and an expired one both land here as the free tier.
+//
+// It trusts Allows completely, and can: license.Status carries an unexported
+// verified flag that only license.Load sets, and only after checking the
+// signature. A Status assembled anywhere else answers false to everything
+// here, so there is no path from a hand-built value to a lifted cap.
 func capsFor(lic license.Status) caps {
 	c := caps{guardrails: maxGuardrailRules, mask: maxMaskRules}
 	if lic.Allows(license.FeatureGuardrails) {

--- a/sidecar/daemon/limits.go
+++ b/sidecar/daemon/limits.go
@@ -3,50 +3,80 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
+	"github.com/hoophq/hoop/sidecar/license"
 	"github.com/hoophq/hoop/sidecar/policy"
 )
 
-// The rule counts this build enforces.
-//
-// They are CONSTANTS, and the distinction from a config field is the whole
-// design. A limit an operator can raise in the same file it limits is not a
-// limit, it is documentation with extra steps: the person the cap applies to
-// is exactly the person holding the editor. So the number lives in the
-// binary, and raising it means forking and rebuilding.
-//
-// That is not a security boundary and must not be described as one. The
-// source is public; anyone who wants these rules gone can delete this file
-// and run `go build`. What the cap does is mark the edge of the free tier at
-// the moment an operator crosses it, in the place they are already reading —
-// startup output — rather than after a support conversation. Treat it the
-// same way as the require_review refusal in analyzer/evaluator.go: a
-// capability this build declines to provide, refused by name, with the
-// alternative in the message.
-//
-// They mirror the control-plane free tier, which caps the same two things at
-// the same number per organization (gateway/api/guardrails/guardrails.go and
-// gateway/api/datamasking/datamasking.go). One product, one limit, two
-// engines.
-//
-// There is no way to lift them in this build. Adding one — a signed license
-// file, most likely, reusing the "guardrails" and "data-masking" feature keys
-// that common/license already defines — is a change to this file, not a
-// config field.
+// The rule counts an UNLICENSED process enforces, mirroring the control
+// plane's free tier. Constants, not config keys: a limit the file it limits
+// can raise is documentation with extra steps. Only a license Hoop signed
+// moves them. Not a security boundary; the source is public.
 const (
 	maxGuardrailRules = 1
 	maxMaskRules      = 1
 )
 
-// LimitsSummary renders the caps as the one line -validate prints.
-//
-// Exported because both entry points report a validated config and neither
-// should learn the numbers by hand: sidecar/cmd through Main, and the CLI
-// through `hoop start sidecar --validate`.
-func LimitsSummary() string {
-	return fmt.Sprintf("limits: %d guardrail rule(s), %d data masking rule(s)",
-		maxGuardrailRules, maxMaskRules)
+// unlimited is the cap a licensed feature runs under. Negative rather than a
+// large number, so a comparison that forgets to test for it fails loudly
+// instead of imposing a cap nobody wrote.
+const unlimited = -1
+
+// caps are the rule counts this process may author, after the license has
+// had its say. A struct because the check, the summary line, the startup log
+// and the admin endpoint all read the pair, and a call site holding one of
+// them can report a cap it does not enforce.
+type caps struct {
+	guardrails int
+	mask       int
+}
+
+// capsFor reads a license into the caps it lifts, per feature: a customer who
+// bought data masking does not get unlimited guardrails with it. Status
+// grants nothing unless the license verified and is an enterprise one, so an
+// oss license and an expired one both land here as the free tier.
+func capsFor(lic license.Status) caps {
+	c := caps{guardrails: maxGuardrailRules, mask: maxMaskRules}
+	if lic.Allows(license.FeatureGuardrails) {
+		c.guardrails = unlimited
+	}
+	if lic.Allows(license.FeatureDataMasking) {
+		c.mask = unlimited
+	}
+	return c
+}
+
+// exceeds reports whether n is over a cap. An unlimited cap is over nothing.
+func exceeds(n, limit int) bool { return limit != unlimited && n > limit }
+
+// capText renders a cap for a human.
+func capText(n int) string {
+	if n == unlimited {
+		return "unlimited"
+	}
+	return strconv.Itoa(n)
+}
+
+// capJSON renders a cap for the admin endpoint. Unlimited is null, the one
+// JSON value meaning "no number applies"; a sentinel reads as a cap of minus
+// one to somebody else's dashboard.
+func capJSON(n int) *int {
+	if n == unlimited {
+		return nil
+	}
+	return &n
+}
+
+// LimitsSummary renders the caps as the one line -validate prints. Exported
+// because both entry points report a validated config and neither should
+// learn the numbers by hand: sidecar/cmd through Main, the CLI through
+// `hoop start sidecar --validate`.
+func LimitsSummary(lic license.Status) string {
+	c := capsFor(lic)
+	return fmt.Sprintf("limits: %s guardrail rule(s), %s data masking rule(s)",
+		capText(c.guardrails), capText(c.mask))
 }
 
 // ruleSite is one place in the config that authors rules, named the way the
@@ -61,46 +91,60 @@ type ruleSite struct {
 	count int
 }
 
-// checkLimits counts what the config AUTHORS and refuses a config that
-// exceeds this build's caps.
-//
-// Authored, not resolved, and the difference is not cosmetic. resolve()
-// concatenates the top-level guardrails.rules into every lane, so counting
-// resolved lanes reports one global rule N times and refuses a two-lane
-// config that holds exactly one rule. Counting what is written also gives an
-// operator a number they can find in their own file.
-//
-// The cap is therefore per PROCESS rather than per lane, which matches the
-// control plane's per-organization cap. A lane-scoped cap would let one
-// process hold one rule per listener, and a config with eight lanes is not
-// the free tier by any reading. Running eight processes still is, and nothing
-// here pretends otherwise.
-//
-// Returns a problem per violation rather than an error, so it composes with
-// the collecting validators either side of it: every problem in one run,
-// never one error per restart.
-func (c *Config) checkLimits() []string {
+// checkLimits counts what the config AUTHORS, not what each lane resolves:
+// resolve() copies top-level rules into every lane, so counting resolved
+// lanes would refuse a two-lane config holding one rule. The cap is per
+// PROCESS, matching the control plane's per-organization one.
+func (c *Config) checkLimits(lic license.Status) []string {
 	var problems []string
+	limit := capsFor(lic)
 
-	if sites, total := c.guardrailSites(); total > maxGuardrailRules {
+	if sites, total := c.guardrailSites(); exceeds(total, limit.guardrails) {
 		problems = append(problems, fmt.Sprintf(
-			"%d guardrail rules are configured (%s) and this build enforces at most %d; "+
-				"merge them into one rule, or contact our support at https://help.hoop.dev. "+
+			"%d guardrail rules are configured (%s) and this process enforces at most %d; "+
+				"merge them into one rule.%s "+
 				"ai_analysis rules are counted separately and are not limited",
-			total, renderSites(sites), maxGuardrailRules))
+			total, renderSites(sites), limit.guardrails, licenseAdvice(lic)))
 	}
 
 	sites, total, errs := c.maskSites()
 	problems = append(problems, errs...)
-	if total > maxMaskRules {
+	if exceeds(total, limit.mask) {
 		problems = append(problems, fmt.Sprintf(
-			"%d data masking rules are configured (%s) and this build enforces at most %d; "+
+			"%d data masking rules are configured (%s) and this process enforces at most %d; "+
 				"one rule may name several columns or one entity, so two rules can often "+
-				"become one. Contact our support at https://help.hoop.dev",
-			total, renderSites(sites), maxMaskRules))
+				"become one.%s",
+			total, renderSites(sites), limit.mask, licenseAdvice(lic)))
 	}
 
 	return problems
+}
+
+// licenseAdvice says what would lift the cap. Hitting one is the moment an
+// operator looks straight at the limit, and "contact our support" wastes it
+// when the reason is a license that expired last week.
+func licenseAdvice(lic license.Status) string {
+	switch lic.State {
+	case license.StateExpired:
+		return " " + licenseName(lic) + " expired, so the free tier caps are back in " +
+			"force; renew it at " + license.Support + "."
+	case license.StateValid:
+		return " " + licenseName(lic) + " does not cover this; ask about it at " +
+			license.Support + "."
+	default:
+		return " A license lifts this cap: add one with the license flag, the " +
+			license.EnvVar + " environment variable, or the \"license\" key in the config " +
+			"file. Contact our support at " + license.Support + "."
+	}
+}
+
+// licenseName says which license a message is about. Naming the source is the
+// difference between an operator editing the right file and editing three.
+func licenseName(lic license.Status) string {
+	if lic.Source == "" {
+		return "This license"
+	}
+	return "The license from " + lic.Source
 }
 
 // guardrailSites counts the non-ai_analysis rules each guardrails block

--- a/sidecar/daemon/limits_test.go
+++ b/sidecar/daemon/limits_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/license/licensetest"
 	"github.com/hoophq/hoop/sidecar/policy"
 )
 
@@ -22,29 +23,31 @@ func overCap() *Config {
 	}
 }
 
-// licenseStatus builds the verdict a daemon runs under. Verdict rather than a
-// signed document, because the daemon consumes a verdict and never checks a
-// signature: sidecar/license owns a key it can sign with and settles that
-// there. The term still applies, so an expired date reports expired.
-func licenseStatus(typ string, features []string, expires time.Time) license.Status {
-	return license.Verdict(&license.License{
-		Payload: license.Payload{
-			Type:         typ,
-			IssuedAt:     time.Now().Add(-time.Hour).Unix(),
-			ExpireAt:     expires.Unix(),
-			AllowedHosts: []string{"*"},
-			Description:  "Acme Corp",
-			Features:     features,
-		},
-		KeyID:     "test-key",
-		Signature: "test-signature",
-	}, "the test")
+// licensed is a license this process genuinely verifies: licensetest signs it
+// and points the trust root at the signing key for the test. Assembling a
+// Status by hand is impossible on purpose, so these tests exercise the same
+// path a customer's license takes.
+func licensed(t *testing.T, features ...string) license.Status {
+	t.Helper()
+	return licensetest.Status(t, licensetest.Enterprise(features...))
 }
 
-// licensed is a current enterprise license. No features named means every
-// feature, which is what most licenses carry.
-func licensed(features ...string) license.Status {
-	return licenseStatus(license.EnterpriseType, features, time.Now().Add(720*time.Hour))
+// licenseFor shapes a payload the caller cares about: an oss type, a term
+// that has already ended, a narrower feature list.
+func licenseFor(shape func(*license.Payload)) license.Payload {
+	p := licensetest.Enterprise()
+	shape(&p)
+	return p
+}
+
+// useLicense hands the config a signed reference the way a control plane
+// would, so every licensing test exercises the verification too. There is no
+// way to skip it, which is the point of UseLicense taking a Ref.
+func useLicense(t *testing.T, cfg *Config, p license.Payload) {
+	t.Helper()
+	if err := cfg.UseLicense(licensetest.Ref(t, p)); err != nil {
+		t.Fatalf("UseLicense: %v", err)
+	}
 }
 
 // limitsLane is a minimal valid listener, so a limits test fails on the limit
@@ -233,7 +236,7 @@ func TestLimitsSummaryNamesBothCaps(t *testing.T) {
 // the config that was refused a moment ago builds.
 func TestALicenseLiftsBothCaps(t *testing.T) {
 	cfg := overCap()
-	cfg.UseLicense(licensed())
+	useLicense(t, cfg, licensetest.Enterprise())
 
 	if problems := cfg.checkLimits(cfg.Licensing()); len(problems) != 0 {
 		t.Errorf("a licensed config was capped: %v", problems)
@@ -244,7 +247,7 @@ func TestALicenseLiftsBothCaps(t *testing.T) {
 // guardrail cap where it was, or a one-feature license pays for two.
 func TestALicenseLiftsOnlyTheFeaturesItNames(t *testing.T) {
 	cfg := overCap()
-	cfg.UseLicense(licensed(license.FeatureDataMasking))
+	useLicense(t, cfg, licensetest.Enterprise(license.FeatureDataMasking))
 
 	problems := cfg.checkLimits(cfg.Licensing())
 	if len(problems) != 1 {
@@ -262,7 +265,7 @@ func TestALicenseLiftsOnlyTheFeaturesItNames(t *testing.T) {
 // verifying license as enterprise would hand the paid caps to the free tier.
 func TestAnOSSLicenseLeavesTheCapsInForce(t *testing.T) {
 	cfg := overCap()
-	cfg.UseLicense(licenseStatus(license.OSSType, nil, time.Now().Add(720*time.Hour)))
+	useLicense(t, cfg, licenseFor(func(p *license.Payload) { p.Type = license.OSSType }))
 
 	if problems := cfg.checkLimits(cfg.Licensing()); len(problems) != 2 {
 		t.Errorf("an oss license changed the caps: %v", problems)
@@ -274,7 +277,9 @@ func TestAnOSSLicenseLeavesTheCapsInForce(t *testing.T) {
 // sends an operator to read their rules instead of their expiry date.
 func TestAnExpiredLicenseRestoresTheCapsAndSaysWhy(t *testing.T) {
 	cfg := overCap()
-	cfg.UseLicense(licenseStatus(license.EnterpriseType, nil, time.Now().Add(-24*time.Hour)))
+	useLicense(t, cfg, licenseFor(func(p *license.Payload) {
+		p.ExpireAt = time.Now().Add(-24 * time.Hour).Unix()
+	}))
 
 	problems := cfg.checkLimits(cfg.Licensing())
 	if len(problems) != 2 {
@@ -305,7 +310,7 @@ func TestAnUncappedMessageNamesEveryLicenseSource(t *testing.T) {
 // licensed process saying "1 guardrail rule(s)" while enforcing none is worse
 // than printing nothing.
 func TestLimitsSummaryReportsUnlimitedWhenLicensed(t *testing.T) {
-	got := LimitsSummary(licensed())
+	got := LimitsSummary(licensed(t))
 	for _, want := range []string{"unlimited guardrail rule(s)", "unlimited data masking rule(s)"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("LimitsSummary() = %q, missing %q", got, want)

--- a/sidecar/daemon/limits_test.go
+++ b/sidecar/daemon/limits_test.go
@@ -3,9 +3,54 @@ package daemon
 import (
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/hoophq/hoop/sidecar/license"
 	"github.com/hoophq/hoop/sidecar/policy"
 )
+
+// overCap builds a config that authors two guardrail rules and two mask
+// rules, which is one of each over the free tier.
+func overCap() *Config {
+	lane := limitsLane("appdb", ":1")
+	lane.Guardrails = &GuardrailsConfig{Rules: []policy.Rule{rule("no-drop-on-appdb")}}
+	lane.Mask = &MaskConfig{Rules: maskRule("US_SSN")}
+	return &Config{
+		Guardrails: &GuardrailsConfig{Mode: ModeEnforce, Rules: []policy.Rule{rule("no-drop")}},
+		Mask:       &MaskConfig{Rules: maskRule("EMAIL_ADDRESS")},
+		Listeners:  []ListenerConfig{lane},
+	}
+}
+
+// licenseStatus builds the verdict a daemon runs under. Assembled rather
+// than signed, because the daemon consumes a verdict and never a document.
+// sidecar/license owns a key it can sign with and settles signatures there;
+// forging one here would test that package twice and this one not at all.
+func licenseStatus(state license.State, typ string, features []string, expires time.Time) license.Status {
+	return license.Status{
+		State:  state,
+		Source: "the test",
+		License: &license.License{
+			Payload: license.Payload{
+				Type:         typ,
+				IssuedAt:     time.Now().Add(-time.Hour).Unix(),
+				ExpireAt:     expires.Unix(),
+				AllowedHosts: []string{"*"},
+				Description:  "Acme Corp",
+				Features:     features,
+			},
+			KeyID:     "test-key",
+			Signature: "test-signature",
+		},
+	}
+}
+
+// licensed is a current enterprise license. No features named means every
+// feature, which is what most licenses carry.
+func licensed(features ...string) license.Status {
+	return licenseStatus(license.StateValid, license.EnterpriseType, features,
+		time.Now().Add(720*time.Hour))
+}
 
 // limitsLane is a minimal valid listener, so a limits test fails on the limit
 // it is about and not on a missing upstream.
@@ -19,18 +64,19 @@ func maskRule(entity string) []byte {
 	return []byte(`[{"name":"r","entity":"` + entity + `","strategy":"redact"}]`)
 }
 
-// The cap fires on the second guardrail rule, and the message says where both
-// of them are. A bare count sends an operator reading a config from the top,
-// which is usually the rule they meant to keep.
+// The cap fires on the second guardrail rule and the message says where both
+// of them are. buildLanes rather than (*Config).Validate: the file validator
+// runs before the license resolves, so the caps moved to the one function
+// every caller that runs or validates a sidecar reaches.
 func TestSecondGuardrailRuleIsRefused(t *testing.T) {
 	lane := limitsLane("appdb", ":1")
 	lane.Guardrails = &GuardrailsConfig{Rules: []policy.Rule{rule("no-drop-on-appdb")}}
 	cfg := &Config{
-		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("no-drop")}},
+		Guardrails: &GuardrailsConfig{Mode: ModeEnforce, Rules: []policy.Rule{rule("no-drop")}},
 		Listeners:  []ListenerConfig{lane},
 	}
 
-	err := cfg.Validate()
+	_, err := buildLanes(cfg, nil, nil)
 	if err == nil {
 		t.Fatal("two guardrail rules were accepted")
 	}
@@ -82,7 +128,7 @@ func TestAIAnalysisRulesAreNotCountedAsGuardrails(t *testing.T) {
 		Listeners: []ListenerConfig{limitsLane("appdb", ":1")},
 	}
 
-	if problems := cfg.checkLimits(); len(problems) != 0 {
+	if problems := cfg.checkLimits(license.Status{}); len(problems) != 0 {
 		t.Errorf("ai_analysis rules counted against the guardrail cap: %v", problems)
 	}
 }
@@ -98,7 +144,7 @@ func TestSecondMaskRuleIsRefused(t *testing.T) {
 		Listeners: []ListenerConfig{lane},
 	}
 
-	err := cfg.Validate()
+	_, err := buildLanes(cfg, nil, nil)
 	if err == nil {
 		t.Fatal("two data masking rules were accepted")
 	}
@@ -120,7 +166,7 @@ func TestLaneOptingOutOfMaskingCostsNothing(t *testing.T) {
 		Listeners: []ListenerConfig{lane},
 	}
 
-	if problems := cfg.checkLimits(); len(problems) != 0 {
+	if problems := cfg.checkLimits(license.Status{}); len(problems) != 0 {
 		t.Errorf("an empty override was counted as a rule: %v", problems)
 	}
 }
@@ -134,7 +180,7 @@ func TestMalformedMaskRulesAreReportedOnceAtTheirSite(t *testing.T) {
 		Listeners: []ListenerConfig{limitsLane("a", ":1"), limitsLane("b", ":2")},
 	}
 
-	err := cfg.Validate()
+	_, err := buildLanes(cfg, nil, nil)
 	if err == nil {
 		t.Fatal("a mask block that is not an array was accepted")
 	}
@@ -143,41 +189,34 @@ func TestMalformedMaskRulesAreReportedOnceAtTheirSite(t *testing.T) {
 	}
 }
 
-// Run and the exported Validate never call (*Config).Validate, so a cap that
-// lived only in the file validator would be skipped by every caller that
-// assembles a Config in Go. buildLanes is the one function all of them reach.
-func TestLimitsHoldWhenTheFileValidatorIsSkipped(t *testing.T) {
-	lane := limitsLane("appdb", ":1")
-	lane.Guardrails = &GuardrailsConfig{Rules: []policy.Rule{rule("second")}}
-	cfg := &Config{
-		Guardrails: &GuardrailsConfig{Mode: ModeEnforce, Rules: []policy.Rule{rule("first")}},
-		Listeners:  []ListenerConfig{lane},
-	}
+// The file validator must not enforce the caps: it runs before Setup
+// resolves the license flag or HOOP_LICENSE, so a config a license makes
+// legal would be refused before anyone read the license.
+func TestTheCapsAreEnforcedAfterTheLicenseIsKnown(t *testing.T) {
+	cfg := overCap()
 
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("the file validator refused a config before the license was read: %v", err)
+	}
 	if _, err := buildLanes(cfg, nil, nil); err == nil {
-		t.Fatal("buildLanes accepted a config over the guardrail cap")
+		t.Fatal("buildLanes accepted a config over the caps")
 	} else if !strings.Contains(err.Error(), "guardrail rules") {
 		t.Errorf("error does not name the cap: %v", err)
 	}
 }
 
 // Every problem in one run: a config over both caps reports both, and still
-// reports the unrelated lane errors beside them.
+// reports the unrelated lane errors beside them. A cap that returned on the
+// first violation would make an operator restart once per rule.
 func TestLimitsAreReportedWithEveryOtherProblem(t *testing.T) {
-	lane := limitsLane("appdb", ":1")
-	lane.Guardrails = &GuardrailsConfig{Rules: []policy.Rule{rule("second")}}
-	lane.Mask = &MaskConfig{Rules: maskRule("US_SSN")}
-	cfg := &Config{
-		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{rule("first")}},
-		Mask:       &MaskConfig{Rules: maskRule("EMAIL_ADDRESS")},
-		Listeners:  []ListenerConfig{lane, {Name: "broken"}},
-	}
+	cfg := overCap()
+	cfg.Listeners = append(cfg.Listeners, ListenerConfig{Name: "broken", Protocol: "postgres"})
 
-	err := cfg.Validate()
+	_, err := buildLanes(cfg, nil, nil)
 	if err == nil {
 		t.Fatal("an invalid config was accepted")
 	}
-	for _, want := range []string{"guardrail rules", "data masking rules", "broken: no protocol"} {
+	for _, want := range []string{"guardrail rules", "data masking rules", "broken"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("message does not contain %q: %v", want, err)
 		}
@@ -187,11 +226,109 @@ func TestLimitsAreReportedWithEveryOtherProblem(t *testing.T) {
 // The caps are reported, not just enforced. An operator who has to discover a
 // limit by hitting it learns it in the worst place.
 func TestLimitsSummaryNamesBothCaps(t *testing.T) {
-	got := LimitsSummary()
+	got := LimitsSummary(license.Status{})
 	for _, want := range []string{"1 guardrail rule(s)", "1 data masking rule(s)"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("LimitsSummary() = %q, missing %q", got, want)
 		}
+	}
+}
+
+// The whole point of the feature. A license Hoop signed lifts both caps, and
+// the config that was refused a moment ago builds.
+func TestALicenseLiftsBothCaps(t *testing.T) {
+	cfg := overCap()
+	cfg.UseLicense(licensed())
+
+	if problems := cfg.checkLimits(cfg.Licensing()); len(problems) != 0 {
+		t.Errorf("a licensed config was capped: %v", problems)
+	}
+}
+
+// A feature list restricts. A license sold for data masking leaves the
+// guardrail cap where it was, or a one-feature license pays for two.
+func TestALicenseLiftsOnlyTheFeaturesItNames(t *testing.T) {
+	cfg := overCap()
+	cfg.UseLicense(licensed(license.FeatureDataMasking))
+
+	problems := cfg.checkLimits(cfg.Licensing())
+	if len(problems) != 1 {
+		t.Fatalf("want exactly the guardrail problem, got %v", problems)
+	}
+	if !strings.Contains(problems[0], "guardrail rules") {
+		t.Errorf("the wrong cap fired: %v", problems)
+	}
+	if !strings.Contains(problems[0], "does not cover this") {
+		t.Errorf("the message does not say the license is the reason: %v", problems[0])
+	}
+}
+
+// An oss license is signed, current, and grants nothing. Treating any
+// verifying license as enterprise would hand the paid caps to the free tier.
+func TestAnOSSLicenseLeavesTheCapsInForce(t *testing.T) {
+	cfg := overCap()
+	cfg.UseLicense(licenseStatus(license.StateValid, license.OSSType, nil,
+		time.Now().Add(720*time.Hour)))
+
+	if problems := cfg.checkLimits(cfg.Licensing()); len(problems) != 2 {
+		t.Errorf("an oss license changed the caps: %v", problems)
+	}
+}
+
+// An expired license drops the process back to the free tier, and the message
+// has to say so. "Contact our support" for a config that loaded last week
+// sends an operator to read their rules instead of their expiry date.
+func TestAnExpiredLicenseRestoresTheCapsAndSaysWhy(t *testing.T) {
+	cfg := overCap()
+	cfg.UseLicense(licenseStatus(license.StateExpired, license.EnterpriseType, nil,
+		time.Now().Add(-24*time.Hour)))
+
+	problems := cfg.checkLimits(cfg.Licensing())
+	if len(problems) != 2 {
+		t.Fatalf("an expired license kept the caps lifted: %v", problems)
+	}
+	for _, p := range problems {
+		if !strings.Contains(p, "expired") || !strings.Contains(p, license.Support) {
+			t.Errorf("the message does not point at the renewal: %v", p)
+		}
+	}
+}
+
+// Unlicensed, the cap message has to name every way a license can be
+// supplied. It is the one moment the operator is looking at the limit.
+func TestAnUncappedMessageNamesEveryLicenseSource(t *testing.T) {
+	problems := overCap().checkLimits(license.Status{})
+	if len(problems) == 0 {
+		t.Fatal("the free tier accepted a config over both caps")
+	}
+	for _, want := range []string{"license flag", license.EnvVar, `"license" key`} {
+		if !strings.Contains(problems[0], want) {
+			t.Errorf("the message does not mention %q: %v", want, problems[0])
+		}
+	}
+}
+
+// The summary is what -validate prints and what the startup log carries. A
+// licensed process saying "1 guardrail rule(s)" while enforcing none is worse
+// than printing nothing.
+func TestLimitsSummaryReportsUnlimitedWhenLicensed(t *testing.T) {
+	got := LimitsSummary(licensed())
+	for _, want := range []string{"unlimited guardrail rule(s)", "unlimited data masking rule(s)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("LimitsSummary() = %q, missing %q", got, want)
+		}
+	}
+}
+
+// The admin endpoint serves the caps to somebody else's dashboard, where a
+// -1 would read as a cap of minus one. Unlimited is null.
+func TestCapJSONRendersUnlimitedAsNull(t *testing.T) {
+	if got := capJSON(unlimited); got != nil {
+		t.Errorf("capJSON(unlimited) = %v, want nil", *got)
+	}
+	got := capJSON(maxGuardrailRules)
+	if got == nil || *got != 1 {
+		t.Errorf("capJSON(1) = %v, want 1", got)
 	}
 }
 

--- a/sidecar/daemon/limits_test.go
+++ b/sidecar/daemon/limits_test.go
@@ -22,34 +22,29 @@ func overCap() *Config {
 	}
 }
 
-// licenseStatus builds the verdict a daemon runs under. Assembled rather
-// than signed, because the daemon consumes a verdict and never a document.
-// sidecar/license owns a key it can sign with and settles signatures there;
-// forging one here would test that package twice and this one not at all.
-func licenseStatus(state license.State, typ string, features []string, expires time.Time) license.Status {
-	return license.Status{
-		State:  state,
-		Source: "the test",
-		License: &license.License{
-			Payload: license.Payload{
-				Type:         typ,
-				IssuedAt:     time.Now().Add(-time.Hour).Unix(),
-				ExpireAt:     expires.Unix(),
-				AllowedHosts: []string{"*"},
-				Description:  "Acme Corp",
-				Features:     features,
-			},
-			KeyID:     "test-key",
-			Signature: "test-signature",
+// licenseStatus builds the verdict a daemon runs under. Verdict rather than a
+// signed document, because the daemon consumes a verdict and never checks a
+// signature: sidecar/license owns a key it can sign with and settles that
+// there. The term still applies, so an expired date reports expired.
+func licenseStatus(typ string, features []string, expires time.Time) license.Status {
+	return license.Verdict(&license.License{
+		Payload: license.Payload{
+			Type:         typ,
+			IssuedAt:     time.Now().Add(-time.Hour).Unix(),
+			ExpireAt:     expires.Unix(),
+			AllowedHosts: []string{"*"},
+			Description:  "Acme Corp",
+			Features:     features,
 		},
-	}
+		KeyID:     "test-key",
+		Signature: "test-signature",
+	}, "the test")
 }
 
 // licensed is a current enterprise license. No features named means every
 // feature, which is what most licenses carry.
 func licensed(features ...string) license.Status {
-	return licenseStatus(license.StateValid, license.EnterpriseType, features,
-		time.Now().Add(720*time.Hour))
+	return licenseStatus(license.EnterpriseType, features, time.Now().Add(720*time.Hour))
 }
 
 // limitsLane is a minimal valid listener, so a limits test fails on the limit
@@ -267,8 +262,7 @@ func TestALicenseLiftsOnlyTheFeaturesItNames(t *testing.T) {
 // verifying license as enterprise would hand the paid caps to the free tier.
 func TestAnOSSLicenseLeavesTheCapsInForce(t *testing.T) {
 	cfg := overCap()
-	cfg.UseLicense(licenseStatus(license.StateValid, license.OSSType, nil,
-		time.Now().Add(720*time.Hour)))
+	cfg.UseLicense(licenseStatus(license.OSSType, nil, time.Now().Add(720*time.Hour)))
 
 	if problems := cfg.checkLimits(cfg.Licensing()); len(problems) != 2 {
 		t.Errorf("an oss license changed the caps: %v", problems)
@@ -280,8 +274,7 @@ func TestAnOSSLicenseLeavesTheCapsInForce(t *testing.T) {
 // sends an operator to read their rules instead of their expiry date.
 func TestAnExpiredLicenseRestoresTheCapsAndSaysWhy(t *testing.T) {
 	cfg := overCap()
-	cfg.UseLicense(licenseStatus(license.StateExpired, license.EnterpriseType, nil,
-		time.Now().Add(-24*time.Hour)))
+	cfg.UseLicense(licenseStatus(license.EnterpriseType, nil, time.Now().Add(-24*time.Hour)))
 
 	problems := cfg.checkLimits(cfg.Licensing())
 	if len(problems) != 2 {

--- a/sidecar/daemon/setupcompat_test.go
+++ b/sidecar/daemon/setupcompat_test.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/license/licensetest"
+)
+
+// setupSignature is the EXACT shape the README has told embedders to call
+// since before licensing existed, variadic included, which is to say not
+// variadic at all.
+//
+// Assigning Setup to it is the whole test, and it is a compile-time one: add
+// a parameter, or turn it variadic, and this file stops building. That is the
+// failure an embedder holding Setup in a typed variable would otherwise
+// discover on upgrade. The license went in as a fourth argument once and
+// broke every caller; a variadic would have broken this one.
+type setupSignature func(string, Loader, PluginBuilder) (*Config, Plugin, error)
+
+var _ setupSignature = Setup
+
+// The three-argument call still compiles and still works. Options are
+// additions, so a caller that wants none passes none.
+func TestSetupTakesThreeArgumentsAsBefore(t *testing.T) {
+	t.Setenv(license.EnvVar, "")
+
+	cfg, det, err := Setup(writeConfig(t, minimalConfig+`}`), nil, nil)
+	if err != nil {
+		t.Fatalf("the three-argument call failed: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("no config came back")
+	}
+	if det != nil {
+		t.Error("a nil PluginBuilder produced a detector")
+	}
+	if cfg.Licensing().State() != license.StateMissing {
+		t.Errorf("state = %q, want missing", cfg.Licensing().State())
+	}
+}
+
+// An embedder who never learned about the option still gets a license from
+// the environment and from the config file. Only the command-line source
+// needs WithLicense, because only a caller with a flag has one.
+func TestTheThreeArgumentCallStillReadsTheOtherTwoSources(t *testing.T) {
+	doc := licensetest.Document(t, licensetest.Enterprise())
+
+	t.Run("from the environment", func(t *testing.T) {
+		t.Setenv(license.EnvVar, doc)
+		cfg, _, err := Setup(writeConfig(t, minimalConfig+`}`), nil, nil)
+		if err != nil {
+			t.Fatalf("Setup: %v", err)
+		}
+		if cfg.Licensing().State() != license.StateValid {
+			t.Errorf("state = %q, want valid", cfg.Licensing().State())
+		}
+	})
+
+	t.Run("from the config file", func(t *testing.T) {
+		t.Setenv(license.EnvVar, "")
+		cfgJSON := minimalConfig + `,"license":` + quote(doc) + `}`
+		cfg, _, err := Setup(writeConfig(t, cfgJSON), nil, nil)
+		if err != nil {
+			t.Fatalf("Setup: %v", err)
+		}
+		if cfg.Licensing().State() != license.StateValid {
+			t.Errorf("state = %q, want valid", cfg.Licensing().State())
+		}
+	})
+}
+
+// WithLicense is the command-line source, and it outranks the other two.
+func TestWithLicenseOutranksTheEnvironment(t *testing.T) {
+	t.Setenv(license.EnvVar, "/no/env.json")
+
+	_, _, err := SetupWith(writeConfig(t, minimalConfig+`}`), nil, nil,
+		WithLicense("/no/flag.json"))
+
+	if err == nil {
+		t.Fatal("a license that cannot be read was accepted")
+	}
+	if !strings.Contains(err.Error(), "the license flag") {
+		t.Errorf("the option did not win: %v", err)
+	}
+}
+
+// An empty WithLicense is the same as passing no option, so a caller can hand
+// through a flag variable without branching on whether the operator set it.
+func TestAnEmptyWithLicenseFallsThrough(t *testing.T) {
+	t.Setenv(license.EnvVar, licensetest.Document(t, licensetest.Enterprise()))
+
+	cfg, _, err := SetupWith(writeConfig(t, minimalConfig+`}`), nil, nil, WithLicense(""))
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if cfg.Licensing().Source != license.EnvVar {
+		t.Errorf("source = %q, want %q", cfg.Licensing().Source, license.EnvVar)
+	}
+}
+
+// Options apply in order, so a caller assembling them from several places
+// gets last-wins rather than a silent merge.
+func TestTheLastOptionWins(t *testing.T) {
+	t.Setenv(license.EnvVar, "")
+
+	_, _, err := SetupWith(writeConfig(t, minimalConfig+`}`), nil, nil,
+		WithLicense("/no/first.json"), WithLicense("/no/second.json"))
+
+	if err == nil {
+		t.Fatal("a license that cannot be read was accepted")
+	}
+	if !strings.Contains(err.Error(), "/no/second.json") {
+		t.Errorf("the last option did not win: %v", err)
+	}
+}

--- a/sidecar/license/expiry_test.go
+++ b/sidecar/license/expiry_test.go
@@ -6,20 +6,21 @@ import (
 	"time"
 )
 
-// term builds a verdict whose signature a caller already checked, so these
-// tests can put the boundary wherever they need it.
-func term(from, to time.Time) Status {
-	return Verdict(&License{
-		Payload: Payload{
-			Type:         EnterpriseType,
-			IssuedAt:     from.Unix(),
-			ExpireAt:     to.Unix(),
-			AllowedHosts: []string{"*"},
-			Description:  "Acme Corp",
-		},
-		KeyID:     "test-key",
-		Signature: "test-signature",
-	}, "the test")
+// term signs a license with the boundary these tests need and puts it
+// through the real Load, so the verdict under test is one a customer could
+// hold. Nothing here can shortcut the signature: there is no constructor for
+// that, which is the property the tests below lean on.
+func term(t *testing.T, from, to time.Time) Status {
+	t.Helper()
+	key := signingKey(t)
+	l := issue(t, key, Payload{
+		Type:         EnterpriseType,
+		IssuedAt:     from.Unix(),
+		ExpireAt:     to.Unix(),
+		AllowedHosts: []string{"*"},
+		Description:  "Acme Corp",
+	})
+	return Load(Ref{Value: document(t, l), Source: "the test"})
 }
 
 // The bug this file exists for. A process that verified a license at startup
@@ -28,7 +29,7 @@ func term(from, to time.Time) Status {
 // answer differently.
 func TestAVerdictExpiresWithoutBeingReloaded(t *testing.T) {
 	start := time.Now().UTC()
-	s := term(start.Add(-time.Hour), start.Add(time.Hour))
+	s := term(t, start.Add(-time.Hour), start.Add(time.Hour))
 
 	if got := s.StateAt(start); got != StateValid {
 		t.Fatalf("inside the term: state = %q", got)
@@ -50,7 +51,7 @@ func TestAVerdictExpiresWithoutBeingReloaded(t *testing.T) {
 // verdict taken exactly on it still grants and one a second later does not.
 func TestTheBoundaryIsExpireAt(t *testing.T) {
 	end := time.Now().UTC().Truncate(time.Second).Add(time.Hour)
-	s := term(end.Add(-24*time.Hour), end)
+	s := term(t, end.Add(-24*time.Hour), end)
 
 	if !s.AllowsAt(end, FeatureGuardrails) {
 		t.Error("the license stopped granting at the last second of its term")
@@ -64,10 +65,10 @@ func TestTheBoundaryIsExpireAt(t *testing.T) {
 // gets an aging verdict. This is what the daemon calls.
 func TestAllowsReadsTheClock(t *testing.T) {
 	now := time.Now().UTC()
-	if live := term(now.Add(-time.Hour), now.Add(time.Hour)); !live.Allows(FeatureGuardrails) {
+	if live := term(t, now.Add(-time.Hour), now.Add(time.Hour)); !live.Allows(FeatureGuardrails) {
 		t.Error("a current license granted nothing")
 	}
-	if dead := term(now.Add(-48*time.Hour), now.Add(-time.Hour)); dead.Allows(FeatureGuardrails) {
+	if dead := term(t, now.Add(-48*time.Hour), now.Add(-time.Hour)); dead.Allows(FeatureGuardrails) {
 		t.Error("a license whose term ended an hour ago still granted a feature")
 	}
 }
@@ -76,7 +77,7 @@ func TestAllowsReadsTheClock(t *testing.T) {
 // line and the admin report are derived, so they move with the verdict.
 func TestTheReportAndTheLineFollowTheVerdict(t *testing.T) {
 	now := time.Now().UTC()
-	s := term(now.Add(-48*time.Hour), now.Add(-time.Hour))
+	s := term(t, now.Add(-48*time.Hour), now.Add(-time.Hour))
 
 	if got := s.Report()["state"]; got != "expired" {
 		t.Errorf("report state = %v, want expired", got)
@@ -100,11 +101,11 @@ func TestTheReportAndTheLineFollowTheVerdict(t *testing.T) {
 	}
 }
 
-// Verdict is the control-plane seam and a licensing bypass by construction.
-// It must not also bypass the term.
-func TestVerdictCannotSkipTheTerm(t *testing.T) {
+// A license that verified and then ran out grants nothing, whatever the
+// verdict said when it loaded.
+func TestALoadedLicenseCannotSkipTheTerm(t *testing.T) {
 	past := time.Now().UTC().Add(-time.Hour)
-	s := term(past.Add(-24*time.Hour), past)
+	s := term(t, past.Add(-24*time.Hour), past)
 
 	if s.State() != StateExpired {
 		t.Errorf("state = %q, want expired", s.State())

--- a/sidecar/license/expiry_test.go
+++ b/sidecar/license/expiry_test.go
@@ -1,0 +1,146 @@
+package license
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// term builds a verdict whose signature a caller already checked, so these
+// tests can put the boundary wherever they need it.
+func term(from, to time.Time) Status {
+	return Verdict(&License{
+		Payload: Payload{
+			Type:         EnterpriseType,
+			IssuedAt:     from.Unix(),
+			ExpireAt:     to.Unix(),
+			AllowedHosts: []string{"*"},
+			Description:  "Acme Corp",
+		},
+		KeyID:     "test-key",
+		Signature: "test-signature",
+	}, "the test")
+}
+
+// The bug this file exists for. A process that verified a license at startup
+// used to hold the caps for its whole life, because the verdict was a field
+// set once. Ask the same Status either side of its expiry and it has to
+// answer differently.
+func TestAVerdictExpiresWithoutBeingReloaded(t *testing.T) {
+	start := time.Now().UTC()
+	s := term(start.Add(-time.Hour), start.Add(time.Hour))
+
+	if got := s.StateAt(start); got != StateValid {
+		t.Fatalf("inside the term: state = %q", got)
+	}
+	if !s.AllowsAt(start, FeatureGuardrails) {
+		t.Fatal("inside the term: the license granted nothing")
+	}
+
+	after := start.Add(2 * time.Hour)
+	if got := s.StateAt(after); got != StateExpired {
+		t.Errorf("past the term: state = %q, want expired", got)
+	}
+	if s.AllowsAt(after, FeatureGuardrails) || s.AllowsAt(after, FeatureDataMasking) {
+		t.Error("past the term: the license still granted a feature")
+	}
+}
+
+// The instant itself. ExpireAt is the last second the license covers, so a
+// verdict taken exactly on it still grants and one a second later does not.
+func TestTheBoundaryIsExpireAt(t *testing.T) {
+	end := time.Now().UTC().Truncate(time.Second).Add(time.Hour)
+	s := term(end.Add(-24*time.Hour), end)
+
+	if !s.AllowsAt(end, FeatureGuardrails) {
+		t.Error("the license stopped granting at the last second of its term")
+	}
+	if s.AllowsAt(end.Add(time.Second), FeatureGuardrails) {
+		t.Error("the license granted a second past its term")
+	}
+}
+
+// Allows reads the wall clock, so a caller that never touches StateAt still
+// gets an aging verdict. This is what the daemon calls.
+func TestAllowsReadsTheClock(t *testing.T) {
+	now := time.Now().UTC()
+	if live := term(now.Add(-time.Hour), now.Add(time.Hour)); !live.Allows(FeatureGuardrails) {
+		t.Error("a current license granted nothing")
+	}
+	if dead := term(now.Add(-48*time.Hour), now.Add(-time.Hour)); dead.Allows(FeatureGuardrails) {
+		t.Error("a license whose term ended an hour ago still granted a feature")
+	}
+}
+
+// The operator has to see the transition, not just feel it. Both the startup
+// line and the admin report are derived, so they move with the verdict.
+func TestTheReportAndTheLineFollowTheVerdict(t *testing.T) {
+	now := time.Now().UTC()
+	s := term(now.Add(-48*time.Hour), now.Add(-time.Hour))
+
+	if got := s.Report()["state"]; got != "expired" {
+		t.Errorf("report state = %v, want expired", got)
+	}
+	if !strings.Contains(s.Line(), "expired") {
+		t.Errorf("the line does not say expired: %q", s.Line())
+	}
+	// No Err: this license loaded clean and ran out later. The reason has
+	// to come from the term instead, or /config reports a problem with no
+	// explanation.
+	if s.Err != nil {
+		t.Fatalf("a license that expired after loading carries an Err: %v", s.Err)
+	}
+	for _, want := range []string{"expired on", Support} {
+		if !strings.Contains(s.Reason(), want) {
+			t.Errorf("Reason() is missing %q: %q", want, s.Reason())
+		}
+	}
+	if got := s.Report()["problem"]; got == nil {
+		t.Error("the report names no problem for an expired license")
+	}
+}
+
+// Verdict is the control-plane seam and a licensing bypass by construction.
+// It must not also bypass the term.
+func TestVerdictCannotSkipTheTerm(t *testing.T) {
+	past := time.Now().UTC().Add(-time.Hour)
+	s := term(past.Add(-24*time.Hour), past)
+
+	if s.State() != StateExpired {
+		t.Errorf("state = %q, want expired", s.State())
+	}
+	if s.Allows(FeatureDataMasking) {
+		t.Error("a hand-built verdict granted a feature past its term")
+	}
+}
+
+// A document that never verified stays invalid whatever the clock says. The
+// expiry check must not become a way around a bad signature.
+func TestAnUnverifiedStatusNeverBecomesValid(t *testing.T) {
+	s := Load(Ref{Value: "/nonexistent/license.json", Source: "the test"})
+	future := time.Now().UTC().Add(-999 * time.Hour)
+
+	if got := s.StateAt(future); got != StateInvalid {
+		t.Errorf("state = %q, want invalid", got)
+	}
+	if s.AllowsAt(future, FeatureGuardrails) {
+		t.Error("an unreadable license granted a feature")
+	}
+}
+
+// The missing state has no document and no term, so no clock makes it grant
+// anything.
+func TestMissingStaysMissingAtEveryInstant(t *testing.T) {
+	var s Status
+	for _, at := range []time.Time{{}, time.Now().UTC(), time.Now().UTC().Add(1e6 * time.Hour)} {
+		if got := s.StateAt(at); got != StateMissing {
+			t.Errorf("at %v: state = %q", at, got)
+		}
+		if s.AllowsAt(at, FeatureGuardrails) {
+			t.Errorf("at %v: a missing license granted a feature", at)
+		}
+	}
+	if !s.ExpiresAt().IsZero() {
+		t.Errorf("ExpiresAt() = %v, want zero", s.ExpiresAt())
+	}
+}

--- a/sidecar/license/internal/trust/trust.go
+++ b/sidecar/license/internal/trust/trust.go
@@ -1,0 +1,52 @@
+// Package trust holds the public key licenses are verified against.
+//
+// The key lives here rather than in license so it has exactly one home and no
+// exported setter reachable from the tree at large: internal/ limits importers
+// to sidecar/license and sidecar/license/licensetest, which are the verifier
+// and the helper that lets a test sign something the verifier accepts.
+package trust
+
+import "sync"
+
+// openssl rsa -in ./license.key -pubout
+var production = []byte(`
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuMaf59LDDC5t06jYtXJB
+xDM3+e1POErhDzV1KcATYN0PS39yeqZ4VYxOr/0b8iqoPmYfReoj1GBiXKkMrO5D
+BOCCFwSUGnEAPVBUsGhcbtPmEW8iJvMCdiG35GpWgBbn8Q5TAMdEweGQSBo0CPRz
+xaOLeCgMv5qx10KpnP/8SRaDmM0vvOksRwJAMmwMaSkQEKOrs97jkDgnBY1mz1TI
+zmo40K3nFT6WHgqETIrl3t/fC1Fv25MDrPLE4M3htqBKLKDR99pPHX0gxB3dvwi6
+p8mG+hifq6xb6bTDH7ilIhFf30v+jjSfLyZUl56xitSiqF92uJTOZ5Q9xqISo7Sq
+yQIDAQAB
+-----END PUBLIC KEY-----
+`)
+
+var (
+	mu  sync.RWMutex
+	key = production
+)
+
+// Key is the PEM a signature must verify against.
+func Key() []byte {
+	mu.RLock()
+	defer mu.RUnlock()
+	return key
+}
+
+// Swap installs a different trusted key and returns a function restoring the
+// production one.
+//
+// The trust root is process-wide, so a test that swaps it must not run beside
+// one that reads it. licensetest is the only caller and it restores through
+// t.Cleanup.
+func Swap(pem []byte) func() {
+	mu.Lock()
+	defer mu.Unlock()
+	previous := key
+	key = pem
+	return func() {
+		mu.Lock()
+		defer mu.Unlock()
+		key = previous
+	}
+}

--- a/sidecar/license/license.go
+++ b/sidecar/license/license.go
@@ -217,15 +217,71 @@ type Ref struct {
 // The zero value is a missing license, so an embedder who forgets to set one
 // keeps the caps rather than losing them.
 type Status struct {
-	State State
+	// verified records that the signature checked out when the document
+	// was read. The TERM is deliberately not recorded with it: State
+	// recomputes that against the clock on every call, so a process
+	// outliving ExpireAt loses what the license bought.
+	verified bool
 	// Source names the Ref that supplied the document, empty when none did.
 	Source string
 	// License is the parsed document, non-nil whenever the JSON decoded.
 	// An expired or forged one still names the customer and the date.
 	License *License
-	// Err says what is wrong and what to do, as one sentence. A failed
-	// startup prints it.
+	// Err is what went wrong at load, as one sentence. Nil for a license
+	// that loaded and expired later; ask Reason for that one.
 	Err error
+}
+
+// Verdict wraps a document whose signature the caller has already checked.
+//
+// The control-plane path lands here: the plane verifies, the sidecar stores.
+// The term still applies, so a document past ExpireAt reports expired
+// however it arrived and whatever the caller believes.
+func Verdict(l *License, source string) Status {
+	return Status{verified: true, License: l, Source: source}
+}
+
+// State is the verdict NOW.
+//
+// Derived rather than stored, which is the whole point: a license that
+// verified at startup reports expired the moment its term ends, so a process
+// running for months cannot hold caps it stopped paying for.
+func (s Status) State() State { return s.StateAt(time.Now().UTC()) }
+
+// StateAt is the verdict at an instant. A caller schedules on it, and a test
+// moves the clock without waiting for one.
+func (s Status) StateAt(now time.Time) State {
+	switch {
+	case s.License == nil && s.Err == nil:
+		return StateMissing
+	case !s.verified:
+		return StateInvalid
+	case now.After(s.ExpiresAt()):
+		return StateExpired
+	}
+	return StateValid
+}
+
+// ExpiresAt is the instant the term ends, zero when no document arrived.
+func (s Status) ExpiresAt() time.Time {
+	if s.License == nil {
+		return time.Time{}
+	}
+	return time.Unix(s.License.Payload.ExpireAt, 0).UTC()
+}
+
+// Reason says what is wrong with the license now, empty when nothing is. A
+// license that expired after it loaded carries no Err, so the sentence comes
+// from the term instead.
+func (s Status) Reason() string {
+	if s.Err != nil {
+		return s.Err.Error()
+	}
+	if s.State() == StateExpired {
+		return fmt.Sprintf("the license from %s expired on %s. Renew it at %s",
+			sourceName(s.Source), expiryDate(*s.License), Support)
+	}
+	return ""
 }
 
 // Resolve picks the license the process runs under from the candidates, in
@@ -239,17 +295,17 @@ func Resolve(candidates ...Ref) Status {
 		}
 		return Load(c)
 	}
-	return Status{State: StateMissing}
+	return Status{}
 }
 
 // Load reads and verifies one reference. The value is the document when it
 // starts with "{" and a path otherwise: a JSON document has one first
 // character, and no path begins with it.
 func Load(ref Ref) Status {
-	s := Status{Source: ref.Source, State: StateInvalid}
+	s := Status{Source: ref.Source}
 	raw := strings.TrimSpace(ref.Value)
 	if raw == "" {
-		return Status{State: StateMissing}
+		return Status{}
 	}
 
 	data := []byte(raw)
@@ -273,11 +329,12 @@ func Load(ref Ref) Status {
 
 	switch err := l.Verify(); {
 	case err == nil:
-		s.State = StateValid
+		s.verified = true
 	case errors.Is(err, ErrExpired):
-		s.State = StateExpired
-		s.Err = fmt.Errorf("the license from %s expired on %s. Renew it at %s",
-			ref.Source, expiryDate(l), Support)
+		// The signature is good and only the term ran out, so this is a
+		// verified license. StateAt reads the same term and reaches
+		// StateExpired without the verdict being stored anywhere.
+		s.verified = true
 	default:
 		s.Err = fmt.Errorf("the license from %s is not valid: %v. Ask for a replacement at %s",
 			ref.Source, err, Support)
@@ -285,21 +342,25 @@ func Load(ref Ref) Status {
 	return s
 }
 
-// Allows reports whether the license grants a feature: it verified, it is an
-// enterprise license, and its feature list names the feature or is empty. An
-// oss license grants nothing, matching the control plane.
-func (s Status) Allows(feature string) bool {
-	return s.State == StateValid &&
-		s.License != nil &&
+// Allows reports whether the license grants a feature right now.
+func (s Status) Allows(feature string) bool { return s.AllowsAt(time.Now().UTC(), feature) }
+
+// AllowsAt reports whether the license grants a feature at an instant: it
+// verified, its term covers that instant, it is an enterprise license, and
+// its feature list names the feature or is empty. An oss license grants
+// nothing, matching the control plane.
+func (s Status) AllowsAt(now time.Time, feature string) bool {
+	return s.StateAt(now) == StateValid &&
 		s.License.Payload.Type == EnterpriseType &&
 		s.License.IsFeatureEnabled(feature)
 }
 
-// Line renders the one line the sidecar prints at startup. Every state gets
-// one, the missing state included: an operator who cannot tell "unlicensed"
-// from "the license did not load" reads the wrong config file for an hour.
+// Line renders the one line the sidecar prints at startup and again when the
+// term ends. Every state gets one, the missing state included: an operator
+// who cannot tell "unlicensed" from "the license did not load" reads the
+// wrong config file for an hour.
 func (s Status) Line() string {
-	switch s.State {
+	switch s.State() {
 	case StateValid:
 		l := s.License
 		body := fmt.Sprintf("license: valid. %s %q, expires %s, features: %s",
@@ -327,12 +388,12 @@ func (s Status) Line() string {
 // endpoint handing out a complete, reusable license is a licensing hole with
 // an HTTP interface.
 func (s Status) Report() map[string]any {
-	out := map[string]any{"state": s.State.String()}
+	out := map[string]any{"state": s.State().String()}
 	if s.Source != "" {
 		out["source"] = s.Source
 	}
-	if s.Err != nil {
-		out["problem"] = s.Err.Error()
+	if reason := s.Reason(); reason != "" {
+		out["problem"] = reason
 	}
 	if l := s.License; l != nil {
 		out["type"] = l.Payload.Type
@@ -409,4 +470,12 @@ func errText(err error) string {
 		return "no reason given"
 	}
 	return err.Error()
+}
+
+// sourceName names a source in a sentence when one is known.
+func sourceName(source string) string {
+	if source == "" {
+		return "this process"
+	}
+	return source
 }

--- a/sidecar/license/license.go
+++ b/sidecar/license/license.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hoophq/hoop/sidecar/license/internal/trust"
 )
 
 // EnvVar names the environment variable a license may arrive in.
@@ -46,21 +48,8 @@ const (
 	FeatureDataMasking = "data-masking"
 )
 
-// trustedKeyPEM is the public key a license must carry a signature from,
-// from `openssl rsa -in ./license.key -pubout`. A var so the round-trip test
-// can sign with a generated key. Assign it outside a test and the build
-// honours licenses Hoop never issued.
-var trustedKeyPEM = []byte(`
------BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuMaf59LDDC5t06jYtXJB
-xDM3+e1POErhDzV1KcATYN0PS39yeqZ4VYxOr/0b8iqoPmYfReoj1GBiXKkMrO5D
-BOCCFwSUGnEAPVBUsGhcbtPmEW8iJvMCdiG35GpWgBbn8Q5TAMdEweGQSBo0CPRz
-xaOLeCgMv5qx10KpnP/8SRaDmM0vvOksRwJAMmwMaSkQEKOrs97jkDgnBY1mz1TI
-zmo40K3nFT6WHgqETIrl3t/fC1Fv25MDrPLE4M3htqBKLKDR99pPHX0gxB3dvwi6
-p8mG+hifq6xb6bTDH7ilIhFf30v+jjSfLyZUl56xitSiqF92uJTOZ5Q9xqISo7Sq
-yQIDAQAB
------END PUBLIC KEY-----
-`)
+// The trusted key lives in internal/trust, which is the only place that can
+// change it and is reachable only from this package and licensetest.
 
 // ErrExpired reports a license that verified and whose term has ended. The
 // sidecar drops to the free tier on this one and refuses to start on the
@@ -214,6 +203,10 @@ type Ref struct {
 
 // Status is the resolved license, and the only thing the daemon reads.
 //
+// It cannot be forged. verified is unexported and only Load sets it, and Load
+// sets it only after checking the signature against the key this build
+// trusts, so a Status assembled anywhere else grants nothing.
+//
 // The zero value is a missing license, so an embedder who forgets to set one
 // keeps the caps rather than losing them.
 type Status struct {
@@ -232,14 +225,10 @@ type Status struct {
 	Err error
 }
 
-// Verdict wraps a document whose signature the caller has already checked.
-//
-// The control-plane path lands here: the plane verifies, the sidecar stores.
-// The term still applies, so a document past ExpireAt reports expired
-// however it arrived and whatever the caller believes.
-func Verdict(l *License, source string) Status {
-	return Status{verified: true, License: l, Source: source}
-}
+// Load is the ONLY way to reach a Status that grants anything: verified is
+// unexported and nothing else sets it. A caller outside this package can
+// build a Status literal, and it will report invalid and grant nothing,
+// which is the point. There is no "trust me" constructor.
 
 // State is the verdict NOW.
 //
@@ -430,7 +419,7 @@ func PublicKeyID() (string, error) {
 }
 
 func parsePublicKey() (*rsa.PublicKey, error) {
-	block, _ := pem.Decode(trustedKeyPEM)
+	block, _ := pem.Decode(trust.Key())
 	if block == nil || block.Type != "PUBLIC KEY" {
 		return nil, errors.New("this build carries no usable license key")
 	}

--- a/sidecar/license/license.go
+++ b/sidecar/license/license.go
@@ -1,0 +1,412 @@
+// Package license verifies the signed license a sidecar runs under. It
+// reimplements common/license over the stdlib, because importing the
+// gateway's module would end this module's one-dependency rule.
+// client/licensecompat pins the two copies to the same key and bytes.
+package license
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// EnvVar names the environment variable a license may arrive in.
+//
+// Not HOOP_SIDECAR_LICENSE: the same document is valid for the gateway, and a
+// deployment setting it twice under two names will set one of them wrong.
+const EnvVar = "HOOP_LICENSE"
+
+// Support is where every message here sends an operator who cannot fix the
+// problem themselves.
+const Support = "https://help.hoop.dev"
+
+// License types. Only Enterprise grants anything. An oss license verifies and
+// changes nothing, which is what the control plane does with the same value.
+const (
+	OSSType        = "oss"
+	EnterpriseType = "enterprise"
+)
+
+// The feature keys this module reads. common/license holds the full catalog;
+// the keys missing here gate no sidecar capability.
+const (
+	FeatureGuardrails  = "guardrails"
+	FeatureDataMasking = "data-masking"
+)
+
+// trustedKeyPEM is the public key a license must carry a signature from,
+// from `openssl rsa -in ./license.key -pubout`. A var so the round-trip test
+// can sign with a generated key. Assign it outside a test and the build
+// honours licenses Hoop never issued.
+var trustedKeyPEM = []byte(`
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuMaf59LDDC5t06jYtXJB
+xDM3+e1POErhDzV1KcATYN0PS39yeqZ4VYxOr/0b8iqoPmYfReoj1GBiXKkMrO5D
+BOCCFwSUGnEAPVBUsGhcbtPmEW8iJvMCdiG35GpWgBbn8Q5TAMdEweGQSBo0CPRz
+xaOLeCgMv5qx10KpnP/8SRaDmM0vvOksRwJAMmwMaSkQEKOrs97jkDgnBY1mz1TI
+zmo40K3nFT6WHgqETIrl3t/fC1Fv25MDrPLE4M3htqBKLKDR99pPHX0gxB3dvwi6
+p8mG+hifq6xb6bTDH7ilIhFf30v+jjSfLyZUl56xitSiqF92uJTOZ5Q9xqISo7Sq
+yQIDAQAB
+-----END PUBLIC KEY-----
+`)
+
+// ErrExpired reports a license that verified and whose term has ended. The
+// sidecar drops to the free tier on this one and refuses to start on the
+// rest, so callers have to tell them apart. See Status.
+var ErrExpired = errors.New("license expired")
+
+// Payload is the signed half of a license. The JSON tags match
+// common/license.Payload, so each package decodes the other's documents.
+type Payload struct {
+	Type     string `json:"type"`
+	IssuedAt int64  `json:"issued_at"`
+	ExpireAt int64  `json:"expire_at"`
+	// AllowedHosts is signed here and enforced nowhere. The gateway checks
+	// it against the API hostname it serves; a sidecar's only candidate is
+	// a scheduler-generated pod name, and checking that refuses every real
+	// deployment.
+	AllowedHosts []string `json:"allowed_hosts"`
+	Description  string   `json:"description"`
+	// Features this license enables. Empty or absent enables all of them.
+	Features []string `json:"features,omitempty"`
+}
+
+// License is the document an operator pastes into a config file or a secret.
+type License struct {
+	Payload   Payload `json:"payload"`
+	KeyID     string  `json:"key_id"`
+	Signature string  `json:"signature"`
+}
+
+// SigningData is the byte string the signature covers. Exported for
+// client/licensecompat, which verifies a gateway signature against these
+// bytes. Change the format without changing the gateway's and every license
+// in the field stops verifying.
+func (p Payload) SigningData() []byte {
+	v := p.Type + ":" +
+		strconv.FormatInt(p.IssuedAt, 10) + ":" +
+		strconv.FormatInt(p.ExpireAt, 10) + ":" +
+		strings.Join(p.AllowedHosts, ",") + ":" +
+		p.Description
+	// Appended only when present, so licenses signed before the field
+	// existed keep verifying against the same data.
+	if len(p.Features) > 0 {
+		v += ":" + strings.Join(p.Features, ",")
+	}
+	return []byte(v)
+}
+
+// IsFeatureEnabled reports whether the license names a feature. An empty
+// feature list means every feature.
+func (l License) IsFeatureEnabled(feature string) bool {
+	if len(l.Payload.Features) == 0 {
+		return true
+	}
+	return slices.Contains(l.Payload.Features, feature)
+}
+
+// Verify checks the signature and the term against the current time. It
+// returns ErrExpired for a sound document that ran out, so a caller can tell
+// that from "this is not a license".
+func (l License) Verify() error { return l.verify(time.Now().UTC()) }
+
+func (l License) verify(now time.Time) error {
+	if err := l.validateAttributes(); err != nil {
+		return err
+	}
+	pubkey, err := parsePublicKey()
+	if err != nil {
+		return err
+	}
+	signature, err := base64.StdEncoding.DecodeString(l.Signature)
+	if err != nil {
+		return fmt.Errorf("the signature is not valid base64: %v", err)
+	}
+	sum := sha256.Sum256(l.Payload.SigningData())
+	if err := rsa.VerifyPSS(pubkey, crypto.SHA256, sum[:], signature, nil); err != nil {
+		return errors.New("the signature does not match the payload, so the license was " +
+			"altered or was not issued by Hoop")
+	}
+	issuedAt := time.Unix(l.Payload.IssuedAt, 0).UTC()
+	expireAt := time.Unix(l.Payload.ExpireAt, 0).UTC()
+	if now.Before(issuedAt) {
+		// A container without NTP far more often than a forged date, so
+		// the message names the clock.
+		return fmt.Errorf("the license is dated %s, which is in the future; check this "+
+			"machine's clock", issuedAt.Format(time.RFC3339))
+	}
+	if now.After(expireAt) {
+		return ErrExpired
+	}
+	return nil
+}
+
+func (l License) validateAttributes() error {
+	if l.Payload.Type != OSSType && l.Payload.Type != EnterpriseType {
+		return fmt.Errorf("unknown license type %q, expected %q or %q",
+			l.Payload.Type, OSSType, EnterpriseType)
+	}
+	if len(l.Payload.AllowedHosts) == 0 {
+		return errors.New("the license names no allowed hosts")
+	}
+	if l.Payload.Description == "" {
+		return errors.New("the license has no description")
+	}
+	if l.Payload.IssuedAt == 0 || l.Payload.ExpireAt == 0 {
+		return errors.New("the license has no issued_at or expire_at")
+	}
+	if l.Signature == "" {
+		return errors.New("the license has no signature")
+	}
+	return nil
+}
+
+// State is what the sidecar concluded about the license it was handed.
+type State string
+
+const (
+	// StateMissing means nobody supplied one, which is the free tier and
+	// not an error. It is the EMPTY string so it is also the zero value:
+	// an embedder who never sets a license gets an unlicensed process
+	// rather than an undefined one.
+	StateMissing State = ""
+	// StateValid means the signature checks out and the term is current.
+	StateValid State = "valid"
+	// StateExpired means the document is genuine and its term has ended.
+	StateExpired State = "expired"
+	// StateInvalid means nobody can read the reference, or what it points
+	// at is not a license Hoop issued. Setup refuses to start on it.
+	StateInvalid State = "invalid"
+)
+
+// String names the state for an operator. A log line or a JSON field
+// carrying "" for the missing state says nothing at all.
+func (s State) String() string {
+	if s == StateMissing {
+		return "missing"
+	}
+	return string(s)
+}
+
+// Ref is one place a license might come from. Source appears in every
+// message, since "your license expired" helps nobody who sets one in three
+// places.
+type Ref struct {
+	// Value is a path to a file holding the document, or the document
+	// itself. Empty means this source supplied nothing.
+	Value string
+	// Source names Value for an operator: "HOOP_LICENSE", "the license
+	// config key".
+	Source string
+}
+
+// Status is the resolved license, and the only thing the daemon reads.
+//
+// The zero value is a missing license, so an embedder who forgets to set one
+// keeps the caps rather than losing them.
+type Status struct {
+	State State
+	// Source names the Ref that supplied the document, empty when none did.
+	Source string
+	// License is the parsed document, non-nil whenever the JSON decoded.
+	// An expired or forged one still names the customer and the date.
+	License *License
+	// Err says what is wrong and what to do, as one sentence. A failed
+	// startup prints it.
+	Err error
+}
+
+// Resolve picks the license the process runs under from the candidates, in
+// the order given. The first Ref holding anything decides, valid or not: fall
+// through from a broken HOOP_LICENSE to the config file and the operator
+// learns their env var never worked on the restart after the file changes.
+func Resolve(candidates ...Ref) Status {
+	for _, c := range candidates {
+		if strings.TrimSpace(c.Value) == "" {
+			continue
+		}
+		return Load(c)
+	}
+	return Status{State: StateMissing}
+}
+
+// Load reads and verifies one reference. The value is the document when it
+// starts with "{" and a path otherwise: a JSON document has one first
+// character, and no path begins with it.
+func Load(ref Ref) Status {
+	s := Status{Source: ref.Source, State: StateInvalid}
+	raw := strings.TrimSpace(ref.Value)
+	if raw == "" {
+		return Status{State: StateMissing}
+	}
+
+	data := []byte(raw)
+	if raw[0] != '{' {
+		b, err := os.ReadFile(raw)
+		if err != nil {
+			s.Err = fmt.Errorf("cannot read the license file named by %s: %v. Give a path "+
+				"to the license document, or paste the document itself", ref.Source, err)
+			return s
+		}
+		data = b
+	}
+
+	var l License
+	if err := json.Unmarshal(data, &l); err != nil {
+		s.Err = fmt.Errorf("the license from %s is not valid JSON: %v. Copy the whole "+
+			"document Hoop issued, braces included", ref.Source, err)
+		return s
+	}
+	s.License = &l
+
+	switch err := l.Verify(); {
+	case err == nil:
+		s.State = StateValid
+	case errors.Is(err, ErrExpired):
+		s.State = StateExpired
+		s.Err = fmt.Errorf("the license from %s expired on %s. Renew it at %s",
+			ref.Source, expiryDate(l), Support)
+	default:
+		s.Err = fmt.Errorf("the license from %s is not valid: %v. Ask for a replacement at %s",
+			ref.Source, err, Support)
+	}
+	return s
+}
+
+// Allows reports whether the license grants a feature: it verified, it is an
+// enterprise license, and its feature list names the feature or is empty. An
+// oss license grants nothing, matching the control plane.
+func (s Status) Allows(feature string) bool {
+	return s.State == StateValid &&
+		s.License != nil &&
+		s.License.Payload.Type == EnterpriseType &&
+		s.License.IsFeatureEnabled(feature)
+}
+
+// Line renders the one line the sidecar prints at startup. Every state gets
+// one, the missing state included: an operator who cannot tell "unlicensed"
+// from "the license did not load" reads the wrong config file for an hour.
+func (s Status) Line() string {
+	switch s.State {
+	case StateValid:
+		l := s.License
+		body := fmt.Sprintf("license: valid. %s %q, expires %s, features: %s",
+			l.Payload.Type, l.Payload.Description, expiryDate(*l), featureList(*l))
+		if l.Payload.Type != EnterpriseType {
+			body += ". The free tier caps still apply"
+		}
+		return body + sourceSuffix(s.Source)
+
+	case StateExpired:
+		return fmt.Sprintf("license: expired. %q expired on %s, running the free tier. "+
+			"Renew it at %s", s.License.Payload.Description, expiryDate(*s.License), Support) +
+			sourceSuffix(s.Source)
+
+	case StateInvalid:
+		return "license: invalid. " + errText(s.Err) + sourceSuffix(s.Source)
+
+	default:
+		return `license: missing, running the free tier. Add one with the license flag, ` +
+			`the ` + EnvVar + ` environment variable, or the "license" key in the config file`
+	}
+}
+
+// Report renders the status for the admin endpoint, without the signature. An
+// endpoint handing out a complete, reusable license is a licensing hole with
+// an HTTP interface.
+func (s Status) Report() map[string]any {
+	out := map[string]any{"state": s.State.String()}
+	if s.Source != "" {
+		out["source"] = s.Source
+	}
+	if s.Err != nil {
+		out["problem"] = s.Err.Error()
+	}
+	if l := s.License; l != nil {
+		out["type"] = l.Payload.Type
+		out["description"] = l.Payload.Description
+		out["issued_at"] = l.Payload.IssuedAt
+		out["expire_at"] = l.Payload.ExpireAt
+		out["key_id"] = l.KeyID
+		// Empty means every feature, so render the list rather than
+		// omitting it and losing the distinction in JSON.
+		features := l.Payload.Features
+		if features == nil {
+			features = []string{}
+		}
+		out["features"] = features
+	}
+	return out
+}
+
+// PublicKeyID is the sha256 of the public key this build trusts, hex encoded.
+// A license carries the same identifier in key_id, so comparing the two tells
+// a rotated key from a corrupted document. client/licensecompat asserts it
+// equals the gateway's.
+func PublicKeyID() (string, error) {
+	pubkey, err := parsePublicKey()
+	if err != nil {
+		return "", err
+	}
+	der, err := x509.MarshalPKIXPublicKey(pubkey)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func parsePublicKey() (*rsa.PublicKey, error) {
+	block, _ := pem.Decode(trustedKeyPEM)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return nil, errors.New("this build carries no usable license key")
+	}
+	obj, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("this build's license key is unreadable: %v", err)
+	}
+	rsaPub, ok := obj.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("this build's license key is a %T, not an RSA key", obj)
+	}
+	return rsaPub, nil
+}
+
+func expiryDate(l License) string {
+	return time.Unix(l.Payload.ExpireAt, 0).UTC().Format(time.DateOnly)
+}
+
+// featureList renders what a license grants. An empty list means every
+// feature, and "[]" says the reverse.
+func featureList(l License) string {
+	if len(l.Payload.Features) == 0 {
+		return "all"
+	}
+	return strings.Join(l.Payload.Features, ", ")
+}
+
+func sourceSuffix(source string) string {
+	if source == "" {
+		return ""
+	}
+	return " (from " + source + ")"
+}
+
+func errText(err error) string {
+	if err == nil {
+		return "no reason given"
+	}
+	return err.Error()
+}

--- a/sidecar/license/license_test.go
+++ b/sidecar/license/license_test.go
@@ -1,0 +1,463 @@
+package license
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// signingKey generates a key and points the verifier at it for one test.
+// Without a signer these tests could only assert that real licenses fail.
+// client/licensecompat covers the other direction: the shipped key and the
+// signing format are the gateway's.
+func signingKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	prev := trustedKeyPEM
+	trustedKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	t.Cleanup(func() { trustedKeyPEM = prev })
+	return key
+}
+
+// issue signs a license the way the gateway's sign endpoint does.
+func issue(t *testing.T, key *rsa.PrivateKey, p Payload) License {
+	t.Helper()
+	sum := sha256.Sum256(p.SigningData())
+	sig, err := rsa.SignPSS(rand.Reader, key, crypto.SHA256, sum[:], nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return License{
+		Payload:   p,
+		KeyID:     "test-key",
+		Signature: base64.StdEncoding.EncodeToString(sig),
+	}
+}
+
+func enterprise() Payload {
+	return Payload{
+		Type:         EnterpriseType,
+		IssuedAt:     time.Now().Add(-time.Hour).Unix(),
+		ExpireAt:     time.Now().Add(720 * time.Hour).Unix(),
+		AllowedHosts: []string{"*"},
+		Description:  "Acme Corp",
+	}
+}
+
+func document(t *testing.T, l License) string {
+	t.Helper()
+	b, err := json.Marshal(l)
+	if err != nil {
+		t.Fatalf("marshal license: %v", err)
+	}
+	return string(b)
+}
+
+func TestValidEnterpriseLicenseGrantsItsFeatures(t *testing.T) {
+	key := signingKey(t)
+	l := issue(t, key, enterprise())
+
+	s := Load(Ref{Value: document(t, l), Source: "the test"})
+
+	if s.State != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	}
+	if !s.Allows(FeatureGuardrails) || !s.Allows(FeatureDataMasking) {
+		t.Error("a license with no feature list did not grant every feature")
+	}
+	if s.Source != "the test" {
+		t.Errorf("source = %q", s.Source)
+	}
+}
+
+// A feature list restricts. A license naming only data-masking leaves the
+// guardrail cap in force, or one-feature licenses pay for two.
+func TestAFeatureListRestrictsWhatIsGranted(t *testing.T) {
+	key := signingKey(t)
+	p := enterprise()
+	p.Features = []string{FeatureDataMasking}
+	s := Load(Ref{Value: document(t, issue(t, key, p))})
+
+	if s.State != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	}
+	if !s.Allows(FeatureDataMasking) {
+		t.Error("the feature the license names was not granted")
+	}
+	if s.Allows(FeatureGuardrails) {
+		t.Error("a feature the license does not name was granted")
+	}
+}
+
+// An oss license is signed, current and grants nothing. Treat any verifying
+// license as enterprise and the free tier gets the paid caps.
+func TestAnOSSLicenseGrantsNothing(t *testing.T) {
+	key := signingKey(t)
+	p := enterprise()
+	p.Type = OSSType
+	s := Load(Ref{Value: document(t, issue(t, key, p))})
+
+	if s.State != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	}
+	if s.Allows(FeatureGuardrails) || s.Allows(FeatureDataMasking) {
+		t.Error("an oss license lifted a cap")
+	}
+	if !strings.Contains(s.Line(), "free tier caps still apply") {
+		t.Errorf("the line does not say the caps remain: %q", s.Line())
+	}
+}
+
+// Expiry is its own state: the daemon drops to the free tier on it and
+// refuses to start on a forgery.
+func TestAnExpiredLicenseIsExpiredAndGrantsNothing(t *testing.T) {
+	key := signingKey(t)
+	p := enterprise()
+	p.IssuedAt = time.Now().Add(-48 * time.Hour).Unix()
+	p.ExpireAt = time.Now().Add(-24 * time.Hour).Unix()
+	s := Load(Ref{Value: document(t, issue(t, key, p)), Source: "the test"})
+
+	if s.State != StateExpired {
+		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	}
+	if s.Allows(FeatureGuardrails) {
+		t.Error("an expired license lifted a cap")
+	}
+	if s.License == nil {
+		t.Fatal("the parsed document was dropped, so no message can name the customer")
+	}
+	for _, want := range []string{"expired on", "Acme Corp", Support} {
+		if !strings.Contains(s.Line(), want) {
+			t.Errorf("the line is missing %q: %q", want, s.Line())
+		}
+	}
+}
+
+// A payload edited to say enterprise, or to move the expiry out a year,
+// must not verify.
+func TestATamperedPayloadIsInvalid(t *testing.T) {
+	key := signingKey(t)
+	l := issue(t, key, enterprise())
+	l.Payload.ExpireAt = time.Now().Add(10 * 365 * 24 * time.Hour).Unix()
+
+	s := Load(Ref{Value: document(t, l), Source: "the test"})
+
+	if s.State != StateInvalid {
+		t.Fatalf("a rewritten payload verified: state = %q", s.State)
+	}
+	if s.Allows(FeatureGuardrails) {
+		t.Error("a tampered license lifted a cap")
+	}
+	if !strings.Contains(s.Err.Error(), "altered") {
+		t.Errorf("the message does not say the document was altered: %v", s.Err)
+	}
+}
+
+// Somebody else's key gets the same refusal. This signs with a second key
+// while the verifier trusts the first.
+func TestALicenseFromAnotherKeyIsInvalid(t *testing.T) {
+	signingKey(t)
+	other, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	s := Load(Ref{Value: document(t, issue(t, other, enterprise())), Source: "the test"})
+
+	if s.State != StateInvalid {
+		t.Fatalf("a license signed with an untrusted key verified: state = %q", s.State)
+	}
+}
+
+// A clock behind the issue date is a container without NTP far more often
+// than a forgery. "License is not valid" for a machine thirty seconds fast
+// sends an operator to support instead of to timedatectl.
+func TestALicenseFromTheFutureBlamesTheClock(t *testing.T) {
+	key := signingKey(t)
+	p := enterprise()
+	p.IssuedAt = time.Now().Add(48 * time.Hour).Unix()
+	p.ExpireAt = time.Now().Add(96 * time.Hour).Unix()
+
+	s := Load(Ref{Value: document(t, issue(t, key, p)), Source: "the test"})
+
+	if s.State != StateInvalid {
+		t.Fatalf("state = %q", s.State)
+	}
+	if !strings.Contains(s.Err.Error(), "clock") {
+		t.Errorf("the message does not mention the clock: %v", s.Err)
+	}
+}
+
+// The reference is a path or the document, told apart by the first byte.
+// Moving a license from a file into an env var must not change the verdict.
+func TestAPathAndTheDocumentItselfAgree(t *testing.T) {
+	key := signingKey(t)
+	doc := document(t, issue(t, key, enterprise()))
+	path := filepath.Join(t.TempDir(), "license.json")
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	fromFile := Load(Ref{Value: path, Source: "a file"})
+	fromInline := Load(Ref{Value: doc, Source: "a string"})
+
+	if fromFile.State != StateValid {
+		t.Fatalf("the file did not verify: %v", fromFile.Err)
+	}
+	if fromInline.State != StateValid {
+		t.Fatalf("the inline document did not verify: %v", fromInline.Err)
+	}
+	if !fromFile.Allows(FeatureGuardrails) || !fromInline.Allows(FeatureGuardrails) {
+		t.Error("the two readings granted different things")
+	}
+}
+
+// A YAML block scalar and a pasted secret both carry leading whitespace. The
+// first byte still has to read as "{".
+func TestAnIndentedDocumentIsStillADocument(t *testing.T) {
+	key := signingKey(t)
+	doc := "\n  " + document(t, issue(t, key, enterprise())) + "\n"
+
+	if s := Load(Ref{Value: doc}); s.State != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	}
+}
+
+// A path that does not resolve is the most common licensing mistake. The
+// message names the knob that supplied it and what a good value looks like.
+// This is the "not a stack trace" requirement, tested.
+func TestAMissingFileNamesTheSourceAndTheFix(t *testing.T) {
+	s := Load(Ref{Value: "/nonexistent/license.json", Source: "HOOP_LICENSE"})
+
+	if s.State != StateInvalid {
+		t.Fatalf("state = %q", s.State)
+	}
+	msg := s.Err.Error()
+	for _, want := range []string{"HOOP_LICENSE", "/nonexistent/license.json", "paste the document"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the message is missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "*errors.errorString") || strings.Contains(msg, "0x") {
+		t.Errorf("the message reads like a dump: %s", msg)
+	}
+}
+
+func TestGarbageIsRefusedWithAdvice(t *testing.T) {
+	s := Load(Ref{Value: "{not json at all", Source: "the license config key"})
+
+	if s.State != StateInvalid {
+		t.Fatalf("state = %q", s.State)
+	}
+	if !strings.Contains(s.Err.Error(), "the license config key") {
+		t.Errorf("the message does not name the source: %v", s.Err)
+	}
+	if s.License != nil {
+		t.Error("a document that did not decode was reported as parsed")
+	}
+}
+
+// Every attribute the signature covers has to arrive before checking the
+// signature is worth anything, and each refusal names the field.
+func TestIncompleteDocumentsNameTheMissingField(t *testing.T) {
+	key := signingKey(t)
+	cases := []struct {
+		name  string
+		edit  func(*Payload)
+		wants string
+	}{
+		{"no type", func(p *Payload) { p.Type = "" }, "unknown license type"},
+		{"no hosts", func(p *Payload) { p.AllowedHosts = nil }, "allowed hosts"},
+		{"no description", func(p *Payload) { p.Description = "" }, "description"},
+		{"no dates", func(p *Payload) { p.IssuedAt, p.ExpireAt = 0, 0 }, "issued_at"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := enterprise()
+			tc.edit(&p)
+			s := Load(Ref{Value: document(t, issue(t, key, p))})
+			if s.State != StateInvalid {
+				t.Fatalf("state = %q", s.State)
+			}
+			if !strings.Contains(s.Err.Error(), tc.wants) {
+				t.Errorf("the message does not name the field: %v", s.Err)
+			}
+		})
+	}
+}
+
+// An empty signature is not "nothing to check". PSS over zero bytes fails
+// anyway; the attribute check is what makes the message say so.
+func TestAnUnsignedDocumentIsRefused(t *testing.T) {
+	signingKey(t)
+	l := License{Payload: enterprise()}
+
+	s := Load(Ref{Value: document(t, l)})
+
+	if s.State != StateInvalid {
+		t.Fatalf("an unsigned license verified: state = %q", s.State)
+	}
+	if !strings.Contains(s.Err.Error(), "signature") {
+		t.Errorf("the message does not mention the signature: %v", s.Err)
+	}
+}
+
+// Precedence is the spec: flag over environment over file, and the control
+// plane over all three later. Resolve honours the order it is given.
+func TestResolveTakesTheFirstSourceThatSuppliedSomething(t *testing.T) {
+	key := signingKey(t)
+	first := enterprise()
+	first.Description = "the winner"
+	second := enterprise()
+	second.Description = "the loser"
+
+	s := Resolve(
+		Ref{Value: "  ", Source: "an empty flag"},
+		Ref{Value: document(t, issue(t, key, first)), Source: EnvVar},
+		Ref{Value: document(t, issue(t, key, second)), Source: "the license config key"},
+	)
+
+	if s.State != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	}
+	if s.License.Payload.Description != "the winner" {
+		t.Errorf("resolved %q", s.License.Payload.Description)
+	}
+	if s.Source != EnvVar {
+		t.Errorf("source = %q, want %q", s.Source, EnvVar)
+	}
+}
+
+// First wins, not first valid. Fall through from a broken license to a
+// working one and the operator learns their env var never worked on the
+// restart after the file changed.
+func TestABrokenHigherSourceIsNotSkipped(t *testing.T) {
+	key := signingKey(t)
+	s := Resolve(
+		Ref{Value: "/nonexistent/license.json", Source: EnvVar},
+		Ref{Value: document(t, issue(t, key, enterprise())), Source: "the license config key"},
+	)
+
+	if s.State != StateInvalid {
+		t.Fatalf("a broken license fell through to a working one: state = %q", s.State)
+	}
+	if s.Source != EnvVar {
+		t.Errorf("source = %q, want %q", s.Source, EnvVar)
+	}
+}
+
+func TestNoSourceIsMissingRatherThanAnError(t *testing.T) {
+	s := Resolve(Ref{Source: "a flag"}, Ref{Value: "\n\t ", Source: EnvVar})
+
+	if s.State != StateMissing {
+		t.Fatalf("state = %q", s.State)
+	}
+	if s.Err != nil {
+		t.Errorf("an absent license produced an error: %v", s.Err)
+	}
+	if s.Allows(FeatureGuardrails) {
+		t.Error("a missing license granted a feature")
+	}
+	line := s.Line()
+	for _, want := range []string{"missing", "free tier", EnvVar, `"license"`} {
+		if !strings.Contains(line, want) {
+			t.Errorf("the line is missing %q: %q", want, line)
+		}
+	}
+}
+
+// An embedder calling Run with a Config built in Go gets the zero Status. It
+// has to be the free tier, not a bypass.
+func TestTheZeroStatusIsTheFreeTier(t *testing.T) {
+	var s Status
+	if s.State != StateMissing {
+		t.Errorf("state = %q", s.State)
+	}
+	if s.Allows(FeatureGuardrails) || s.Allows(FeatureDataMasking) {
+		t.Error("the zero value granted a feature")
+	}
+	if s.Line() == "" {
+		t.Error("the zero value prints nothing at startup")
+	}
+}
+
+// The endpoint reports what a running process concluded. It must never hand
+// back a reusable document.
+func TestReportOmitsTheSignature(t *testing.T) {
+	key := signingKey(t)
+	l := issue(t, key, enterprise())
+	s := Load(Ref{Value: document(t, l), Source: EnvVar})
+
+	got, err := json.Marshal(s.Report())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(got), l.Signature) {
+		t.Errorf("the report carries the signature: %s", got)
+	}
+	for _, want := range []string{`"state":"valid"`, `"type":"enterprise"`, `"Acme Corp"`} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("the report is missing %s: %s", want, got)
+		}
+	}
+}
+
+// An absent feature list means every feature. JSON has to keep that apart
+// from a list that happens to be empty.
+func TestReportRendersFeaturesAsAList(t *testing.T) {
+	key := signingKey(t)
+	s := Load(Ref{Value: document(t, issue(t, key, enterprise()))})
+
+	got, err := json.Marshal(s.Report())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(got), `"features":[]`) {
+		t.Errorf("features did not render as an empty list: %s", got)
+	}
+}
+
+func TestPublicKeyIDIsStable(t *testing.T) {
+	id, err := PublicKeyID()
+	if err != nil {
+		t.Fatalf("PublicKeyID: %v", err)
+	}
+	if len(id) != 64 {
+		t.Errorf("key id is not a sha256 hex digest: %q", id)
+	}
+	again, err := PublicKeyID()
+	if err != nil || again != id {
+		t.Errorf("PublicKeyID is not stable: %q, %q, %v", id, again, err)
+	}
+}
+
+// The daemon reads ErrExpired to tell "renew this" from "not a license", so
+// it has to stay matchable.
+func TestExpiredIsMatchable(t *testing.T) {
+	key := signingKey(t)
+	p := enterprise()
+	p.IssuedAt = time.Now().Add(-48 * time.Hour).Unix()
+	p.ExpireAt = time.Now().Add(-time.Second).Unix()
+	l := issue(t, key, p)
+
+	if err := l.Verify(); !errors.Is(err, ErrExpired) {
+		t.Errorf("Verify() = %v, want ErrExpired", err)
+	}
+}

--- a/sidecar/license/license_test.go
+++ b/sidecar/license/license_test.go
@@ -15,12 +15,14 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hoophq/hoop/sidecar/license/internal/trust"
 )
 
 // signingKey generates a key and points the verifier at it for one test.
-// Without a signer these tests could only assert that real licenses fail.
-// client/licensecompat covers the other direction: the shipped key and the
-// signing format are the gateway's.
+// internal/trust is the only place that can move the trust root, and this and
+// licensetest are the only callers. client/licensecompat covers the other
+// direction: the shipped key and the signing format are the gateway's.
 func signingKey(t *testing.T) *rsa.PrivateKey {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -31,9 +33,7 @@ func signingKey(t *testing.T) *rsa.PrivateKey {
 	if err != nil {
 		t.Fatalf("marshal public key: %v", err)
 	}
-	prev := trustedKeyPEM
-	trustedKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
-	t.Cleanup(func() { trustedKeyPEM = prev })
+	t.Cleanup(trust.Swap(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})))
 	return key
 }
 

--- a/sidecar/license/license_test.go
+++ b/sidecar/license/license_test.go
@@ -77,8 +77,8 @@ func TestValidEnterpriseLicenseGrantsItsFeatures(t *testing.T) {
 
 	s := Load(Ref{Value: document(t, l), Source: "the test"})
 
-	if s.State != StateValid {
-		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	if s.State() != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State(), s.Err)
 	}
 	if !s.Allows(FeatureGuardrails) || !s.Allows(FeatureDataMasking) {
 		t.Error("a license with no feature list did not grant every feature")
@@ -96,8 +96,8 @@ func TestAFeatureListRestrictsWhatIsGranted(t *testing.T) {
 	p.Features = []string{FeatureDataMasking}
 	s := Load(Ref{Value: document(t, issue(t, key, p))})
 
-	if s.State != StateValid {
-		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	if s.State() != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State(), s.Err)
 	}
 	if !s.Allows(FeatureDataMasking) {
 		t.Error("the feature the license names was not granted")
@@ -115,8 +115,8 @@ func TestAnOSSLicenseGrantsNothing(t *testing.T) {
 	p.Type = OSSType
 	s := Load(Ref{Value: document(t, issue(t, key, p))})
 
-	if s.State != StateValid {
-		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	if s.State() != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State(), s.Err)
 	}
 	if s.Allows(FeatureGuardrails) || s.Allows(FeatureDataMasking) {
 		t.Error("an oss license lifted a cap")
@@ -135,8 +135,8 @@ func TestAnExpiredLicenseIsExpiredAndGrantsNothing(t *testing.T) {
 	p.ExpireAt = time.Now().Add(-24 * time.Hour).Unix()
 	s := Load(Ref{Value: document(t, issue(t, key, p)), Source: "the test"})
 
-	if s.State != StateExpired {
-		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	if s.State() != StateExpired {
+		t.Fatalf("state = %q, err = %v", s.State(), s.Err)
 	}
 	if s.Allows(FeatureGuardrails) {
 		t.Error("an expired license lifted a cap")
@@ -160,8 +160,8 @@ func TestATamperedPayloadIsInvalid(t *testing.T) {
 
 	s := Load(Ref{Value: document(t, l), Source: "the test"})
 
-	if s.State != StateInvalid {
-		t.Fatalf("a rewritten payload verified: state = %q", s.State)
+	if s.State() != StateInvalid {
+		t.Fatalf("a rewritten payload verified: state = %q", s.State())
 	}
 	if s.Allows(FeatureGuardrails) {
 		t.Error("a tampered license lifted a cap")
@@ -181,8 +181,8 @@ func TestALicenseFromAnotherKeyIsInvalid(t *testing.T) {
 	}
 	s := Load(Ref{Value: document(t, issue(t, other, enterprise())), Source: "the test"})
 
-	if s.State != StateInvalid {
-		t.Fatalf("a license signed with an untrusted key verified: state = %q", s.State)
+	if s.State() != StateInvalid {
+		t.Fatalf("a license signed with an untrusted key verified: state = %q", s.State())
 	}
 }
 
@@ -197,8 +197,8 @@ func TestALicenseFromTheFutureBlamesTheClock(t *testing.T) {
 
 	s := Load(Ref{Value: document(t, issue(t, key, p)), Source: "the test"})
 
-	if s.State != StateInvalid {
-		t.Fatalf("state = %q", s.State)
+	if s.State() != StateInvalid {
+		t.Fatalf("state = %q", s.State())
 	}
 	if !strings.Contains(s.Err.Error(), "clock") {
 		t.Errorf("the message does not mention the clock: %v", s.Err)
@@ -218,10 +218,10 @@ func TestAPathAndTheDocumentItselfAgree(t *testing.T) {
 	fromFile := Load(Ref{Value: path, Source: "a file"})
 	fromInline := Load(Ref{Value: doc, Source: "a string"})
 
-	if fromFile.State != StateValid {
+	if fromFile.State() != StateValid {
 		t.Fatalf("the file did not verify: %v", fromFile.Err)
 	}
-	if fromInline.State != StateValid {
+	if fromInline.State() != StateValid {
 		t.Fatalf("the inline document did not verify: %v", fromInline.Err)
 	}
 	if !fromFile.Allows(FeatureGuardrails) || !fromInline.Allows(FeatureGuardrails) {
@@ -235,8 +235,8 @@ func TestAnIndentedDocumentIsStillADocument(t *testing.T) {
 	key := signingKey(t)
 	doc := "\n  " + document(t, issue(t, key, enterprise())) + "\n"
 
-	if s := Load(Ref{Value: doc}); s.State != StateValid {
-		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	if s := Load(Ref{Value: doc}); s.State() != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State(), s.Err)
 	}
 }
 
@@ -246,8 +246,8 @@ func TestAnIndentedDocumentIsStillADocument(t *testing.T) {
 func TestAMissingFileNamesTheSourceAndTheFix(t *testing.T) {
 	s := Load(Ref{Value: "/nonexistent/license.json", Source: "HOOP_LICENSE"})
 
-	if s.State != StateInvalid {
-		t.Fatalf("state = %q", s.State)
+	if s.State() != StateInvalid {
+		t.Fatalf("state = %q", s.State())
 	}
 	msg := s.Err.Error()
 	for _, want := range []string{"HOOP_LICENSE", "/nonexistent/license.json", "paste the document"} {
@@ -263,8 +263,8 @@ func TestAMissingFileNamesTheSourceAndTheFix(t *testing.T) {
 func TestGarbageIsRefusedWithAdvice(t *testing.T) {
 	s := Load(Ref{Value: "{not json at all", Source: "the license config key"})
 
-	if s.State != StateInvalid {
-		t.Fatalf("state = %q", s.State)
+	if s.State() != StateInvalid {
+		t.Fatalf("state = %q", s.State())
 	}
 	if !strings.Contains(s.Err.Error(), "the license config key") {
 		t.Errorf("the message does not name the source: %v", s.Err)
@@ -293,8 +293,8 @@ func TestIncompleteDocumentsNameTheMissingField(t *testing.T) {
 			p := enterprise()
 			tc.edit(&p)
 			s := Load(Ref{Value: document(t, issue(t, key, p))})
-			if s.State != StateInvalid {
-				t.Fatalf("state = %q", s.State)
+			if s.State() != StateInvalid {
+				t.Fatalf("state = %q", s.State())
 			}
 			if !strings.Contains(s.Err.Error(), tc.wants) {
 				t.Errorf("the message does not name the field: %v", s.Err)
@@ -311,8 +311,8 @@ func TestAnUnsignedDocumentIsRefused(t *testing.T) {
 
 	s := Load(Ref{Value: document(t, l)})
 
-	if s.State != StateInvalid {
-		t.Fatalf("an unsigned license verified: state = %q", s.State)
+	if s.State() != StateInvalid {
+		t.Fatalf("an unsigned license verified: state = %q", s.State())
 	}
 	if !strings.Contains(s.Err.Error(), "signature") {
 		t.Errorf("the message does not mention the signature: %v", s.Err)
@@ -334,8 +334,8 @@ func TestResolveTakesTheFirstSourceThatSuppliedSomething(t *testing.T) {
 		Ref{Value: document(t, issue(t, key, second)), Source: "the license config key"},
 	)
 
-	if s.State != StateValid {
-		t.Fatalf("state = %q, err = %v", s.State, s.Err)
+	if s.State() != StateValid {
+		t.Fatalf("state = %q, err = %v", s.State(), s.Err)
 	}
 	if s.License.Payload.Description != "the winner" {
 		t.Errorf("resolved %q", s.License.Payload.Description)
@@ -355,8 +355,8 @@ func TestABrokenHigherSourceIsNotSkipped(t *testing.T) {
 		Ref{Value: document(t, issue(t, key, enterprise())), Source: "the license config key"},
 	)
 
-	if s.State != StateInvalid {
-		t.Fatalf("a broken license fell through to a working one: state = %q", s.State)
+	if s.State() != StateInvalid {
+		t.Fatalf("a broken license fell through to a working one: state = %q", s.State())
 	}
 	if s.Source != EnvVar {
 		t.Errorf("source = %q, want %q", s.Source, EnvVar)
@@ -366,8 +366,8 @@ func TestABrokenHigherSourceIsNotSkipped(t *testing.T) {
 func TestNoSourceIsMissingRatherThanAnError(t *testing.T) {
 	s := Resolve(Ref{Source: "a flag"}, Ref{Value: "\n\t ", Source: EnvVar})
 
-	if s.State != StateMissing {
-		t.Fatalf("state = %q", s.State)
+	if s.State() != StateMissing {
+		t.Fatalf("state = %q", s.State())
 	}
 	if s.Err != nil {
 		t.Errorf("an absent license produced an error: %v", s.Err)
@@ -387,8 +387,8 @@ func TestNoSourceIsMissingRatherThanAnError(t *testing.T) {
 // has to be the free tier, not a bypass.
 func TestTheZeroStatusIsTheFreeTier(t *testing.T) {
 	var s Status
-	if s.State != StateMissing {
-		t.Errorf("state = %q", s.State)
+	if s.State() != StateMissing {
+		t.Errorf("state = %q", s.State())
 	}
 	if s.Allows(FeatureGuardrails) || s.Allows(FeatureDataMasking) {
 		t.Error("the zero value granted a feature")

--- a/sidecar/license/licensetest/licensetest.go
+++ b/sidecar/license/licensetest/licensetest.go
@@ -1,0 +1,108 @@
+// Package licensetest issues licenses that a test process genuinely verifies.
+//
+// The verifier has no bypass on purpose: license.Status cannot be assembled by
+// hand and license.Load grants nothing without a signature from the key the
+// build trusts. That leaves a test with no way to exercise a licensed daemon,
+// so this package closes the loop honestly. It generates a keypair, points the
+// trust root at it for the duration of one test, and signs real documents that
+// go through the real Load.
+//
+// Every function takes a *testing.T, and that is the guard. Production code
+// calling one would have to import "testing" and fabricate a T, which no
+// review lets through and which the binary size announces anyway.
+package licensetest
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/license/internal/trust"
+)
+
+// Enterprise is a current enterprise payload for "Acme Corp". Naming no
+// features means every feature, which is what most licenses carry.
+func Enterprise(features ...string) license.Payload {
+	return license.Payload{
+		Type:         license.EnterpriseType,
+		IssuedAt:     time.Now().Add(-time.Hour).Unix(),
+		ExpireAt:     time.Now().Add(720 * time.Hour).Unix(),
+		AllowedHosts: []string{"*"},
+		Description:  "Acme Corp",
+		Features:     features,
+	}
+}
+
+// Expiring is Enterprise with the term ending after d. A negative d has
+// already ended.
+func Expiring(d time.Duration) license.Payload {
+	p := Enterprise()
+	p.ExpireAt = time.Now().Add(d).Unix()
+	return p
+}
+
+// Sign issues a license for the payload and makes this process trust the key
+// that signed it until t finishes.
+//
+// The trust root is process-wide, so a test calling this must not run beside
+// one that reads it: no t.Parallel in a package that signs.
+func Sign(t *testing.T, p license.Payload) license.License {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("licensetest: generate key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("licensetest: marshal public key: %v", err)
+	}
+	t.Cleanup(trust.Swap(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})))
+
+	sum := sha256.Sum256(p.SigningData())
+	sig, err := rsa.SignPSS(rand.Reader, key, crypto.SHA256, sum[:], nil)
+	if err != nil {
+		t.Fatalf("licensetest: sign: %v", err)
+	}
+	id, err := license.PublicKeyID()
+	if err != nil {
+		t.Fatalf("licensetest: key id: %v", err)
+	}
+	return license.License{Payload: p, KeyID: id, Signature: base64.StdEncoding.EncodeToString(sig)}
+}
+
+// Ref is Sign marshalled into the reference a config or a flag would carry,
+// ready for license.Load or Config.UseLicense.
+func Ref(t *testing.T, p license.Payload) license.Ref {
+	t.Helper()
+	return license.Ref{Value: Document(t, p), Source: "the test"}
+}
+
+// Document is the signed license as the JSON an operator pastes.
+func Document(t *testing.T, p license.Payload) string {
+	t.Helper()
+	b, err := json.Marshal(Sign(t, p))
+	if err != nil {
+		t.Fatalf("licensetest: marshal license: %v", err)
+	}
+	return string(b)
+}
+
+// Status is the verdict Load reaches for a freshly signed license. It went
+// through the real verifier, so a test asserting on it is asserting on what a
+// customer gets.
+func Status(t *testing.T, p license.Payload) license.Status {
+	t.Helper()
+	s := license.Load(Ref(t, p))
+	if s.License == nil {
+		t.Fatalf("licensetest: the signed license did not load: %v", s.Err)
+	}
+	return s
+}

--- a/sidecar/scripts/dev/01-validate.sh
+++ b/sidecar/scripts/dev/01-validate.sh
@@ -11,9 +11,10 @@
 # fires is the failure this whole config surface exists to prevent. Each
 # negative case below is a config that would otherwise look fine.
 #
-# The last two are the free-tier caps rather than a misconfiguration: this
-# build enforces one guardrail rule and one data masking rule per process, and
-# a cap nobody tests is a cap that stops firing.
+# The last two are the free-tier caps rather than a misconfiguration: an
+# unlicensed process enforces one guardrail rule and one data masking rule,
+# and a cap nobody tests is a cap that stops firing. This script runs without
+# a license on purpose; pass -license to see both refusals disappear.
 #
 # Usage:
 #   HOOP_PROJECT=my-project ./01-validate.sh


### PR DESCRIPTION
 > [!IMPORTANT]
 > Label this PR **`minor`**: it adds a feature and breaks nothing.

   ## 📝 Description

   The sidecar had no way to receive a license, so every process was stuck on the
   free tier: one guardrail rule and one data masking rule, with no way to lift
   them. This adds a license path.

   A license can arrive three ways, and the first one that holds anything wins:

   1. `--license` on the command line
   2. the `HOOP_LICENSE` environment variable
   3. a `license:` key in `config.yaml`

   The value is either a path to the license file or the license document itself,
   so moving one from a mounted file to a secret is not also a rename.

   The sidecar cannot import `common/license`, because that would pull the
   gateway's whole dependency tree (gin, three cloud SDKs, pgx) into a module that
   allows exactly one dependency. So `sidecar/license` reimplements the same
   scheme over the standard library: same key, same signature, same JSON. A
   license issued for a gateway works in a sidecar unchanged.

   Two copies of a verifier can drift apart, and drift would lock paying customers
   out of features they bought. `client/licensecompat` prevents that. It is the
   only module that can import both, and it fails if either side changes the key
   or the bytes that get signed.

   ## 📣 User-facing impact

   You can now license a sidecar. Add your license with `--license`,
   `HOOP_LICENSE`, or the `license:` key in your config, and the guardrail and
   data masking rule limits lift for the features your license covers. The sidecar
   prints its license state at startup, so you can see what you are running.

   ## 🚀 Type of Change

   - [x] ✨ New feature (non-breaking change which adds functionality)
  ## 🧪 Testing

   ### Test Configuration:
   - **OS**: macOS 15 (darwin/arm64), Go 1.26.5

   ### Tests performed:
   - [x] Unit tests pass
   - [x] Integration tests pass
   - [x] Manual testing completed

   **Validated with a real Hoop-signed license.** The shipped binary, no test
   keys. Its `key_id` matches what both the sidecar and the gateway trust.

   | Case | Result |
   |---|---|
   | Real license, 5 guardrail + 4 mask rules | all 9 load |
   | Same config, license removed | refused, "at most 1" |
   | Real license via `--license` | valid, caps lift |
   | Real license via `HOOP_LICENSE` | valid, caps lift |
   | Real license via the `license:` config key | valid, caps lift |
   | Real license with `expire_at` pushed out 10 years | refused, "the license was altered" |
   | No license | free tier, message names all three sources |
   | Expired | starts, warns, caps stay |
   | Path that does not exist | one sentence, names the source and the fix |
   | Broken `HOOP_LICENSE` + valid config file | refused, first source wins |

   Running with the license:

   ```
   INFO license: valid. enterprise "Dev License", expires 2028-11-28, features: all (from the "license" config key)
   INFO rule limits guardrail_rules=unlimited mask_rules=unlimited
   ```

   `/config` returns `"limits":{"guardrail_rules":null,"mask_rules":null}` and the
   license verdict. The signature never appears in the response.

   To reproduce:

   ```bash
   cd sidecar/cmd && go build -o hoop-inspect .
   ./hoop-inspect -validate -config your-config.yaml                      # free tier
   ./hoop-inspect -validate -config your-config.yaml -license license.json # licensed
   ```

   Automated:

   ```bash
   make test-sidecar
   go test ./client/licensecompat/... ./common/license/...
   ```

   ## 📄 Additional Notes

   **Two things worth a reviewer's eye.**

   **The verifier exists twice.** That is deliberate and the reasoning is in
   `sidecar/CLAUDE.md`. If you change the signing key or the signed bytes on one
   side, you must change the other, and `client/licensecompat` will fail until you
   do.

   **`allowed_hosts` is signed but not checked in the sidecar.** The gateway
   verifies it against the API hostname it serves. A sidecar runs on loopback
   inside a pod, and the only hostname it could offer is a scheduler-generated pod
   name, so checking it would refuse every real deployment. The field still sits
   inside the signature, so nobody can edit it. Push back if you want this
   enforced some other way.

   No secrets in this PR. The license used for testing lives outside the repo.