### PR TITLE
feat: OPA

### DIFF
--- a/gateway/analytics/events.go
+++ b/gateway/analytics/events.go
@@ -49,6 +49,11 @@ const (
 	EventCreateSidecar = "hoop-create-sidecar"
 	EventDeleteSidecar = "hoop-delete-sidecar"
 
+	// opa
+	EventCreateOPAConfig = "hoop-create-opa-config"
+	EventUpdateOPAConfig = "hoop-update-opa-config"
+	EventDeleteOPAConfig = "hoop-delete-opa-config"
+
 	// plugins
 	EventCreatePlugin          = "hoop-create-plugin"
 	EventUpdatePlugin          = "hoop-update-plugin"

--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -187,9 +187,7 @@ func Put(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
 		return
 	}
-	// Absent means "leave as is": a client that does not know about sidecars
-	// must not clear the assignment on every save. The kept assignment is
-	// still checked against the new type.
+
 	sidecarID := conn.SidecarID
 	if req.SidecarID != nil {
 		resolved, err := resolveSidecarAssignment(ctx.OrgID, req.SidecarID, req.Type, req.SubType)
@@ -198,13 +196,10 @@ func Put(c *gin.Context) {
 			return
 		}
 		sidecarID = resolved
-	} else if err := revalidateSidecarAssignment(sidecarID, req.Type, req.SubType); err != nil {
-		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
-		return
+	} else {
+		sidecarID = sql.NullString{String: "", Valid: false}
 	}
-	// Same "absent means leave as is" contract as sidecar_id. Nothing about a
-	// connection's type can invalidate an OPA endpoint, so there is no
-	// revalidation twin.
+
 	opaConfigID := conn.OPAConfigID
 	if req.OPAConfigID != nil {
 		resolved, err := resolveOPAConfigAssignment(ctx.OrgID, req.OPAConfigID)
@@ -213,6 +208,8 @@ func Put(c *gin.Context) {
 			return
 		}
 		opaConfigID = resolved
+	} else {
+		opaConfigID = sql.NullString{String: "", Valid: false}
 	}
 	setConnectionDefaults(&req)
 

--- a/gateway/api/connections/connections.go
+++ b/gateway/api/connections/connections.go
@@ -59,7 +59,12 @@ func Post(c *gin.Context) {
 	}
 	sidecarID, err := resolveSidecarAssignment(ctx.OrgID, req.SidecarID, req.Type, req.SubType)
 	if err != nil {
-		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
+		abortAssignment(c, err)
+		return
+	}
+	opaConfigID, err := resolveOPAConfigAssignment(ctx.OrgID, req.OPAConfigID)
+	if err != nil {
+		abortAssignment(c, err)
 		return
 	}
 	existingConn, err := models.GetConnectionByNameOrID(ctx, req.Name)
@@ -93,6 +98,7 @@ func Post(c *gin.Context) {
 		ResourceName:            req.ResourceName,
 		AgentID:                 sql.NullString{String: req.AgentId, Valid: true},
 		SidecarID:               sidecarID,
+		OPAConfigID:             opaConfigID,
 		Name:                    req.Name,
 		Command:                 req.Command,
 		Type:                    req.Type,
@@ -188,13 +194,25 @@ func Put(c *gin.Context) {
 	if req.SidecarID != nil {
 		resolved, err := resolveSidecarAssignment(ctx.OrgID, req.SidecarID, req.Type, req.SubType)
 		if err != nil {
-			c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
+			abortAssignment(c, err)
 			return
 		}
 		sidecarID = resolved
 	} else if err := revalidateSidecarAssignment(sidecarID, req.Type, req.SubType); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
 		return
+	}
+	// Same "absent means leave as is" contract as sidecar_id. Nothing about a
+	// connection's type can invalidate an OPA endpoint, so there is no
+	// revalidation twin.
+	opaConfigID := conn.OPAConfigID
+	if req.OPAConfigID != nil {
+		resolved, err := resolveOPAConfigAssignment(ctx.OrgID, req.OPAConfigID)
+		if err != nil {
+			abortAssignment(c, err)
+			return
+		}
+		opaConfigID = resolved
 	}
 	setConnectionDefaults(&req)
 
@@ -230,6 +248,7 @@ func Put(c *gin.Context) {
 		ResourceName:            req.ResourceName,
 		AgentID:                 sql.NullString{String: req.AgentId, Valid: true},
 		SidecarID:               sidecarID,
+		OPAConfigID:             opaConfigID,
 		Name:                    conn.Name,
 		Command:                 req.Command,
 		Type:                    req.Type,
@@ -356,13 +375,21 @@ func Patch(c *gin.Context) {
 	if req.SidecarID != nil {
 		resolved, err := resolveSidecarAssignment(ctx.OrgID, req.SidecarID, conn.Type, conn.SubType.String)
 		if err != nil {
-			c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
+			abortAssignment(c, err)
 			return
 		}
 		conn.SidecarID = resolved
 	} else if err := revalidateSidecarAssignment(conn.SidecarID, conn.Type, conn.SubType.String); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
 		return
+	}
+	if req.OPAConfigID != nil {
+		resolved, err := resolveOPAConfigAssignment(ctx.OrgID, req.OPAConfigID)
+		if err != nil {
+			abortAssignment(c, err)
+			return
+		}
+		conn.OPAConfigID = resolved
 	}
 	if req.Reviewers != nil {
 		conn.Reviewers = *req.Reviewers
@@ -758,6 +785,7 @@ func ToOpenApi(conn *models.Connection, hideRoleInfo bool) openapi.Connection {
 		DefaultDatabase:         string(defaultDB),
 		AgentId:                 conn.AgentID.String,
 		SidecarID:               sidecarIDPtr(conn.SidecarID),
+		OPAConfigID:             opaConfigIDPtr(conn.OPAConfigID),
 		Status:                  conn.Status,
 		Reviewers:               conn.Reviewers,
 		RedactEnabled:           conn.RedactEnabled,

--- a/gateway/api/connections/helpers.go
+++ b/gateway/api/connections/helpers.go
@@ -6,12 +6,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	pb "github.com/hoophq/hoop/common/proto"
+	"github.com/hoophq/hoop/gateway/api/httputils"
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	apivalidation "github.com/hoophq/hoop/gateway/api/validation"
 	"github.com/hoophq/hoop/gateway/models"
@@ -735,7 +738,7 @@ func resolveSidecarAssignment(orgID string, sidecarID *string, connType, subType
 		if errors.Is(err, models.ErrNotFound) {
 			return sql.NullString{}, fmt.Errorf("sidecar %q not found", *sidecarID)
 		}
-		return sql.NullString{}, err
+		return sql.NullString{}, fmt.Errorf("%w: sidecar %q: %v", errAssignmentLookup, *sidecarID, err)
 	}
 	return sql.NullString{String: sidecar.ID, Valid: true}, nil
 }
@@ -750,4 +753,50 @@ func revalidateSidecarAssignment(current sql.NullString, connType, subType strin
 	}
 	_, err := services.SidecarProtocol(connType, subType)
 	return err
+}
+
+// opaConfigIDPtr maps the nullable column onto the optional API field: nil
+// when the connection has no OPA configuration assigned.
+func opaConfigIDPtr(v sql.NullString) *string {
+	if !v.Valid || v.String == "" {
+		return nil
+	}
+	s := v.String
+	return &s
+}
+
+// errAssignmentLookup marks a resolve failure that is the gateway's problem
+// rather than the request's. Every other error a resolve returns names
+// something the caller got wrong, so the caller answers 422 by default and
+// keeps a database error out of the response body.
+var errAssignmentLookup = errors.New("assignment lookup failed")
+
+// resolveOPAConfigAssignment turns a name or id into the id stored on the
+// connection. A nil or empty value is not an assignment. It does NOT require
+// the connection to be fronted by a sidecar: the endpoint takes effect when
+// one is assigned, and forcing an order on two independent assignments buys
+// nothing.
+func resolveOPAConfigAssignment(orgID string, ref *string) (sql.NullString, error) {
+	if ref == nil || *ref == "" {
+		return sql.NullString{}, nil
+	}
+	item, err := models.GetOPAConfigByNameOrID(models.DB, orgID, *ref)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			return sql.NullString{}, fmt.Errorf("opa configuration %q not found", *ref)
+		}
+		return sql.NullString{}, fmt.Errorf("%w: opa configuration %q: %v", errAssignmentLookup, *ref, err)
+	}
+	return sql.NullString{String: item.ID, Valid: true}, nil
+}
+
+// abortAssignment answers a failed sidecar or OPA assignment: a 500 when the
+// lookup itself failed, a 422 when the request named something the gateway
+// cannot serve or cannot find.
+func abortAssignment(c *gin.Context, err error) {
+	if errors.Is(err, errAssignmentLookup) {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed resolving connection assignment")
+		return
+	}
+	c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
 }

--- a/gateway/api/opaconfigs/opaconfigs.go
+++ b/gateway/api/opaconfigs/opaconfigs.go
@@ -1,0 +1,267 @@
+package apiopaconfigs
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/gateway/api/httputils"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	apivalidation "github.com/hoophq/hoop/gateway/api/validation"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2"
+)
+
+// validateOPAConfigRequest keeps the validation shape-only on purpose: the
+// gateway usually sits in a different network from the OPA the sidecar talks
+// to, so a reachability probe would reject correct configurations.
+func validateOPAConfigRequest(req *openapi.OPAConfigRequest) error {
+	if err := apivalidation.ValidateResourceName(req.Name); err != nil {
+		return err
+	}
+	// Every name-or-id lookup resolves a parsable uuid as an id, so a
+	// uuid-shaped name would create a row nothing can address by name.
+	if _, err := uuid.Parse(req.Name); err == nil {
+		return errors.New("name: it must not be a uuid, that spelling is reserved for addressing a configuration by its id")
+	}
+	u, err := url.Parse(req.URL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Hostname() == "" {
+		return errors.New("url: it must be an absolute http or https decision endpoint, e.g. http://opa:8181/v1/data/hoop/inspect")
+	}
+	// url.Parse accepts any digit run as a port, and the sidecar only checks
+	// that the URL is non-empty, so an unusable port would surface as every
+	// decision failing at dial time rather than here.
+	if port := u.Port(); port != "" {
+		n, err := strconv.Atoi(port)
+		if err != nil || n < 1 || n > 65535 {
+			return errors.New("url: the port must be between 1 and 65535")
+		}
+	}
+	// The URL is stored in clear, echoed by the read endpoints an auditor can
+	// call, and recorded verbatim in the audit log, which redacts by key name
+	// and so would not redact a credential embedded here.
+	if u.User != nil {
+		return errors.New("url: it must not embed credentials, the audit log and the read endpoints would expose them")
+	}
+	if req.TimeoutSec < 0 || req.TimeoutSec > 300 {
+		return errors.New("timeout_sec: it must be between 0 and 300, where 0 uses the sidecar default of 2 seconds")
+	}
+	if req.Gate {
+		return errors.New("gate: not supported yet, the generated configuration carries no ai_analysis rules so a gated decision would gate nothing and the sidecar would refuse the whole configuration")
+	}
+	return nil
+}
+
+// Create OPA Configuration
+//
+//	@Summary		Create OPA Configuration
+//	@Description	Register an OPA decision endpoint. A connection points at one by name or ID and it reaches the sidecar as the per-listener "opa" block.
+//	@Tags			OPA
+//	@Accept			json
+//	@Produce		json
+//	@Param			request			body		openapi.OPAConfigRequest	true	"The request body resource"
+//	@Success		201				{object}	openapi.OPAConfigResponse
+//	@Failure		400,409,422,500	{object}	openapi.HTTPError
+//	@Router			/opa-configs [post]
+func Post(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	var req openapi.OPAConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+	if err := validateOPAConfigRequest(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
+		return
+	}
+
+	obj := &models.OPAConfig{
+		OrgID:      ctx.OrgID,
+		Name:       req.Name,
+		URL:        req.URL,
+		TimeoutSec: req.TimeoutSec,
+		FailOpen:   req.FailOpen,
+		Gate:       req.Gate,
+		CreatedBy:  ctx.UserEmail,
+	}
+	switch err := models.CreateOPAConfig(models.DB, obj); {
+	case err == nil:
+	case errors.Is(err, models.ErrAlreadyExists):
+		c.JSON(http.StatusConflict, gin.H{"message": "an opa configuration with this name already exists"})
+		return
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating opa configuration")
+		return
+	}
+
+	item, err := models.GetOPAConfigByNameOrID(models.DB, ctx.OrgID, obj.ID)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching opa configuration")
+		return
+	}
+	c.JSON(http.StatusCreated, toResponse(*item))
+}
+
+// List OPA Configurations
+//
+//	@Summary		List OPA Configurations
+//	@Description	List all OPA decision endpoints for the organization
+//	@Tags			OPA
+//	@Produce		json
+//	@Success		200	{array}		openapi.OPAConfigResponse
+//	@Failure		500	{object}	openapi.HTTPError
+//	@Router			/opa-configs [get]
+func List(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	items, err := models.ListOPAConfigs(models.DB, ctx.OrgID)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed listing opa configurations")
+		return
+	}
+	result := []openapi.OPAConfigResponse{}
+	for _, item := range items {
+		result = append(result, toResponse(item))
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// Get OPA Configuration
+//
+//	@Summary		Get OPA Configuration
+//	@Description	Get an OPA decision endpoint by name or ID
+//	@Tags			OPA
+//	@Produce		json
+//	@Param			nameOrID	path		string	true	"Name or UUID of the opa configuration"
+//	@Success		200			{object}	openapi.OPAConfigResponse
+//	@Failure		404,500		{object}	openapi.HTTPError
+//	@Router			/opa-configs/{nameOrID} [get]
+func Get(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	item, err := models.GetOPAConfigByNameOrID(models.DB, ctx.OrgID, c.Param("nameOrID"))
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"message": "opa configuration not found"})
+			return
+		}
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching opa configuration")
+		return
+	}
+	c.JSON(http.StatusOK, toResponse(*item))
+}
+
+// Update OPA Configuration
+//
+//	@Summary		Update OPA Configuration
+//	@Description	Update an OPA decision endpoint. The connections pointed at it pick up the change on their next sidecar configuration fetch.
+//	@Tags			OPA
+//	@Accept			json
+//	@Produce		json
+//	@Param			nameOrID			path		string						true	"Name or UUID of the opa configuration"
+//	@Param			request				body		openapi.OPAConfigRequest	true	"The request body resource"
+//	@Success		200					{object}	openapi.OPAConfigResponse
+//	@Failure		400,404,409,422,500	{object}	openapi.HTTPError
+//	@Router			/opa-configs/{nameOrID} [put]
+func Put(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	var req openapi.OPAConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+	if err := validateOPAConfigRequest(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
+		return
+	}
+
+	obj := &models.OPAConfig{
+		Name:       req.Name,
+		URL:        req.URL,
+		TimeoutSec: req.TimeoutSec,
+		FailOpen:   req.FailOpen,
+		Gate:       req.Gate,
+	}
+	updatedID, err := models.UpdateOPAConfigByNameOrID(models.DB, ctx.OrgID, c.Param("nameOrID"), obj)
+	switch {
+	case err == nil:
+	case errors.Is(err, models.ErrNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"message": "opa configuration not found"})
+		return
+	case errors.Is(err, models.ErrAlreadyExists):
+		c.JSON(http.StatusConflict, gin.H{"message": "an opa configuration with this name already exists"})
+		return
+	default:
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed updating opa configuration")
+		return
+	}
+
+	// By id, not by the new name: the name is what this request just changed,
+	// so reading it back is a race against the next rename.
+	item, err := models.GetOPAConfigByNameOrID(models.DB, ctx.OrgID, updatedID)
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching opa configuration")
+		return
+	}
+	c.JSON(http.StatusOK, toResponse(*item))
+}
+
+// Delete OPA Configuration
+//
+//	@Summary		Delete OPA Configuration
+//	@Description	Delete an OPA decision endpoint. Refused while any connection points at it, because losing policy enforcement silently is worse than an error.
+//	@Tags			OPA
+//	@Produce		json
+//	@Param			nameOrID	path	string	true	"Name or UUID of the opa configuration"
+//	@Success		204
+//	@Failure		404,409,500	{object}	openapi.HTTPError
+//	@Router			/opa-configs/{nameOrID} [delete]
+func Delete(c *gin.Context) {
+	ctx := storagev2.ParseContext(c)
+	item, err := models.GetOPAConfigByNameOrID(models.DB, ctx.OrgID, c.Param("nameOrID"))
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"message": "opa configuration not found"})
+			return
+		}
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed fetching opa configuration")
+		return
+	}
+	if len(item.Connections) > 0 {
+		c.JSON(http.StatusConflict, gin.H{
+			"message": "opa configuration is assigned to connection(s): " + strings.Join(item.Connections, ", "),
+		})
+		return
+	}
+	// The foreign key is ON DELETE RESTRICT, so a race that slips past the
+	// pre-check still fails in the database.
+	if err := models.DeleteOPAConfigByID(models.DB, ctx.OrgID, item.ID); err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"message": "opa configuration not found"})
+			return
+		}
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed deleting opa configuration")
+		return
+	}
+	c.Writer.WriteHeader(http.StatusNoContent)
+}
+
+func toResponse(o models.OPAConfig) openapi.OPAConfigResponse {
+	connections := []string{}
+	connections = append(connections, o.Connections...)
+	return openapi.OPAConfigResponse{
+		ID:          o.ID,
+		OrgID:       o.OrgID,
+		Name:        o.Name,
+		URL:         o.URL,
+		TimeoutSec:  o.TimeoutSec,
+		FailOpen:    o.FailOpen,
+		Gate:        o.Gate,
+		Connections: connections,
+		CreatedBy:   o.CreatedBy,
+		CreatedAt:   o.CreatedAt,
+		UpdatedAt:   o.UpdatedAt,
+	}
+}

