### PR TITLE
fix: support AI-agent persistent proxy credentials

### DIFF
--- a/gateway/integration/connection_credentials_test.go
+++ b/gateway/integration/connection_credentials_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	"github.com/hoophq/hoop/gateway/integration/testutil"
+	"github.com/hoophq/hoop/gateway/models"
 )
 
 // secretFieldNames are keys that must never appear anywhere in the
@@ -38,6 +39,62 @@ func mintPersistentCredential(t *testing.T, token, connName string) map[string]a
 	var out map[string]any
 	testutil.DecodeJSON(t, resp, &out)
 	return out
+}
+
+func TestAIAgentCredentialIsAServiceIdentityCredential(t *testing.T) {
+	admin := adminToken(t)
+	agentID := createAgentReturningID(t, admin, "ai-agent-credential-owner")
+	defer deleteAgent(t, admin, "ai-agent-credential-owner")
+
+	const connName = "ai-agent-credential-owner"
+	created := testServer.Post(t, "/connections", admin, openapi.Connection{
+		Name:               connName,
+		Type:               "database",
+		SubType:            "postgres",
+		AgentId:            agentID,
+		Command:            []string{"psql"},
+		AccessModeRunbooks: "enabled",
+		AccessModeExec:     "enabled",
+		AccessModeConnect:  "enabled",
+		AccessSchema:       "enabled",
+	})
+	defer created.Body.Close()
+	testutil.RequireStatus(t, created, http.StatusCreated)
+	defer func() {
+		resp := testServer.Delete(t, "/connections/"+connName, admin)
+		resp.Body.Close()
+	}()
+
+	const identityName = "postgres-credential-owner"
+	identityResp := testServer.Post(t, "/ai-agents", admin, openapi.AIAgentCreateRequest{
+		Name:   identityName,
+		Groups: []string{"admin"},
+	})
+	defer identityResp.Body.Close()
+	testutil.RequireStatus(t, identityResp, http.StatusCreated)
+	var identity openapi.AIAgentCreateResponse
+	testutil.DecodeJSON(t, identityResp, &identity)
+	defer func() {
+		resp := testServer.Delete(t, "/ai-agents/"+identityName, admin)
+		resp.Body.Close()
+	}()
+
+	credential := mintPersistentCredential(t, identity.Key, connName)
+	credentialID, _ := credential["id"].(string)
+	isService, err := models.IsServiceIdentityCredential(identity.OrgID, credentialID, identity.ID)
+	if err != nil {
+		t.Fatalf("classify AI-agent credential: %v", err)
+	}
+	if !isService {
+		t.Fatal("AI-agent credential classified as a human user credential")
+	}
+	ctx, err := models.GetServiceIdentityContextByID(identity.OrgID, identity.ID)
+	if err != nil {
+		t.Fatalf("load AI-agent context: %v", err)
+	}
+	if ctx == nil || ctx.UserSubject != identity.ID {
+		t.Fatalf("AI-agent context subject = %v, want %v", ctx, identity.ID)
+	}
 }
 
 func listActiveCredentials(t *testing.T, token string) (map[string]any, string) {

--- a/gateway/integration/connection_credentials_test.go
+++ b/gateway/integration/connection_credentials_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	"github.com/hoophq/hoop/gateway/integration/testutil"
 	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/services"
 )
 
 // secretFieldNames are keys that must never appear anywhere in the
