### PR TITLE
feat(sidecar): connect sidecar with control plane and hot reload config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -123,3 +123,10 @@ HOOP_RS_BUILD=false
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
+# Sidecar -> Control Plane connection (hoop start sidecar).
+# HOOP_CONTROL_PLANE_URL outranks the config file's control_plane_url key;
+# the sidecar then fetches its whole config from the control plane.
+HOOP_CONTROL_PLANE_URL=
+# The token shown once when the sidecar is registered (POST /api/sidecars).
+# The --token flag outranks this. The value is the token itself, never a path.
+HOOP_SIDECAR_TOKEN=

--- a/client/cmd/startsidecar.go
+++ b/client/cmd/startsidecar.go
@@ -29,6 +29,7 @@ const deprecatedSidecarAlias = "inspect"
 var (
 	sidecarConfigFlag   string
 	sidecarLicenseFlag  string
+	sidecarTokenFlag    string
 	sidecarValidateFlag bool
 	sidecarStrictFlag   bool
 )
@@ -62,25 +63,36 @@ prints a warning naming its replacement. Use --strict to fail on one.
 Without a license the process caps guardrail and data masking rules at one
 each and says so at startup. A license lifts the caps for the features it
 names. It may be a path or the document itself, and --license outranks
-HOOP_LICENSE, which outranks the "license" key in the config file.`,
+HOOP_LICENSE, which outranks the "license" key in the config file.
+
+A sidecar may connect to a Control Plane instead of carrying its own
+listeners: set HOOP_CONTROL_PLANE_URL or the "control_plane_url" config key
+(the env var outranks the key), and pass the token from the sidecar's
+registration with --token, which outranks HOOP_SIDECAR_TOKEN. The handshake
+then supplies the whole running config, --config becomes optional, and a
+file that still declares listeners is refused. The token is shown once when
+the sidecar is created; a lost one means registering a new sidecar.`,
 	Example: `  hoop start sidecar --config /etc/hoop-inspect/config.yaml
   hoop start sidecar --config config.yaml --license /etc/hoop-inspect/license.json
   hoop start sidecar --config config.yaml --validate
-  hoop start sidecar --config config.yaml --validate --strict`,
+  hoop start sidecar --config config.yaml --validate --strict
+  HOOP_CONTROL_PLANE_URL=https://cp.example.com hoop start sidecar --token hsc_...`,
 	// A bad config is not a usage error, and dumping the flag list under one
 	// buries the message that says which field is wrong.
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		warnDeprecatedSidecarAlias(os.Stderr, cmd.CalledAs())
 
-		if sidecarConfigFlag == "" {
+		if sidecarConfigFlag == "" && os.Getenv(daemon.ControlPlaneURLEnv) == "" {
 			// The one genuine usage error here, so let cobra show the flags.
 			cmd.SilenceUsage = false
-			return fmt.Errorf("--config is required (or set HOOP_SIDECAR_CONFIG)")
+			return fmt.Errorf("--config is required (or set HOOP_SIDECAR_CONFIG or %s)",
+				daemon.ControlPlaneURLEnv)
 		}
 
 		cfg, det, err := daemon.SetupWith(sidecarConfigFlag, configyaml.Load, buildSidecarPlugin,
-			daemon.WithLicense(sidecarLicenseFlag))
+			daemon.WithLicense(sidecarLicenseFlag),
+			daemon.WithControlPlaneToken(sidecarTokenFlag))
 		if err != nil {
 			return err
 		}
@@ -161,6 +173,12 @@ func init() {
 	startSidecarCmd.Flags().StringVar(&sidecarLicenseFlag, "license", "",
 		"Path to the license file, or the license document itself. Overrides "+
 			license.EnvVar+" and the config file's \"license\" key")
+	// Same rule as --license: no default from the environment, so daemon
+	// setup holds the precedence in one place and the token stays out of
+	// --help output.
+	startSidecarCmd.Flags().StringVar(&sidecarTokenFlag, "token", "",
+		"The token identifying this sidecar to the control plane. Overrides "+
+			daemon.SidecarTokenEnv)
 	startSidecarCmd.Flags().BoolVar(&sidecarValidateFlag, "validate", false,
 		"Validate the config, report what each listener resolved to, and exit")
 	startSidecarCmd.Flags().BoolVar(&sidecarStrictFlag, "strict", false,

--- a/docs/adr/0014-sidecar-config-hot-reload.md
+++ b/docs/adr/0014-sidecar-config-hot-reload.md
@@ -1,0 +1,172 @@
+# ADR-0014: Sidecar config hot reload for rule-only drift
+
+- **Status:** Proposed
+- **Date:** 2026-09-08
+- **Author:** @matheusfrancisco
+- **Deciders:** TBD
+- **Supersedes / Superseded by:** —
+
+## Context
+
+A sidecar connected to the Control Plane (DEP-197) fetches its whole config
+from `POST /api/sidecars/handshake` at startup and re-runs the handshake
+every minute as a heartbeat. The gateway rebuilds the document from the
+database on every call, so a guardrail or masking rule edited in the UI is
+in the next answer. The gateway also serves `GET /sidecars/configuration`:
+the same document under the same `hoop-sidecar-token` auth, with no side
+effects, so a poll never overwrites the version and last-seen the sidecar
+reported at its last handshake.
+
+Today the sidecar only logs the drift: `the control plane configuration
+changed; restart to apply it`. A restart closes every live client
+connection. For a fleet where rule edits are routine, each edit costs
+either an outage window per sidecar or an unbounded delay until someone
+restarts it. The sidecar fronts databases; its clients hold long-lived
+connections (`psql`, connection pools) that reconnect on their own
+schedule.
+
+Two facts about the daemon constrain the design:
+
+1. `proxy.Server.handle` captures `Policy` and `Masker` once per accepted
+   connection, into that connection's Gate (`sidecar/proxy/proxy.go:351`).
+   Nothing on the statement path reads them from shared state.
+2. Listener topology (bind address, upstream, protocol, TLS posture) is
+   bound at startup. Changing it means closing and opening sockets under
+   live traffic.
+
+Config drift therefore splits into two classes: rule content changed
+(guardrails, masking, pii narrowing, OPA endpoints) with the listener set
+identical, and topology changed (a listener added, removed, or re-pointed).
+
+Related constraints:
+
+- `buildLanes` enforces the license caps at startup. Any reload path that
+  skips it turns the heartbeat into a cap bypass.
+- The PII detector is built by the entry points (`PluginBuilder`) and handed
+  to `Run` ready-made; the daemon cannot rebuild it today.
+- gRPC lanes (ADR-0013) receive their evaluator and masker through
+  `buildGRPCServer`'s callback injection, a different seam from relay lanes.
+
+## Options considered
+
+1. **Restart-only (status quo).** The heartbeat logs, an operator or a
+   container restart policy applies. Simple, already shipped. Loses live
+   connections on every rule edit and leaves a window where the fleet
+   enforces stale rules for as long as restarts take.
+2. **Full hot reload, topology included.** Rebind listeners, drain removed
+   lanes, dial new upstreams in place. Handles every drift, and is the only
+   option that never needs a restart. Loses to complexity: port rebinding
+   races, a drain policy for removed lanes, and failure states where half
+   the new topology is live. The rare event (topology change) would carry
+   the risk for the common one (rule edit).
+3. **Rule-only hot swap behind a topology guard.** When the listener
+   identity set is unchanged, rebuild each lane's evaluator and masker from
+   the fetched config and swap them atomically; existing connections keep
+   the Gate they started with, new connections get the new rules. Any
+   topology difference keeps today's restart log. Covers the common case
+   with a small, bounded change; the capture-at-accept design in fact (1)
+   makes the swap point one field.
+
+## Decision
+
+We will implement option 3, in stages:
+
+1. **Poll endpoint** (shipped with this ADR's PR): `GET
+   /sidecars/configuration` on the gateway, sharing `respondConfig` with the
+   handshake so the two answers cannot drift.
+2. **Swap point:** `proxy.Server` holds `{Policy, Masker, FailOnAuditError}`
+   in an `atomic.Pointer`, loaded once per accepted connection. The current
+   unsynchronized `s.cfg.Policy` read becomes the pointer load; nothing else
+   on the accept path changes.
+3. **Reload in the heartbeat:** on drift, run the fetched config through the
+   same pipeline startup uses — `LoadConfigBytes`, per-listener `resolve`,
+   `buildPolicy`, masker build, and the license cap checks in `buildLanes`.
+   A config the caps refuse is logged and not applied, the same verdict
+   startup would reach. Lanes match by listener name; the topology guard
+   compares `name`, `protocol`, `network`, `listen`, `upstream`, and both
+   TLS blocks. Any mismatch, addition, or removal falls back to the restart
+   log.
+4. **Detector rebuild:** `SetupWith` already receives the entry point's
+   `PluginBuilder`; the control-plane state retains it for the reloader, so
+   a changed `pii` section rebuilds the detector the way startup would. A
+   caller that passed no builder keeps a drifted `pii` section on the
+   restart path rather than swapping in rules the old detector cannot
+   serve.
+5. **gRPC lanes stay on the restart path** in this iteration, with a log
+   line saying so. Their swap needs its own seam through the ADR-0013
+   callback injection and earns its own change.
+
+Swap semantics are connection-granular: a connection opened before the swap
+keeps the rules it started with until it closes; every connection accepted
+after the swap runs the new rules. Statement-granular semantics (a live
+session picks up new rules on its next statement) move the atomic load into
+the Gate's per-statement path and are deferred until connection-granular
+proves itself in the field.
+
+The heartbeat's decision per fetched document:
+
+```mermaid
+flowchart TD
+    HB[heartbeat tick:<br/>POST /api/sidecars/handshake] --> CMP{bytes differ from<br/>running config?}
+    CMP -- no --> HB
+    CMP -- yes --> LOAD[LoadConfigBytes:<br/>strict decode + Validate]
+    LOAD -- refused --> KEEP[warn, keep running rules]
+    LOAD -- ok --> GUARD{non-rule doc identical?<br/>listeners, audit, admin,<br/>log_level, analyzer}
+    GUARD -- no --> RESTART[warn: restart to apply it]
+    GUARD -- yes --> DET{pii drifted?}
+    DET -- "builder retained" --> REBUILD[rebuild detector<br/>+ analyzer deps]
+    DET -- "no builder" --> RESTART
+    DET -- unchanged --> LANES
+    REBUILD --> LANES[buildLanes:<br/>caps + policy + masker,<br/>same path as startup]
+    LANES -- refused --> KEEP
+    LANES -- ok --> SWAP[atomic SwapRules<br/>per relay lane]
+    SWAP --> GRPC[grpc lanes with drifted rules:<br/>warn, restart path]
+```
+
+What each connection runs across a swap:
+
+```mermaid
+sequenceDiagram
+    participant A as psql (opened before swap)
+    participant S as proxy.Server
+    participant B as psql (opened after swap)
+    Note over S: rules v1
+    A->>S: connect
+    S->>A: Gate captures rules v1
+    Note over S: heartbeat swaps to rules v2
+    B->>S: connect
+    S->>B: Gate captures rules v2
+    A->>S: statement
+    Note over A,S: still evaluated under v1<br/>until this session closes
+    B->>S: statement
+    Note over B,S: evaluated under v2
+```
+
+## Consequences
+
+Easier: a rule edited in the UI reaches every connected sidecar within one
+heartbeat, with zero dropped connections. Fleet-wide policy changes stop
+being restart campaigns.
+
+Harder: one process can run two rule generations at once, old Gates beside
+new ones. The admin `/config` and `/stats` endpoints must say which config
+generation is active, or an operator debugging "why did this not deny"
+reads rules a draining connection no longer runs. Session audit events need
+nothing: each Gate already records what it enforced.
+
+Two generations must also never mean two budgets: an analyzer rule's
+call counter is a per-rule cell that outlives its evaluators, so a draining
+generation and its replacement pay `max_calls` from one purse. A rebuilt
+evaluator continues the count; only a renamed rule starts a new one.
+
+Committed: the reload pipeline and the startup pipeline stay one code path.
+A config startup would refuse, reload refuses for the same reason with the
+same message. The moment those diverge, the heartbeat becomes a side door
+past validation and the caps.
+
+Revisit if topology drift turns out to be common (connections re-pointed at
+new hosts as a matter of routine). That is option 2's territory: listener
+rebinding with a drain policy, and this ADR's guard becomes the fallback
+rather than the boundary. Revisit the connection-granular choice if
+customers expect an edited deny rule to bind existing sessions; that is the
+statement-granular follow-up, not a reason to hold this stage.

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -10209,6 +10209,54 @@ const docTemplate = `{
                 }
             }
         },
+        "/sidecars/configuration": {
+            "get": {
+                "description": "Authenticated with the hoop-sidecar-token header. Returns the configuration the sidecar must serve, rebuilt from the connections assigned to it. Unlike the handshake it records nothing, so a poll never overwrites what the sidecar last reported about itself.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sidecars"
+                ],
+                "summary": "Sidecar Configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The token returned when the sidecar was created",
+                        "name": "hoop-sidecar-token",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/sidecars/handshake": {
             "post": {
                 "description": "Authenticated with the hoop-sidecar-token header. Records the reported version and returns the configuration the sidecar must serve.",

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -22079,6 +22079,69 @@
         ]
       }
     },