--- a/gateway/api/opaconfigs/opaconfigs_test.go
+++ b/gateway/api/opaconfigs/opaconfigs_test.go
@@ -1,0 +1,77 @@
+package apiopaconfigs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hoophq/hoop/gateway/api/openapi"
+)
+
+func TestValidateOPAConfigRequest(t *testing.T) {
+	valid := func(mutate func(*openapi.OPAConfigRequest)) *openapi.OPAConfigRequest {
+		req := &openapi.OPAConfigRequest{
+			Name:       "prod-opa",
+			URL:        "http://opa:8181/v1/data/hoop/inspect",
+			TimeoutSec: 2,
+		}
+		if mutate != nil {
+			mutate(req)
+		}
+		return req
+	}
+
+	for _, tt := range []struct {
+		name    string
+		req     *openapi.OPAConfigRequest
+		wantErr string
+	}{
+		{"http endpoint", valid(nil), ""},
+		{"https endpoint", valid(func(r *openapi.OPAConfigRequest) {
+			r.URL = "https://opa.internal/v1/data/hoop/inspect"
+		}), ""},
+		{"host without path", valid(func(r *openapi.OPAConfigRequest) { r.URL = "http://opa:8181" }), ""},
+
+		{"uuid name", valid(func(r *openapi.OPAConfigRequest) {
+			r.Name = "1837453e-01fc-46f3-9e4c-dcf22d395393"
+		}), "name: it must not be a uuid"},
+		{"name too short", valid(func(r *openapi.OPAConfigRequest) { r.Name = "op" }), "name: it must contain"},
+
+		{"relative url", valid(func(r *openapi.OPAConfigRequest) { r.URL = "/v1/data/hoop/inspect" }), "url: it must be an absolute"},
+		{"scheme relative url", valid(func(r *openapi.OPAConfigRequest) { r.URL = "//opa:8181/v1/data" }), "url: it must be an absolute"},
+		{"host only", valid(func(r *openapi.OPAConfigRequest) { r.URL = "opa:8181" }), "url: it must be an absolute"},
+		{"unsupported scheme", valid(func(r *openapi.OPAConfigRequest) { r.URL = "grpc://opa:8181/v1/data" }), "url: it must be an absolute"},
+		{"empty url", valid(func(r *openapi.OPAConfigRequest) { r.URL = "" }), "url: it must be an absolute"},
+		{"unparsable url", valid(func(r *openapi.OPAConfigRequest) { r.URL = "http://opa:81 81/v1" }), "url: it must be an absolute"},
+
+		{"port lower bound", valid(func(r *openapi.OPAConfigRequest) { r.URL = "http://opa:1/v1/data" }), ""},
+		{"port upper bound", valid(func(r *openapi.OPAConfigRequest) { r.URL = "http://opa:65535/v1/data" }), ""},
+		{"port zero", valid(func(r *openapi.OPAConfigRequest) { r.URL = "http://opa:0/v1/data" }), "url: the port must be between"},
+		{"port above range", valid(func(r *openapi.OPAConfigRequest) { r.URL = "http://opa:65536/v1/data" }), "url: the port must be between"},
+
+		{"credentials in url", valid(func(r *openapi.OPAConfigRequest) {
+			r.URL = "http://user:secret@opa:8181/v1/data"
+		}), "url: it must not embed credentials"},
+		{"username only in url", valid(func(r *openapi.OPAConfigRequest) {
+			r.URL = "http://user@opa:8181/v1/data"
+		}), "url: it must not embed credentials"},
+
+		{"timeout zero uses sidecar default", valid(func(r *openapi.OPAConfigRequest) { r.TimeoutSec = 0 }), ""},
+		{"timeout upper bound", valid(func(r *openapi.OPAConfigRequest) { r.TimeoutSec = 300 }), ""},
+		{"timeout negative", valid(func(r *openapi.OPAConfigRequest) { r.TimeoutSec = -1 }), "timeout_sec: it must be between"},
+		{"timeout above range", valid(func(r *openapi.OPAConfigRequest) { r.TimeoutSec = 301 }), "timeout_sec: it must be between"},
+
+		{"gate refused", valid(func(r *openapi.OPAConfigRequest) { r.Gate = true }), "gate: not supported yet"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOPAConfigRequest(tt.req)
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("want no error, got %v", err)
+			case tt.wantErr != "" && err == nil:
+				t.Fatalf("want error containing %q, got nil", tt.wantErr)
+			case tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr):
+				t.Fatalf("want error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -5421,6 +5421,243 @@ const docTemplate = `{
                 }
             }
         },
