### PR TITLE
EVL-245 register the gateway's full HTTP API in control-plane mode

### DIFF
--- a/client/cmd/start.go
+++ b/client/cmd/start.go
@@ -81,10 +81,10 @@ var startControlPlaneCmd = &cobra.Command{
 	Long: `Runs the control plane: the HTTP API used to administer a fleet of
 sidecars.
 
-It shares the gateway binary and its database, and starts none of the
-gateway's data plane: no gRPC transport on :8010, no protocol proxies, no
-transport plugins and no web UI. The API surface starts near-empty and grows
-as routes are ported, so today it answers /api/healthz and nothing else.
+It shares the gateway binary, its database and its HTTP API, and starts none
+of the gateway's data plane: no gRPC transport on :8010, no protocol proxies,
+no transport plugins and no web UI. A route that needs an agent or a client
+stream is still registered and fails per request.
 
 It reads the same database and API configuration the gateway does
 (POSTGRES_DB_URI, API_URL, AUTH_METHOD, ...); nothing in it is agent- or

--- a/client/cmd/start.go
+++ b/client/cmd/start.go
@@ -81,10 +81,10 @@ var startControlPlaneCmd = &cobra.Command{
 	Long: `Runs the control plane: the HTTP API used to administer a fleet of
 sidecars.
 
-It shares the gateway binary, its database and its HTTP API, and starts none
-of the gateway's data plane: no gRPC transport on :8010, no protocol proxies,
-no transport plugins and no web UI. A route that needs an agent or a client
-stream is still registered and fails per request.
+It shares the gateway binary, its database, its HTTP API and its web UI, and
+starts none of the gateway's data plane: no gRPC transport on :8010, no
+protocol proxies and no transport plugins. A route that needs an agent or a
+client stream is still registered and fails per request.
 
 It reads the same database and API configuration the gateway does
 (POSTGRES_DB_URI, API_URL, AUTH_METHOD, ...); nothing in it is agent- or

--- a/controlplane/frontend/CLAUDE.md
+++ b/controlplane/frontend/CLAUDE.md
@@ -37,9 +37,11 @@ too: both modes answer the same routes.
 
 The control plane serves every route the gateway serves (ADR-0013). `buildRoutes` in
 `gateway/api/server.go` is the whole list, and `gateway/api/controlplane_routes_test.go`
-fails if the two modes drift apart. What it does not start is the data plane: no gRPC
-transport, no protocol proxies, no transport plugins and no web UI. A route that needs
-one of those is still registered and fails per request, so do not call one from here:
+fails if the two modes drift apart. It also serves the gateway's web UI (`webapp_v2`) at
+`/`; this app is separate and is not embedded in the binary. What it does not start is
+the data plane: no gRPC transport, no protocol proxies and no transport plugins. A route
+that needs one of those is still registered and fails per request, so do not call one
+from here:
 session creation and exec, schema browsing (`/connections/:id/{databases,tables,columns,test}`),
 runbook execution, the proxy manager, resource plan/apply/health and `/dbroles/jobs`.
 

--- a/controlplane/frontend/CLAUDE.md
+++ b/controlplane/frontend/CLAUDE.md
@@ -29,37 +29,36 @@ Zustand · Axios · React Router v7 · lucide-react.
 | Lint | `npm run lint` |
 | Preview | `npm run preview` |
 
-There is no separate control plane backend: the API is the gateway booted into its
-control-plane surface. Put `APP_MODE=control-plane` in the repo-root `.env`, then
-`make run-dev`. It must be in the file: `scripts/dev/run.sh` starts the gateway in a
-container with `--env-file=.env`, so a shell prefix never reaches it.
+There is no separate control plane backend: the API is the gateway binary started with
+`hoop start control-plane`. From the repo root: `make run-dev-postgres` once, then
+`make run-dev-control-plane` (port 8019, reads `.env`); here,
+`API_URL=http://localhost:8019 npm run dev`. `make run-dev`, the gateway on :8009, works
+too: both modes answer the same routes.
 
-`APP_MODE` is not optional. Without it the gateway registers all 264 of its routes, so a
-service call to something the control plane blocks succeeds here and 404s in production.
-`buildControlPlaneRoutes` in `gateway/api/server.go` is the whole list of routes this app
-may call — the backend's counterpart to `Router.jsx`. `gateway/api/controlplane_routes_test.go`
-pins that list exactly, so a route added there without a decision fails the build.
-
-Nothing checks the two against each other, though: adding a service call here to a route
-the control plane does not serve compiles, builds and 404s at runtime. Check the list
-before adding one. `layout/ModeBanner` warns on screen, in dev builds, when the backend
-is answering in gateway mode and would hide the mistake.
+The control plane serves every route the gateway serves (ADR-0013). `buildRoutes` in
+`gateway/api/server.go` is the whole list, and `gateway/api/controlplane_routes_test.go`
+fails if the two modes drift apart. What it does not start is the data plane: no gRPC
+transport, no protocol proxies, no transport plugins and no web UI. A route that needs
+one of those is still registered and fails per request, so do not call one from here:
+session creation and exec, schema browsing (`/connections/:id/{databases,tables,columns,test}`),
+runbook execution, the proxy manager, resource plan/apply/health and `/dbroles/jobs`.
 
 Two features are only partly there, and the UI must not imply otherwise:
 
-- **Reviews are read only.** `GET /reviews` and `GET /reviews/:id` are served; approving
-  is not. `PUT /reviews/:id` releases the gRPC stream waiting on the verdict, and this
-  mode runs no transport. A sidecar review is a different entity anyway (ADR-0009).
+- **Reviews.** `PUT /reviews/:id` writes the verdict, but this process holds no session
+  stream to release: a session waiting on a gateway is not signalled from here, and
+  nothing creates a review here, since sessions only run on the gateway. A sidecar
+  review is a different entity anyway (ADR-0009).
 - **Slack stores configuration and runs nothing.** The plugin runtime is registered in
-  `runGateway`, so nothing starts here — no listener, no notifications. The config is
+  `runGateway`, so nothing starts here: no listener, no notifications. The config is
   kept for when a control-plane notification path exists.
 
-Two things it deliberately does not expose, so do not add UI that calls
-them: **access-control group management** (`GET /users/groups` is allowed because review
-rules name approvers by group; creating and deleting them is not) and **attributes**
-(blocked entirely — the pickers were removed from Guardrails, Data Masking and Review
-Rules, and each form carries the record's existing value through untouched rather than
-clearing it).
+Two things it deliberately does not expose, so do not add UI that calls them:
+**access-control group management** (`GET /users/groups` is used because review rules
+name approvers by group; creating and deleting them is a product decision, not a backend
+limit) and **attributes** (the pickers were removed from Guardrails, Data Masking and
+Review Rules, and each form carries the record's existing value through untouched rather
+than clearing it).
 
 ## Routing
 

--- a/controlplane/frontend/README.md
+++ b/controlplane/frontend/README.md
@@ -9,8 +9,9 @@ Coding rules, styling hierarchy and the colour-scheme rule: [CLAUDE.md](./CLAUDE
 
 There is no separate control plane backend: the API is the gateway binary
 started with `hoop start control-plane`. It serves every route the gateway
-serves and starts none of the data plane: no gRPC transport, no protocol
-proxies, no transport plugins and no web UI (ADR-0013).
+serves, the gateway's web UI at `/` included, and starts none of the data
+plane: no gRPC transport, no protocol proxies and no transport plugins
+(ADR-0013). This app is not that web UI; it runs on its own through Vite.
 
 ```bash
 make run-dev-postgres        # once, from the repo root

--- a/controlplane/frontend/README.md
+++ b/controlplane/frontend/README.md
@@ -7,30 +7,21 @@ Coding rules, styling hierarchy and the colour-scheme rule: [CLAUDE.md](./CLAUDE
 
 ## Running it
 
-There is no separate control plane backend: the API is the gateway, booted into
-its control-plane surface.
-
-Add this to the repo-root `.env` **before** starting the gateway:
-
-```
-APP_MODE=control-plane
-```
-
-It has to go in the file, not on the command line — `scripts/dev/run.sh` runs
-the gateway in a container with `--env-file=.env`, so a shell prefix never
-reaches it.
+There is no separate control plane backend: the API is the gateway binary
+started with `hoop start control-plane`. It serves every route the gateway
+serves and starts none of the data plane: no gRPC transport, no protocol
+proxies, no transport plugins and no web UI (ADR-0013).
 
 ```bash
-make run-dev          # gateway on :8009, from the repo root
+make run-dev-postgres        # once, from the repo root
+make run-dev-control-plane   # control plane on :8019, reads the repo-root .env
 npm install
-npm run dev           # Vite on :5173
+API_URL=http://localhost:8019 npm run dev   # Vite on :5173
 ```
 
-Without `APP_MODE` the gateway registers all 264 of its routes, so a call to
-something the control plane blocks works here and 404s in production. The
-routes the control plane serves are listed in
-`buildControlPlaneRoutes` in `gateway/api/server.go`, and an amber banner appears at the top of
-every page (dev builds only) when the backend is answering in gateway mode.
+`make run-dev`, the gateway on :8009 and the default proxy target, works as a
+backend too: both modes answer the same routes. `/api/serverinfo` reports
+which one is answering as `application_mode`.
 
 Only `/api` is proxied. There is no ClojureScript dev server and no asset proxy —
 everything under `/images`, `/icons` and `/data` is served from `public/`.

--- a/controlplane/frontend/src/layout/ModeBanner/index.jsx
+++ b/controlplane/frontend/src/layout/ModeBanner/index.jsx
@@ -3,17 +3,15 @@ import { TriangleAlert } from 'lucide-react'
 import Alert from '@/components/Alert'
 import { useUserStore } from '@/stores/useUserStore'
 
-// Warns when this app is talking to a backend running the full gateway API.
+// Tells a developer that this app is talking to a gateway, not a control plane.
 //
-// The control plane is a subset of the gateway: a gateway booted without
-// APP_MODE=control-plane answers every route, including the ones a real
-// control-plane deployment returns 404 for. Developing against one means a
-// service call to a blocked route works locally and fails in production, which
-// is the single easiest mistake to make on this app and the hardest to spot.
-// A line in the README does not prevent it; this does, on first load.
+// The control plane serves every route the gateway serves (ADR-0013), so a
+// gateway backend hides nothing from this app. The difference is what runs
+// behind the routes: a gateway also starts the gRPC transport, the protocol
+// proxies and the transport plugins, and the deployment this app ships
+// against does not.
 //
-// Dev only. In a production build the operator cannot act on it, and the
-// gateway already logs the matching warning at startup.
+// Dev only. In a production build the operator cannot act on it.
 export default function ModeBanner() {
   const applicationMode = useUserStore((state) => state.applicationMode)
 
@@ -30,7 +28,7 @@ export default function ModeBanner() {
       icon={<TriangleAlert size={18} />}
     >
       <Text size="sm" component="span">
-        {'This backend serves the full gateway API. Routes the control plane blocks in production will work here — set APP_MODE=control-plane on the gateway to develop against the real surface.'}
+        {'This backend runs as the gateway. The control plane serves the same routes, so this app behaves the same here, but the real deployment starts no gRPC transport, proxies or plugins. Run make run-dev-control-plane to develop against it.'}
       </Text>
     </Alert>
   )

--- a/controlplane/frontend/src/services/connections.js
+++ b/controlplane/frontend/src/services/connections.js
@@ -32,8 +32,8 @@ export const connectionsService = {
     api.delete(`/connections/${encodeURIComponent(name)}`),
 
   // testConnection, the MCP OAuth flow (mcpOAuthAuthorize/mcpOAuthToken) and
-  // mcpCatalog were deleted with the control-plane surface. None had a call
-  // site, and all four target routes that are not on
-  // buildControlPlaneRoutes in gateway/api/server.go — /connections/:name/test, /mcp-oauth/*
-  // and /mcp-catalog serve a resource-opening flow this app does not have.
+  // mcpCatalog were deleted from this service. None had a call site: all four
+  // serve a resource-opening flow this app does not have, and
+  // /connections/:name/test needs the gRPC transport the control plane does
+  // not start.
 }

--- a/controlplane/frontend/src/services/userGroups.js
+++ b/controlplane/frontend/src/services/userGroups.js
@@ -6,9 +6,9 @@ export const userGroupsService = {
   // organizations return `[]`; older gateways return `null`, so callers still
   // coalesce.
   //
-  // Read only. create and remove used to live here and were deleted with the
-  // control-plane surface: POST /users/groups and DELETE /users/groups/:name
-  // are not on buildControlPlaneRoutes in gateway/api/server.go, so they answer 404. The read
-  // stays because a review rule names its approvers by group.
+  // Read only. create and remove used to live here and were deleted: the
+  // control plane serves POST /users/groups and DELETE /users/groups/:name,
+  // but this app does not manage access-control groups (see CLAUDE.md). The
+  // read stays because a review rule names its approvers by group.
   list: () => api.get('/users/groups'),
 }

--- a/controlplane/frontend/src/stores/useUserStore.js
+++ b/controlplane/frontend/src/stores/useUserStore.js
@@ -39,10 +39,9 @@ export const useUserStore = create((set, get) => ({
   // /serverinfo postgres_proxy_enabled. Fail closed: without a Postgres proxy
   // listen address the gateway cannot serve a native postgres session.
   postgresProxyEnabled: false,
-  // Which API surface the backend serves: 'gateway' or 'control-plane'. Null
-  // until /serverinfo resolves. A backend in gateway mode answers every route,
-  // including the ones a control-plane deployment blocks, so developing
-  // against one hides the gap until production.
+  // Which product the backend runs as: 'gateway' or 'control-plane'. Null
+  // until /serverinfo resolves. Both serve the same routes; the control plane
+  // starts no gRPC transport, proxies or plugins. layout/ModeBanner reads it.
   applicationMode: null,
   loading: false,
 

--- a/gateway/api/controlplane_routes_test.go
+++ b/gateway/api/controlplane_routes_test.go
@@ -17,10 +17,10 @@ func routeSet(engine *gin.Engine) map[string]bool {
 	return set
 }
 
-// The control plane serves every route the gateway serves; only the web UI
-// stays out, because the control plane has its own frontend. A route added
-// to the gateway reaches the control plane by construction, and this test
-// fails when either surface drifts from the other (ADR-0013).
+// The control plane serves exactly the routes the gateway serves, the web UI
+// included; only the /healthz handler differs. A route added to the gateway
+// reaches the control plane by construction, and this test fails when either
+// surface drifts from the other (ADR-0013).
 func TestControlPlaneServesEveryGatewayRoute(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	gateway := routeSet((&Api{}).buildEngine(appconfig.AppModeGateway))
@@ -29,21 +29,7 @@ func TestControlPlaneServesEveryGatewayRoute(t *testing.T) {
 		t.Fatal("the gateway registered no routes")
 	}
 
-	// Registered only when a web UI build resolves, so they may be absent
-	// from the gateway set too; they must never be in the control plane's.
-	baseURL := appconfig.Get().ApiURLPath()
-	webUI := map[string]bool{
-		"GET " + baseURL + "/index.html": true,
-		"GET " + baseURL + "/js/app.js":  true,
-	}
-
 	for route := range gateway {
-		if webUI[route] {
-			if controlPlane[route] {
-				t.Errorf("control plane serves the web UI route %s", route)
-			}
-			continue
-		}
 		if !controlPlane[route] {
 			t.Errorf("gateway route %s is missing from the control plane", route)
 		}

--- a/gateway/api/controlplane_routes_test.go
+++ b/gateway/api/controlplane_routes_test.go
@@ -3,139 +3,54 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
-	"sort"
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/hoophq/hoop/gateway/api/apiroutes"
+	"github.com/hoophq/hoop/gateway/appconfig"
 )
 
-// The control plane answers only what this test lists. A route added to
-// buildControlPlaneRoutes without being added here fails the test, which is
-// the point: routes are ported one at a time and each one is a decision.
-func TestControlPlaneRoutes(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	engine := gin.New()
-	a := &Api{}
-	a.buildControlPlaneRoutes(apiroutes.New(engine.Group("/api")))
-
-	var got []string
+func routeSet(engine *gin.Engine) map[string]bool {
+	set := map[string]bool{}
 	for _, r := range engine.Routes() {
-		got = append(got, r.Method+" "+r.Path)
+		set[r.Method+" "+r.Path] = true
 	}
-	sort.Strings(got)
+	return set
+}
 
-	// apiroutes.Router.GET registers HEAD alongside GET.
-	// The surface the shipped controlplane/frontend calls, measured from its
-	// service files and verified endpoint by endpoint against a running
-	// gateway. Adding a route to buildControlPlaneRoutes without adding it
-	// here fails this test, which is the point.
-	want := []string{
-		"DELETE /api/access-requests/rules/:name",
-		"DELETE /api/ai/session-analyzer/providers",
-		"DELETE /api/ai/session-analyzer/rules/:name",
-		"DELETE /api/connections/:nameOrID",
-		"DELETE /api/datamasking-rules/:id",
-		"DELETE /api/guardrails/:id",
-		"DELETE /api/users/:emailOrID",
-		"GET /api/access-requests/rules",
-		"GET /api/access-requests/rules/:name",
-		"GET /api/ai/session-analyzer/providers",
-		"GET /api/ai/session-analyzer/rules",
-		"GET /api/ai/session-analyzer/rules/:name",
-		"GET /api/ai/session-analyzer/system-prompt",
-		"GET /api/callback",
-		"GET /api/connection-tags",
-		"GET /api/connections",
-		"GET /api/connections/:nameOrID",
-		"GET /api/connections/:nameOrID/ai-session-analyzer-rule",
-		"GET /api/datamasking-rules",
-		"GET /api/datamasking-rules/:id",
-		"GET /api/feature-flags",
-		"GET /api/guardrails",
-		"GET /api/guardrails/:id",
-		"GET /api/healthz",
-		"GET /api/login",
-		"GET /api/openapiv2.json",
-		"GET /api/openapiv3.json",
-		"GET /api/plugins",
-		"GET /api/plugins/:name",
-		"GET /api/publicserverinfo",
-		"GET /api/reviews",
-		"GET /api/reviews/:id",
-		"GET /api/saml/login",
-		"GET /api/serverinfo",
-		"GET /api/sessions",
-		"GET /api/sessions/:session_id",
-		"GET /api/userinfo",
-		"GET /api/users",
-		"GET /api/users/:emailOrID",
-		"GET /api/users/groups",
-		"HEAD /api/access-requests/rules",
-		"HEAD /api/access-requests/rules/:name",
-		"HEAD /api/ai/session-analyzer/providers",
-		"HEAD /api/ai/session-analyzer/rules",
-		"HEAD /api/ai/session-analyzer/rules/:name",
-		"HEAD /api/ai/session-analyzer/system-prompt",
-		"HEAD /api/callback",
-		"HEAD /api/connection-tags",
-		"HEAD /api/connections",
-		"HEAD /api/connections/:nameOrID",
-		"HEAD /api/connections/:nameOrID/ai-session-analyzer-rule",
-		"HEAD /api/datamasking-rules",
-		"HEAD /api/datamasking-rules/:id",
-		"HEAD /api/feature-flags",
-		"HEAD /api/guardrails",
-		"HEAD /api/guardrails/:id",
-		"HEAD /api/healthz",
-		"HEAD /api/login",
-		"HEAD /api/openapiv2.json",
-		"HEAD /api/openapiv3.json",
-		"HEAD /api/plugins",
-		"HEAD /api/plugins/:name",
-		"HEAD /api/publicserverinfo",
-		"HEAD /api/reviews",
-		"HEAD /api/reviews/:id",
-		"HEAD /api/saml/login",
-		"HEAD /api/serverinfo",
-		"HEAD /api/sessions",
-		"HEAD /api/sessions/:session_id",
-		"HEAD /api/userinfo",
-		"HEAD /api/users",
-		"HEAD /api/users/:emailOrID",
-		"HEAD /api/users/groups",
-		"PATCH /api/connections/:nameOrID",
-		"PATCH /api/sessions/:session_id/metadata",
-		"PATCH /api/users/self/slack",
-		"POST /api/access-requests/rules",
-		"POST /api/ai/session-analyzer/providers",
-		"POST /api/ai/session-analyzer/rules",
-		"POST /api/connections",
-		"POST /api/datamasking-rules",
-		"POST /api/guardrails",
-		"POST /api/localauth/login",
-		"POST /api/localauth/register",
-		"POST /api/orgs/invitations",
-		"POST /api/plugins",
-		"POST /api/saml/callback",
-		"POST /api/signup",
-		"POST /api/users",
-		"POST /api/users/self/signup-origin",
-		"PUT /api/access-requests/rules/:name",
-		"PUT /api/ai/session-analyzer/rules/:name",
-		"PUT /api/datamasking-rules/:id",
-		"PUT /api/feature-flags/:name",
-		"PUT /api/guardrails/:id",
-		"PUT /api/plugins/:name",
-		"PUT /api/plugins/:name/config",
-		"PUT /api/users/:emailOrID",
+// The control plane serves every route the gateway serves; only the web UI
+// stays out, because the control plane has its own frontend. A route added
+// to the gateway reaches the control plane by construction, and this test
+// fails when either surface drifts from the other (ADR-0013).
+func TestControlPlaneServesEveryGatewayRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	gateway := routeSet((&Api{}).buildEngine(appconfig.AppModeGateway))
+	controlPlane := routeSet((&Api{}).buildEngine(appconfig.AppModeControlPlane))
+	if len(gateway) == 0 {
+		t.Fatal("the gateway registered no routes")
 	}
-	if len(got) != len(want) {
-		t.Fatalf("registered routes\ngot:  %v\nwant: %v", got, want)
+
+	// Registered only when a web UI build resolves, so they may be absent
+	// from the gateway set too; they must never be in the control plane's.
+	baseURL := appconfig.Get().ApiURLPath()
+	webUI := map[string]bool{
+		"GET " + baseURL + "/index.html": true,
+		"GET " + baseURL + "/js/app.js":  true,
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("route %d: got %q, want %q", i, got[i], want[i])
+
+	for route := range gateway {
+		if webUI[route] {
+			if controlPlane[route] {
+				t.Errorf("control plane serves the web UI route %s", route)
+			}
+			continue
+		}
+		if !controlPlane[route] {
+			t.Errorf("gateway route %s is missing from the control plane", route)
+		}
+	}
+	for route := range controlPlane {
+		if !gateway[route] {
+			t.Errorf("control plane route %s is missing from the gateway", route)
 		}
 	}
 }
@@ -144,9 +59,7 @@ func TestControlPlaneRoutes(t *testing.T) {
 // starts one, so probing it would fail every health check.
 func TestControlPlaneHealthzIsOKWithoutGRPC(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	engine := gin.New()
-	a := &Api{}
-	a.buildControlPlaneRoutes(apiroutes.New(engine.Group("/api")))
+	engine := (&Api{}).buildEngine(appconfig.AppModeControlPlane)
 
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/healthz", nil))

--- a/gateway/api/plugins/plugin.go
+++ b/gateway/api/plugins/plugin.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hoophq/hoop/common/log"
 	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/api/openapi"
-	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/hoophq/hoop/gateway/storagev2"
 	"github.com/hoophq/hoop/gateway/storagev2/types"
@@ -32,27 +31,6 @@ type PluginRequest struct {
 	Config      *types.PluginConfig        `json:"config"`
 }
 
-// controlPlanePlugin is the only plugin the control plane administers. Slack is
-// where review approvals are delivered; the rest (dlp, review, audit,
-// access_control, webhooks, runbooks, indexer) configure the gateway's session
-// pipeline, which a control plane does not run.
-const controlPlanePlugin = "slack"
-
-// hiddenOnControlPlane answers 404 for any plugin other than slack when the
-// process serves the control-plane surface.
-//
-// The route allow-list in gateway/api/apiroutes/controlplane.go cannot express this:
-// /plugins is one route for every plugin, and the name arrives in the body or a
-// path param. This is the case the APP_MODE flag exists for. The response
-// matches a blocked route exactly, so the two are indistinguishable to a caller.
-func hiddenOnControlPlane(c *gin.Context, pluginName string) bool {
-	if !appconfig.Get().IsControlPlane() || pluginName == controlPlanePlugin {
-		return false
-	}
-	c.JSON(http.StatusNotFound, gin.H{"message": "resource not found"})
-	return true
-}
-
 // CreatePlugin
 //
 //	@Summary		Create Plugin
@@ -71,10 +49,6 @@ func Post(c *gin.Context) {
 	var req PluginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
-		return
-	}
-
-	if hiddenOnControlPlane(c, req.Name) {
 		return
 	}
 
@@ -140,10 +114,6 @@ func Put(c *gin.Context) {
 		return
 	}
 
-	if hiddenOnControlPlane(c, req.Name) {
-		return
-	}
-
 	existingPlugin, err := models.GetPluginByName(models.DB, ctx.OrgID, req.Name)
 	switch err {
 	case models.ErrNotFound:
@@ -180,9 +150,6 @@ func Put(c *gin.Context) {
 func PutConfig(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
 	pluginName := c.Param("name")
-	if hiddenOnControlPlane(c, pluginName) {
-		return
-	}
 	var envVars map[string]string
 	if err := c.ShouldBindJSON(&envVars); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
@@ -239,9 +206,6 @@ func PutConfig(c *gin.Context) {
 func Get(c *gin.Context) {
 	ctx := storagev2.ParseContext(c)
 	name := c.Param("name")
-	if hiddenOnControlPlane(c, name) {
-		return
-	}
 	obj, err := models.GetPluginByName(models.DB, ctx.OrgID, name)
 	switch err {
 	case models.ErrNotFound:
@@ -271,15 +235,8 @@ func List(c *gin.Context) {
 		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed listing plugins: %v", err)
 		return
 	}
-	isControlPlane := appconfig.Get().IsControlPlane()
 	var out []*openapi.Plugin
 	for _, p := range itemList {
-		// Listing has no name in the request, so the filter is applied to the
-		// result instead of refused up front. Without it a control-plane admin
-		// sees every gateway plugin and can read which are enabled.
-		if isControlPlane && p.Name != controlPlanePlugin {
-			continue
-		}
 		plugin := toOpenApi(&p)
 		if config := plugin.Config; config != nil {
 			for key := range config.EnvVars {

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -137,45 +137,24 @@ type Api struct {
 // share the exact same handler — tests exercise the production middleware
 // chain and validators rather than a stripped-down router.
 //
-// In control-plane mode it returns the much smaller engine described in
-// buildControlPlaneEngine.
+// The control plane gets the same engine minus the web UI (ADR-0013). It
+// has its own frontend, controlplane/frontend, and the routes it does not
+// need are cheaper to leave in than to list: a route added to the gateway
+// reaches the control plane by construction. A route that needs the gRPC
+// transport that mode never starts fails per request instead.
 func (a *Api) BuildEngine() *gin.Engine {
+	return a.buildEngine(appconfig.Get().AppMode())
+}
+
+// buildEngine takes the mode as a parameter so a test can build both
+// surfaces in one process and diff them.
+func (a *Api) buildEngine(mode appconfig.AppMode) *gin.Engine {
 	route := a.newEngine()
 	baseURL := appconfig.Get().ApiURLPath()
 
-	if appconfig.Get().IsControlPlane() {
-		return a.buildControlPlaneEngine(route, baseURL)
+	if mode != appconfig.AppModeControlPlane {
+		serveWebUI(route, baseURL)
 	}
-
-	// UI: assets resolved from STATIC_UI_PATH, the default disk path or the
-	// build embedded in the binary; index.html and js/app.js are
-	// transformed in memory with this gateway's URL and served from memory.
-	webappUI, err := webappui.Resolve()
-	if err != nil {
-		log.Warnf("failed loading the web UI, running API-only, reason=%v", err)
-	}
-	webappui.LogSource(webappUI)
-	if webappUI != nil {
-		route.Use(static.Serve(baseURL+"/", webappUI.FileSystem()))
-		route.GET(baseURL+"/index.html", func(c *gin.Context) {
-			webappUI.WriteIndex(c.Writer, http.StatusOK)
-		})
-		if webappUI.HasAppJs() {
-			route.GET(baseURL+"/js/app.js", func(c *gin.Context) {
-				webappUI.WriteAppJs(c.Writer)
-			})
-		}
-	}
-	route.NoRoute(func(c *gin.Context) {
-		if !strings.HasPrefix(c.Request.RequestURI, baseURL+"/api") {
-			if webappUI != nil {
-				webappUI.WriteIndex(c.Writer, http.StatusOK)
-				return
-			}
-			c.Status(http.StatusNotFound)
-			return
-		}
-	})
 
 	route.GET("/.well-known/oauth-protected-resource", apimcpauth.MetadataHandler)
 	route.GET("/.well-known/oauth-protected-resource"+apimcpauth.McpResourcePath(), apimcpauth.MetadataHandler)
@@ -202,10 +181,44 @@ func (a *Api) BuildEngine() *gin.Engine {
 	ironRdpInstance := rdp.GetIronServerInstance()
 	ironRdpInstance.AttachHandlers(ironRdpGroup)
 
-	a.buildRoutes(a.newAPIRouter(route, baseURL))
+	a.buildRoutes(a.newAPIRouter(route, baseURL), mode)
 	openapi.RegisterGinValidators()
 
 	return route
+}
+
+// serveWebUI mounts the gateway's web app: assets resolved from
+// STATIC_UI_PATH, the default disk path or the build embedded in the binary;
+// index.html and js/app.js are transformed in memory with this gateway's URL
+// and served from memory. Any path outside /api falls back to index.html so
+// the SPA router owns it.
+func serveWebUI(route *gin.Engine, baseURL string) {
+	webappUI, err := webappui.Resolve()
+	if err != nil {
+		log.Warnf("failed loading the web UI, running API-only, reason=%v", err)
+	}
+	webappui.LogSource(webappUI)
+	if webappUI != nil {
+		route.Use(static.Serve(baseURL+"/", webappUI.FileSystem()))
+		route.GET(baseURL+"/index.html", func(c *gin.Context) {
+			webappUI.WriteIndex(c.Writer, http.StatusOK)
+		})
+		if webappUI.HasAppJs() {
+			route.GET(baseURL+"/js/app.js", func(c *gin.Context) {
+				webappUI.WriteAppJs(c.Writer)
+			})
+		}
+	}
+	route.NoRoute(func(c *gin.Context) {
+		if !strings.HasPrefix(c.Request.RequestURI, baseURL+"/api") {
+			if webappUI != nil {
+				webappUI.WriteIndex(c.Writer, http.StatusOK)
+				return
+			}
+			c.Status(http.StatusNotFound)
+			return
+		}
+	})
 }
 
 // newEngine builds the gin engine with the middleware every mode needs:
@@ -232,17 +245,6 @@ func (a *Api) newAPIRouter(route *gin.Engine, baseURL string) *apiroutes.Router 
 	rg.Use(sentrygin.New(sentrygin.Options{Repanic: true}))
 	rg.Use(sentryCatchAll5xxMiddleware)
 	return apiroutes.New(rg)
-}
-
-// buildControlPlaneEngine wires the control plane's HTTP surface. It shares
-// the middleware chain with the gateway and stops there: no static UI and no
-// SPA fallback (the gateway's web app calls routes the control plane does not
-// serve), no MCP well-known handlers, no SSM and no RDP proxy group — those
-// belong to the traffic path the control plane does not have.
-func (a *Api) buildControlPlaneEngine(route *gin.Engine, baseURL string) *gin.Engine {
-	a.buildControlPlaneRoutes(a.newAPIRouter(route, baseURL))
-	openapi.RegisterGinValidators()
-	return route
 }
 
 func (a *Api) StartAPI() {
@@ -278,363 +280,19 @@ func (a *Api) StartAPI() {
 	}
 }
 
-// buildControlPlaneRoutes registers the control plane's API surface. It is
-// deliberately near-empty: the gateway's routes are being ported one at a
-// time, and a route answers here only after it has been reviewed for a
-// deployment that has no agents, no connections and no sessions of its own.
-//
-// /healthz is the exception, and not an optional one: the helm service, the
-// AWS load balancer template and the docker-compose healthcheck all probe
-// /api/healthz, so a control plane without it never passes its health check.
-func (api *Api) buildControlPlaneRoutes(r *apiroutes.Router) {
-	// runControlPlane builds Api without a ReleaseConnectionFn because this
-	// mode runs no gRPC transport. Only reviewapi.ReviewByIdOrSid calls it, and
-	// that route is not registered below — this stub is here so that adding it
-	// back fails with a named error instead of a nil dereference after the
-	// review has already been written.
-	reviewHandler := reviewapi.NewHandler(func(orgID, sid, _, _, _, _ string) {
-		log.With("org", orgID, "sid", sid).
-			Error("control plane: asked to release a gRPC connection, but this mode runs no transport")
-	})
-	loginOidcApiHandler := loginoidcapi.New()
-	loginSamlApiHandler := loginsamlapi.New()
-
-	// Probes and specs.
-	r.GET("/healthz", apihealthz.ControlPlaneLivenessHandler())
-	r.GET("/openapiv2.json", openapi.Handler)
-	r.GET("/openapiv3.json", openapi.HandlerV3)
-
-	// Obtaining a session. controlplane/frontend/src/services/auth.js calls every one of these.
-	r.GET("/publicserverinfo", apipublicserverinfo.Get)
-	r.GET("/serverinfo",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		apiserverinfo.Get)
-	r.GET("/login", loginOidcApiHandler.Login)
-	r.GET("/callback", loginOidcApiHandler.LoginCallback)
-	r.GET("/saml/login", loginSamlApiHandler.SamlLogin)
-	r.POST("/saml/callback", loginSamlApiHandler.SamlLoginCallback)
-	r.POST("/localauth/register",
-		api.TrackRequest(analytics.EventSignup),
-		loginlocalapi.Register)
-	r.POST("/localauth/login",
-		api.TrackRequest(analytics.EventLogin),
-		loginlocalapi.Login)
-	r.POST("/signup",
-		api.TrackRequest(analytics.EventSignup),
-		signupapi.Post)
-	r.GET("/userinfo",
-		apiroutes.UserInfoRouteType,
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		userapi.GetUserInfo)
-	r.POST("/orgs/invitations",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		userapi.HandleOrgInvitation)
-
-	// Feature flags: the Settings -> Experimental surface.
-	r.GET("/feature-flags",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		apifeatureflags.List)
-	r.PUT("/feature-flags/:name",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		apifeatureflags.Update)
-
-	// Administrators.
-	r.GET("/users",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		userapi.List)
-	r.POST("/users",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		userapi.Create)
-	r.GET("/users/:emailOrID",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		userapi.GetUserByEmailOrID)
-	r.PUT("/users/:emailOrID",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		api.TrackRequest(analytics.EventUpdateUser),
-		userapi.Update)
-	r.DELETE("/users/:emailOrID",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		userapi.Delete)
-	r.PATCH("/users/self/slack",
-		r.AuthMiddleware,
-		api.TrackRequest(analytics.EventUpdateUser),
-		userapi.PatchSlackID)
-	r.POST("/users/self/signup-origin",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		userapi.PostSignupOrigin)
-
-	// Groups are READ ONLY. The control plane administers none; it reads the ones
-	// that exist because a review rule names its approvers by group.
-	r.GET("/users/groups",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		userapi.ListAllGroups)
-
-	// Guardrails.
-	r.POST("/guardrails",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		api.TrackRequest(analytics.EventCreateGuardRailRules),
-		apiguardrails.Post)
-	r.GET("/guardrails",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		apiguardrails.List)
-	r.GET("/guardrails/:id",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		apiguardrails.Get)
-	r.PUT("/guardrails/:id",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		api.TrackRequest(analytics.EventUpdateGuardRailRules),
-		apiguardrails.Put)
-	r.DELETE("/guardrails/:id",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		api.TrackRequest(analytics.EventDeleteGuardRailRules),
-		apiguardrails.Delete)
-
-	// Live data masking.
-	r.POST("/datamasking-rules",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		apidatamasking.Post)
-	r.GET("/datamasking-rules",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		apidatamasking.List)
-	r.GET("/datamasking-rules/:id",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		apidatamasking.Get)
-	r.PUT("/datamasking-rules/:id",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		apidatamasking.Put)
-	r.DELETE("/datamasking-rules/:id",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		apidatamasking.Delete)
-
-	// AI session analyzer.
-	r.GET("/ai/session-analyzer/providers",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		apiai.GetSessionAnalyzerProvider)
-	r.POST("/ai/session-analyzer/providers",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		apiai.UpsertSessionAnalyzerProvider)
-	r.DELETE("/ai/session-analyzer/providers",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		apiai.DeleteSessionAnalyzerProvider)
-	r.GET("/ai/session-analyzer/rules",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		apiai.ListSessionAnalyzerRules)
-	r.POST("/ai/session-analyzer/rules",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		apiai.CreateSessionAnalyzerRule)
-	r.GET("/ai/session-analyzer/rules/:name",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		apiai.GetSessionAnalyzerRule)
-	r.PUT("/ai/session-analyzer/rules/:name",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		apiai.UpdateSessionAnalyzerRule)
-	r.DELETE("/ai/session-analyzer/rules/:name",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		apiai.DeleteSessionAnalyzerRule)
-	r.GET("/ai/session-analyzer/system-prompt",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		apiai.GetSessionAnalyzerSystemPrompt)
-	r.GET("/connections/:nameOrID/ai-session-analyzer-rule",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		apiai.GetConnectionAnalyzerRule)
-
-	// Reviews, READ ONLY.
-	//
-	// PUT /reviews/:id is deliberately absent. Approving or rejecting calls
-	// TransportReleaseConnection to free the gRPC stream waiting on the
-	// verdict, and this mode starts no transport — so the callback is nil and
-	// the call panics *after* DoReview has already committed, which a recovered
-	// 500 hides from the client. There is nothing to release here either way:
-	// a sidecar pulls its configuration over HTTP and holds no stream.
-	//
-	// Reviews raised by a sidecar are a different entity from the gateway
-	// session reviews these two routes list (see ADR-0009). Approving belongs
-	// with that entity, not with a nil-guard on this one.
-	r.GET("/reviews",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		api.TrackRequest(analytics.EventFetchReviews),
-		reviewHandler.List,
-	)
-	r.GET("/reviews/:id",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		api.TrackRequest(analytics.EventFetchReviews),
-		reviewHandler.GetByIdOrSid,
-	)
-
-	// Review rules.
-	r.GET("/access-requests/rules",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		accessrequestsapi.ListAccessRequestRules,
-	)
-	r.POST("/access-requests/rules",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		accessrequestsapi.CreateAccessRequestRule,
-	)
-	r.GET("/access-requests/rules/:name",
-		apiroutes.AdminAndAuditorAccessRole,
-		r.AuthMiddleware,
-		accessrequestsapi.GetAccessRequestRule,
-	)
-	r.PUT("/access-requests/rules/:name",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		accessrequestsapi.UpdateAccessRequestRule,
-	)
-	r.DELETE("/access-requests/rules/:name",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		accessrequestsapi.DeleteAccessRequestRule,
-	)
-
-	// Sessions, read only, as the surface behind Reviews. download, stream and
-	// result/stream stay out: nothing calls them, and GET /sessions/:session_id/download
-	// carries no auth middleware at all.
-	r.GET("/sessions",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		sessionapi.List)
-	r.GET("/sessions/:session_id",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		sessionapi.Get)
-	r.PATCH("/sessions/:session_id/metadata",
-		r.AuthMiddleware,
-		sessionapi.PatchMetadata)
-
-	// Slack. /plugins is one route for every plugin and the name arrives in the
-	// body, so gateway/api/plugins narrows it to slack in the handler — a route
-	// list cannot express that.
-	//
-	// LIMITATION, and it is visible to an admin: these routes persist Slack
-	// configuration and nothing more. plugintypes.RegisteredPlugins is
-	// populated in runGateway, so in this mode processOnUpdatePluginPhase
-	// iterates an empty list and no Slack runtime starts — no event listener,
-	// no notifications. Nothing is lost: the configuration is read when a
-	// runtime does start. But an admin who configures Slack here will not
-	// receive anything, and there is no review to notify about yet either,
-	// since PUT /reviews/:id is not on this surface.
-	//
-	// Keep the routes or drop them, but do not add a Slack-shaped feature on
-	// top of them until a control-plane notification path exists.
-	r.POST("/plugins",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.TrackRequest(analytics.EventCreatePlugin),
-		apiplugins.Post)
-	r.GET("/plugins",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		apiplugins.List)
-	r.GET("/plugins/:name",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		apiplugins.Get)
-	r.PUT("/plugins/:name",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.TrackRequest(analytics.EventUpdatePlugin),
-		apiplugins.Put)
-	r.PUT("/plugins/:name/config",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.TrackRequest(analytics.EventUpdatePluginConfig),
-		apiplugins.PutConfig)
-
-	// Resources. The control plane reads and edits connection metadata; it never
-	// opens one. PUT /connections/:nameOrID is absent because the frontend uses PATCH.
-	r.GET("/connections",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		apiconnections.List)
-	r.POST("/connections",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		api.TrackRequest(analytics.EventCreateConnection),
-		apiconnections.Post)
-	r.GET("/connections/:nameOrID",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		apiconnections.Get)
-	r.PATCH("/connections/:nameOrID",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		api.TrackRequest(analytics.EventUpdateConnection),
-		apiconnections.Patch)
-	r.DELETE("/connections/:nameOrID",
-		apiroutes.AdminOnlyAccessRole,
-		r.AuthMiddleware,
-		api.AuditMiddleware(),
-		api.TrackRequest(analytics.EventDeleteConnection),
-		apiconnections.Delete)
-	r.GET("/connection-tags",
-		apiroutes.ReadOnlyAccessRole,
-		r.AuthMiddleware,
-		apiconnections.ListTags,
-	)
-}
-
-func (api *Api) buildRoutes(r *apiroutes.Router) {
+func (api *Api) buildRoutes(r *apiroutes.Router, mode appconfig.AppMode) {
 	reviewHandler := reviewapi.NewHandler(api.ReleaseConnectionFn)
 	loginOidcApiHandler := loginoidcapi.New()
 	loginSamlApiHandler := loginsamlapi.New()
 
-	r.GET("/healthz", apihealthz.LivenessHandler())
+	// The gateway's probe dials the gRPC port to prove the transport is up.
+	// The control plane never opens that port, so its probe answers without
+	// dialing; otherwise no control plane would ever pass a health check.
+	liveness := apihealthz.LivenessHandler()
+	if mode == appconfig.AppModeControlPlane {
+		liveness = apihealthz.ControlPlaneLivenessHandler()
+	}
+	r.GET("/healthz", liveness)
 	r.GET("/openapiv2.json", openapi.Handler)
 	r.GET("/openapiv3.json", openapi.HandlerV3)
 

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -137,11 +137,11 @@ type Api struct {
 // share the exact same handler — tests exercise the production middleware
 // chain and validators rather than a stripped-down router.
 //
-// The control plane gets the same engine minus the web UI (ADR-0013). It
-// has its own frontend, controlplane/frontend, and the routes it does not
-// need are cheaper to leave in than to list: a route added to the gateway
-// reaches the control plane by construction. A route that needs the gRPC
-// transport that mode never starts fails per request instead.
+// The control plane gets the same engine (ADR-0013): every route, the web
+// UI included. The routes it does not need are cheaper to leave in than to
+// list, so a route added to the gateway reaches the control plane by
+// construction; one that needs the gRPC transport that mode never starts
+// fails per request instead. The one handler that differs is /healthz.
 func (a *Api) BuildEngine() *gin.Engine {
 	return a.buildEngine(appconfig.Get().AppMode())
 }
@@ -152,9 +152,7 @@ func (a *Api) buildEngine(mode appconfig.AppMode) *gin.Engine {
 	route := a.newEngine()
 	baseURL := appconfig.Get().ApiURLPath()
 
-	if mode != appconfig.AppModeControlPlane {
-		serveWebUI(route, baseURL)
-	}
+	serveWebUI(route, baseURL)
 
 	route.GET("/.well-known/oauth-protected-resource", apimcpauth.MetadataHandler)
 	route.GET("/.well-known/oauth-protected-resource"+apimcpauth.McpResourcePath(), apimcpauth.MetadataHandler)

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -193,10 +193,15 @@ func Run(mode appconfig.AppMode) {
 // needs the gRPC transport fails per request, while /api/ws still accepts an
 // agent over WebSocket and /rdpproxy relays through it (ADR-0013).
 func runControlPlane(tlsConfig *tls.Config) {
+	// Same wiring as runGateway. The transport server exists for its review
+	// callback and is never started, so the handlers run the gateway's code.
+	g := &transport.Server{
+		TLSConfig:   tlsConfig,
+		ApiHostname: appconfig.Get().ApiHostname(),
+		AppConfig:   appconfig.Get(),
+	}
 	a := &api.Api{
-		// A review verdict releases the gRPC stream that waits on it. This
-		// mode holds no stream, so the verdict is complete once written.
-		ReleaseConnectionFn: func(_, _, _, _, _, _ string) {},
+		ReleaseConnectionFn: g.ReleaseConnectionOnReview,
 		TLSConfig:           tlsConfig,
 	}
 

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -188,10 +188,10 @@ func Run(mode appconfig.AppMode) {
 }
 
 // runControlPlane serves the control plane: the HTTP API and nothing else.
-// It administers a fleet of sidecars, so it accepts no agent or client
-// connection — the gRPC transport, the protocol proxies and the transport
-// plugins never start. The HTTP API is the gateway's (see Api.BuildEngine);
-// a route that needs the transport fails per request.
+// The gRPC transport, the protocol proxies and the transport plugins never
+// start. The HTTP API is the gateway's (see Api.BuildEngine): a route that
+// needs the gRPC transport fails per request, while /api/ws still accepts an
+// agent over WebSocket and /rdpproxy relays through it (ADR-0013).
 func runControlPlane(tlsConfig *tls.Config) {
 	a := &api.Api{
 		// A review verdict releases the gRPC stream that waits on it. This

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -190,10 +190,15 @@ func Run(mode appconfig.AppMode) {
 // runControlPlane serves the control plane: the HTTP API and nothing else.
 // It administers a fleet of sidecars, so it accepts no agent or client
 // connection — the gRPC transport, the protocol proxies and the transport
-// plugins never start. The API surface is still being ported route by route
-// (see Api.buildControlPlaneRoutes), so today it answers /api/healthz only.
+// plugins never start. The HTTP API is the gateway's (see Api.BuildEngine);
+// a route that needs the transport fails per request.
 func runControlPlane(tlsConfig *tls.Config) {
-	a := &api.Api{TLSConfig: tlsConfig}
+	a := &api.Api{
+		// A review verdict releases the gRPC stream that waits on it. This
+		// mode holds no stream, so the verdict is complete once written.
+		ReleaseConnectionFn: func(_, _, _, _, _, _ string) {},
+		TLSConfig:           tlsConfig,
+	}
 
 	bootstrap.Phase("Starting API")
 	apiStep := bootstrap.Step("HTTP API")


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

## 📝 Description

`hoop start control-plane` now builds the same engine as the gateway: every route, the web UI included. The hand-written allowlist in `buildControlPlaneRoutes`, the test that pinned it and the Slack-only plugin filter are removed. The only handler that differs is `/healthz`, which keeps the probe that does not dial the gRPC port. The control plane is the gateway minus the data plane: no gRPC transport, no protocol proxies, no transport plugins.

Routes that need the gRPC transport (21 of 271) are registered and fail per request with an HTTP error. `/api/ws` and `/rdpproxy/*` work without gRPC: an agent can connect over WebSocket and RDP relays through it. ADR-0013 (#1774) is updated in place to record the decision.

## 📣 User-facing impact

None. The gateway is unchanged and the control plane is not shipped yet.

## 🔗 Related Issue

EVL-245. ADR: #1774.

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [x] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- `gateway/api/server.go`: `BuildEngine` builds one engine for both modes through `buildEngine(mode)`. The web UI block moves to `serveWebUI` and runs in both modes. `buildRoutes` picks the `/healthz` handler by mode. `buildControlPlaneEngine` and `buildControlPlaneRoutes` are deleted.
- `gateway/api/plugins/plugin.go`: `hiddenOnControlPlane` and the Slack-only list filter are deleted.
- `gateway/main.go`: `runControlPlane` wires the gateway's own `ReleaseConnectionOnReview` from a transport server it builds and never starts, so the review handler runs the same code as on the gateway.
- `gateway/api/controlplane_routes_test.go`: the pinned list becomes a parity test. The two modes must register the same routes, in both directions.
- `client/cmd/start.go`: help text for `hoop start control-plane`.
- `controlplane/frontend/README.md`, `controlplane/frontend/CLAUDE.md`: how to run this app against the control plane, that the binary serves the gateway's web UI at `/`, and which routes fail there.
- `controlplane/frontend/src/layout/ModeBanner/index.jsx`: the dev banner now only says the backend is a gateway, since the control plane blocks no routes.
- `controlplane/frontend/src/services/{connections,userGroups}.js`, `stores/useUserStore.js`: comments no longer claim routes answer 404 on the control plane.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: none
- **OS**: macOS (darwin/arm64)

### Tests performed:
- [x] Unit tests pass (`make test-oss`, 0 failures)
- [ ] Integration tests pass (not run separately; the integration packages are part of `make test-oss`)
- [x] Manual testing completed (both modes booted from one binary, see below)

## How to test

### Setup

No Postgres needed; the embedded PGlite is enough. Build the CLI once:

```bash
make build-dev-client
export HOOP=$HOME/.hoop/bin/hoop
```

Terminal 1, control plane:

```bash
POSTGRES_DB_URI=pglite:///tmp/hoop-cp PORT=18019 API_URL=http://localhost:18019 \
GIN_MODE=debug AUTH_METHOD=local $HOOP start control-plane 2>&1 | tee /tmp/cp.log
```

### Steps

1. Count registered routes and probe the surface:
   ```bash
   grep -c -- '-->' /tmp/cp.log
   curl -s localhost:18019/api/healthz; echo
   curl -s -o /dev/null -w '%{http_code}\n' localhost:18019/
   curl -s -o /dev/null -w '%{http_code}\n' localhost:18019/api/users
   nc -z -w1 127.0.0.1 8010 || echo "8010 closed"
   ```
2. Register a local admin and take a token (it comes back in the `Token` header):
   ```bash
   curl -s -X POST localhost:18019/api/localauth/register -H 'Content-Type: application/json' \
     -d '{"name":"Admin","email":"admin@example.com","password":"Passw0rd!Passw0rd!"}'
   TOKEN=$(curl -s -D - -o /dev/null -X POST localhost:18019/api/localauth/login -H 'Content-Type: application/json' \
     -d '{"email":"admin@example.com","password":"Passw0rd!Passw0rd!"}' | awk -F': ' 'tolower($1)=="token"{gsub(/\r/,"",$2); print $2}')
   ```
3. Routes the old allowlist blocked now answer:
   ```bash
   for p in api-keys audit/logs server-logs agents serverconfig/auth plugins; do
     printf '%-20s ' $p; curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" localhost:18019/api/$p
   done
   curl -s -H "Authorization: Bearer $TOKEN" localhost:18019/api/plugins | grep -o '"name":"[a-z_]*"'
   ```
4. Negative path, a route that needs the transport. Create an agent and a connection, then exec:
   ```bash
   curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' localhost:18019/api/agents -d '{"name":"cp-agent","mode":"standard"}'
   AGENT_ID=$(curl -s -H "Authorization: Bearer $TOKEN" localhost:18019/api/agents | python3 -c 'import sys,json; print(json.load(sys.stdin)[0]["id"])')
   curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' localhost:18019/api/connections \
     -d "{\"name\":\"cp-pg\",\"type\":\"database\",\"subtype\":\"postgres\",\"agent_id\":\"$AGENT_ID\",\"command\":[\"psql\"],\"secret\":{\"envvar:HOST\":\"bG9jYWxob3N0\"},\"access_mode_runbooks\":\"enabled\",\"access_mode_exec\":\"enabled\",\"access_mode_connect\":\"enabled\",\"access_schema\":\"enabled\"}"
   curl -s -w '\n%{http_code}\n' -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' localhost:18019/api/sessions -d '{"connection":"cp-pg","script":"select 1"}'
   curl -s -w '\n%{http_code}\n' -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' localhost:18019/api/proxymanager/connect -d '{"connection_name":"cp-pg","port":"5433"}'
   curl -s localhost:18019/api/healthz; echo
   ```

### Expected

1. `389`. `{"liveness":"OK"}`. `404` for `/` (the dev build embeds no web UI; the regression check below serves one). `401` for `/api/users` (auth middleware unchanged). `8010 closed`.
2. `{"message":"User created successfully"}`; `echo ${#TOKEN}` is non-zero.
3. `200` for all six. The plugin list names every plugin (`audit`, `dlp`, `review`, `slack`, ...), not only `slack`.
4. `POST /api/sessions` answers `500` with `failed creating client: ...` (on a macOS host it fails preparing `/opt/hoop`; in a container the dial to `127.0.0.1:8010` is refused). `POST /api/proxymanager/connect` answers `400` `proxy manager state ... not found`. The health check still answers `200` and the process stays up; `grep -ci panic /tmp/cp.log` prints `0`.

### Regression check

- Gateway mode, same binary, port 18009 so it does not collide (the audit plugin needs a writable directory):
  ```bash
  mkdir -p /tmp/hoop-audit
  POSTGRES_DB_URI=pglite:///tmp/hoop-gw PORT=18009 API_URL=http://localhost:18009 PLUGIN_AUDIT_PATH=/tmp/hoop-audit \
  GIN_MODE=debug AUTH_METHOD=local $HOOP start gateway 2>&1 | tee /tmp/gw.log
  ```
  Expected: `grep -c -- '-->' /tmp/gw.log` prints `389`; `diff <(grep -- '-->' /tmp/gw.log | awk '{print $2,$3}' | sort -u) <(grep -- '-->' /tmp/cp.log | awk '{print $2,$3}' | sort -u)` is empty; `nc -z 127.0.0.1 8010` succeeds; `curl -s localhost:18009/api/healthz` is `{"liveness":"OK"}`.
- Web UI in both modes: `mkdir -p /tmp/hoop-ui && echo '<html>ui</html>' > /tmp/hoop-ui/index.html`, then add `STATIC_UI_PATH=/tmp/hoop-ui` to either start command above. Expected: `curl -s localhost:18019/` prints the html, `/any/spa/path` answers `200`, and the route count becomes `390` in both modes.
- Unit: `cd gateway && go test ./api/ -run 'TestControlPlane'` passes.

Needs no enterprise libhoop beyond what the build already requires, no IdP and no cloud resource.

## 📸 Screenshots (if applicable)

None.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- Routes that cannot work in control-plane mode (21 of 271): exec and schema browsing (`POST /sessions`, `POST /sessions/:id/exec`, `POST /runbooks/exec`, `POST /plugins/runbooks/connections/:name/exec`, `GET /connections/:id/{test,databases,tables,columns}`, `POST /federation/test`), resource plan/apply/health and `POST /dbroles/jobs` (agent stream), `POST /proxymanager/{connect,disconnect}` (client stream), `/ssm/*`. `/mcp` answers but its exec, schema and review-execute tools fail. `PUT /serverconfig/misc` starts native proxy listeners inside the control plane process. `GET /api/ws` and `/rdpproxy/*` are the WebSocket agent transport and the RDP relay on top of it; they work without gRPC, so a WebSocket agent makes the control plane an RDP data plane. Accepted by decision (no mode gates) and recorded in ADR-0013.
- #1781 (sidecars) merged and was merged in here: `buildSidecarRoutes` stays, called from `buildRoutes` only. #1778 still edits two entries of the deleted allowlist and will need a small rebase.
- `controlplane/frontend` README, CLAUDE.md, `layout/ModeBanner` and the comments in `services/connections.js`, `services/userGroups.js` and `stores/useUserStore.js` are updated here. Nothing in the frontend describes the allowlist any more.
- No feature flag: ADR-0013 rejects flags for deployment topology.

https://claude.ai/code/session_015cPRg1gLRKKwLjHE2iiut2