+    "/sidecars/configuration": {
+      "get": {
+        "description": "Authenticated with the hoop-sidecar-token header. Returns the configuration the sidecar must serve, rebuilt from the connections assigned to it. Unlike the handshake it records nothing, so a poll never overwrites what the sidecar last reported about itself.",
+        "parameters": [
+          {
+            "description": "The token returned when the sidecar was created",
+            "in": "header",
+            "name": "hoop-sidecar-token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Sidecar Configuration",
+        "tags": [
+          "Sidecars"
+        ]
+      }
+    },
     "/sidecars/handshake": {
       "post": {
         "description": "Authenticated with the hoop-sidecar-token header. Records the reported version and returns the configuration the sidecar must serve.",

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -301,6 +301,7 @@ func (api *Api) buildSidecarRoutes(r *apiroutes.Router) {
 	// obvious ones to a reader. Post also refuses these two as resource
 	// names, so no sidecar can be shadowed by them.
 	r.POST("/sidecars/handshake", r.SidecarAuthMiddleware, apisidecar.Handshake)
+	r.GET("/sidecars/configuration", r.SidecarAuthMiddleware, apisidecar.Configuration)
 
 	r.GET("/sidecars/:nameOrID",
 		apiroutes.ReadOnlyAccessRole,

--- a/gateway/api/sidecar/sidecar.go
+++ b/gateway/api/sidecar/sidecar.go
@@ -171,6 +171,25 @@ func Handshake(c *gin.Context) {
 	respondConfig(c, sidecar)
 }
 
+// Sidecar Configuration
+//
+//	@Summary		Sidecar Configuration
+//	@Description	Authenticated with the hoop-sidecar-token header. Returns the configuration the sidecar must serve, rebuilt from the connections assigned to it. Unlike the handshake it records nothing, so a poll never overwrites what the sidecar last reported about itself.
+//	@Tags			Sidecars
+//	@Produce		json
+//	@Param			hoop-sidecar-token	header		string	true	"The token returned when the sidecar was created"
+//	@Success		200				{object}	map[string]interface{}
+//	@Failure		401,422,500		{object}	openapi.HTTPError
+//	@Router			/sidecars/configuration [get]
+func Configuration(c *gin.Context) {
+	sidecar := apiroutes.SidecarFromContext(c)
+	if sidecar == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"message": "access denied"})
+		return
+	}
+	respondConfig(c, sidecar)
+}
+
 // respondConfig is shared so the handshake and the poll can never drift.
 func respondConfig(c *gin.Context, sidecar *models.Sidecar) {
 	cfg, err := services.BuildSidecarConfig(models.DB, sidecar.OrgID, sidecar.ID)

--- a/gateway/services/sidecar.go
+++ b/gateway/services/sidecar.go
@@ -177,6 +177,7 @@ func buildConfig(conns []sidecarConnection) (*daemon.Config, error) {
 	var piiEntities []string
 	seenEntity := map[string]bool{}
 	var piiThreshold *float64
+	usedPorts := map[int]bool{}
 
 	for _, conn := range conns {
 		protocol, err := SidecarProtocol(conn.connType, conn.subType)
@@ -191,7 +192,7 @@ func buildConfig(conns []sidecarConnection) (*daemon.Config, error) {
 		listener := daemon.ListenerConfig{
 			Name:     conn.name,
 			Protocol: protocol,
-			Listen:   "0.0.0.0:" + port,
+			Listen:   "0.0.0.0:" + strconv.Itoa(allocateListenPort(usedPorts, port)),
 			Upstream: upstream,
 		}
 		// An empty, non-nil TLSConfig turns on upstream TLS with normal
@@ -335,6 +336,26 @@ func isValidPort(port string) bool {
 		return false
 	}
 	return strconv.Itoa(n) == port
+}
+
+// allocateListenPort binds each lane to its upstream's port, so an agent
+// pointed at the sidecar changes only the host in its connection string. On
+// a collision it walks upward to the next free port: two databases commonly
+// share 5432, and one wildcard listener cannot serve both. Connections
+// arrive ordered by name, so the allocation is deterministic for a given
+// set; the first name keeps the natural port, and the sidecar treats a
+// shifted port as topology drift, which is a restart, never a surprise.
+func allocateListenPort(used map[int]bool, natural string) int {
+	// natural passed isValidPort before reaching here.
+	p, _ := strconv.Atoi(natural)
+	for used[p] {
+		p++
+		if p > 65535 {
+			p = 1024
+		}
+	}
+	used[p] = true
+	return p
 }
 
 // decodeEnv reads a connection env-var secret, stored base64-encoded under

--- a/gateway/services/sidecar_test.go
+++ b/gateway/services/sidecar_test.go
@@ -125,13 +125,26 @@ func TestBuildConfigEmitsPerListenerOPA(t *testing.T) {
 	}
 }
 
-func TestBuildConfigDuplicateListenAddress(t *testing.T) {
-	_, err := buildConfig([]sidecarConnection{
+// Two databases commonly share an upstream port. The generated config must
+// still load in the sidecar, so the second lane (by name order) walks to the
+// next free listen port while both upstreams keep their own.
+func TestBuildConfigAllocatesDistinctListenPorts(t *testing.T) {
+	cfg, err := buildConfig([]sidecarConnection{
 		pgConn("pg-a", "a.internal", "5432"),
 		pgConn("pg-b", "b.internal", "5432"),
 	})
-	if err == nil || !strings.Contains(err.Error(), "duplicate listen address") {
-		t.Fatalf("want a duplicate listen address error, got %v", err)
+	if err != nil {
+		t.Fatalf("buildConfig: %v", err)
+	}
+	if got := cfg.Listeners[0].Listen; got != "0.0.0.0:5432" {
+		t.Errorf("first lane listen = %q, want the natural port", got)
+	}
+	if got := cfg.Listeners[1].Listen; got != "0.0.0.0:5433" {
+		t.Errorf("second lane listen = %q, want the next free port", got)
+	}
+	if cfg.Listeners[0].Upstream != "a.internal:5432" || cfg.Listeners[1].Upstream != "b.internal:5432" {
+		t.Errorf("upstreams moved with the listen allocation: %q, %q",
+			cfg.Listeners[0].Upstream, cfg.Listeners[1].Upstream)
 	}
 }
 

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -221,6 +221,51 @@ neither signature moves again. `daemon.Setup` briefly took the license as a
 fourth argument, which broke every embedder that upgraded; that is what the
 split is for.
 
+### Connecting it to a Control Plane
+
+A sidecar can fetch its whole configuration from a Hoop Control Plane instead
+of carrying its own listeners. Two facts connect it, each with two sources,
+highest precedence first:
+
+| Fact | Sources |
+|---|---|
+| URL | `HOOP_CONTROL_PLANE_URL`, then the `control_plane_url` config key |
+| Token | the token flag (`--token` / `-token`), then `HOOP_SIDECAR_TOKEN` |
+
+First wins, not first valid, same as the license sources: an env var holding
+garbage is an error, never a reason to fall through to the file.
+
+```bash
+# No config file at all: the env pair is the whole configuration.
+HOOP_CONTROL_PLANE_URL=https://cp.example.com \
+  hoop start sidecar --token hsc_...
+
+# Or name the plane in the file and pass only the token.
+echo 'control_plane_url: https://cp.example.com' > config.yaml
+hoop start sidecar --config config.yaml --token hsc_...
+```
+
+The plane issues the token once, when you register the sidecar
+(`POST /api/sidecars`), and stores only a hash of it, so losing the token
+means registering a new sidecar. Both sources hold the token itself, never a
+path, and no config key exists for it: a bearer secret does not belong in a
+file that gets committed.
+
+At startup the process runs the handshake
+(`POST {url}/api/sidecars/handshake`). The plane builds the answer from the
+connections assigned to this sidecar, and that document becomes the running
+config, checked by the same strict decoder the file path uses. `--config`
+becomes optional; a file may still name the plane and a license, but the
+process refuses one that also declares listeners: two authorities for one
+fact is the same mistake as a field written in two spellings. A first
+handshake that fails stops startup, since there is nothing to serve yet.
+
+Once running, a heartbeat repeats the handshake every minute. It keeps the
+plane's last-seen fresh and notices a config edited there: the process logs
+the change (`restart to apply it`) and keeps serving what it started with.
+A failed heartbeat also changes nothing, because losing the phone line home
+must not take the data path down with it.
+
 ## Configuring it: config.yaml
 
 One file is the whole configuration. The process reads it at startup, resolves
@@ -439,6 +484,12 @@ log_level: info
 # A path to the license Hoop issued, or the document itself. The license flag
 # and HOOP_LICENSE both outrank this. Omit it to run the free tier.
 license: /etc/hoop-inspect/license.json
+
+# The Control Plane this sidecar connects to. HOOP_CONTROL_PLANE_URL outranks
+# this. When set, the handshake supplies the whole running config and this
+# file must not also declare listeners; omit it to run standalone from this
+# file alone.
+# control_plane_url: https://cp.example.com
 
 admin:
   listen: 127.0.0.1:19000   # /healthz /stats /config /events /api/*

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -261,10 +261,14 @@ fact is the same mistake as a field written in two spellings. A first
 handshake that fails stops startup, since there is nothing to serve yet.
 
 Once running, a heartbeat repeats the handshake every minute. It keeps the
-plane's last-seen fresh and notices a config edited there: the process logs
-the change (`restart to apply it`) and keeps serving what it started with.
-A failed heartbeat also changes nothing, because losing the phone line home
-must not take the data path down with it.
+plane's last-seen fresh and picks up edits: a change that only touches rules
+(guardrails, masking, pii, OPA) is applied in place, logged as
+`configuration applied` with a generation number. Connections already open
+drain under the rules they were accepted with; new connections run the new
+rules, and nothing rebinds or drops. A change beyond the rules (listeners,
+audit, admin, log_level, analyzer) logs `restart to apply it` instead, and
+a failed heartbeat changes nothing, because losing the phone line home must
+not take the data path down with it. ADR-0014 records the boundary.
 
 ## Configuring it: config.yaml
 

--- a/sidecar/analyzer/evaluator.go
+++ b/sidecar/analyzer/evaluator.go
@@ -140,13 +140,22 @@ type Config struct {
 	CacheSize int
 	CacheTTL  time.Duration
 
-	// MaxCallsPerSession bounds classifications for one Evaluator's
-	// lifetime. Zero means unbounded.
+	// MaxCallsPerSession bounds classifications charged to this rule's
+	// budget. Zero means unbounded.
 	//
 	// An Evaluator is shared across connections, so this is a process-wide
 	// budget rather than a per-connection one. It is a backstop against a
-	// pathological workload, not a quota.
+	// pathological workload, not a quota. The counter it bounds may be
+	// shared through Budget, in which case it also spans evaluator
+	// generations.
 	MaxCalls int
+
+	// Budget optionally supplies the call counter itself. A hot reload
+	// that rebuilds an evaluator hands the replacement the SAME cell, so
+	// the draining generation and the new one together never exceed
+	// MaxCalls; independent counters would let each generation spend the
+	// full budget. Nil allocates a private counter.
+	Budget *atomic.Int64
 
 	// Redact rewrites content before it leaves the process. Nil sends the
 	// statement as-is.
@@ -173,7 +182,7 @@ type Evaluator struct {
 	// their change to take effect would see nothing.
 	promptKey string
 
-	calls  atomic.Int64
+	calls  *atomic.Int64
 	denied atomic.Int64
 	errs   atomic.Int64
 
@@ -212,11 +221,16 @@ func New(cfg Config) (*Evaluator, error) {
 		}
 	}
 	prompt := BuildSystemPrompt(cfg.Guidance)
+	calls := cfg.Budget
+	if calls == nil {
+		calls = new(atomic.Int64)
+	}
 	return &Evaluator{
 		cfg:       cfg,
 		cache:     newCache(cfg.CacheSize, cfg.CacheTTL),
 		prompt:    prompt,
 		promptKey: fingerprint(prompt),
+		calls:     calls,
 	}, nil
 }
 

--- a/sidecar/daemon/analyzer.go
+++ b/sidecar/daemon/analyzer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/hoophq/hoop/sidecar/inspect"
@@ -335,25 +336,40 @@ func splitAnalyzerRules(rules []policy.Rule) (local, ai []policy.Rule) {
 	return local, ai
 }
 
+// budgetFor returns the rule's process-lifetime call counter, creating it
+// on first sight. See analyzerDeps.budgets for the sharing contract.
+func (ac *analyzerDeps) budgetFor(rule string) *atomic.Int64 {
+	if ac.budgets == nil {
+		ac.budgets = map[string]*atomic.Int64{}
+	}
+	cell, ok := ac.budgets[rule]
+	if !ok {
+		cell = new(atomic.Int64)
+		ac.budgets[rule] = cell
+	}
+	return cell
+}
+
 // buildAnalyzerEvaluators turns ai_analysis rules into evaluators.
 //
 // Each rule becomes its own Evaluator, so two rules on one lane get their own
 // trigger, action map and denial message while sharing the provider and,
-// through the provider, the credential.
+// through the provider, the credential. The call BUDGET comes from ac's
+// per-rule registry, so a rebuilt evaluator (a hot reload that edited the
+// rule's lane) continues the running count instead of starting a fresh one.
 func buildAnalyzerEvaluators(
 	rules []policy.Rule,
-	cfg *AnalyzerConfig,
-	provider analyzer.Provider,
-	redact func(string) string,
+	ac *analyzerDeps,
 	hasOPA bool,
 ) ([]policy.Evaluator, error) {
 	if len(rules) == 0 {
 		return nil, nil
 	}
-	if cfg == nil || provider == nil {
+	if ac == nil || ac.cfg == nil || ac.provider == nil {
 		return nil, fmt.Errorf(
 			"ai_analysis rule %q needs an analyzer section, and none is configured", rules[0].Name)
 	}
+	cfg, provider, redact := ac.cfg, ac.provider, ac.redact
 
 	out := make([]policy.Evaluator, 0, len(rules))
 	for _, r := range rules {
@@ -379,6 +395,7 @@ func buildAnalyzerEvaluators(
 			CacheSize:     cfg.Cache.Size,
 			CacheTTL:      time.Duration(cfg.Cache.TTLSec) * time.Second,
 			MaxCalls:      cfg.MaxCalls,
+			Budget:        ac.budgetFor(r.Name),
 			Redact:        redact,
 		})
 		if err != nil {

--- a/sidecar/daemon/analyzer_test.go
+++ b/sidecar/daemon/analyzer_test.go
@@ -291,7 +291,8 @@ func TestPromptPrecedence(t *testing.T) {
 			r.Prompt = tc.rulePrompt
 			cfg := &AnalyzerConfig{Provider: "stub", Model: "m", Prompt: tc.cfgPrompt}
 
-			evs, err := buildAnalyzerEvaluators([]policy.Rule{r}, cfg, stubAnalyzerProvider{}, nil, true)
+			evs, err := buildAnalyzerEvaluators([]policy.Rule{r},
+				&analyzerDeps{cfg: cfg, provider: stubAnalyzerProvider{}}, true)
 			if err != nil {
 				t.Fatalf("buildAnalyzerEvaluators: %v", err)
 			}
@@ -322,6 +323,50 @@ func (stubAnalyzerProvider) Name() string { return "stub" }
 
 func (stubAnalyzerProvider) Classify(context.Context, string, string) (*analyzer.Result, error) {
 	return &analyzer.Result{RiskLevel: analyzer.RiskLow}, nil
+}
+
+// A hot reload that rebuilds a rule's evaluator must not re-arm its call
+// budget: the draining generation and the replacement pay from one purse.
+// Two builds against one analyzerDeps stand in for two generations.
+func TestTheCallBudgetSurvivesAnEvaluatorRebuild(t *testing.T) {
+	deps := &analyzerDeps{
+		cfg:      &AnalyzerConfig{Provider: "stub", Model: "m", MaxCalls: 1},
+		provider: stubAnalyzerProvider{},
+	}
+	stmt := inspect.Statement{
+		Protocol:  inspect.Postgres,
+		Direction: inspect.FromClient,
+		Text:      "DELETE FROM t",
+		Operation: inspect.OpDelete,
+	}
+
+	gen1, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("risky")}, deps, false)
+	if err != nil {
+		t.Fatalf("buildAnalyzerEvaluators: %v", err)
+	}
+	gen1[0].Evaluate(stmt) // spends the whole budget of 1
+
+	gen2, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("risky")}, deps, false)
+	if err != nil {
+		t.Fatalf("buildAnalyzerEvaluators: %v", err)
+	}
+	gen2[0].Evaluate(stmt)
+
+	// One purse: the second generation saw the budget already spent. The
+	// counter never exceeds MaxCalls across generations.
+	if got := gen2[0].(*analyzer.Evaluator).Stats().Calls; got != 1 {
+		t.Fatalf("calls across generations = %d, want the budget of 1", got)
+	}
+
+	// A DIFFERENT rule name is a different identity with its own purse.
+	other, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("other")}, deps, false)
+	if err != nil {
+		t.Fatalf("buildAnalyzerEvaluators: %v", err)
+	}
+	other[0].Evaluate(stmt)
+	if got := other[0].(*analyzer.Evaluator).Stats().Calls; got != 1 {
+		t.Fatalf("a fresh rule's budget = %d, want its own count of 1", got)
+	}
 }
 
 // An ai_analysis rule on an HTTP lane with no body capture classifies nothing:

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/hoophq/hoop/sidecar/analyzer"
@@ -1136,13 +1137,7 @@ func buildPolicy(gc GuardrailsConfig, opa *OPAConfig, det Plugin, ac *analyzerDe
 	}
 
 	if len(aiRules) > 0 {
-		var cfg *AnalyzerConfig
-		var provider analyzer.Provider
-		var redact func(string) string
-		if ac != nil {
-			cfg, provider, redact = ac.cfg, ac.provider, ac.redact
-		}
-		evs, err := buildAnalyzerEvaluators(aiRules, cfg, provider, redact, opa.enabled())
+		evs, err := buildAnalyzerEvaluators(aiRules, ac, opa.enabled())
 		if err != nil {
 			return nil, err
 		}
@@ -1196,6 +1191,15 @@ type analyzerDeps struct {
 	cfg      *AnalyzerConfig
 	provider analyzer.Provider
 	redact   func(string) string
+
+	// budgets hands every generation of a rule's evaluator the same call
+	// counter, so MaxCalls bounds the rule's spend across hot reloads: a
+	// draining generation and its replacement pay from one purse. Keyed
+	// by rule name, the identity an operator edits; two lanes naming one
+	// rule share a budget too, which is what "process-wide" already
+	// promised. Entries are never dropped, and single-goroutine access
+	// (startup builds, then only the heartbeat) needs no lock.
+	budgets map[string]*atomic.Int64
 }
 
 // BuildTLS turns a TLSConfig into a *tls.Config.

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -106,6 +106,14 @@ type Config struct {
 	// precedence of the three sources; ResolveLicense holds the order.
 	License string `json:"license,omitempty"`
 
+	// ControlPlaneURL is the Control Plane this sidecar connects to. Empty
+	// means standalone: the process reads only this file, and nothing
+	// changes from a build that predates the field. When set, the plane
+	// supplies the whole running config through the handshake, so this
+	// file must not also declare listeners. HOOP_CONTROL_PLANE_URL
+	// outranks this key; resolveControlPlaneURL holds the order.
+	ControlPlaneURL string `json:"control_plane_url,omitempty"`
+
 	// Policy is the DEPRECATED pre-ADR-0011 spelling of Guardrails and OPA
 	// combined. normalize empties it.
 	Policy *PolicyConfig `json:"policy,omitempty"`
@@ -124,6 +132,12 @@ type Config struct {
 	// config key: the file names a license and does not carry a verdict.
 	// The zero value is missing, so an embedder who skips it keeps the caps.
 	lic license.Status
+
+	// cp is the resolved control plane connection, when one is configured.
+	// resolveConfigSource fills it; Run starts the heartbeat from it. Not a
+	// config key: the file names a URL and does not carry a token or a
+	// verdict about reachability.
+	cp *controlPlane
 }
 
 // Licensing reports the license this config runs under. The zero value is a
@@ -796,7 +810,11 @@ func (c *Config) resolve(lc ListenerConfig) (GuardrailsConfig, *OPAConfig, MaskC
 func (c *Config) Validate() error {
 	var problems []string
 
-	if len(c.Listeners) == 0 {
+	// A file that names a control plane carries no listeners of its own:
+	// the plane supplies them through the handshake. resolveConfigSource
+	// checks that what the plane sent has at least one, so an empty config
+	// still cannot start.
+	if len(c.Listeners) == 0 && !c.controlPlaneConfigured() {
 		problems = append(problems, "no listeners configured")
 	}
 

--- a/sidecar/daemon/controlplane.go
+++ b/sidecar/daemon/controlplane.go
@@ -1,0 +1,309 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// The control plane connection is two facts, each with two sources.
+//
+//	URL:   HOOP_CONTROL_PLANE_URL, then the config file's "control_plane_url" key.
+//	Token: the token flag, then HOOP_SIDECAR_TOKEN. Never a config key: a
+//	       bearer secret does not belong in a file that gets committed.
+//
+// First wins, not first valid, the same rule license.Resolve follows: an env
+// var holding garbage is an error rather than a reason to fall through,
+// because a process that quietly ignored it will surprise the operator on
+// the restart after the other source changes.
+const (
+	// ControlPlaneURLEnv outranks the config file's "control_plane_url" key.
+	ControlPlaneURLEnv = "HOOP_CONTROL_PLANE_URL"
+	// SidecarTokenEnv holds the token itself, not a path to one. The token
+	// flag outranks it.
+	SidecarTokenEnv = "HOOP_SIDECAR_TOKEN"
+
+	// sidecarTokenHeader matches the gateway's SidecarAuthMiddleware.
+	sidecarTokenHeader = "hoop-sidecar-token"
+	// controlPlaneHandshakePath is appended to the base URL. The handshake
+	// both authenticates and answers: the response body is the full config
+	// this sidecar must serve, and the gateway records the reported version
+	// as the sidecar's liveness.
+	controlPlaneHandshakePath = "/api/sidecars/handshake"
+
+	controlPlaneTimeout = 15 * time.Second
+	// maxControlPlaneConfig bounds the response read. A config is a few KB;
+	// anything near this is a misdirected URL, not a big deployment.
+	maxControlPlaneConfig = 8 << 20
+
+	// heartbeatEvery is how often Run re-runs the handshake. It keeps the
+	// gateway's last-seen fresh and notices a config edited in the UI; a
+	// minute is fast enough for both and costs one small request.
+	heartbeatEvery = time.Minute
+)
+
+// controlPlane is the resolved connection Setup reached: where to call, what
+// to present, and the config bytes this process is serving, kept for the
+// heartbeat's change detection.
+type controlPlane struct {
+	url       string
+	urlSource string
+	token     string
+	lastRaw   []byte
+}
+
+// WithControlPlaneToken supplies the sidecar token from the command line,
+// which outranks HOOP_SIDECAR_TOKEN. Only a caller with such a flag needs it;
+// Setup reads the env var on its own. An empty value falls through, so an
+// entry point hands its flag variable straight in without branching.
+func WithControlPlaneToken(token string) Option {
+	return func(o *setupOptions) { o.token = token }
+}
+
+// controlPlaneConfigured reports whether this process gets its listeners
+// from a control plane. It reads the env var directly for the same reason
+// ResolveLicense does: Validate runs inside LoadConfigBytes, before Setup
+// resolves anything, and it would refuse a deployment configured through
+// the environment alone for the listeners the plane holds.
+func (c *Config) controlPlaneConfigured() bool {
+	return c.ControlPlaneURL != "" || os.Getenv(ControlPlaneURLEnv) != ""
+}
+
+// ControlPlane reports the connection this config runs under, for logs and
+// reports. The token stays out on purpose; only its existence is anyone's
+// business.
+func (c *Config) ControlPlane() (planeURL, source string, ok bool) {
+	if c.cp == nil {
+		return "", "", false
+	}
+	return c.cp.url, c.cp.urlSource, true
+}
+
+// resolveControlPlaneURL picks the URL, highest precedence first: the
+// environment, then the config file's key. Empty everywhere means standalone.
+func resolveControlPlaneURL(fileValue string) (value, source string, err error) {
+	if v := os.Getenv(ControlPlaneURLEnv); v != "" {
+		return checkControlPlaneURL(v, ControlPlaneURLEnv)
+	}
+	if fileValue != "" {
+		return checkControlPlaneURL(fileValue, `the "control_plane_url" config key`)
+	}
+	return "", "", nil
+}
+
+func checkControlPlaneURL(value, source string) (string, string, error) {
+	u, err := url.Parse(value)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", "", fmt.Errorf("%s holds %q, which is not an http(s) URL", source, value)
+	}
+	return value, source, nil
+}
+
+// resolveSidecarToken picks the token, highest precedence first: the command
+// line, then HOOP_SIDECAR_TOKEN. Both hold the token itself, never a path.
+func resolveSidecarToken(flagValue string) (value, source string) {
+	if flagValue != "" {
+		return flagValue, "the token flag"
+	}
+	if v := os.Getenv(SidecarTokenEnv); v != "" {
+		return v, SidecarTokenEnv
+	}
+	return "", ""
+}
+
+// resolveConfigSource decides where the running config comes from: the local
+// file alone (standalone, today's behavior), or the control plane handshake.
+//
+// The two do not merge. A plane-connected process serves what the plane
+// sent, so a file that also declares listeners is refused rather than
+// half-read: no operator can predict which half of a merged config wins, the
+// same reason normalize refuses a field written in two spellings. The file
+// keeps two jobs in plane mode: naming the URL, and naming a license
+// (the documented precedence keeps the config file as a license source, and
+// the plane sends none today).
+func resolveConfigSource(local *Config, tokenFlag string) (*Config, error) {
+	fileURL := ""
+	if local != nil {
+		fileURL = local.ControlPlaneURL
+	}
+	planeURL, urlSource, err := resolveControlPlaneURL(fileURL)
+	if err != nil {
+		return nil, err
+	}
+	token, tokenSource := resolveSidecarToken(tokenFlag)
+
+	if planeURL == "" {
+		if token != "" {
+			// A token someone set that does nothing will surprise them the
+			// day they rely on it. Same posture as a broken HOOP_LICENSE.
+			return nil, fmt.Errorf("%s is set but no control plane is configured; "+
+				"set %s or the \"control_plane_url\" config key, or drop the token", tokenSource, ControlPlaneURLEnv)
+		}
+		if local == nil {
+			return nil, errors.New("no config file was given and no control plane is configured")
+		}
+		return local, nil
+	}
+
+	if token == "" {
+		return nil, fmt.Errorf("a control plane is configured (%s) but no token was given; "+
+			"pass the token flag or set %s", urlSource, SidecarTokenEnv)
+	}
+	if local != nil && len(local.Listeners) > 0 {
+		return nil, fmt.Errorf("the config file declares %d listener(s) and a control plane is configured (%s); "+
+			"the control plane supplies the listeners, so remove them from the file or remove the control plane",
+			len(local.Listeners), urlSource)
+	}
+
+	raw, err := fetchControlPlaneConfig(planeURL, token, Version)
+	if err != nil {
+		return nil, err
+	}
+	// The same strict decode, deprecation folding and validation the file
+	// path gets. The gateway round-trips through this decoder before
+	// answering, so a refusal here means the two builds disagree on the
+	// schema, which the error should say out loud.
+	cfg, err := LoadConfigBytes(raw)
+	if err != nil {
+		return nil, fmt.Errorf("the control plane at %s sent a config this build cannot load "+
+			"(the two versions may disagree on the schema): %w", planeURL, err)
+	}
+	// Validate relaxes the listener check whenever a plane is configured,
+	// which includes this process. The plane refuses to build a config for
+	// a sidecar with no connections, so an empty one here is a bug worth
+	// stopping on, not serving.
+	if len(cfg.Listeners) == 0 {
+		return nil, fmt.Errorf("the control plane at %s sent a config with no listeners", planeURL)
+	}
+	if local != nil && cfg.License == "" {
+		cfg.License = local.License
+	}
+	cfg.ControlPlaneURL = planeURL
+	cfg.cp = &controlPlane{url: planeURL, urlSource: urlSource, token: token, lastRaw: raw}
+	return cfg, nil
+}
+
+// fetchControlPlaneConfig runs one handshake: it presents the token, reports
+// the version, and returns the config document the plane answered with.
+func fetchControlPlaneConfig(baseURL, token, version string) ([]byte, error) {
+	body, err := json.Marshal(map[string]string{"version": version})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost,
+		strings.TrimRight(baseURL, "/")+controlPlaneHandshakePath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("control plane request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(sidecarTokenHeader, token)
+
+	resp, err := (&http.Client{Timeout: controlPlaneTimeout}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("the control plane at %s is unreachable: %w", baseURL, err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxControlPlaneConfig+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading the control plane response from %s: %w", baseURL, err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if len(raw) > maxControlPlaneConfig {
+			return nil, fmt.Errorf("the control plane at %s answered with more than %d bytes; "+
+				"check that the URL is the control plane and not something in front of it",
+				baseURL, maxControlPlaneConfig)
+		}
+		return raw, nil
+	case http.StatusUnauthorized:
+		// Not self-healing: a mistyped token and a deleted sidecar both land
+		// here, and the plane shows the token once at creation, so a lost
+		// one means registering a new sidecar.
+		return nil, fmt.Errorf("the control plane at %s rejected the token; "+
+			"check it against the one shown when this sidecar was created", baseURL)
+	case http.StatusUnprocessableEntity:
+		// An operator misconfiguration on the plane side (say, a connection
+		// type no codec speaks). Retrying never fixes it; the message names
+		// what to change.
+		return nil, fmt.Errorf("the control plane at %s cannot build this sidecar's config: %s",
+			baseURL, controlPlaneMessage(raw))
+	default:
+		return nil, fmt.Errorf("the control plane at %s answered %s: %s",
+			baseURL, resp.Status, controlPlaneMessage(raw))
+	}
+}
+
+// controlPlaneMessage extracts the gateway's {"message": ...} error shape,
+// falling back to the raw body so an unexpected proxy page is still visible.
+func controlPlaneMessage(raw []byte) string {
+	var m struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(raw, &m) == nil && m.Message != "" {
+		return m.Message
+	}
+	s := strings.TrimSpace(string(raw))
+	if s == "" {
+		return "no detail"
+	}
+	if len(s) > 300 {
+		s = s[:300] + "..."
+	}
+	return s
+}
+
+// heartbeat re-runs the handshake until ctx ends. It keeps the gateway's
+// last-seen fresh and notices a config edited in the UI.
+//
+// Failures degrade and never stop the process: the lanes keep serving the
+// last good config, because killing a data-path proxy over a lost phone line
+// home is an outage. The heartbeat logs a changed config and applies
+// nothing; listeners can appear and disappear between fetches, and swapping
+// bound ports under live connections is a restart's job.
+func (cp *controlPlane) heartbeat(ctx context.Context, log *slog.Logger) {
+	t := time.NewTicker(heartbeatEvery)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+		changed, err := cp.poll()
+		switch {
+		case err != nil:
+			log.Warn("control plane handshake failed; serving the last good config",
+				"url", cp.url, "error", err)
+		case changed:
+			log.Warn("the control plane configuration changed; restart to apply it",
+				"url", cp.url)
+		}
+	}
+}
+
+// poll fetches the current config and reports whether it differs from what
+// this process is serving. lastRaw advances on change so one edit logs once,
+// not once per tick. The byte compare is sound because the gateway builds
+// the document with encoding/json, which orders struct fields by declaration
+// and map keys alphabetically.
+func (cp *controlPlane) poll() (changed bool, err error) {
+	raw, err := fetchControlPlaneConfig(cp.url, cp.token, Version)
+	if err != nil {
+		return false, err
+	}
+	if bytes.Equal(raw, cp.lastRaw) {
+		return false, nil
+	}
+	cp.lastRaw = raw
+	return true, nil
+}

--- a/sidecar/daemon/controlplane.go
+++ b/sidecar/daemon/controlplane.go
@@ -58,7 +58,17 @@ type controlPlane struct {
 	url       string
 	urlSource string
 	token     string
-	lastRaw   []byte
+	// lastRaw is the startup handshake's document. The reloader seeds its
+	// handled-tracking from it; the heartbeat itself keeps no compare
+	// state.
+	lastRaw []byte
+
+	// build is the PluginBuilder SetupWith received, retained so a reload
+	// can rebuild the detector when the pii section drifts. Nil means the
+	// entry point linked no detector; a drifted pii section then stays on
+	// the restart path instead of swapping in rules the running detector
+	// cannot serve.
+	build PluginBuilder
 }
 
 // WithControlPlaneToken supplies the sidecar token from the command line,
@@ -100,10 +110,20 @@ func resolveControlPlaneURL(fileValue string) (value, source string, err error) 
 	return "", "", nil
 }
 
+// checkControlPlaneURL admits only what the handshake can use: an http(s)
+// URL with a host, optionally a path prefix for a plane behind one. Query,
+// fragment and userinfo are refused rather than carried into a request
+// whose path would then not be the handshake's; the error names the source
+// the operator has to fix.
 func checkControlPlaneURL(value, source string) (string, string, error) {
 	u, err := url.Parse(value)
 	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
 		return "", "", fmt.Errorf("%s holds %q, which is not an http(s) URL", source, value)
+	}
+	if u.RawQuery != "" || u.Fragment != "" || u.User != nil {
+		return "", "", fmt.Errorf("%s holds %q; a control plane URL carries no query, "+
+			"fragment or user information, only a scheme, a host and an optional path prefix",
+			source, value)
 	}
 	return value, source, nil
 }
@@ -199,19 +219,38 @@ func fetchControlPlaneConfig(baseURL, token, version string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The base was validated by checkControlPlaneURL; JoinPath keeps a
+	// path prefix (a plane behind /hoop) and normalizes trailing slashes.
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("control plane URL %q: %w", baseURL, err)
+	}
 	req, err := http.NewRequest(http.MethodPost,
-		strings.TrimRight(baseURL, "/")+controlPlaneHandshakePath, bytes.NewReader(body))
+		u.JoinPath(controlPlaneHandshakePath).String(), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("control plane request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(sidecarTokenHeader, token)
 
-	resp, err := (&http.Client{Timeout: controlPlaneTimeout}).Do(req)
+	client := &http.Client{
+		Timeout: controlPlaneTimeout,
+		// Never follow a redirect: the token rides a custom header, which
+		// Go's redirect handling forwards even across origins (it strips
+		// only the headers it knows are credentials). Surfacing the 3xx
+		// turns a misdirected URL into an error naming the fix instead of
+		// a bearer token handed to whoever answered the Location.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("the control plane at %s is unreachable: %w", baseURL, err)
 	}
-	defer resp.Body.Close()
+	// The body is always read to completion below; a close error after a
+	// full read carries nothing actionable, so it is dropped on purpose.
+	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxControlPlaneConfig+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading the control plane response from %s: %w", baseURL, err)
@@ -237,10 +276,15 @@ func fetchControlPlaneConfig(baseURL, token, version string) ([]byte, error) {
 		// what to change.
 		return nil, fmt.Errorf("the control plane at %s cannot build this sidecar's config: %s",
 			baseURL, controlPlaneMessage(raw))
-	default:
-		return nil, fmt.Errorf("the control plane at %s answered %s: %s",
-			baseURL, resp.Status, controlPlaneMessage(raw))
 	}
+
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return nil, fmt.Errorf("the control plane at %s redirected to %q; the handshake "+
+			"never follows one, so the token was not re-sent. Configure the final URL",
+			baseURL, resp.Header.Get("Location"))
+	}
+	return nil, fmt.Errorf("the control plane at %s answered %s: %s",
+		baseURL, resp.Status, controlPlaneMessage(raw))
 }
 
 // controlPlaneMessage extracts the gateway's {"message": ...} error shape,
@@ -267,10 +311,12 @@ func controlPlaneMessage(raw []byte) string {
 //
 // Failures degrade and never stop the process: the lanes keep serving the
 // last good config, because killing a data-path proxy over a lost phone line
-// home is an outage. The heartbeat logs a changed config and applies
-// nothing; listeners can appear and disappear between fetches, and swapping
-// bound ports under live connections is a restart's job.
-func (cp *controlPlane) heartbeat(ctx context.Context, log *slog.Logger) {
+// home is an outage. Every fetched document goes to the reloader, which
+// owns the seen/handled bookkeeping: it swaps rule-only drift into the
+// running lanes, answers "restart to apply it" for everything a live
+// process cannot change, and retries a document whose failure can clear
+// without another edit (ADR-0014).
+func (cp *controlPlane) heartbeat(ctx context.Context, log *slog.Logger, rl *reloader) {
 	t := time.NewTicker(heartbeatEvery)
 	defer t.Stop()
 	for {
@@ -279,31 +325,12 @@ func (cp *controlPlane) heartbeat(ctx context.Context, log *slog.Logger) {
 			return
 		case <-t.C:
 		}
-		changed, err := cp.poll()
-		switch {
-		case err != nil:
+		raw, err := fetchControlPlaneConfig(cp.url, cp.token, Version)
+		if err != nil {
 			log.Warn("control plane handshake failed; serving the last good config",
 				"url", cp.url, "error", err)
-		case changed:
-			log.Warn("the control plane configuration changed; restart to apply it",
-				"url", cp.url)
+			continue
 		}
+		rl.handle(log, raw)
 	}
-}
-
-// poll fetches the current config and reports whether it differs from what
-// this process is serving. lastRaw advances on change so one edit logs once,
-// not once per tick. The byte compare is sound because the gateway builds
-// the document with encoding/json, which orders struct fields by declaration
-// and map keys alphabetically.
-func (cp *controlPlane) poll() (changed bool, err error) {
-	raw, err := fetchControlPlaneConfig(cp.url, cp.token, Version)
-	if err != nil {
-		return false, err
-	}
-	if bytes.Equal(raw, cp.lastRaw) {
-		return false, nil
-	}
-	cp.lastRaw = raw
-	return true, nil
 }

--- a/sidecar/daemon/controlplane_test.go
+++ b/sidecar/daemon/controlplane_test.go
@@ -112,6 +112,70 @@ func TestABrokenControlPlaneEnvDoesNotFallThrough(t *testing.T) {
 	}
 }
 
+// A URL carrying a query, fragment or userinfo would build a request whose
+// path is not the handshake's, so validation refuses each one and names the
+// source the operator has to fix.
+func TestAControlPlaneURLCarriesNoQueryFragmentOrUser(t *testing.T) {
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+	for _, bad := range []string{
+		"http://plane.example?tenant=a",
+		"http://plane.example#frag",
+		"http://user:pw@plane.example",
+	} {
+		t.Setenv(ControlPlaneURLEnv, bad)
+		_, _, err := SetupWith("", nil, nil)
+		if err == nil {
+			t.Fatalf("%q was accepted", bad)
+		}
+		if !strings.Contains(err.Error(), ControlPlaneURLEnv) {
+			t.Errorf("the error for %q does not name the source: %v", bad, err)
+		}
+	}
+}
+
+// A plane behind a path prefix keeps it: the handshake path joins the
+// configured base instead of replacing it.
+func TestAPathPrefixedPlaneURLKeepsItsPrefix(t *testing.T) {
+	srv, calls := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(ControlPlaneURLEnv, srv.URL+"/hoop/")
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+
+	if _, _, err := SetupWith("", nil, nil); err != nil {
+		t.Fatalf("SetupWith: %v", err)
+	}
+	if got := (*calls)[0].path; got != "/hoop"+controlPlaneHandshakePath {
+		t.Errorf("path = %q, want the prefix kept", got)
+	}
+}
+
+// The token rides a custom header, which Go forwards on redirects even
+// across origins. The handshake never follows one: the 3xx surfaces as an
+// error naming the Location, and the token goes nowhere else.
+func TestARedirectingPlaneIsRefusedWithoutResendingTheToken(t *testing.T) {
+	leaked := false
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		leaked = true
+	}))
+	t.Cleanup(sink.Close)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, sink.URL, http.StatusMovedPermanently)
+	}))
+	t.Cleanup(redirector.Close)
+	t.Setenv(ControlPlaneURLEnv, redirector.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_secret")
+
+	_, _, err := SetupWith("", nil, nil)
+	if err == nil {
+		t.Fatal("a redirecting plane was accepted")
+	}
+	if !strings.Contains(err.Error(), "redirected") {
+		t.Errorf("the error does not say it was a redirect: %v", err)
+	}
+	if leaked {
+		t.Fatal("the redirect target was contacted; the token traveled")
+	}
+}
+
 func TestTheTokenFlagOutranksTheEnvironment(t *testing.T) {
 	srv, calls := planeServer(t, http.StatusOK, planeConfig)
 	t.Setenv(ControlPlaneURLEnv, srv.URL)
@@ -279,18 +343,20 @@ func TestAnEmptyPlaneConfigIsRefused(t *testing.T) {
 	}
 }
 
-// One edit on the plane logs once, not once per tick: lastRaw advances when
-// a change is seen.
-func TestPollNoticesAChangeOnce(t *testing.T) {
-	srv, _ := planeServer(t, http.StatusOK, planeConfig)
-	cp := &controlPlane{url: srv.URL, token: "hsc_x", lastRaw: []byte(`{"old":true}`)}
+// One edit is handled once, not once per tick: the reloader remembers the
+// last document that reached a terminal outcome, and the same bytes on the
+// next tick do nothing. reload_test.go covers what handling decides.
+func TestTheSameDocumentIsHandledOnce(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
 
-	changed, err := cp.poll()
-	if err != nil || !changed {
-		t.Fatalf("first poll = %v, %v; want a change", changed, err)
+	drifted := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	if got := handleWith(rl, buf, drifted); got != reloadApplied {
+		t.Fatalf("first handle = %v, want applied; log:\n%s", got, buf)
 	}
-	changed, err = cp.poll()
-	if err != nil || changed {
-		t.Fatalf("second poll = %v, %v; want no change", changed, err)
+	if got := handleWith(rl, buf, drifted); got != reloadUnchanged {
+		t.Fatalf("second handle = %v, want unchanged; log:\n%s", got, buf)
+	}
+	if rl.gen != 1 {
+		t.Fatalf("generation = %d; the duplicate was re-applied", rl.gen)
 	}
 }

--- a/sidecar/daemon/controlplane_test.go
+++ b/sidecar/daemon/controlplane_test.go
@@ -1,0 +1,296 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/license/licensetest"
+)
+
+// planeConfig is what a healthy control plane answers: one postgres lane,
+// the same shape the gateway's BuildSidecarConfig produces.
+const planeConfig = `{"listeners":[{"name":"appdb","protocol":"postgres","listen":":1","upstream":"h:5432"}]}`
+
+// handshakeCall records what the fake plane saw, so a test can assert the
+// token and version that arrived rather than only the outcome.
+type handshakeCall struct {
+	token   string
+	version string
+	path    string
+}
+
+// planeServer serves the handshake with body, capturing each call. A nil
+// check leaves the default 200 handler.
+func planeServer(t *testing.T, status int, body string) (*httptest.Server, *[]handshakeCall) {
+	t.Helper()
+	calls := &[]handshakeCall{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Version string `json:"version"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		*calls = append(*calls, handshakeCall{
+			token:   r.Header.Get(sidecarTokenHeader),
+			version: req.Version,
+			path:    r.URL.Path,
+		})
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, calls
+}
+
+func TestSetupFetchesTheConfigFromTheControlPlane(t *testing.T) {
+	srv, calls := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(ControlPlaneURLEnv, srv.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_env")
+
+	// No config file at all: the env pair is the whole configuration.
+	cfg, _, err := SetupWith("", nil, nil)
+	if err != nil {
+		t.Fatalf("SetupWith: %v", err)
+	}
+	if len(cfg.Listeners) != 1 || cfg.Listeners[0].Name != "appdb" {
+		t.Fatalf("the plane's config did not become the running config: %+v", cfg.Listeners)
+	}
+	if url, source, ok := cfg.ControlPlane(); !ok || url != srv.URL || source != ControlPlaneURLEnv {
+		t.Errorf("ControlPlane() = %q, %q, %v", url, source, ok)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("handshakes = %d, want 1", len(*calls))
+	}
+	got := (*calls)[0]
+	if got.token != "hsc_env" {
+		t.Errorf("token = %q", got.token)
+	}
+	if got.version != Version {
+		t.Errorf("version = %q, want %q", got.version, Version)
+	}
+	if got.path != controlPlaneHandshakePath {
+		t.Errorf("path = %q", got.path)
+	}
+}
+
+func TestTheEnvironmentOutranksTheConfigKeyForTheControlPlaneURL(t *testing.T) {
+	fromKey, _ := planeServer(t, http.StatusOK,
+		`{"listeners":[{"name":"from-key","protocol":"postgres","listen":":1","upstream":"h:5432"}]}`)
+	fromEnv, _ := planeServer(t, http.StatusOK,
+		`{"listeners":[{"name":"from-env","protocol":"postgres","listen":":1","upstream":"h:5432"}]}`)
+	t.Setenv(ControlPlaneURLEnv, fromEnv.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+
+	cfg, _, err := SetupWith(writeConfig(t, `{"control_plane_url":"`+fromKey.URL+`"}`), nil, nil)
+	if err != nil {
+		t.Fatalf("SetupWith: %v", err)
+	}
+	if cfg.Listeners[0].Name != "from-env" {
+		t.Fatalf("the config key won over the environment: %q", cfg.Listeners[0].Name)
+	}
+}
+
+// First wins, not first valid: a broken env var is an error, never a reason
+// to fall through to the config key. Same rule the license sources follow.
+func TestABrokenControlPlaneEnvDoesNotFallThrough(t *testing.T) {
+	srv, calls := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(ControlPlaneURLEnv, "not a url")
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+
+	_, _, err := SetupWith(writeConfig(t, `{"control_plane_url":"`+srv.URL+`"}`), nil, nil)
+	if err == nil {
+		t.Fatal("a broken env URL fell through to the config key")
+	}
+	if !strings.Contains(err.Error(), ControlPlaneURLEnv) {
+		t.Errorf("the error does not name the source: %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("the plane named by the config key was contacted %d time(s)", len(*calls))
+	}
+}
+
+func TestTheTokenFlagOutranksTheEnvironment(t *testing.T) {
+	srv, calls := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(ControlPlaneURLEnv, srv.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_env")
+
+	if _, _, err := SetupWith("", nil, nil, WithControlPlaneToken("hsc_flag")); err != nil {
+		t.Fatalf("SetupWith: %v", err)
+	}
+	if got := (*calls)[0].token; got != "hsc_flag" {
+		t.Errorf("token = %q, want the flag value", got)
+	}
+}
+
+// An empty flag is the same as no flag, so an entry point hands its variable
+// through without branching on whether the operator set it.
+func TestAnEmptyTokenFlagFallsThroughToTheEnvironment(t *testing.T) {
+	srv, calls := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(ControlPlaneURLEnv, srv.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_env")
+
+	if _, _, err := SetupWith("", nil, nil, WithControlPlaneToken("")); err != nil {
+		t.Fatalf("SetupWith: %v", err)
+	}
+	if got := (*calls)[0].token; got != "hsc_env" {
+		t.Errorf("token = %q, want the env value", got)
+	}
+}
+
+func TestAControlPlaneWithoutATokenStopsStartup(t *testing.T) {
+	srv, calls := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(ControlPlaneURLEnv, srv.URL)
+	t.Setenv(SidecarTokenEnv, "")
+
+	_, _, err := SetupWith("", nil, nil)
+	if err == nil {
+		t.Fatal("a control plane with no token was accepted")
+	}
+	for _, want := range []string{"token flag", SidecarTokenEnv} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error does not name the fix %q: %v", want, err)
+		}
+	}
+	if len(*calls) != 0 {
+		t.Errorf("the plane was contacted without a token %d time(s)", len(*calls))
+	}
+}
+
+// A token that configures nothing will surprise whoever set it the day they
+// rely on it, so Setup refuses it rather than ignoring it.
+func TestATokenWithoutAControlPlaneStopsStartup(t *testing.T) {
+	t.Setenv(ControlPlaneURLEnv, "")
+	t.Setenv(SidecarTokenEnv, "hsc_orphan")
+
+	_, _, err := SetupWith(writeConfig(t, minimalConfig+`}`), nil, nil)
+	if err == nil {
+		t.Fatal("an orphan token was accepted")
+	}
+	if !strings.Contains(err.Error(), SidecarTokenEnv) {
+		t.Errorf("the error does not name the source: %v", err)
+	}
+}
+
+// The plane supplies the listeners, so a file that also declares them is two
+// authorities for one fact. Refused for the same reason normalize refuses a
+// field written in both spellings: nobody can predict the winner.
+func TestAConfigFileWithListenersConflictsWithAControlPlane(t *testing.T) {
+	srv, _ := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(ControlPlaneURLEnv, srv.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+
+	_, _, err := SetupWith(writeConfig(t, minimalConfig+`}`), nil, nil)
+	if err == nil {
+		t.Fatal("a file with listeners was accepted beside a control plane")
+	}
+	if !strings.Contains(err.Error(), "listener") {
+		t.Errorf("the error does not say what conflicts: %v", err)
+	}
+}
+
+// A file whose whole job is naming the plane must load even though it has no
+// listeners of its own.
+func TestAPlanePointingFileNeedsNoListeners(t *testing.T) {
+	srv, _ := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+	t.Setenv(ControlPlaneURLEnv, "")
+
+	cfg, _, err := SetupWith(writeConfig(t, `{"control_plane_url":"`+srv.URL+`"}`), nil, nil)
+	if err != nil {
+		t.Fatalf("SetupWith: %v", err)
+	}
+	if len(cfg.Listeners) != 1 {
+		t.Fatalf("listeners = %d", len(cfg.Listeners))
+	}
+	if _, source, _ := cfg.ControlPlane(); !strings.Contains(source, "control_plane_url") {
+		t.Errorf("source = %q, want the config key", source)
+	}
+}
+
+// The plane sends no license today, so the file's "license" key stays a
+// license source in plane mode; the documented precedence is unchanged.
+func TestTheFileLicenseKeySurvivesThePlaneConfig(t *testing.T) {
+	srv, _ := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+	t.Setenv(ControlPlaneURLEnv, "")
+	doc := licensetest.Document(t, licensetest.Enterprise())
+
+	body, err := json.Marshal(map[string]string{"control_plane_url": srv.URL, "license": doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, _, err := SetupWith(writeConfig(t, string(body)), nil, nil)
+	if err != nil {
+		t.Fatalf("SetupWith: %v", err)
+	}
+	if cfg.Licensing().State() != license.StateValid {
+		t.Fatalf("license state = %q, want valid", cfg.Licensing().State())
+	}
+}
+
+func TestARejectedTokenNamesTheProblem(t *testing.T) {
+	srv, _ := planeServer(t, http.StatusUnauthorized, `{"message":"access denied"}`)
+	t.Setenv(ControlPlaneURLEnv, srv.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_wrong")
+
+	_, _, err := SetupWith("", nil, nil)
+	if err == nil {
+		t.Fatal("a 401 was accepted")
+	}
+	if !strings.Contains(err.Error(), "rejected the token") {
+		t.Errorf("the error does not say the token was rejected: %v", err)
+	}
+}
+
+// A 422 is an operator misconfiguration on the plane side; the message names
+// what to change and must reach whoever reads the startup failure.
+func TestAPlaneMisconfigurationReachesTheOperator(t *testing.T) {
+	srv, _ := planeServer(t, http.StatusUnprocessableEntity,
+		`{"message":"no connections are assigned to this sidecar"}`)
+	t.Setenv(ControlPlaneURLEnv, srv.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+
+	_, _, err := SetupWith("", nil, nil)
+	if err == nil {
+		t.Fatal("a 422 was accepted")
+	}
+	if !strings.Contains(err.Error(), "no connections are assigned") {
+		t.Errorf("the plane's message was lost: %v", err)
+	}
+}
+
+// Validate relaxes the listener check whenever a plane is configured, so the
+// explicit check on the FETCHED config is what stands between an empty
+// answer and a process serving nothing.
+func TestAnEmptyPlaneConfigIsRefused(t *testing.T) {
+	srv, _ := planeServer(t, http.StatusOK, `{"listeners":[]}`)
+	t.Setenv(ControlPlaneURLEnv, srv.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+
+	_, _, err := SetupWith("", nil, nil)
+	if err == nil {
+		t.Fatal("a config with no listeners was accepted from the plane")
+	}
+	if !strings.Contains(err.Error(), "no listeners") {
+		t.Errorf("the error does not say what is missing: %v", err)
+	}
+}
+
+// One edit on the plane logs once, not once per tick: lastRaw advances when
+// a change is seen.
+func TestPollNoticesAChangeOnce(t *testing.T) {
+	srv, _ := planeServer(t, http.StatusOK, planeConfig)
+	cp := &controlPlane{url: srv.URL, token: "hsc_x", lastRaw: []byte(`{"old":true}`)}
+
+	changed, err := cp.poll()
+	if err != nil || !changed {
+		t.Fatalf("first poll = %v, %v; want a change", changed, err)
+	}
+	changed, err = cp.poll()
+	if err != nil || changed {
+		t.Fatalf("second poll = %v, %v; want no change", changed, err)
+	}
+}

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -81,6 +81,7 @@ type Option func(*setupOptions)
 
 type setupOptions struct {
 	licenseFlag string
+	token       string
 }
 
 // WithLicense supplies a license from the command line, which outranks
@@ -111,6 +112,13 @@ func Setup(path string, load Loader, build PluginBuilder) (*Config, Plugin, erro
 //
 // An UNREADABLE license stops startup and an expired one does not, since
 // killing a data-path proxy over billing is an outage.
+//
+// When a control plane is configured (HOOP_CONTROL_PLANE_URL or the config
+// file's "control_plane_url" key), the running config comes from its
+// handshake and path may be empty; see resolveConfigSource for what a file
+// still contributes then. A first fetch that fails stops startup, because
+// there is nothing to serve yet; once running, the heartbeat degrades
+// instead.
 func SetupWith(path string, load Loader, build PluginBuilder, opts ...Option) (*Config, Plugin, error) {
 	var o setupOptions
 	for _, apply := range opts {
@@ -119,7 +127,15 @@ func SetupWith(path string, load Loader, build PluginBuilder, opts ...Option) (*
 	if load == nil {
 		load = LoadConfig
 	}
-	cfg, err := load(path)
+	var local *Config
+	if path != "" {
+		var err error
+		local, err = load(path)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	cfg, err := resolveConfigSource(local, o.token)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -189,6 +205,8 @@ func Main(version string, load Loader, build PluginBuilder) error {
 		licenseRef = fs.String("license", "", "path to the license file, or the license "+
 			"document itself; overrides "+license.EnvVar+" and the config file's "+
 			`"license" key`)
+		tokenRef = fs.String("token", "", "the token identifying this sidecar to the "+
+			"control plane; overrides "+SidecarTokenEnv)
 		validate = fs.Bool("validate", false, "validate the config and exit")
 		strict   = fs.Bool("strict", false, "treat a deprecated config field as an error")
 		showVer  = fs.Bool("version", false, "print the version and exit")
@@ -206,12 +224,13 @@ func Main(version string, load Loader, build PluginBuilder) error {
 		fmt.Println("hoop-inspect", version)
 		return nil
 	}
-	if *configPath == "" {
+	if *configPath == "" && os.Getenv(ControlPlaneURLEnv) == "" {
 		fs.Usage()
-		return fmt.Errorf("%w: -config is required", ErrUsage)
+		return fmt.Errorf("%w: -config is required unless %s is set", ErrUsage, ControlPlaneURLEnv)
 	}
 
-	cfg, det, err := SetupWith(*configPath, load, build, WithLicense(*licenseRef))
+	cfg, det, err := SetupWith(*configPath, load, build,
+		WithLicense(*licenseRef), WithControlPlaneToken(*tokenRef))
 	if err != nil {
 		return err
 	}
@@ -562,6 +581,17 @@ func Run(cfg *Config, det Plugin) error {
 	var licenseExpired <-chan struct{}
 	if cfg.dependsOnLicense() {
 		licenseExpired = watchLicense(ctx, cfg.lic, licenseCheckEvery, log)
+	}
+
+	if cfg.cp != nil {
+		// The heartbeat keeps the plane's last-seen fresh and logs when the
+		// config there no longer matches this process. It shares the run
+		// context, so shutdown stops it with everything else.
+		log.Info("control plane connected",
+			"url", cfg.cp.url,
+			"source", cfg.cp.urlSource,
+			"poll", heartbeatEvery.String())
+		go cfg.cp.heartbeat(ctx, log)
 	}
 
 	// Two server kinds, one loop of lane facts. Relay lanes run

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -38,6 +38,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -138,6 +139,11 @@ func SetupWith(path string, load Loader, build PluginBuilder, opts ...Option) (*
 	cfg, err := resolveConfigSource(local, o.token)
 	if err != nil {
 		return nil, nil, err
+	}
+	if cfg.cp != nil {
+		// Retained so a pii drift from the plane rebuilds the detector the
+		// way startup would. See reloader.
+		cfg.cp.build = build
 	}
 	cfg.lic = ResolveLicense(o.licenseFlag, cfg.License)
 	if cfg.lic.State() == license.StateInvalid {
@@ -583,17 +589,6 @@ func Run(cfg *Config, det Plugin) error {
 		licenseExpired = watchLicense(ctx, cfg.lic, licenseCheckEvery, log)
 	}
 
-	if cfg.cp != nil {
-		// The heartbeat keeps the plane's last-seen fresh and logs when the
-		// config there no longer matches this process. It shares the run
-		// context, so shutdown stops it with everything else.
-		log.Info("control plane connected",
-			"url", cfg.cp.url,
-			"source", cfg.cp.urlSource,
-			"poll", heartbeatEvery.String())
-		go cfg.cp.heartbeat(ctx, log)
-	}
-
 	// Two server kinds, one loop of lane facts. Relay lanes run
 	// proxy.Server; grpc lanes run the transport the plugin registered
 	// (ADR-0013). The stats zip in serveAdmin pairs servers with
@@ -645,9 +640,35 @@ func Run(cfg *Config, det Plugin) error {
 		}
 	}
 
+	// view is the generation the admin endpoints render. Startup publishes
+	// generation zero; every applied reload publishes the next, so /config
+	// answers for the rules the data path runs, not for a snapshot.
+	view := &atomic.Pointer[laneState]{}
+	view.Store(&laneState{lanes: lanes})
+
+	if cfg.cp != nil {
+		// The heartbeat keeps the plane's last-seen fresh and hands drift to
+		// the reloader: rule-only changes swap into the servers built above,
+		// everything else keeps the restart log (ADR-0014). It shares the
+		// run context, so shutdown stops it with everything else.
+		byName := make(map[string]*proxy.Server, len(servers))
+		for i, srv := range servers {
+			byName[relayNames[i]] = srv
+		}
+		rl, rerr := newReloader(cfg, lanes, byName, det, analyzerDeps, view)
+		if rerr != nil {
+			return rerr
+		}
+		log.Info("control plane connected",
+			"url", cfg.cp.url,
+			"source", cfg.cp.urlSource,
+			"poll", heartbeatEvery.String())
+		go cfg.cp.heartbeat(ctx, log, rl)
+	}
+
 	if cfg.Admin.Listen != "" {
 		go serveAdmin(ctx, cfg.Admin.Listen, servers, relayNames, grpcServers, grpcNames,
-			lanes, ac, cfg.Analyzer, cfg.lic, log)
+			view, ac, cfg.Analyzer, cfg.lic, log)
 	}
 
 	var wg sync.WaitGroup
@@ -1080,7 +1101,7 @@ func serveAdmin(
 	relayNames []string,
 	grpcServers []GRPCServer,
 	grpcNames []string,
-	lanes []lane,
+	view *atomic.Pointer[laneState],
 	ac auditChain,
 	analyzerCfg *AnalyzerConfig,
 	lic license.Status,
@@ -1174,8 +1195,12 @@ func serveAdmin(
 			AIRules     []string `json:"ai_rules,omitempty"`
 			CaptureBody bool     `json:"capture_body,omitempty"`
 		}
-		out := make([]laneView, 0, len(lanes))
-		for _, ln := range lanes {
+		// The generation the data path runs. A reload publishes new lanes
+		// and its generation as one store, so this render never mixes the
+		// two (ADR-0014).
+		st := view.Load()
+		out := make([]laneView, 0, len(st.lanes))
+		for _, ln := range st.lanes {
 			mode := ModeEnforce
 			if ln.observing {
 				mode = ModeObserve
@@ -1208,6 +1233,10 @@ func serveAdmin(
 		resp := map[string]any{
 			"version": Version,
 			"lanes":   out,
+			// Zero until a control-plane reload applies; each applied
+			// reload increments it, matching the "configuration applied"
+			// log line.
+			"config_generation": st.gen,
 			// Named in the payload rather than only in the README, so a
 			// control plane can warn its own developers without reading
 			// prose. These keys still carry correct values.

--- a/sidecar/daemon/reload.go
+++ b/sidecar/daemon/reload.go
@@ -1,0 +1,283 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/proxy"
+)
+
+// This file is the ADR-0014 hot reload: when the control plane's config
+// drifts in rule content only, the running relay lanes swap evaluators and
+// maskers atomically instead of asking for a restart. Connections already
+// open keep the Gate they captured at accept time; connections accepted
+// after the swap run the new rules.
+//
+// The boundary is the non-rule document: listener topology, audit, admin,
+// log_level and the analyzer section are bound at startup (sockets, sinks,
+// loggers, provider credentials), so any drift there keeps the restart log.
+//
+// Everything here runs on the heartbeat goroutine alone. Run hands the
+// reloader over before starting it and never touches it again, which is why
+// no field needs a lock; the one cross-goroutine surface is laneState,
+// published through an atomic pointer the admin endpoints load.
+
+// reloadOutcome is what handle concluded, returned so a test asserts the
+// decision rather than parsing log lines.
+type reloadOutcome int
+
+const (
+	// reloadApplied swapped the rules into the running lanes.
+	reloadApplied reloadOutcome = iota
+	// reloadRestart names drift a live process cannot absorb.
+	reloadRestart
+	// reloadRefused kept the running rules because the new document failed
+	// the same checks startup runs.
+	reloadRefused
+	// reloadUnchanged is a document this reloader already handled; nothing
+	// is re-run and nothing is re-logged.
+	reloadUnchanged
+	// reloadRetry kept the running rules over a failure that may clear
+	// without another edit, so the same document is retried next tick.
+	reloadRetry
+)
+
+// laneState is one config generation as the admin endpoints see it: the
+// lanes serving traffic and the generation they came from. Published
+// atomically so /config renders what the data path runs, never the startup
+// snapshot of a process that reloaded since (ADR-0014's admin consequence).
+type laneState struct {
+	lanes []lane
+	gen   int
+}
+
+// reloader holds what a running process needs to rebuild and swap lane
+// rules. Run assembles one when a control plane is connected; the heartbeat
+// owns it afterwards.
+type reloader struct {
+	// baseline is the running config's non-rule document. A fetched config
+	// whose non-rule document differs needs a restart.
+	baseline []byte
+	// piiRaw is the pii section the running detector was built from. The
+	// detector is rebuilt only when this drifts, never per reload: a
+	// rebuilt detector forces every masker and pii rule to swap, and most
+	// reloads touch neither.
+	piiRaw []byte
+	// laneDocs maps every lane to the resolved rule document it is
+	// serving. A lane whose document is unchanged is skipped, keeping its
+	// evaluator instances alive: analyzer call budgets, verdict caches and
+	// counters survive every reload that does not edit that lane's rules.
+	laneDocs map[string][]byte
+	// prevLanes keeps the lane structs the skipped lanes still serve, so a
+	// published generation renders the truth for swapped and kept lanes
+	// alike.
+	prevLanes map[string]lane
+	// servers maps relay lane names to their running servers, the swap
+	// targets.
+	servers map[string]*proxy.Server
+	// view is where an applied generation is published for the admin
+	// endpoints.
+	view *atomic.Pointer[laneState]
+
+	lic license.Status
+	det Plugin
+	// ac is the startup analyzer state, retained whole: the provider and
+	// its credential are restart-guarded, so a reload never rebuilds them.
+	// Only the redactor is replaced, and only when the detector changed.
+	ac    *analyzerDeps
+	build PluginBuilder
+
+	// lastHandled is the last document that reached a terminal outcome.
+	// Tracked apart from the fetch dedupe in the heartbeat on purpose: a
+	// retryable failure leaves it alone, so the same bytes run again next
+	// tick instead of waiting for another edit.
+	lastHandled []byte
+	gen         int
+}
+
+// newReloader captures the startup state handle compares against.
+func newReloader(cfg *Config, lanes []lane, servers map[string]*proxy.Server,
+	det Plugin, ac *analyzerDeps, view *atomic.Pointer[laneState]) (*reloader, error) {
+	baseline, err := nonRuleDoc(cfg)
+	if err != nil {
+		return nil, err
+	}
+	laneDocs := make(map[string][]byte, len(lanes))
+	prevLanes := make(map[string]lane, len(lanes))
+	for _, ln := range lanes {
+		doc, derr := laneRuleDoc(cfg, ln.cfg)
+		if derr != nil {
+			return nil, derr
+		}
+		laneDocs[ln.name] = doc
+		prevLanes[ln.name] = ln
+	}
+	return &reloader{
+		baseline:    baseline,
+		piiRaw:      cfg.PII,
+		laneDocs:    laneDocs,
+		prevLanes:   prevLanes,
+		servers:     servers,
+		view:        view,
+		lic:         cfg.lic,
+		det:         det,
+		ac:          ac,
+		build:       cfg.cp.build,
+		lastHandled: cfg.cp.lastRaw,
+	}, nil
+}
+
+// handle is the heartbeat's entry: it drops documents already handled and
+// remembers terminal outcomes, so one edit logs once while a retryable
+// failure runs again next tick.
+func (r *reloader) handle(log *slog.Logger, raw []byte) reloadOutcome {
+	if bytes.Equal(raw, r.lastHandled) {
+		return reloadUnchanged
+	}
+	out := r.apply(log, raw)
+	if out != reloadRetry {
+		r.lastHandled = raw
+	}
+	return out
+}
+
+// apply decides what a drifted document means for the running process and
+// swaps it in when it can. Every refusal runs the same checks startup runs
+// (LoadConfigBytes, the caps in buildLanes), so a config startup would
+// refuse is refused here with the same message; the heartbeat must never be
+// a side door past validation.
+func (r *reloader) apply(log *slog.Logger, raw []byte) reloadOutcome {
+	newCfg, err := LoadConfigBytes(raw)
+	if err != nil {
+		log.Warn("the control plane sent a config this build refuses; keeping the running rules",
+			"error", err)
+		return reloadRefused
+	}
+
+	doc, err := nonRuleDoc(newCfg)
+	if err != nil {
+		// A marshal failure here is internal, not a fact about the
+		// document; retrying costs one compare and may clear.
+		log.Warn("config compare failed; keeping the running rules", "error", err)
+		return reloadRetry
+	}
+	if !bytes.Equal(doc, r.baseline) {
+		log.Warn("the control plane configuration changed beyond the rules; restart to apply it")
+		return reloadRestart
+	}
+
+	det, detChanged := r.det, false
+	if !bytes.Equal(bytes.TrimSpace(r.piiRaw), bytes.TrimSpace(newCfg.PII)) {
+		if r.build == nil {
+			log.Warn("the pii section changed and this build retained no detector builder; restart to apply it")
+			return reloadRestart
+		}
+		det, err = r.build(newCfg.PII)
+		if err != nil {
+			log.Warn("detector rebuild failed; keeping the running rules", "error", err)
+			return reloadRefused
+		}
+		detChanged = true
+		if r.ac != nil {
+			// The provider and its credential stay: the analyzer section
+			// is inside the baseline. Only the redactor holds the
+			// detector, so only it follows the rebuild.
+			r.ac.redact = redactorFor(r.ac.cfg.Send, det)
+		}
+	}
+
+	newCfg.lic = r.lic
+	lanes, err := buildLanes(newCfg, det, r.ac)
+	if err != nil {
+		log.Warn("the control plane sent a config the rules or the caps refuse; keeping the running rules",
+			"error", err)
+		return reloadRefused
+	}
+
+	swapped, kept := 0, 0
+	viewLanes := make([]lane, 0, len(lanes))
+	for _, ln := range lanes {
+		doc, derr := laneRuleDoc(newCfg, ln.cfg)
+		if derr != nil {
+			log.Warn("lane compare failed; keeping the running rules",
+				"listener", ln.name, "error", derr)
+			return reloadRetry
+		}
+		if isGRPC(ln.cfg) {
+			// gRPC lanes stay on the restart path (ADR-0014); drift is
+			// reported, never swapped, and the view keeps the serving lane.
+			if !bytes.Equal(doc, r.laneDocs[ln.name]) {
+				log.Warn("grpc lane rules changed on the control plane; restart to apply them",
+					"listener", ln.name)
+			}
+			viewLanes = append(viewLanes, r.prevLanes[ln.name])
+			continue
+		}
+		if !detChanged && bytes.Equal(doc, r.laneDocs[ln.name]) {
+			// This lane's rules did not move, so its running evaluators
+			// keep serving: analyzer call budgets, verdict caches and
+			// per-rule counters survive the reload. Only an edit to THIS
+			// lane's rules re-arms them.
+			viewLanes = append(viewLanes, r.prevLanes[ln.name])
+			kept++
+			continue
+		}
+		srv, ok := r.servers[ln.name]
+		if !ok {
+			// The baseline compare guarantees the same listener set, so a
+			// miss is a bug worth a line, not a silent skip.
+			log.Warn("no running server for a reloaded lane", "listener", ln.name)
+			continue
+		}
+		srv.SwapRules(ln.policy, ln.masker)
+		r.laneDocs[ln.name] = doc
+		r.prevLanes[ln.name] = ln
+		viewLanes = append(viewLanes, ln)
+		swapped++
+	}
+
+	r.det = det
+	r.piiRaw = newCfg.PII
+	r.gen++
+	r.view.Store(&laneState{lanes: viewLanes, gen: r.gen})
+	log.Info("control plane configuration applied",
+		"generation", r.gen, "swapped", swapped, "kept", kept)
+	return reloadApplied
+}
+
+// nonRuleDoc renders everything a hot swap cannot change: the config with
+// every rule-bearing section removed. Two configs with equal documents
+// differ in rules alone.
+//
+// A JSON render rather than a field-by-field compare, so a new Config field
+// is restart-guarded by default; forgetting it here fails safe.
+func nonRuleDoc(c *Config) ([]byte, error) {
+	cp := *c
+	cp.Guardrails, cp.OPA, cp.Mask, cp.Policy = nil, nil, nil, nil
+	cp.PII = nil
+	// The running config carries the resolved URL and the file's license
+	// reference; the fetched one carries neither. Neither is a lane fact.
+	cp.License = ""
+	cp.ControlPlaneURL = ""
+	listeners := make([]ListenerConfig, len(c.Listeners))
+	for i, lc := range c.Listeners {
+		lc.Guardrails, lc.OPA, lc.Mask, lc.Policy = nil, nil, nil, nil
+		listeners[i] = lc
+	}
+	cp.Listeners = listeners
+	return json.Marshal(&cp)
+}
+
+// laneRuleDoc renders one listener's RESOLVED rule stack: the skip decision
+// per lane, and the drift report on grpc lanes.
+func laneRuleDoc(c *Config, lc ListenerConfig) ([]byte, error) {
+	gc, opa, mc := c.resolve(lc)
+	return json.Marshal(struct {
+		G GuardrailsConfig `json:"g"`
+		O *OPAConfig       `json:"o"`
+		M MaskConfig       `json:"m"`
+	}{gc, opa, mc})
+}

--- a/sidecar/daemon/reload_test.go
+++ b/sidecar/daemon/reload_test.go
@@ -1,0 +1,270 @@
+package daemon
+
+import (
+	"bytes"
+	"log/slog"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/proxy"
+)
+
+// reloadBase is the running config every reload test starts from: one
+// postgres lane with one guardrail rule, the shape the gateway emits.
+const reloadBase = `{
+  "listeners": [{
+    "name": "appdb", "protocol": "postgres",
+    "listen": "127.0.0.1:0", "upstream": "h:5432",
+    "guardrails": {"mode": "enforce", "rules": [
+      {"name": "r0", "type": "deny_words_list", "words": ["drop table"]}
+    ]}
+  }],
+  "audit": {"file": "-"},
+  "log_level": "info"
+}`
+
+// editJSON applies a crude replacement so each case states only its drift.
+func editJSON(t *testing.T, doc, old, new string) string {
+	t.Helper()
+	if !strings.Contains(doc, old) {
+		t.Fatalf("test bug: %q not in the base document", old)
+	}
+	return strings.Replace(doc, old, new, 1)
+}
+
+// testReloader builds a reloader over a running-shaped config, with a real
+// (unserved) proxy.Server per relay lane so a swap has a target. It returns
+// the log buffer; startupLanes are reachable through rl.prevLanes.
+func testReloader(t *testing.T, raw string) (*reloader, *bytes.Buffer) {
+	t.Helper()
+	cfg, err := LoadConfigBytes([]byte(raw))
+	if err != nil {
+		t.Fatalf("LoadConfigBytes: %v", err)
+	}
+	cfg.cp = &controlPlane{url: "http://plane", token: "hsc_x", lastRaw: []byte(raw)}
+
+	lanes, err := buildLanes(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildLanes: %v", err)
+	}
+	servers := map[string]*proxy.Server{}
+	for _, ln := range lanes {
+		if isGRPC(ln.cfg) {
+			continue
+		}
+		srv, serr := buildServer(ln, cfg.Audit, nil, slog.Default())
+		if serr != nil {
+			t.Fatalf("buildServer: %v", serr)
+		}
+		servers[ln.name] = srv
+	}
+	view := &atomic.Pointer[laneState]{}
+	view.Store(&laneState{lanes: lanes})
+	rl, err := newReloader(cfg, lanes, servers, nil, nil, view)
+	if err != nil {
+		t.Fatalf("newReloader: %v", err)
+	}
+	var buf bytes.Buffer
+	return rl, &buf
+}
+
+func applyWith(rl *reloader, buf *bytes.Buffer, raw string) reloadOutcome {
+	log := slog.New(slog.NewTextHandler(buf, nil))
+	return rl.apply(log, []byte(raw))
+}
+
+func handleWith(rl *reloader, buf *bytes.Buffer, raw string) reloadOutcome {
+	log := slog.New(slog.NewTextHandler(buf, nil))
+	return rl.handle(log, []byte(raw))
+}
+
+func TestARuleOnlyDriftIsApplied(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	if got := applyWith(rl, buf, drifted); got != reloadApplied {
+		t.Fatalf("outcome = %v, want applied; log:\n%s", got, buf)
+	}
+	if !strings.Contains(buf.String(), "configuration applied") {
+		t.Errorf("no applied log line:\n%s", buf)
+	}
+	if rl.gen != 1 {
+		t.Errorf("generation = %d, want 1", rl.gen)
+	}
+}
+
+// The generation advances per applied reload, so an operator can match a log
+// line to the config edit that produced it.
+func TestEachAppliedReloadAdvancesTheGeneration(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	first := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	second := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["delete from"]`)
+	applyWith(rl, buf, first)
+	applyWith(rl, buf, second)
+	if rl.gen != 2 {
+		t.Fatalf("generation = %d, want 2", rl.gen)
+	}
+}
+
+func TestATopologyDriftKeepsTheRestartPath(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase, `"upstream": "h:5432"`, `"upstream": "other:5432"`)
+	if got := applyWith(rl, buf, drifted); got != reloadRestart {
+		t.Fatalf("outcome = %v, want restart; log:\n%s", got, buf)
+	}
+	if !strings.Contains(buf.String(), "restart to apply it") {
+		t.Errorf("no restart log line:\n%s", buf)
+	}
+}
+
+// An added listener is topology, not rules: sockets would have to bind.
+func TestAnAddedListenerKeepsTheRestartPath(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase, `"listeners": [{`,
+		`"listeners": [{"name": "second", "protocol": "postgres", "listen": "127.0.0.1:1", "upstream": "h2:5432"}, {`)
+	if got := applyWith(rl, buf, drifted); got != reloadRestart {
+		t.Fatalf("outcome = %v, want restart; log:\n%s", got, buf)
+	}
+}
+
+// A document startup would refuse is refused on reload with the running
+// rules kept: the heartbeat must never be a side door past validation.
+func TestABrokenDocumentIsRefused(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	if got := applyWith(rl, buf, `{"listeners": [{"protocol": "nope"}]}`); got != reloadRefused {
+		t.Fatalf("outcome = %v, want refused; log:\n%s", got, buf)
+	}
+}
+
+// The caps bind on reload exactly as at startup: this process runs the free
+// tier, and the plane sending two guardrail rules must not lift it.
+func TestAnOverCapReloadIsRefused(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase,
+		`{"name": "r0", "type": "deny_words_list", "words": ["drop table"]}`,
+		`{"name": "r0", "type": "deny_words_list", "words": ["drop table"]},
+		 {"name": "r1", "type": "deny_words_list", "words": ["truncate"]}`)
+	if got := applyWith(rl, buf, drifted); got != reloadRefused {
+		t.Fatalf("outcome = %v, want refused; log:\n%s", got, buf)
+	}
+	if !strings.Contains(buf.String(), "keeping the running rules") {
+		t.Errorf("the refusal does not say the running rules survive:\n%s", buf)
+	}
+}
+
+// Without a retained detector builder, a pii drift cannot be swapped: the
+// running detector was built from the old section.
+func TestAPIIDriftWithoutABuilderKeepsTheRestartPath(t *testing.T) {
+	base := editJSON(t, reloadBase, `"log_level": "info"`,
+		`"log_level": "info", "pii": {"entities": ["EMAIL_ADDRESS"]}`)
+	// A pii section needs a detector at Run time, but the reloader only
+	// compares bytes when no builder exists; det stays nil in this harness.
+	rl, buf := testReloader(t, base)
+
+	drifted := editJSON(t, base, `["EMAIL_ADDRESS"]`, `["CREDIT_CARD"]`)
+	if got := applyWith(rl, buf, drifted); got != reloadRestart {
+		t.Fatalf("outcome = %v, want restart; log:\n%s", got, buf)
+	}
+	if !strings.Contains(buf.String(), "no detector builder") {
+		t.Errorf("the log does not name the missing builder:\n%s", buf)
+	}
+}
+
+// A reload that changes nothing but rules back and forth still applies: the
+// swap is idempotent and cheap, and refusing a revert would strand a fleet
+// on an edit the operator undid.
+func TestARevertToTheBaselineRulesStillApplies(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	applyWith(rl, buf, drifted)
+	if got := applyWith(rl, buf, reloadBase); got != reloadApplied {
+		t.Fatalf("outcome = %v, want applied; log:\n%s", got, buf)
+	}
+}
+
+func TestNonRuleDocIgnoresEveryRuleSection(t *testing.T) {
+	a, err := LoadConfigBytes([]byte(reloadBase))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := LoadConfigBytes([]byte(editJSON(t, reloadBase,
+		`"words": ["drop table"]`, `"words": ["truncate"]`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	docA, errA := nonRuleDoc(a)
+	docB, errB := nonRuleDoc(b)
+	if errA != nil || errB != nil {
+		t.Fatalf("nonRuleDoc: %v, %v", errA, errB)
+	}
+	if !bytes.Equal(docA, docB) {
+		t.Fatalf("rule drift leaked into the non-rule document:\n%s\n%s", docA, docB)
+	}
+}
+
+// A two-lane config where only one lane's rules drift: the untouched lane
+// keeps its RUNNING evaluator instances, so analyzer call budgets, verdict
+// caches and counters survive reloads that never edited it. The free tier
+// allows one guardrail rule per process, so lane A carries it and lane B
+// consults OPA, which gives B a non-nil evaluator without touching a cap.
+const twoLaneBase = `{
+  "listeners": [
+    {"name": "appdb", "protocol": "postgres",
+     "listen": "127.0.0.1:0", "upstream": "h:5432",
+     "guardrails": {"mode": "enforce", "rules": [
+       {"name": "r0", "type": "deny_words_list", "words": ["drop table"]}
+     ]}},
+    {"name": "webdb", "protocol": "postgres",
+     "listen": "127.0.0.1:1", "upstream": "h2:5432",
+     "opa": {"url": "http://opa.local/v1/data/hoop/allow"}}
+  ],
+  "audit": {"file": "-"},
+  "log_level": "info"
+}`
+
+func TestAnUntouchedLaneKeepsItsRunningEvaluators(t *testing.T) {
+	rl, buf := testReloader(t, twoLaneBase)
+	before, ok := rl.prevLanes["webdb"]
+	if !ok {
+		t.Fatal("test bug: no webdb lane")
+	}
+	if before.policy == nil {
+		t.Fatal("test bug: webdb built no evaluator, identity would compare nil to nil")
+	}
+
+	drifted := editJSON(t, twoLaneBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	if got := handleWith(rl, buf, drifted); got != reloadApplied {
+		t.Fatalf("outcome = %v, want applied; log:\n%s", got, buf)
+	}
+
+	st := rl.view.Load()
+	if st.gen != 1 {
+		t.Fatalf("published generation = %d, want 1", st.gen)
+	}
+	var after *lane
+	for i := range st.lanes {
+		if st.lanes[i].name == "webdb" {
+			after = &st.lanes[i]
+		}
+	}
+	if after == nil {
+		t.Fatal("webdb missing from the published generation")
+	}
+	// Instance identity, not equality: a policy.Chain is a slice, so the
+	// underlying data pointer is what proves the running evaluator (and
+	// its budgets and counters) kept serving.
+	if reflect.ValueOf(after.policy).Pointer() != reflect.ValueOf(before.policy).Pointer() {
+		t.Error("webdb's evaluator was rebuilt by a drift that never touched it")
+	}
+	if !strings.Contains(buf.String(), "kept=1") {
+		t.Errorf("the applied line does not count the kept lane:\n%s", buf)
+	}
+}

--- a/sidecar/proxy/proxy.go
+++ b/sidecar/proxy/proxy.go
@@ -134,11 +134,25 @@ type Config struct {
 	Logger *slog.Logger
 }
 
+// laneRules bundles the enforcement facts a connection captures at accept
+// time, so a swap replaces them as one unit: a policy from one config
+// generation must never run beside a masker from another.
+type laneRules struct {
+	policy policy.Evaluator
+	masker gate.Masker
+}
+
 // Server accepts connections and relays them through a Gate.
 type Server struct {
 	cfg      Config
 	log      *slog.Logger
 	listener net.Listener
+
+	// rules is what handle reads instead of cfg.Policy/cfg.Masker, so a
+	// config reload can replace both without a restart. Loaded once per
+	// accepted connection: the Gate keeps what it captured, which is what
+	// makes a swap safe under live traffic.
+	rules atomic.Pointer[laneRules]
 
 	mu      sync.Mutex
 	conns   map[net.Conn]struct{}
@@ -175,11 +189,25 @@ func NewServer(cfg Config) (*Server, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
-	return &Server{
+	s := &Server{
 		cfg:   cfg,
 		log:   cfg.Logger,
 		conns: map[net.Conn]struct{}{},
-	}, nil
+	}
+	s.rules.Store(&laneRules{policy: cfg.Policy, masker: cfg.Masker})
+	return s, nil
+}
+
+// SwapRules replaces the policy evaluator and masker for every connection
+// accepted from now on. Connections already open keep the Gate they
+// captured at accept time and drain under the rules they started with;
+// nothing rebinds and nothing closes.
+//
+// This is the seam a control-plane config reload swaps through. Both fields
+// travel together on purpose: rules and masking come from one config
+// document, and mixing generations would enforce a config nobody wrote.
+func (s *Server) SwapRules(pol policy.Evaluator, masker gate.Masker) {
+	s.rules.Store(&laneRules{policy: pol, masker: masker})
 }
 
 // reclaimStaleSocket removes a leftover unix socket file so a restart can
@@ -270,9 +298,14 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 
 		s.track(conn)
+		// The rule generation is pinned HERE, at the accept boundary, not
+		// in the asynchronously scheduled handler: a swap landing between
+		// accept and the goroutine running must not blur which side of it
+		// this connection is on.
+		rules := s.rules.Load()
 		go func() {
 			defer s.untrack(conn)
-			s.handle(ctx, conn)
+			s.handle(ctx, conn, rules)
 		}()
 	}
 }
@@ -332,8 +365,9 @@ func (s *Server) untrack(c net.Conn) {
 	_ = c.Close()
 }
 
-// handle relays one connection.
-func (s *Server) handle(ctx context.Context, client net.Conn) {
+// handle relays one connection under rules, the immutable generation Serve
+// pinned at the accept boundary.
+func (s *Server) handle(ctx context.Context, client net.Conn, rules *laneRules) {
 	identity := session.Identity{PeerAddr: client.RemoteAddr().String()}
 	if s.cfg.IdentityFn != nil {
 		identity = s.cfg.IdentityFn(client)
@@ -350,9 +384,9 @@ func (s *Server) handle(ctx context.Context, client net.Conn) {
 
 	g, err := gate.New(sess, gate.Config{
 		Protocol:         s.cfg.Protocol,
-		Policy:           s.cfg.Policy,
+		Policy:           rules.policy,
 		Audit:            s.cfg.Audit,
-		Masker:           s.cfg.Masker,
+		Masker:           rules.masker,
 		FailOnAuditError: s.cfg.FailOnAuditError,
 		CodecFactory:     s.cfg.CodecFactory,
 	})

--- a/sidecar/proxy/swap_test.go
+++ b/sidecar/proxy/swap_test.go
@@ -1,0 +1,44 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/inspect"
+	"github.com/hoophq/hoop/sidecar/policy"
+)
+
+type stubEval struct{ name string }
+
+func (s stubEval) Evaluate(inspect.Statement) policy.Verdict { return policy.Verdict{} }
+
+// A connection captures the rules current at accept time, so the swap
+// contract is entirely in the pointer: what Load returns after SwapRules is
+// what the next accepted connection's Gate runs.
+func TestSwapRulesReplacesWhatTheNextConnectionCaptures(t *testing.T) {
+	before := stubEval{name: "before"}
+	s, err := NewServer(Config{
+		Listen:   "127.0.0.1:0",
+		Upstream: "h:5432",
+		Protocol: inspect.Postgres,
+		Policy:   before,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	got := s.rules.Load()
+	if got.policy != policy.Evaluator(before) {
+		t.Fatalf("the seeded policy is not what NewServer was given")
+	}
+
+	after := stubEval{name: "after"}
+	s.SwapRules(after, nil)
+
+	got = s.rules.Load()
+	if got.policy != policy.Evaluator(after) {
+		t.Fatalf("SwapRules did not replace the policy")
+	}
+	if got.masker != nil {
+		t.Fatalf("SwapRules kept a masker the new generation does not carry")
+	}
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

<!-- label: minor -->

## 📝 Description

Connects the sidecar to the Control Plane. A sidecar can now fetch its whole running config from the plane's `POST /api/sidecars/handshake` endpoint instead of carrying its own listeners in the config file:

- New config key `control_plane_url` (top-level, optional). Omitted = standalone, byte-for-byte today's behavior.
- New env var `HOOP_CONTROL_PLANE_URL`, which outranks the config key (same precedence pattern as `HOOP_LICENSE` over the `license` key).
- New `--token` flag on `hoop start sidecar` (and `-token` on the standalone `hoop-inspect` binary) carrying the `hsc_` bearer token; new env var `HOOP_SIDECAR_TOKEN` as its fallback. Flag outranks env. No config key for the token on purpose.
- "First wins, not first valid": a set-but-broken source errors instead of falling through, matching the license sources.
- When a plane is configured: `--config` becomes optional, the handshake answer becomes the running config (same strict decoder as the file path), and a file that also declares listeners is refused. URL without token and token without URL both stop startup with errors naming the fix.
- A heartbeat re-runs the handshake every minute: keeps the plane's `last_seen`/version fresh, logs `restart to apply it` when the config changed there, and keeps serving the last good config when the plane is unreachable.

## 📣 User-facing impact

Sidecars can now be managed from the Control Plane: register a sidecar, assign connections to it, and start it anywhere with just `HOOP_CONTROL_PLANE_URL` and its token — no local config file to maintain.

## 🔗 Related Issue

Fixes DEP-197

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- `sidecar/daemon/config.go`: `Config.ControlPlaneURL` (`control_plane_url`); `Validate` allows zero listeners only when a plane is configured.
- `sidecar/daemon/controlplane.go` (new): source resolution (URL: env > key; token: flag > env), handshake client with per-status errors (401/422/other), `WithControlPlaneToken` option, heartbeat with change detection.
- `sidecar/daemon/daemon.go`: `SetupWith` routes through the config-source resolution; `Main` gains `-token` and relaxes `-config` when `HOOP_CONTROL_PLANE_URL` is set; `Run` starts the heartbeat on the shutdown context.
- `client/cmd/startsidecar.go`: `--token` flag, relaxed `--config` requirement, help text.
- `sidecar/daemon/controlplane_test.go` (new): 14 tests covering precedence, no-fall-through, conflicts, error texts, and heartbeat change detection.
- `sidecar/README.md`: "Connecting it to a Control Plane" section and `control_plane_url` in the annotated example.

## 🧪 Testing

### How to test

**Setup** (gateway as control plane + CLI, per `DEV.md`):

```bash
make run-dev          # gateway with API on :8009
export API=http://127.0.0.1:8009
export JWT=<admin token>
```

**Steps**

1. Register a sidecar and capture the token (shown only once):
   ```bash
   curl -s -X POST $API/api/sidecars -H "Authorization: Bearer $JWT" \
     -H 'Content-Type: application/json' -d '{"name":"qa-sidecar"}'
   ```
   **Expected**: `201` with `"token": "hsc_..."`.
2. Assign a postgres connection to it (set `sidecar_id` on the connection via API/UI), then validate without any config file:
   ```bash
   HOOP_CONTROL_PLANE_URL=$API hoop start sidecar --token hsc_... --validate
   ```
   **Expected**: `config OK: 1 listener(s)` with one lane per assigned connection.
3. Run it: `HOOP_CONTROL_PLANE_URL=$API hoop start sidecar --token hsc_...`
   **Expected** startup log: `control plane connected url=... source=HOOP_CONTROL_PLANE_URL poll=1m0s`, then `lane ready` per connection. `GET /api/sidecars/qa-sidecar` now reports `version` and `last_seen_at`.
4. Edit a guardrail rule attached to the assigned connection.
   **Expected** within ~1 minute: `WARN the control plane configuration changed; restart to apply it`.
5. Config-file spelling: a file containing only `control_plane_url: http://127.0.0.1:8009` plus `--token` behaves identically to step 3, with `source="the \"control_plane_url\" config key"`.

**Negative paths**

- Wrong token → `the control plane at ... rejected the token`, exit 1.
- URL set, no token → `a control plane is configured (...) but no token was given; pass the token flag or set HOOP_SIDECAR_TOKEN`.
- `HOOP_SIDECAR_TOKEN` set with no URL anywhere → startup error naming the orphan token.
- A config file with listeners plus a plane URL → refused, error names the listener count and the URL source.
- Stop the gateway while the sidecar runs → `WARN control plane handshake failed; serving the last good config`, lanes keep serving.

**Regression check**

- Standalone is untouched: `hoop start sidecar --config config.yaml --validate` with a listener-carrying file works with no plane env vars set.
- `cd sidecar && go test ./...` — full module green.

### Test Configuration:
- **Browser(s)**: n/a (CLI/daemon)
- **OS**: macOS 15 arm64 (darwin/arm64)

### Tests performed:
- [x] Unit tests pass (`go test ./sidecar/daemon` — 14 new tests; full sidecar module green)
- [x] Integration tests pass (`client/cmd`, `gateway/services` suites; sidecar e2e in module run)
- [x] Manual testing completed (live run against a handshake server: startup fetch, 401, missing token, conflict, heartbeat change detection one tick after an edit)

## 📸 Screenshots (if applicable)

n/a

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- A changed plane config is logged, not hot-applied: listeners can appear/disappear between fetches and rebinding ports under live connections is a restart's job. Follow-up if we want live reload.
- The plane sends no license yet; the file's `license` key keeps its precedence slot in plane mode, and `Config.UseLicense` remains the seam for a plane-delivered license.
- Reviewers: `resolveConfigSource` in `sidecar/daemon/controlplane.go` holds every precedence/conflict decision — that's the file to read first.

---

<!-- Thank you for contributing to our project! 🙏 -->