+        "/opa-configs": {
+            "get": {
+                "description": "List all OPA decision endpoints for the organization",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "OPA"
+                ],
+                "summary": "List OPA Configurations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/openapi.OPAConfigResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Register an OPA decision endpoint. A connection points at one by name or ID and it reaches the sidecar as the per-listener \"opa\" block.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "OPA"
+                ],
+                "summary": "Create OPA Configuration",
+                "parameters": [
+                    {
+                        "description": "The request body resource",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/openapi.OPAConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.OPAConfigResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/opa-configs/{nameOrID}": {
+            "get": {
+                "description": "Get an OPA decision endpoint by name or ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "OPA"
+                ],
+                "summary": "Get OPA Configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name or UUID of the opa configuration",
+                        "name": "nameOrID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.OPAConfigResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update an OPA decision endpoint. The connections pointed at it pick up the change on their next sidecar configuration fetch.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "OPA"
+                ],
+                "summary": "Update OPA Configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name or UUID of the opa configuration",
+                        "name": "nameOrID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "The request body resource",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/openapi.OPAConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.OPAConfigResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete an OPA decision endpoint. Refused while any connection points at it, because losing policy enforcement silently is worse than an error.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "OPA"
+                ],
+                "summary": "Delete OPA Configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name or UUID of the opa configuration",
+                        "name": "nameOrID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/orgs/analytics-mode": {
             "get": {
                 "description": "Get the analytics privacy mode of the caller's organization",
@@ -12928,6 +13165,12 @@ const docTemplate = `{
                     "type": "string",
                     "example": "pgdemo"
                 },
+                "opa_config_id": {
+                    "description": "The OPA decision endpoint consulted for this connection when a sidecar\nfronts it. Accepts the name or the id of a registered OPA\nconfiguration. Absent leaves the current assignment untouched, an\nempty string unassigns it.",
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "1837453e-01fc-46f3-9e4c-dcf22d395393"
+                },
                 "redact_enabled": {
                     "description": "When this option is enabled it will allow managing the redact types through the attribute ` + "`" + `redact_types` + "`" + `",
                     "type": "boolean"
@@ -13406,6 +13649,12 @@ const docTemplate = `{
                     "description": "MCPOAuthFlowID adopts a completed MCP OAuth login into a durable grant\nfor this connection. Write-only, and only meaningful for the \"mcpproxy\"\nsubtype. See Connection.MCPOAuthFlowID for the full rationale.\n\nPATCH needs it for the same reason POST and PUT do, and more urgently:\nre-authorizing an EXISTING connection is the only way to replace a\ncredential the provider has expired, and the edit screen speaks PATCH.\nWithout this the browser could obtain a fresh token but never hand over\nthe flow that owns its refresh token, so every re-authorization would\nfreeze another token destined to expire exactly like the last one.",
                     "type": "string",
                     "example": "7c8a1234-5678-9abc-def0-123456789abc"
+                },
+                "opa_config_id": {
+                    "description": "The OPA decision endpoint consulted for this connection when a sidecar\nfronts it. Accepts the name or the id of a registered OPA\nconfiguration. An empty string unassigns it.",
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "1837453e-01fc-46f3-9e4c-dcf22d395393"
                 },
                 "redact_types": {
                     "description": "Redact Types is a list of info types that will used to redact the output of the connection.\nPossible values are described in the DLP documentation: https://cloud.google.com/sensitive-data-protection/docs/infotypes-reference",
@@ -15511,6 +15760,104 @@ const docTemplate = `{
                     "type": "string",
                     "readOnly": true,
                     "example": "2024-07-25T15:56:35.317601Z"
+                }
+            }
+        },
+        "openapi.OPAConfigRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "url"
+            ],
+            "properties": {
+                "fail_open": {
+                    "description": "Allow the statement when OPA is unreachable. False stops traffic on\nan OPA outage instead of silently disabling enforcement.",
+                    "type": "boolean",
+                    "example": false
+                },
+                "gate": {
+                    "description": "Adds a decision before the AI analyzer runs. Refused while true: the\ngateway emits no ai_analysis rules, so the sidecar would reject the\nwhole configuration.",
+                    "type": "boolean",
+                    "example": false
+                },
+                "name": {
+                    "description": "Unique name of the resource",
+                    "type": "string",
+                    "example": "prod-opa"
+                },
+                "timeout_sec": {
+                    "description": "Per-decision timeout. 0 uses the sidecar default of 2 seconds.",
+                    "type": "integer",
+                    "example": 2
+                },
+                "url": {
+                    "description": "The FULL decision endpoint the sidecar POSTs to, not a base URL.",
+                    "type": "string",
+                    "example": "http://opa:8181/v1/data/hoop/inspect"
+                }
+            }
+        },
+        "openapi.OPAConfigResponse": {
+            "type": "object",
+            "properties": {
+                "connections": {
+                    "description": "Names of the connections pointed at this endpoint",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "pg-prod"
+                    ]
+                },
+                "created_at": {
+                    "description": "Creation timestamp",
+                    "type": "string"
+                },
+                "created_by": {
+                    "description": "Subject of the admin who created it",
+                    "type": "string"
+                },
+                "fail_open": {
+                    "description": "Allow the statement when OPA is unreachable",
+                    "type": "boolean",
+                    "example": false
+                },
+                "gate": {
+                    "description": "Adds a decision before the AI analyzer runs",
+                    "type": "boolean",
+                    "example": false
+                },
+                "id": {
+                    "description": "Unique identifier",
+                    "type": "string",
+                    "format": "uuid",
+                    "readOnly": true
+                },
+                "name": {
+                    "description": "Human-readable name",
+                    "type": "string",
+                    "example": "prod-opa"
+                },
+                "org_id": {
+                    "description": "Organization ID",
+                    "type": "string",
+                    "format": "uuid",
+                    "readOnly": true
+                },
+                "timeout_sec": {
+                    "description": "Per-decision timeout. 0 uses the sidecar default of 2 seconds.",
+                    "type": "integer",
+                    "example": 2
+                },
+                "updated_at": {
+                    "description": "Last update timestamp",
+                    "type": "string"
+                },
+                "url": {
+                    "description": "The decision endpoint the sidecar POSTs to",
+                    "type": "string",
+                    "example": "http://opa:8181/v1/data/hoop/inspect"
                 }
             }
         },

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -13166,7 +13166,7 @@ const docTemplate = `{
                     "example": "pgdemo"
                 },
                 "opa_config_id": {
-                    "description": "The OPA decision endpoint consulted for this connection when a sidecar\nfronts it. Accepts the name or the id of a registered OPA\nconfiguration. Absent leaves the current assignment untouched, an\nempty string unassigns it.",
+                    "description": "The OPA decision endpoint consulted for this connection when a sidecar\nfronts it. Accepts the name or the id of a registered OPA\nconfiguration.",
                     "type": "string",
                     "format": "uuid",
                     "example": "1837453e-01fc-46f3-9e4c-dcf22d395393"
@@ -13212,7 +13212,7 @@ const docTemplate = `{
                     "example": "2025-01-15T10:30:00Z"
                 },
                 "sidecar_id": {
-                    "description": "The sidecar that fronts this connection. Only \"postgres\", \"mssql\" and\n\"httpproxy\" connections may be assigned to one. Absent leaves the\ncurrent assignment untouched, an empty string unassigns it.",
+                    "description": "The sidecar that fronts this connection. Only \"postgres\", \"mssql\" and\n\"httpproxy\" connections may be assigned to one.",
                     "type": "string",
                     "format": "uuid",
                     "example": "1837453e-01fc-46f3-9e4c-dcf22d395393"

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -2048,6 +2048,12 @@
             "example": "pgdemo",
             "type": "string"
           },
+          "opa_config_id": {
+            "description": "The OPA decision endpoint consulted for this connection when a sidecar\nfronts it. Accepts the name or the id of a registered OPA\nconfiguration. Absent leaves the current assignment untouched, an\nempty string unassigns it.",
+            "example": "1837453e-01fc-46f3-9e4c-dcf22d395393",
+            "format": "uuid",
+            "type": "string"
+          },
           "redact_enabled": {
             "description": "When this option is enabled it will allow managing the redact types through the attribute `redact_types`",
             "type": "boolean"
@@ -2534,6 +2540,12 @@
           "mcp_oauth_flow_id": {
             "description": "MCPOAuthFlowID adopts a completed MCP OAuth login into a durable grant\nfor this connection. Write-only, and only meaningful for the \"mcpproxy\"\nsubtype. See Connection.MCPOAuthFlowID for the full rationale.\n\nPATCH needs it for the same reason POST and PUT do, and more urgently:\nre-authorizing an EXISTING connection is the only way to replace a\ncredential the provider has expired, and the edit screen speaks PATCH.\nWithout this the browser could obtain a fresh token but never hand over\nthe flow that owns its refresh token, so every re-authorization would\nfreeze another token destined to expire exactly like the last one.",
             "example": "7c8a1234-5678-9abc-def0-123456789abc",
+            "type": "string"
+          },
+          "opa_config_id": {
+            "description": "The OPA decision endpoint consulted for this connection when a sidecar\nfronts it. Accepts the name or the id of a registered OPA\nconfiguration. An empty string unassigns it.",
+            "example": "1837453e-01fc-46f3-9e4c-dcf22d395393",
+            "format": "uuid",
             "type": "string"
           },
           "redact_types": {
@@ -4642,6 +4654,104 @@
         "required": [
           "name"
         ],
+        "type": "object"
+      },
+      "openapi.OPAConfigRequest": {
+        "properties": {
+          "fail_open": {
+            "description": "Allow the statement when OPA is unreachable. False stops traffic on\nan OPA outage instead of silently disabling enforcement.",
+            "example": false,
+            "type": "boolean"
+          },
+          "gate": {
+            "description": "Adds a decision before the AI analyzer runs. Refused while true: the\ngateway emits no ai_analysis rules, so the sidecar would reject the\nwhole configuration.",
+            "example": false,
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Unique name of the resource",
+            "example": "prod-opa",
+            "type": "string"
+          },
+          "timeout_sec": {
+            "description": "Per-decision timeout. 0 uses the sidecar default of 2 seconds.",
+            "example": 2,
+            "type": "integer"
+          },
+          "url": {
+            "description": "The FULL decision endpoint the sidecar POSTs to, not a base URL.",
+            "example": "http://opa:8181/v1/data/hoop/inspect",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url"
+        ],
+        "type": "object"
+      },
+      "openapi.OPAConfigResponse": {
+        "properties": {
+          "connections": {
+            "description": "Names of the connections pointed at this endpoint",
+            "example": [
+              "pg-prod"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "created_at": {
+            "description": "Creation timestamp",
+            "type": "string"
+          },
+          "created_by": {
+            "description": "Subject of the admin who created it",
+            "type": "string"
+          },
+          "fail_open": {
+            "description": "Allow the statement when OPA is unreachable",
+            "example": false,
+            "type": "boolean"
+          },
+          "gate": {
+            "description": "Adds a decision before the AI analyzer runs",
+            "example": false,
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Unique identifier",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Human-readable name",
+            "example": "prod-opa",
+            "type": "string"
+          },
+          "org_id": {
+            "description": "Organization ID",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "timeout_sec": {
+            "description": "Per-decision timeout. 0 uses the sidecar default of 2 seconds.",
+            "example": 2,
+            "type": "integer"
+          },
+          "updated_at": {
+            "description": "Last update timestamp",
+            "type": "string"
+          },
+          "url": {
+            "description": "The decision endpoint the sidecar POSTs to",
+            "example": "http://opa:8181/v1/data/hoop/inspect",
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "openapi.OrgAnalyticsModeRequest": {
@@ -15792,6 +15902,308 @@
         "summary": "Get Session Metrics",
         "tags": [
           "Session Metrics"
+        ]
+      }
+    },
+    "/opa-configs": {
+      "get": {
+        "description": "List all OPA decision endpoints for the organization",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/openapi.OPAConfigResponse"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "List OPA Configurations",
+        "tags": [
+          "OPA"
+        ]
+      },
+      "post": {
+        "description": "Register an OPA decision endpoint. A connection points at one by name or ID and it reaches the sidecar as the per-listener \"opa\" block.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi.OPAConfigRequest"
+              }
+            }
+          },
+          "description": "The request body resource",
+          "required": true,
+          "x-originalParamName": "request"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.OPAConfigResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Create OPA Configuration",
+        "tags": [
+          "OPA"
+        ]
+      }
+    },
+    "/opa-configs/{nameOrID}": {
+      "delete": {
+        "description": "Delete an OPA decision endpoint. Refused while any connection points at it, because losing policy enforcement silently is worse than an error.",
+        "parameters": [
+          {
+            "description": "Name or UUID of the opa configuration",
+            "in": "path",
+            "name": "nameOrID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Delete OPA Configuration",
+        "tags": [
+          "OPA"
+        ]
+      },
+      "get": {
+        "description": "Get an OPA decision endpoint by name or ID",
+        "parameters": [
+          {
+            "description": "Name or UUID of the opa configuration",
+            "in": "path",
+            "name": "nameOrID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.OPAConfigResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get OPA Configuration",
+        "tags": [
+          "OPA"
+        ]
+      },
+      "put": {
+        "description": "Update an OPA decision endpoint. The connections pointed at it pick up the change on their next sidecar configuration fetch.",
+        "parameters": [
+          {
+            "description": "Name or UUID of the opa configuration",
+            "in": "path",
+            "name": "nameOrID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi.OPAConfigRequest"
+              }
+            }
+          },
+          "description": "The request body resource",
+          "required": true,
+          "x-originalParamName": "request"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.OPAConfigResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Update OPA Configuration",
+        "tags": [
+          "OPA"
         ]
       }
     },

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -2049,7 +2049,7 @@
             "type": "string"
           },
           "opa_config_id": {
-            "description": "The OPA decision endpoint consulted for this connection when a sidecar\nfronts it. Accepts the name or the id of a registered OPA\nconfiguration. Absent leaves the current assignment untouched, an\nempty string unassigns it.",
+            "description": "The OPA decision endpoint consulted for this connection when a sidecar\nfronts it. Accepts the name or the id of a registered OPA\nconfiguration.",
             "example": "1837453e-01fc-46f3-9e4c-dcf22d395393",
             "format": "uuid",
             "type": "string"
@@ -2095,7 +2095,7 @@
             "type": "string"
           },
           "sidecar_id": {
-            "description": "The sidecar that fronts this connection. Only \"postgres\", \"mssql\" and\n\"httpproxy\" connections may be assigned to one. Absent leaves the\ncurrent assignment untouched, an empty string unassigns it.",
+            "description": "The sidecar that fronts this connection. Only \"postgres\", \"mssql\" and\n\"httpproxy\" connections may be assigned to one.",
             "example": "1837453e-01fc-46f3-9e4c-dcf22d395393",
             "format": "uuid",
             "type": "string"

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -318,6 +318,47 @@ type SidecarHandshakeRequest struct {
 	Version string `json:"version" binding:"required" example:"1.0.0"`
 }
 
+type OPAConfigRequest struct {
+	// Unique name of the resource
+	Name string `json:"name" binding:"required" example:"prod-opa"`
+	// The FULL decision endpoint the sidecar POSTs to, not a base URL.
+	URL string `json:"url" binding:"required" example:"http://opa:8181/v1/data/hoop/inspect"`
+	// Per-decision timeout. 0 uses the sidecar default of 2 seconds.
+	TimeoutSec int `json:"timeout_sec" example:"2"`
+	// Allow the statement when OPA is unreachable. False stops traffic on
+	// an OPA outage instead of silently disabling enforcement.
+	FailOpen bool `json:"fail_open" example:"false"`
+	// Adds a decision before the AI analyzer runs. Refused while true: the
+	// gateway emits no ai_analysis rules, so the sidecar would reject the
+	// whole configuration.
+	Gate bool `json:"gate" example:"false"`
+}
+
+type OPAConfigResponse struct {
+	// Unique identifier
+	ID string `json:"id" readonly:"true" format:"uuid"`
+	// Organization ID
+	OrgID string `json:"org_id" readonly:"true" format:"uuid"`
+	// Human-readable name
+	Name string `json:"name" example:"prod-opa"`
+	// The decision endpoint the sidecar POSTs to
+	URL string `json:"url" example:"http://opa:8181/v1/data/hoop/inspect"`
+	// Per-decision timeout. 0 uses the sidecar default of 2 seconds.
+	TimeoutSec int `json:"timeout_sec" example:"2"`
+	// Allow the statement when OPA is unreachable
+	FailOpen bool `json:"fail_open" example:"false"`
+	// Adds a decision before the AI analyzer runs
+	Gate bool `json:"gate" example:"false"`
+	// Names of the connections pointed at this endpoint
+	Connections []string `json:"connections" example:"pg-prod"`
+	// Subject of the admin who created it
+	CreatedBy string `json:"created_by"`
+	// Creation timestamp
+	CreatedAt time.Time `json:"created_at"`
+	// Last update timestamp
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 // AgentSPIFFEMapping ties a SPIFFE identity (exact ID or prefix) to a Hoop
 // agent plus a set of groups that feed into RBAC on authentication.
 //
@@ -446,6 +487,11 @@ type Connection struct {
 	// "httpproxy" connections may be assigned to one. Absent leaves the
 	// current assignment untouched, an empty string unassigns it.
 	SidecarID *string `json:"sidecar_id,omitempty" format:"uuid" example:"1837453e-01fc-46f3-9e4c-dcf22d395393"`
+	// The OPA decision endpoint consulted for this connection when a sidecar
+	// fronts it. Accepts the name or the id of a registered OPA
+	// configuration. Absent leaves the current assignment untouched, an
+	// empty string unassigns it.
+	OPAConfigID *string `json:"opa_config_id,omitempty" format:"uuid" example:"1837453e-01fc-46f3-9e4c-dcf22d395393"`
 	// Status is a read only field that informs if the connection is available for interaction
 	// * online - The agent is connected and alive
 	// * offline - The agent is not connected
@@ -646,6 +692,10 @@ type ConnectionPatch struct {
 	// The sidecar that fronts this connection. Only "postgres", "mssql" and
 	// "httpproxy" connections may be assigned to one. An empty string unassigns it.
 	SidecarID *string `json:"sidecar_id" format:"uuid" example:"1837453e-01fc-46f3-9e4c-dcf22d395393"`
+	// The OPA decision endpoint consulted for this connection when a sidecar
+	// fronts it. Accepts the name or the id of a registered OPA
+	// configuration. An empty string unassigns it.
+	OPAConfigID *string `json:"opa_config_id" format:"uuid" example:"1837453e-01fc-46f3-9e4c-dcf22d395393"`
 	// Reviewers is a list of groups that will review the connection before the user could execute it
 	Reviewers *[]string `json:"reviewers" example:"dba-group"`
 	// Redact Types is a list of info types that will used to redact the output of the connection.

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -484,13 +484,11 @@ type Connection struct {
 	// The agent associated with this connection
 	AgentId string `json:"agent_id" binding:"required" format:"uuid" example:"1837453e-01fc-46f3-9e4c-dcf22d395393"`
 	// The sidecar that fronts this connection. Only "postgres", "mssql" and
-	// "httpproxy" connections may be assigned to one. Absent leaves the
-	// current assignment untouched, an empty string unassigns it.
+	// "httpproxy" connections may be assigned to one.
 	SidecarID *string `json:"sidecar_id,omitempty" format:"uuid" example:"1837453e-01fc-46f3-9e4c-dcf22d395393"`
 	// The OPA decision endpoint consulted for this connection when a sidecar
 	// fronts it. Accepts the name or the id of a registered OPA
-	// configuration. Absent leaves the current assignment untouched, an
-	// empty string unassigns it.
+	// configuration.
 	OPAConfigID *string `json:"opa_config_id,omitempty" format:"uuid" example:"1837453e-01fc-46f3-9e4c-dcf22d395393"`
 	// Status is a read only field that informs if the connection is available for interaction
 	// * online - The agent is connected and alive

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -43,6 +43,7 @@ import (
 	apimcpserver "github.com/hoophq/hoop/gateway/api/mcpserver"
 	metricsapi "github.com/hoophq/hoop/gateway/api/metrics"
 	"github.com/hoophq/hoop/gateway/api/openapi"
+	apiopaconfigs "github.com/hoophq/hoop/gateway/api/opaconfigs"
 	apiorgs "github.com/hoophq/hoop/gateway/api/orgs"
 	apipluginconnections "github.com/hoophq/hoop/gateway/api/pluginconnections"
 	apiplugins "github.com/hoophq/hoop/gateway/api/plugins"
@@ -311,6 +312,37 @@ func (api *Api) buildSidecarRoutes(r *apiroutes.Router) {
 		api.AuditMiddleware(),
 		api.TrackRequest(analytics.EventDeleteSidecar),
 		apisidecar.Delete)
+}
+
+// buildOPAConfigRoutes registers the OPA decision endpoints a connection can
+// be pointed at. They reach a sidecar as the per-listener "opa" block.
+func (api *Api) buildOPAConfigRoutes(r *apiroutes.Router) {
+	r.POST("/opa-configs",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		api.AuditMiddleware(),
+		api.TrackRequest(analytics.EventCreateOPAConfig),
+		apiopaconfigs.Post)
+	r.PUT("/opa-configs/:nameOrID",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		api.AuditMiddleware(),
+		api.TrackRequest(analytics.EventUpdateOPAConfig),
+		apiopaconfigs.Put)
+	r.DELETE("/opa-configs/:nameOrID",
+		apiroutes.AdminOnlyAccessRole,
+		r.AuthMiddleware,
+		api.AuditMiddleware(),
+		api.TrackRequest(analytics.EventDeleteOPAConfig),
+		apiopaconfigs.Delete)
+	r.GET("/opa-configs",
+		apiroutes.AdminAndAuditorAccessRole,
+		r.AuthMiddleware,
+		apiopaconfigs.List)
+	r.GET("/opa-configs/:nameOrID",
+		apiroutes.AdminAndAuditorAccessRole,
+		r.AuthMiddleware,
+		apiopaconfigs.Get)
 }
 
 func (api *Api) buildRoutes(r *apiroutes.Router, mode appconfig.AppMode) {
@@ -811,6 +843,7 @@ func (api *Api) buildRoutes(r *apiroutes.Router, mode appconfig.AppMode) {
 		apiagents.Delete)
 
 	api.buildSidecarRoutes(r)
+	api.buildOPAConfigRoutes(r)
 
 	r.POST("/orgs/keys",
 		apiroutes.AdminOnlyAccessRole,

--- a/gateway/audit/audit.go
+++ b/gateway/audit/audit.go
@@ -34,6 +34,7 @@ const (
 	ResourceAISessionAnalyzerProvider ResourceType = "ai_session_analyzer_providers"
 	ResourceAttribute                 ResourceType = "attributes"
 	ResourceOrgFeature                ResourceType = "org_features"
+	ResourceOPAConfig                 ResourceType = "opa_configs"
 )
 
 // Action is the operation performed.

--- a/gateway/audit/resource_mapping.go
+++ b/gateway/audit/resource_mapping.go
@@ -45,6 +45,7 @@ var root = buildRoutes([]struct {
 	{[]string{"spiffe-mappings"}, ResourceAgentSPIFFEMapping},
 	{[]string{"spiffemappings"}, ResourceAgentSPIFFEMapping},
 	{[]string{"feature-flags"}, ResourceFeatureFlag},
+	{[]string{"opa-configs"}, ResourceOPAConfig},
 })
 
 func buildRoutes(entries []struct {

--- a/gateway/migrations/000115_opa_configs.down.sql
+++ b/gateway/migrations/000115_opa_configs.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+SET search_path TO private;
+
+DROP INDEX IF EXISTS idx_connections_opa_config_id;
+ALTER TABLE connections DROP COLUMN IF EXISTS opa_config_id;
+DROP TABLE IF EXISTS opa_configs;
+
+COMMIT;

--- a/gateway/migrations/000115_opa_configs.up.sql
+++ b/gateway/migrations/000115_opa_configs.up.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+SET search_path TO private;
+
+CREATE TABLE IF NOT EXISTS opa_configs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID NOT NULL REFERENCES orgs(id),
+    name VARCHAR(255) NOT NULL,
+    url TEXT NOT NULL,
+    timeout_sec INT NOT NULL DEFAULT 0,
+    fail_open BOOLEAN NOT NULL DEFAULT FALSE,
+    gate BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_opa_configs_org_name ON opa_configs(org_id, name);
+
+ALTER TABLE connections ADD COLUMN opa_config_id UUID NULL
+    REFERENCES opa_configs(id) ON DELETE RESTRICT;
+CREATE INDEX idx_connections_opa_config_id ON connections(opa_config_id)
+    WHERE opa_config_id IS NOT NULL;
+
+COMMIT;

--- a/gateway/migrations/000115_opa_configs.up.sql
+++ b/gateway/migrations/000115_opa_configs.up.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS opa_configs (
 CREATE UNIQUE INDEX idx_opa_configs_org_name ON opa_configs(org_id, name);
 
 ALTER TABLE connections ADD COLUMN opa_config_id UUID NULL
-    REFERENCES opa_configs(id) ON DELETE RESTRICT;
+    REFERENCES opa_configs(id) ON DELETE SET NULL;
 CREATE INDEX idx_connections_opa_config_id ON connections(opa_config_id)
     WHERE opa_config_id IS NOT NULL;
 

--- a/gateway/models/connections.go
+++ b/gateway/models/connections.go
@@ -45,6 +45,7 @@ type Connection struct {
 	ResourceName            string         `gorm:"column:resource_name"`
 	AgentID                 sql.NullString `gorm:"column:agent_id"`
 	SidecarID               sql.NullString `gorm:"column:sidecar_id"`
+	OPAConfigID             sql.NullString `gorm:"column:opa_config_id"`
 	Name                    string         `gorm:"column:name"`
 	Command                 pq.StringArray `gorm:"column:command;type:text[]"`
 	Type                    string         `gorm:"column:type"`
@@ -547,7 +548,7 @@ func GetBareConnectionByNameOrID(ctx UserContext, nameOrID string, tx *gorm.DB) 
 	SELECT
 		c.id, c.org_id, c.resource_name, c.name, c.command, c.status, c.type, c.subtype, c.managed_by,
 		c.access_mode_runbooks, c.access_mode_exec, c.access_mode_connect, c.access_schema, c.access_max_duration,
-		c.agent_id, c.sidecar_id, a.name AS agent_name, a.mode AS agent_mode, c.force_approve_groups, c.min_review_approvals,
+		c.agent_id, c.sidecar_id, c.opa_config_id, a.name AS agent_name, a.mode AS agent_mode, c.force_approve_groups, c.min_review_approvals,
 		c.jira_issue_template_id, it.issue_transition_name_on_close, c.secrets_updated_at,
 		COALESCE(it.skip_transition_on_nonzero_exit_code, FALSE) AS skip_transition_on_nonzero_exit_code,
 		COALESCE(c.mandatory_metadata_fields, ARRAY[]::TEXT[]) AS mandatory_metadata_fields,
@@ -681,7 +682,7 @@ func getConnectionByNameOrID(ctx UserContext, nameOrID string, tx *gorm.DB) (*Co
 	SELECT
 		c.id, c.org_id, c.resource_name, c.name, c.command, c.status, c.type, c.subtype, c.managed_by,
 		c.access_mode_runbooks, c.access_mode_exec, c.access_mode_connect, c.access_schema,
-		COALESCE(c.agent_id, r.agent_id) AS agent_id, c.sidecar_id, a.name AS agent_name, a.mode AS agent_mode, c.access_max_duration,
+		COALESCE(c.agent_id, r.agent_id) AS agent_id, c.sidecar_id, c.opa_config_id, a.name AS agent_name, a.mode AS agent_mode, c.access_max_duration,
 		c.jira_issue_template_id, it.issue_transition_name_on_close, c.force_approve_groups, c.min_review_approvals, c.secrets_updated_at,
 		COALESCE(it.skip_transition_on_nonzero_exit_code, FALSE) AS skip_transition_on_nonzero_exit_code, 
 		COALESCE(c.mandatory_metadata_fields, ARRAY[]::TEXT[]) AS mandatory_metadata_fields,
@@ -863,7 +864,7 @@ func ListConnections(ctx UserContext, opts ConnectionFilterOption) ([]Connection
 		SELECT * FROM json_to_recordset(?::JSON) AS x(key TEXT, op TEXT, val TEXT)
 	)
 	SELECT
-		c.id, c.org_id, c.agent_id, c.sidecar_id, c.name, c.command, c.status, c.type, c.subtype, c.managed_by,
+		c.id, c.org_id, c.agent_id, c.sidecar_id, c.opa_config_id, c.name, c.command, c.status, c.type, c.subtype, c.managed_by,
 		c.access_mode_runbooks, c.access_mode_exec, c.access_mode_connect, c.access_schema,
 		c.jira_issue_template_id, c.resource_name,
 		-- legacy tags
@@ -1011,7 +1012,8 @@ func SearchConnectionsBySimilarity(orgID string, userGroups []string, searchTerm
 			c.access_mode_runbooks,
 			c.access_mode_exec,
 			c.access_mode_connect,
-			c.sidecar_id
+			c.sidecar_id,
+			c.opa_config_id
 		FROM private.connections c
 		LEFT JOIN private.plugins ac ON ac.name = 'access_control' AND ac.org_id = ?
 		LEFT JOIN private.plugin_connections acc ON acc.connection_id = c.id AND acc.plugin_id = ac.id
@@ -1112,7 +1114,7 @@ func ListConnectionsPaginated(orgID string, userGroups []string, opts Connection
 		SELECT * FROM json_to_recordset(?::JSON) AS x(key TEXT, op TEXT, val TEXT)
 	)
 	SELECT
-		c.id, c.org_id, c.agent_id, c.sidecar_id, c.name, c.command, c.status, c.type, c.subtype, c.managed_by,
+		c.id, c.org_id, c.agent_id, c.sidecar_id, c.opa_config_id, c.name, c.command, c.status, c.type, c.subtype, c.managed_by,
 		c.access_mode_runbooks, c.access_mode_exec, c.access_mode_connect, c.access_schema,
 		c.resource_name,
 		COALESCE(c.mandatory_metadata_fields, ARRAY[]::TEXT[]) AS mandatory_metadata_fields,
@@ -1262,7 +1264,7 @@ func ListConnectionsPaginated(orgID string, userGroups []string, opts Connection
 func ListConnectionsBySidecarID(db *gorm.DB, orgID, sidecarID string) ([]Connection, error) {
 	var items []Connection
 	err := db.Raw(`
-	SELECT c.id, c.org_id, c.name, c.type, c.subtype,
+	SELECT c.id, c.org_id, c.name, c.type, c.subtype, c.opa_config_id,
 		COALESCE((SELECT envs FROM private.env_vars WHERE id = c.id), '{}') AS envs
 	FROM private.connections c
 	WHERE c.org_id = ? AND c.sidecar_id = ?

--- a/gateway/models/opa_configs.go
+++ b/gateway/models/opa_configs.go
@@ -1,0 +1,183 @@
+package models
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+type OPAConfig struct {
+	ID         string    `gorm:"column:id;type:uuid;default:gen_random_uuid();primaryKey"`
+	OrgID      string    `gorm:"column:org_id"`
+	Name       string    `gorm:"column:name"`
+	URL        string    `gorm:"column:url"`
+	TimeoutSec int       `gorm:"column:timeout_sec"`
+	FailOpen   bool      `gorm:"column:fail_open"`
+	Gate       bool      `gorm:"column:gate"`
+	CreatedBy  string    `gorm:"column:created_by"`
+	CreatedAt  time.Time `gorm:"column:created_at"`
+	UpdatedAt  time.Time `gorm:"column:updated_at"`
+	// Connections is derived, not stored: the names of the connections whose
+	// opa_config_id points here. It is what makes a delete refusal name the
+	// connections still using this endpoint.
+	Connections pq.StringArray `gorm:"column:connections;type:text[];->"`
+}
+
+const opaConfigColumns = `
+	o.id, o.org_id, o.name, o.url, o.timeout_sec, o.fail_open, o.gate,
+	o.created_by, o.created_at, o.updated_at,
+	COALESCE((
+		SELECT array_agg(c.name::TEXT) FROM private.connections c
+		WHERE c.opa_config_id = o.id
+	), ARRAY[]::TEXT[]) AS connections`
+
+func CreateOPAConfig(db *gorm.DB, o *OPAConfig) error {
+	if o.ID == "" {
+		o.ID = uuid.NewString()
+	}
+	o.CreatedAt = time.Now().UTC()
+	o.UpdatedAt = o.CreatedAt
+	err := db.Table("private.opa_configs").Create(map[string]any{
+		"id":          o.ID,
+		"org_id":      o.OrgID,
+		"name":        o.Name,
+		"url":         o.URL,
+		"timeout_sec": o.TimeoutSec,
+		"fail_open":   o.FailOpen,
+		"gate":        o.Gate,
+		"created_by":  o.CreatedBy,
+		"created_at":  o.CreatedAt,
+		"updated_at":  o.UpdatedAt,
+	}).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return ErrAlreadyExists
+		}
+		return err
+	}
+	return nil
+}
+
+func ListOPAConfigs(db *gorm.DB, orgID string) ([]OPAConfig, error) {
+	var items []OPAConfig
+	err := db.Raw(`
+	SELECT`+opaConfigColumns+`
+	FROM private.opa_configs o
+	WHERE o.org_id = ?
+	ORDER BY o.name`, orgID).
+		Find(&items).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func GetOPAConfigByNameOrID(db *gorm.DB, orgID, nameOrID string) (*OPAConfig, error) {
+	identifierClause := "o.name = ?"
+	if _, err := uuid.Parse(nameOrID); err == nil {
+		identifierClause = "o.id = ?"
+	}
+
+	var item OPAConfig
+	err := db.Raw(`
+	SELECT`+opaConfigColumns+`
+	FROM private.opa_configs o
+	WHERE o.org_id = ? AND `+identifierClause, orgID, nameOrID).
+		Scan(&item).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	if item.ID == "" {
+		return nil, ErrNotFound
+	}
+	return &item, nil
+}
+
+// UpdateOPAConfigByNameOrID returns the id of the row it changed, so the
+// caller can read the result back by a key the update itself cannot move.
+//
+// The identifier is resolved to an id first and the write goes through gorm
+// rather than a RETURNING statement: gorm's TranslateError only reaches the
+// callback pipeline, so a raw UPDATE reports a unique-violation as a driver
+// error instead of gorm.ErrDuplicatedKey and the caller loses its 409.
+func UpdateOPAConfigByNameOrID(db *gorm.DB, orgID, nameOrID string, o *OPAConfig) (string, error) {
+	identifierClause := "name = ?"
+	if _, err := uuid.Parse(nameOrID); err == nil {
+		identifierClause = "id = ?"
+	}
+
+	var updatedID string
+	err := db.Raw(`
+	SELECT id FROM private.opa_configs
+	WHERE org_id = ? AND `+identifierClause, orgID, nameOrID).
+		Scan(&updatedID).
+		Error
+	if err != nil {
+		return "", err
+	}
+	if updatedID == "" {
+		return "", ErrNotFound
+	}
+
+	res := db.Table("private.opa_configs").
+		Where("org_id = ? AND id = ?", orgID, updatedID).
+		Updates(map[string]any{
+			"name":        o.Name,
+			"url":         o.URL,
+			"timeout_sec": o.TimeoutSec,
+			"fail_open":   o.FailOpen,
+			"gate":        o.Gate,
+			"updated_at":  time.Now().UTC(),
+		})
+	if res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrDuplicatedKey) {
+			return "", ErrAlreadyExists
+		}
+		return "", res.Error
+	}
+	if res.RowsAffected == 0 {
+		return "", ErrNotFound
+	}
+	return updatedID, nil
+}
+
+func DeleteOPAConfigByID(db *gorm.DB, orgID, id string) error {
+	res := db.Exec(`
+	DELETE FROM private.opa_configs
+	WHERE org_id = ? AND id = ?`, orgID, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListOPAConfigsByIDs is the batched lookup the sidecar configuration build
+// uses. It does not select the derived connections column.
+func ListOPAConfigsByIDs(db *gorm.DB, orgID string, ids []string) (map[string]OPAConfig, error) {
+	result := map[string]OPAConfig{}
+	if len(ids) == 0 {
+		return result, nil
+	}
+	var items []OPAConfig
+	err := db.Raw(`
+	SELECT o.id, o.org_id, o.name, o.url, o.timeout_sec, o.fail_open, o.gate
+	FROM private.opa_configs o
+	WHERE o.org_id = ? AND o.id = ANY(?)`, orgID, pq.Array(ids)).
+		Find(&items).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		result[item.ID] = item
+	}
+	return result, nil
+}

--- a/gateway/services/sidecar.go
+++ b/gateway/services/sidecar.go
@@ -85,6 +85,7 @@ type sidecarConnection struct {
 	guardRailInputRules  json.RawMessage
 	guardRailOutputRules json.RawMessage
 	dataMaskingRules     json.RawMessage
+	opa                  *daemon.OPAConfig
 }
 
 // dataMaskingRule is the shape GetDataMaskingEntityTypesByConnectionAndAttributes
@@ -132,6 +133,37 @@ func BuildSidecarConfig(db *gorm.DB, orgID, sidecarID string) (*daemon.Config, e
 		item.dataMaskingRules = maskRules
 		items = append(items, item)
 	}
+
+	// One batched lookup for the OPA endpoints the assigned connections
+	// point at, so a sidecar with N lanes costs one query rather than N.
+	var opaIDs []string
+	for _, conn := range conns {
+		if conn.OPAConfigID.Valid && conn.OPAConfigID.String != "" {
+			opaIDs = append(opaIDs, conn.OPAConfigID.String)
+		}
+	}
+	opaByID, err := models.ListOPAConfigsByIDs(db, orgID, opaIDs)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrSidecarLookup, err)
+	}
+	for i, conn := range conns {
+		if !conn.OPAConfigID.Valid || conn.OPAConfigID.String == "" {
+			continue
+		}
+		row, ok := opaByID[conn.OPAConfigID.String]
+		if !ok {
+			// The foreign key makes this unreachable; refusing the whole
+			// fetch is the fail-closed answer, since serving the lane
+			// without its policy is what the association exists to prevent.
+			return nil, fmt.Errorf("%w: opa configuration for connection %q", ErrSidecarLookup, conn.Name)
+		}
+		items[i].opa = &daemon.OPAConfig{
+			URL:        row.URL,
+			TimeoutSec: row.TimeoutSec,
+			FailOpen:   row.FailOpen,
+			Gate:       row.Gate,
+		}
+	}
 	return buildConfig(items)
 }
 