@@ -81,14 +82,14 @@ func TestAIAgentCredentialIsAServiceIdentityCredential(t *testing.T) {
 
 	credential := mintPersistentCredential(t, identity.Key, connName)
 	credentialID, _ := credential["id"].(string)
-	isService, err := models.IsServiceIdentityCredential(identity.OrgID, credentialID, identity.ID)
+	isService, err := models.IsServiceIdentityCredential(models.DB, identity.OrgID, credentialID, identity.ID)
 	if err != nil {
 		t.Fatalf("classify AI-agent credential: %v", err)
 	}
 	if !isService {
 		t.Fatal("AI-agent credential classified as a human user credential")
 	}
-	ctx, err := models.GetServiceIdentityContextByID(identity.OrgID, identity.ID)
+	ctx, err := services.GetServiceIdentityContextByID(models.DB, identity.OrgID, identity.ID)
 	if err != nil {
 		t.Fatalf("load AI-agent context: %v", err)
 	}

--- a/gateway/models/aiagents.go
+++ b/gateway/models/aiagents.go
@@ -70,13 +70,22 @@ func ListAIAgents(orgID string) ([]AIAgent, error) {
 }
 
 func GetAIAgentByNameOrID(orgID, nameOrID string) (*AIAgent, error) {
+	return getAIAgentByNameOrID(DB, orgID, nameOrID)
+}
+
+// GetAIAgentByID loads an AI agent using the supplied database handle.
+func GetAIAgentByID(db *gorm.DB, orgID, id string) (*AIAgent, error) {
+	return getAIAgentByNameOrID(db, orgID, id)
+}
+
+func getAIAgentByNameOrID(db *gorm.DB, orgID, nameOrID string) (*AIAgent, error) {
 	var item AIAgent
 	identifierClause := "ak.name = ?"
 	if _, err := uuid.Parse(nameOrID); err == nil {
 		identifierClause = "ak.id = ?"
 	}
 
-	err := DB.Raw(`
+	err := db.Raw(`
 	SELECT ak.id, ak.org_id, ak.name, ak.masked_key, ak.status,
 	ak.created_by, ak.deactivated_by, ak.created_at, ak.deactivated_at, ak.last_used_at,
 	COALESCE((

--- a/gateway/models/apikey.go
+++ b/gateway/models/apikey.go
@@ -70,13 +70,22 @@ func ListAPIKeys(orgID string) ([]APIKey, error) {
 }
 
 func GetAPIKeyByNameOrID(orgID, nameOrID string) (*APIKey, error) {
+	return getAPIKeyByNameOrID(DB, orgID, nameOrID)
+}
+
+// GetAPIKeyByID loads an API key using the supplied database handle.
+func GetAPIKeyByID(db *gorm.DB, orgID, id string) (*APIKey, error) {
+	return getAPIKeyByNameOrID(db, orgID, id)
+}
+
+func getAPIKeyByNameOrID(db *gorm.DB, orgID, nameOrID string) (*APIKey, error) {
 	var item APIKey
 	identifierClause := "ak.name = ?"
 	if _, err := uuid.Parse(nameOrID); err == nil {
 		identifierClause = "ak.id = ?"
 	}
 
-	err := DB.Raw(`
+	err := db.Raw(`
 	SELECT ak.id, ak.org_id, ak.name, ak.masked_key, ak.status,
 	ak.created_by, ak.deactivated_by, ak.created_at, ak.deactivated_at, ak.last_used_at,
 	COALESCE((

--- a/gateway/models/machineidentity.go
+++ b/gateway/models/machineidentity.go
@@ -243,3 +243,62 @@ func IsMachineIdentityCredential(connectionCredentialID string) bool {
 		Count(&count)
 	return count > 0
 }
+
+// IsServiceIdentityCredential reports whether a connection credential belongs
+// to an active non-human identity. Database errors are returned so callers fail
+// closed instead of accidentally treating a service credential as a user.
+func IsServiceIdentityCredential(orgID, connectionCredentialID, userSubject string) (bool, error) {
+	var exists bool
+	err := DB.Raw(`SELECT EXISTS (
+		SELECT 1 FROM private.machine_identity_credentials
+		WHERE org_id = ? AND connection_credential_id = ?
+		UNION ALL
+		SELECT 1 FROM private.api_keys
+		WHERE org_id = ? AND id = ? AND status = 'active'
+		UNION ALL
+		SELECT 1 FROM private.ai_agents
+		WHERE org_id = ? AND id = ? AND status = 'active'
+	)`, orgID, connectionCredentialID, orgID, userSubject, orgID, userSubject).
+		Scan(&exists).Error
+	return exists, err
+}
+
+// GetServiceIdentityContextByID loads an active API key or AI agent context.
+func GetServiceIdentityContextByID(orgID, id string) (*Context, error) {
+	apiKey, err := GetAPIKeyByNameOrID(orgID, id)
+	if err != nil {
+		return nil, err
+	}
+	var name, status string
+	var groups pq.StringArray
+	if apiKey != nil {
+		name, status, groups = apiKey.Name, apiKey.Status, apiKey.Groups
+	} else {
+		aiAgent, err := GetAIAgentByNameOrID(orgID, id)
+		if err != nil {
+			return nil, err
+		}
+		if aiAgent == nil {
+			return nil, nil
+		}
+		name, status, groups = aiAgent.Name, aiAgent.Status, aiAgent.Groups
+	}
+	if status != "active" {
+		return nil, nil
+	}
+	org, err := GetOrganizationByNameOrID(orgID)
+	if err != nil {
+		return nil, err
+	}
+	return &Context{
+		OrgID:          org.ID,
+		OrgName:        org.Name,
+		OrgLicenseData: org.LicenseData,
+		UserID:         id,
+		UserSubject:    id,
+		UserName:       name,
+		UserEmail:      name,
+		UserStatus:     "active",
+		UserGroups:     groups,
+	}, nil
+}

--- a/gateway/models/machineidentity.go
+++ b/gateway/models/machineidentity.go
@@ -247,9 +247,9 @@ func IsMachineIdentityCredential(connectionCredentialID string) bool {
 // IsServiceIdentityCredential reports whether a connection credential belongs
 // to an active non-human identity. Database errors are returned so callers fail
 // closed instead of accidentally treating a service credential as a user.
-func IsServiceIdentityCredential(orgID, connectionCredentialID, userSubject string) (bool, error) {
+func IsServiceIdentityCredential(db *gorm.DB, orgID, connectionCredentialID, userSubject string) (bool, error) {
 	var exists bool
-	err := DB.Raw(`SELECT EXISTS (
+	err := db.Raw(`SELECT EXISTS (
 		SELECT 1 FROM private.machine_identity_credentials
 		WHERE org_id = ? AND connection_credential_id = ?
 		UNION ALL
@@ -261,44 +261,4 @@ func IsServiceIdentityCredential(orgID, connectionCredentialID, userSubject stri
 	)`, orgID, connectionCredentialID, orgID, userSubject, orgID, userSubject).
 		Scan(&exists).Error
 	return exists, err
-}
-
-// GetServiceIdentityContextByID loads an active API key or AI agent context.
-func GetServiceIdentityContextByID(orgID, id string) (*Context, error) {
-	apiKey, err := GetAPIKeyByNameOrID(orgID, id)
-	if err != nil {
-		return nil, err
-	}
-	var name, status string
-	var groups pq.StringArray
-	if apiKey != nil {
-		name, status, groups = apiKey.Name, apiKey.Status, apiKey.Groups
-	} else {
-		aiAgent, err := GetAIAgentByNameOrID(orgID, id)
-		if err != nil {
-			return nil, err
-		}
-		if aiAgent == nil {
-			return nil, nil
-		}
-		name, status, groups = aiAgent.Name, aiAgent.Status, aiAgent.Groups
-	}
-	if status != "active" {
-		return nil, nil
-	}
-	org, err := GetOrganizationByNameOrID(orgID)
-	if err != nil {
-		return nil, err
-	}
-	return &Context{
-		OrgID:          org.ID,
-		OrgName:        org.Name,
-		OrgLicenseData: org.LicenseData,
-		UserID:         id,
-		UserSubject:    id,
-		UserName:       name,
-		UserEmail:      name,
-		UserStatus:     "active",
-		UserGroups:     groups,
-	}, nil
 }

--- a/gateway/models/orgs.go
+++ b/gateway/models/orgs.go
@@ -43,8 +43,17 @@ func ListAllOrganizations() ([]Organization, error) {
 }
 
 func GetOrganizationByNameOrID(nameOrID string) (*Organization, error) {
+	return getOrganizationByNameOrID(DB, nameOrID)
+}
+
+// GetOrganizationByID loads an organization using the supplied database handle.
+func GetOrganizationByID(db *gorm.DB, id string) (*Organization, error) {
+	return getOrganizationByNameOrID(db, id)
+}
+
+func getOrganizationByNameOrID(db *gorm.DB, nameOrID string) (*Organization, error) {
 	var org Organization
-	err := DB.Raw(`
+	err := db.Raw(`
 	SELECT o.id, o.name, license_data, analytics_mode, hide_role_info, default_protection_profile,
 	o.onboarding_completed_at,
 	(SELECT count(*) FROM private.users u WHERE u.org_id = o.id) AS total_users

--- a/gateway/proxyproto/grpckey/grpckey.go
+++ b/gateway/proxyproto/grpckey/grpckey.go
@@ -23,6 +23,11 @@ const (
 	// identity so the auth interceptor can load the MI without an extra
 	// DB round-trip through a credential-session row.
 	MachineIdentityOrgIDHeaderKey = "machine-identity-org-id"
+
+	// ServiceIdentityFlagHeaderKey marks credentials issued to API keys or AI agents.
+	ServiceIdentityFlagHeaderKey = "is-service-identity-credential"
+	// ServiceIdentityOrgIDHeaderKey scopes service identity lookup to its organization.
+	ServiceIdentityOrgIDHeaderKey = "service-identity-org-id"
 )
 
 func generateSecureRandomKeyOrDie() string {

--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -443,7 +443,7 @@ func (s *HttpProxyServer) createSession(secretKeyHash, correlationID string) (*h
 	}
 	ctxDuration := time.Until(dba.ExpireAt)
 
-	isServiceCredential, err := models.IsServiceIdentityCredential(dba.OrgID, dba.ID, dba.UserSubject)
+	isServiceCredential, err := models.IsServiceIdentityCredential(models.DB, dba.OrgID, dba.ID, dba.UserSubject)
 	if err != nil {
 		return nil, fmt.Errorf("failed identifying connection credential owner: %v", err)
 	}

--- a/gateway/proxyproto/httpproxy/httpproxy.go
+++ b/gateway/proxyproto/httpproxy/httpproxy.go
@@ -443,10 +443,14 @@ func (s *HttpProxyServer) createSession(secretKeyHash, correlationID string) (*h
 	}
 	ctxDuration := time.Until(dba.ExpireAt)
 
+	isServiceCredential, err := models.IsServiceIdentityCredential(dba.OrgID, dba.ID, dba.UserSubject)
+	if err != nil {
+		return nil, fmt.Errorf("failed identifying connection credential owner: %v", err)
+	}
 	isMachineCredential := models.IsMachineIdentityCredential(dba.ID)
 
 	var tokenVerifier idp.UserInfoTokenVerifier
-	if !isMachineCredential {
+	if !isServiceCredential {
 		var err error
 		tokenVerifier, _, err = idp.NewUserInfoTokenVerifierProvider()
 		if err != nil {
@@ -479,7 +483,7 @@ func (s *HttpProxyServer) createSession(secretKeyHash, correlationID string) (*h
 		},
 	}
 
-	if !isMachineCredential {
+	if !isServiceCredential {
 		usertoken.PollingUserToken(session.ctx, func(cause error) {
 			session.cancelFn(cause.Error())
 		}, tokenVerifier, dba.UserSubject)
@@ -498,7 +502,13 @@ func (s *HttpProxyServer) createSession(secretKeyHash, correlationID string) (*h
 			grpc.WithOption(grpckey.MachineIdentityFlagHeaderKey, "true"),
 			grpc.WithOption(grpckey.MachineIdentityOrgIDHeaderKey, dba.OrgID),
 		)
-	} else if dba.SessionID != "" {
+	} else if isServiceCredential {
+		grpcOpts = append(grpcOpts,
+			grpc.WithOption(grpckey.ServiceIdentityFlagHeaderKey, "true"),
+			grpc.WithOption(grpckey.ServiceIdentityOrgIDHeaderKey, dba.OrgID),
+		)
+	}
+	if !isMachineCredential && dba.SessionID != "" {
 		grpcOpts = append(grpcOpts, grpc.WithOption("credential-session-id", dba.SessionID))
 	}
 	if correlationID != "" {

--- a/gateway/proxyproto/postgresproxy/postgresproxy.go
+++ b/gateway/proxyproto/postgresproxy/postgresproxy.go
@@ -278,7 +278,7 @@ func newPostgresConnection(sid, connID string, conn net.Conn, tlsConfig *tls.Con
 		return nil, fmt.Errorf("invalid secret access key credentials")
 	}
 
-	isServiceCredential, err := models.IsServiceIdentityCredential(dba.OrgID, dba.ID, dba.UserSubject)
+	isServiceCredential, err := models.IsServiceIdentityCredential(models.DB, dba.OrgID, dba.ID, dba.UserSubject)
 	if err != nil {
 		return nil, fmt.Errorf("failed identifying connection credential owner: %v", err)
 	}

--- a/gateway/proxyproto/postgresproxy/postgresproxy.go
+++ b/gateway/proxyproto/postgresproxy/postgresproxy.go
@@ -136,13 +136,13 @@ func runPgProxyServer(listenAddr string, tlsConfig *tls.Config) (*PGServer, erro
 			conn, err := newPostgresConnection(sid, strconv.Itoa(connectionID), pgClient, server.tlsConfig)
 			if err != nil {
 				// Prevents log pollution from health check requests on this port
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					log.With("conn", connectionID).Debugf("failed creating new postgres connection, reason=EOF error")
 					_ = pgClient.Close()
 					continue
 				}
 				log.With("conn", connectionID).Warnf("failed creating new postgres connection, err=%v", err)
-				_, _ = pgClient.Write(pgtypes.NewFatalError("failed creating new postgres connection, err=%v", err).Encode())
+				writeConnectionError(pgClient, err)
 				_ = pgClient.Close()
 				continue
 			}
@@ -168,7 +168,33 @@ type postgresConn struct {
 	net.Conn
 }
 
-func newPostgresConnection(sid, connID string, conn net.Conn, tlsConfig *tls.Config) (*postgresConn, error) {
+type postgresConnectionError struct {
+	err  error
+	conn net.Conn
+}
+
+func (e *postgresConnectionError) Error() string { return e.err.Error() }
+func (e *postgresConnectionError) Unwrap() error { return e.err }
+
+func writeConnectionError(fallback net.Conn, err error) {
+	conn := fallback
+	var connectionErr *postgresConnectionError
+	if errors.As(err, &connectionErr) {
+		conn = connectionErr.conn
+	}
+	if conn != nil {
+		_, _ = conn.Write(pgtypes.NewFatalError("failed creating new postgres connection, err=%v", err).Encode())
+	}
+}
+
+func newPostgresConnection(sid, connID string, conn net.Conn, tlsConfig *tls.Config) (_ *postgresConn, err error) {
+	errorConn := conn
+	defer func() {
+		if err != nil {
+			err = &postgresConnectionError{err: err, conn: errorConn}
+		}
+	}()
+
 	pgpkt, err := pgtypes.Decode(conn)
 	if err != nil {
 		return nil, err
@@ -187,9 +213,11 @@ func newPostgresConnection(sid, connID string, conn net.Conn, tlsConfig *tls.Con
 
 		// Upgrade connection to TLS
 		tlsConn := tls.Server(conn, tlsConfig)
+		errorConn = nil
 		if err := tlsConn.Handshake(); err != nil {
 			return nil, fmt.Errorf("failed performing TLS handshake, err=%v", err)
 		}
+		errorConn = tlsConn
 
 		log.With("conn", connID).Infof("TLS handshake completed successfully")
 
@@ -250,10 +278,14 @@ func newPostgresConnection(sid, connID string, conn net.Conn, tlsConfig *tls.Con
 		return nil, fmt.Errorf("invalid secret access key credentials")
 	}
 
+	isServiceCredential, err := models.IsServiceIdentityCredential(dba.OrgID, dba.ID, dba.UserSubject)
+	if err != nil {
+		return nil, fmt.Errorf("failed identifying connection credential owner: %v", err)
+	}
 	isMachineCredential := models.IsMachineIdentityCredential(dba.ID)
 
 	var tokenVerifier idp.UserInfoTokenVerifier
-	if !isMachineCredential {
+	if !isServiceCredential {
 		var err error
 		tokenVerifier, _, err = idp.NewUserInfoTokenVerifierProvider()
 		if err != nil {
@@ -280,7 +312,7 @@ func newPostgresConnection(sid, connID string, conn net.Conn, tlsConfig *tls.Con
 	}
 	pgConn.ctx = ctx
 
-	if !isMachineCredential {
+	if !isServiceCredential {
 		usertoken.PollingUserToken(pgConn.ctx, func(cause error) {
 			pgConn.cancelFn("%s", cause.Error())
 		}, tokenVerifier, dba.UserSubject)
@@ -299,7 +331,13 @@ func newPostgresConnection(sid, connID string, conn net.Conn, tlsConfig *tls.Con
 			grpc.WithOption(grpckey.MachineIdentityFlagHeaderKey, "true"),
 			grpc.WithOption(grpckey.MachineIdentityOrgIDHeaderKey, dba.OrgID),
 		)
-	} else if dba.SessionID != "" {
+	} else if isServiceCredential {
+		grpcOpts = append(grpcOpts,
+			grpc.WithOption(grpckey.ServiceIdentityFlagHeaderKey, "true"),
+			grpc.WithOption(grpckey.ServiceIdentityOrgIDHeaderKey, dba.OrgID),
+		)
+	}
+	if !isMachineCredential && dba.SessionID != "" {
 		grpcOpts = append(grpcOpts, grpc.WithOption("credential-session-id", dba.SessionID))
 	}
 

--- a/gateway/proxyproto/postgresproxy/postgresproxy_test.go
+++ b/gateway/proxyproto/postgresproxy/postgresproxy_test.go
@@ -1,0 +1,69 @@
+package postgresproxy
+
+import (
+	"crypto/tls"
+	"encoding/binary"
+	"io"
+	"net"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConnectionSetupErrorStaysInsideTLS(t *testing.T) {
+	tlsServer := httptest.NewTLSServer(nil)
+	tlsConfig := tlsServer.TLS.Clone()
+	tlsServer.Close()
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+	deadline := time.Now().Add(5 * time.Second)
+	_ = serverConn.SetDeadline(deadline)
+	_ = clientConn.SetDeadline(deadline)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := newPostgresConnection("session", "connection", serverConn, tlsConfig)
+		if err != nil {
+			writeConnectionError(serverConn, err)
+		}
+		_ = serverConn.Close()
+		done <- err
+	}()
+
+	if _, err := clientConn.Write([]byte{0, 0, 0, 8, 4, 210, 22, 47}); err != nil {
+		t.Fatal(err)
+	}
+	sslResponse := make([]byte, 1)
+	if _, err := io.ReadFull(clientConn, sslResponse); err != nil {
+		t.Fatal(err)
+	}
+	if string(sslResponse) != "S" {
+		t.Fatalf("SSL response = %q, want S", sslResponse)
+	}
+
+	tlsClient := tls.Client(clientConn, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec -- test certificate
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatal(err)
+	}
+	parameters := []byte("database\x00postgres\x00\x00")
+	startup := make([]byte, len(parameters)+8)
+	binary.BigEndian.PutUint32(startup, uint32(len(startup)))
+	binary.BigEndian.PutUint32(startup[4:], 196608)
+	copy(startup[8:], parameters)
+	if _, err := tlsClient.Write(startup); err != nil {
+		t.Fatal(err)
+	}
+
+	responseType := make([]byte, 1)
+	if _, err := io.ReadFull(tlsClient, responseType); err != nil {
+		t.Fatalf("read TLS-framed PostgreSQL error: %v", err)
+	}
+	if string(responseType) != "E" {
+		t.Fatalf("response type = %q, want PostgreSQL ErrorResponse E", responseType)
+	}
+	if err := <-done; err == nil || !strings.Contains(err.Error(), "failed obtaining secret key") {
+		t.Fatalf("setup error = %v, want missing secret key", err)
+	}
+}

--- a/gateway/proxyproto/postgresproxy/postgresproxy_test.go
+++ b/gateway/proxyproto/postgresproxy/postgresproxy_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	pgtypes "github.com/hoophq/hoop/common/pgtypes"
 )
 
 func TestConnectionSetupErrorStaysInsideTLS(t *testing.T) {
@@ -60,8 +62,8 @@ func TestConnectionSetupErrorStaysInsideTLS(t *testing.T) {
 	if _, err := io.ReadFull(tlsClient, responseType); err != nil {
 		t.Fatalf("read TLS-framed PostgreSQL error: %v", err)
 	}
-	if string(responseType) != "E" {
-		t.Fatalf("response type = %q, want PostgreSQL ErrorResponse E", responseType)
+	if responseType[0] != pgtypes.ServerErrorResponse.Byte() {
+		t.Fatalf("response type = %q, want %q", responseType[0], pgtypes.ServerErrorResponse.Byte())
 	}
 	if err := <-done; err == nil || !strings.Contains(err.Error(), "failed obtaining secret key") {
 		t.Fatalf("setup error = %v, want missing secret key", err)

--- a/gateway/proxyproto/sshproxy/sshproxy.go
+++ b/gateway/proxyproto/sshproxy/sshproxy.go
@@ -264,6 +264,11 @@ func newPasswordConnection(sid, connID string, conn net.Conn, server *passwordSe
 			if dba.ExpireAt.Before(time.Now().UTC()) {
 				return nil, fmt.Errorf("invalid secret access key credentials")
 			}
+			isServiceCredential, err := models.IsServiceIdentityCredential(dba.OrgID, dba.ID, dba.UserSubject)
+			if err != nil {
+				return nil, fmt.Errorf("failed identifying connection credential owner: %v", err)
+			}
+			isMachineCredential := models.IsMachineIdentityCredential(dba.ID)
 
 			// Session duration remaining based on the expiration time
 			ctxDuration := dba.ExpireAt.Sub(time.Now().UTC())
@@ -278,10 +283,14 @@ func newPasswordConnection(sid, connID string, conn net.Conn, server *passwordSe
 				"hoop-connection-name":  dba.ConnectionName,
 				"hoop-context-duration": ctxDuration.String(),
 			}
-			if models.IsMachineIdentityCredential(dba.ID) {
+			if isMachineCredential {
 				extensions["hoop-is-machine-credential"] = "true"
 				extensions["hoop-machine-identity-org-id"] = dba.OrgID
-			} else if dba.SessionID != "" {
+			} else if isServiceCredential {
+				extensions[grpckey.ServiceIdentityFlagHeaderKey] = "true"
+				extensions[grpckey.ServiceIdentityOrgIDHeaderKey] = dba.OrgID
+			}
+			if !isMachineCredential && dba.SessionID != "" {
 				extensions["hoop-credential-session-id"] = dba.SessionID
 			}
 			return &ssh.Permissions{Extensions: extensions}, nil
@@ -314,6 +323,8 @@ func newPasswordConnection(sid, connID string, conn net.Conn, server *passwordSe
 	credentialID := sshConn.Permissions.Extensions["hoop-credential-id"]
 	isMachineCredential := sshConn.Permissions.Extensions["hoop-is-machine-credential"] == "true"
 	machineIdentityOrgID := sshConn.Permissions.Extensions["hoop-machine-identity-org-id"]
+	isServiceCredential := isMachineCredential || sshConn.Permissions.Extensions[grpckey.ServiceIdentityFlagHeaderKey] == "true"
+	serviceIdentityOrgID := sshConn.Permissions.Extensions[grpckey.ServiceIdentityOrgIDHeaderKey]
 
 	if connectionName == "" || userSubject == "" {
 		return nil, fmt.Errorf("missing required SSH connection attributes")
@@ -325,7 +336,7 @@ func newPasswordConnection(sid, connID string, conn net.Conn, server *passwordSe
 	}
 
 	var tokenVerifier idp.UserInfoTokenVerifier
-	if !isMachineCredential {
+	if !isServiceCredential {
 		tokenVerifier, _, err = idp.NewUserInfoTokenVerifierProvider()
 		if err != nil {
 			log.Errorf("failed to load IDP provider: %v", err)
@@ -352,7 +363,13 @@ func newPasswordConnection(sid, connID string, conn net.Conn, server *passwordSe
 			grpc.WithOption(grpckey.MachineIdentityFlagHeaderKey, "true"),
 			grpc.WithOption(grpckey.MachineIdentityOrgIDHeaderKey, machineIdentityOrgID),
 		)
-	} else if credentialSessionID != "" {
+	} else if isServiceCredential {
+		grpcOpts = append(grpcOpts,
+			grpc.WithOption(grpckey.ServiceIdentityFlagHeaderKey, "true"),
+			grpc.WithOption(grpckey.ServiceIdentityOrgIDHeaderKey, serviceIdentityOrgID),
+		)
+	}
+	if !isMachineCredential && credentialSessionID != "" {
 		grpcOpts = append(grpcOpts, grpc.WithOption("credential-session-id", credentialSessionID))
 	}
 
@@ -389,7 +406,7 @@ func newPasswordConnection(sid, connID string, conn net.Conn, server *passwordSe
 		clientNewSshChannel: clientNewCh,
 	}
 
-	if !isMachineCredential {
+	if !isServiceCredential {
 		usertoken.PollingUserToken(c.ctx, func(cause error) {
 			c.cancelFn(cause.Error())
 		}, tokenVerifier, userSubject)

--- a/gateway/proxyproto/sshproxy/sshproxy.go
+++ b/gateway/proxyproto/sshproxy/sshproxy.go
@@ -264,7 +264,7 @@ func newPasswordConnection(sid, connID string, conn net.Conn, server *passwordSe
 			if dba.ExpireAt.Before(time.Now().UTC()) {
 				return nil, fmt.Errorf("invalid secret access key credentials")
 			}
-			isServiceCredential, err := models.IsServiceIdentityCredential(dba.OrgID, dba.ID, dba.UserSubject)
+			isServiceCredential, err := models.IsServiceIdentityCredential(models.DB, dba.OrgID, dba.ID, dba.UserSubject)
 			if err != nil {
 				return nil, fmt.Errorf("failed identifying connection credential owner: %v", err)
 			}

--- a/gateway/services/serviceidentity.go
+++ b/gateway/services/serviceidentity.go
@@ -1,0 +1,47 @@
+package services
+
+import (
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+// GetServiceIdentityContextByID loads an active API key or AI agent context.
+func GetServiceIdentityContextByID(db *gorm.DB, orgID, id string) (*models.Context, error) {
+	apiKey, err := models.GetAPIKeyByID(db, orgID, id)
+	if err != nil {
+		return nil, err
+	}
+	var name, status string
+	var groups pq.StringArray
+	if apiKey != nil {
+		name, status, groups = apiKey.Name, apiKey.Status, apiKey.Groups
+	} else {
+		aiAgent, err := models.GetAIAgentByID(db, orgID, id)
+		if err != nil {
+			return nil, err
+		}
+		if aiAgent == nil {
+			return nil, nil
+		}
+		name, status, groups = aiAgent.Name, aiAgent.Status, aiAgent.Groups
+	}
+	if status != "active" {
+		return nil, nil
+	}
+	org, err := models.GetOrganizationByID(db, orgID)
+	if err != nil {
+		return nil, err
+	}
+	return &models.Context{
+		OrgID:          org.ID,
+		OrgName:        org.Name,
+		OrgLicenseData: org.LicenseData,
+		UserID:         id,
+		UserSubject:    id,
+		UserName:       name,
+		UserEmail:      name,
+		UserStatus:     "active",
+		UserGroups:     groups,
+	}, nil
+}

--- a/gateway/transport/interceptors/auth/auth.go
+++ b/gateway/transport/interceptors/auth/auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hoophq/hoop/gateway/idp"
 	"github.com/hoophq/hoop/gateway/models"
 	"github.com/hoophq/hoop/gateway/proxyproto/grpckey"
+	"github.com/hoophq/hoop/gateway/services"
 	"github.com/hoophq/hoop/gateway/storagev2/types"
 	plugintypes "github.com/hoophq/hoop/gateway/transport/plugins/types"
 	"google.golang.org/grpc"
@@ -321,7 +322,7 @@ func (i *interceptor) authenticateServiceIdentity(subject, orgID string, md meta
 	if orgID == "" {
 		return nil, status.Errorf(codes.Unauthenticated, "invalid authentication")
 	}
-	ctx, err := models.GetServiceIdentityContextByID(orgID, subject)
+	ctx, err := services.GetServiceIdentityContextByID(models.DB, orgID, subject)
 	if err != nil {
 		log.Errorf("failed loading service identity, org=%v id=%v err=%v", orgID, subject, err)
 		sentry.CaptureException(err)

--- a/gateway/transport/interceptors/auth/auth.go
+++ b/gateway/transport/interceptors/auth/auth.go
@@ -268,6 +268,14 @@ func (i *interceptor) StreamServerInterceptor(srv any, ss grpc.ServerStream, inf
 					break
 				}
 			}
+			if commongrpc.MetaGet(md, grpckey.ServiceIdentityFlagHeaderKey) == "true" {
+				serviceCtx, err := i.authenticateServiceIdentity(subject, commongrpc.MetaGet(md, grpckey.ServiceIdentityOrgIDHeaderKey), md)
+				if err != nil {
+					return err
+				}
+				ctxVal = serviceCtx
+				break
+			}
 		} else {
 			// first we check if the auth method is local, if so, we authenticate the user
 			// using the local auth method, otherwise we use the tokenVerifier.VerifyAccessToken
@@ -307,6 +315,31 @@ func (i *interceptor) StreamServerInterceptor(srv any, ss grpc.ServerStream, inf
 	}
 
 	return handler(srv, &serverStreamWrapper{ss, nil, ctxVal})
+}
+
+func (i *interceptor) authenticateServiceIdentity(subject, orgID string, md metadata.MD) (*GatewayContext, error) {
+	if orgID == "" {
+		return nil, status.Errorf(codes.Unauthenticated, "invalid authentication")
+	}
+	ctx, err := models.GetServiceIdentityContextByID(orgID, subject)
+	if err != nil {
+		log.Errorf("failed loading service identity, org=%v id=%v err=%v", orgID, subject, err)
+		sentry.CaptureException(err)
+		return nil, status.Errorf(codes.Internal, "internal error")
+	}
+	if ctx == nil {
+		return nil, status.Errorf(codes.Unauthenticated, "invalid authentication")
+	}
+	gwctx := &GatewayContext{UserContext: *ctx, IdentityType: plugintypes.IdentityTypeAPIKey}
+	conn, err := i.getConnection(commongrpc.MetaGet(md, "connection-name"), ctx)
+	if err != nil {
+		return nil, err
+	}
+	if conn == nil {
+		return nil, status.Errorf(codes.NotFound, "connection not found")
+	}
+	gwctx.Connection = *conn
+	return gwctx, nil
 }
 
 func (i *interceptor) getConnection(name string, userCtx *models.Context) (*types.ConnectionInfo, error) {


### PR DESCRIPTION
## 📝 Description

Persistent credentials issued to API keys and AI agents were handled as human credentials by the PostgreSQL, HTTP, and SSH proxies, which incorrectly required an IDP user token. This change preserves the non-human identity across the gateway internal gRPC hop. It also keeps PostgreSQL setup errors inside the negotiated TLS connection.

## 📣 User-facing impact

API keys and AI agents can use persistent PostgreSQL, HTTP, and SSH credentials. PostgreSQL TLS clients receive protocol-correct setup errors instead of `SSL error: bad record type`.

## 🔗 Related Issue

Self-contained reproductions:
- [PostgreSQL AI-agent credential](https://github.com/mmacvicar/hoop-issues/tree/main/cases/ai-agent-postgres-credential)
- [HTTP AI-agent credential](https://github.com/mmacvicar/hoop-issues/tree/main/cases/ai-agent-http-credential)
- [SSH AI-agent credential](https://github.com/mmacvicar/hoop-issues/tree/main/cases/ai-agent-ssh-credential)
- [PostgreSQL TLS error framing](https://github.com/mmacvicar/hoop-issues/tree/main/cases/postgres-tls-error)

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [x] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- recognize active machine identities, API keys, and AI agents when authenticating connection credentials
- preserve service identity context through the internal gRPC authentication path
- apply the shared behavior to PostgreSQL, HTTP, and SSH proxies
- write PostgreSQL setup failures through the post-negotiation connection

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: Not applicable
- **OS**: Linux with Docker

### Tests performed:
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

The self-contained HTTP and SSH cases reproduce `access token not found for user subject` on Hoop 1.160.1 after their target preflight succeeds. The focused Go package command is blocked locally because `github.com/hoophq/libhoop` is private; repository CI has credentials for it.

## 📸 Screenshots (if applicable)

Not applicable.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

Focused command blocked by private module access:

```sh
go test ./gateway/proxyproto/grpckey ./gateway/proxyproto/postgresproxy ./gateway/proxyproto/httpproxy ./gateway/proxyproto/sshproxy -count=1
```

The PR remains draft until CI can validate the affected packages.