@@ -176,6 +208,12 @@ func buildConfig(conns []sidecarConnection) (*daemon.Config, error) {
 		if len(rules) > 0 {
 			listener.Guardrails = &daemon.GuardrailsConfig{Mode: daemon.ModeEnforce, Rules: rules}
 		}
+
+		// A nil pointer leaves the block absent, which is what a connection
+		// with no OPA configuration must produce. cfg.OPA stays unset: a
+		// top-level default would reach every lane, and a per-listener block
+		// REPLACES it rather than merging.
+		listener.OPA = conn.opa
 
 		maskRules, entities, threshold, err := sidecarMaskRules(conn)
 		if err != nil {

--- a/gateway/services/sidecar_test.go
+++ b/gateway/services/sidecar_test.go
@@ -90,6 +90,41 @@ func TestBuildConfigPostgresListener(t *testing.T) {
 	}
 }
 
+func TestBuildConfigEmitsPerListenerOPA(t *testing.T) {
+	withOPA := pgConn("pg-prod", "prod.internal", "5432")
+	withOPA.opa = &daemon.OPAConfig{
+		URL:        "http://opa:8181/v1/data/hoop/inspect",
+		TimeoutSec: 3,
+		FailOpen:   true,
+	}
+	withoutOPA := pgConn("pg-stage", "stage.internal", "5433")
+
+	cfg, err := buildConfig([]sidecarConnection{withOPA, withoutOPA})
+	if err != nil {
+		t.Fatalf("buildConfig: %v", err)
+	}
+	if len(cfg.Listeners) != 2 {
+		t.Fatalf("want 2 listeners, got %d", len(cfg.Listeners))
+	}
+	opa := cfg.Listeners[0].OPA
+	if opa == nil {
+		t.Fatal("pg-prod must carry an opa block")
+	}
+	if opa.URL != "http://opa:8181/v1/data/hoop/inspect" {
+		t.Errorf("url: want http://opa:8181/v1/data/hoop/inspect, got %q", opa.URL)
+	}
+	if opa.TimeoutSec != 3 {
+		t.Errorf("timeout_sec: want 3, got %d", opa.TimeoutSec)
+	}
+	if !opa.FailOpen {
+		t.Error("fail_open: want true")
+	}
+	// A connection with no assignment must consult no OPA, not inherit one.
+	if cfg.Listeners[1].OPA != nil {
+		t.Errorf("pg-stage must have no opa block, got %+v", cfg.Listeners[1].OPA)
+	}
+}
+
 func TestBuildConfigDuplicateListenAddress(t *testing.T) {
 	_, err := buildConfig([]sidecarConnection{
 		pgConn("pg-a", "a.internal", "5432"),


### PR DESCRIPTION
## What & Why

Adds OPA (Open Policy Agent) configuration management to the gateway. An admin
registers an OPA decision endpoint and points a sidecar-fronted connection at
it; the sidecar consults it as its per-listener `opa` block, so wire statements
can be gated by an external policy engine.

- New `opa_configs` table plus a nullable `connections.opa_config_id` FK
  (`ON DELETE RESTRICT`), migration `000115`. Model in `gateway/models/opa_configs.go`.
- New API package `gateway/api/opaconfigs/` with CRUD under `/opa-configs`:
  mutations are `AdminOnly`, reads `AdminAndAuditor`. Requests are shape-validated
  only (no reachability probe — the gateway usually can't reach the OPA the
  sidecar talks to).
- Connection `Post`/`Put`/`Patch` accept `opa_config_id` (name or id) and
  resolve/validate the assignment; `absent = leave as is`, empty string
  unassigns. Column threaded through connection reads and `ToOpenApi`.
- `BuildSidecarConfig` emits a per-listener `OPA` block via one batched lookup
  for all assigned connections; a nil pointer leaves the block absent (no
  top-level default, so a listener block replaces rather than merges).
- Analytics events (`hoop-{create,update,delete}-opa-config`), new OpenAPI
  types (`OPAConfigRequest`/`OPAConfigResponse`, connection `opa_config_id`),
  regenerated autogen docs.

## Notes for Reviewers

- `gate: true` is refused for now: the gateway emits no `ai_analysis` rules, so
  a gate-before-analyzer config would make the sidecar reject the whole config.
- Delete is refused while any connection still points at the config (the
  `Connections` field names them) — losing enforcement silently is worse than a 409.
- `fail_open` defaults false: an OPA outage stops traffic rather than silently
  disabling enforcement. `timeout_sec: 0` falls back to the sidecar's 2s default.
- Config is rebuilt on every sidecar fetch (nothing cached), so an edited OPA
  config reaches the sidecar on its next fetch.
- No frontend changes here — API/backend only.