### PR TITLE
feat(sidecar):  hot reload configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -123,3 +123,10 @@ HOOP_RS_BUILD=false
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
+# Sidecar -> Control Plane connection (hoop start sidecar).
+# HOOP_CONTROL_PLANE_URL outranks the config file's control_plane_url key;
+# the sidecar then fetches its whole config from the control plane.
+HOOP_CONTROL_PLANE_URL=
+# The token shown once when the sidecar is registered (POST /api/sidecars).
+# The --token flag outranks this. The value is the token itself, never a path.
+HOOP_SIDECAR_TOKEN=

--- a/docs/adr/0014-sidecar-config-hot-reload.md
+++ b/docs/adr/0014-sidecar-config-hot-reload.md
@@ -154,6 +154,11 @@ generation is active, or an operator debugging "why did this not deny"
 reads rules a draining connection no longer runs. Session audit events need
 nothing: each Gate already records what it enforced.
 
+Two generations must also never mean two budgets: an analyzer rule's
+call counter is a per-rule cell that outlives its evaluators, so a draining
+generation and its replacement pay `max_calls` from one purse. A rebuilt
+evaluator continues the count; only a renamed rule starts a new one.
+
 Committed: the reload pipeline and the startup pipeline stay one code path.
 A config startup would refuse, reload refuses for the same reason with the
 same message. The moment those diverge, the heartbeat becomes a side door

--- a/docs/adr/0014-sidecar-config-hot-reload.md
+++ b/docs/adr/0014-sidecar-config-hot-reload.md
@@ -1,0 +1,127 @@
+# ADR-0014: Sidecar config hot reload for rule-only drift
+
+- **Status:** Proposed
+- **Date:** 2026-09-08
+- **Author:** @matheusfrancisco
+- **Deciders:** TBD
+- **Supersedes / Superseded by:** —
+
+## Context
+
+A sidecar connected to the Control Plane (DEP-197) fetches its whole config
+from `POST /api/sidecars/handshake` at startup and re-runs the handshake
+every minute as a heartbeat. The gateway rebuilds the document from the
+database on every call, so a guardrail or masking rule edited in the UI is
+in the next answer. The gateway also serves `GET /sidecars/configuration`:
+the same document under the same `hoop-sidecar-token` auth, with no side
+effects, so a poll never overwrites the version and last-seen the sidecar
+reported at its last handshake.
+
+Today the sidecar only logs the drift: `the control plane configuration
+changed; restart to apply it`. A restart closes every live client
+connection. For a fleet where rule edits are routine, each edit costs
+either an outage window per sidecar or an unbounded delay until someone
+restarts it. The sidecar fronts databases; its clients hold long-lived
+connections (`psql`, connection pools) that reconnect on their own
+schedule.
+
+Two facts about the daemon constrain the design:
+
+1. `proxy.Server.handle` captures `Policy` and `Masker` once per accepted
+   connection, into that connection's Gate (`sidecar/proxy/proxy.go:351`).
+   Nothing on the statement path reads them from shared state.
+2. Listener topology (bind address, upstream, protocol, TLS posture) is
+   bound at startup. Changing it means closing and opening sockets under
+   live traffic.
+
+Config drift therefore splits into two classes: rule content changed
+(guardrails, masking, pii narrowing, OPA endpoints) with the listener set
+identical, and topology changed (a listener added, removed, or re-pointed).
+
+Related constraints:
+
+- `buildLanes` enforces the license caps at startup. Any reload path that
+  skips it turns the heartbeat into a cap bypass.
+- The PII detector is built by the entry points (`PluginBuilder`) and handed
+  to `Run` ready-made; the daemon cannot rebuild it today.
+- gRPC lanes (ADR-0013) receive their evaluator and masker through
+  `buildGRPCServer`'s callback injection, a different seam from relay lanes.
+
+## Options considered
+
+1. **Restart-only (status quo).** The heartbeat logs, an operator or a
+   container restart policy applies. Simple, already shipped. Loses live
+   connections on every rule edit and leaves a window where the fleet
+   enforces stale rules for as long as restarts take.
+2. **Full hot reload, topology included.** Rebind listeners, drain removed
+   lanes, dial new upstreams in place. Handles every drift, and is the only
+   option that never needs a restart. Loses to complexity: port rebinding
+   races, a drain policy for removed lanes, and failure states where half
+   the new topology is live. The rare event (topology change) would carry
+   the risk for the common one (rule edit).
+3. **Rule-only hot swap behind a topology guard.** When the listener
+   identity set is unchanged, rebuild each lane's evaluator and masker from
+   the fetched config and swap them atomically; existing connections keep
+   the Gate they started with, new connections get the new rules. Any
+   topology difference keeps today's restart log. Covers the common case
+   with a small, bounded change; the capture-at-accept design in fact (1)
+   makes the swap point one field.
+
+## Decision
+
+We will implement option 3, in stages:
+
+1. **Poll endpoint** (shipped with this ADR's PR): `GET
+   /sidecars/configuration` on the gateway, sharing `respondConfig` with the
+   handshake so the two answers cannot drift.
+2. **Swap point:** `proxy.Server` holds `{Policy, Masker, FailOnAuditError}`
+   in an `atomic.Pointer`, loaded once per accepted connection. The current
+   unsynchronized `s.cfg.Policy` read becomes the pointer load; nothing else
+   on the accept path changes.
+3. **Reload in the heartbeat:** on drift, run the fetched config through the
+   same pipeline startup uses — `LoadConfigBytes`, per-listener `resolve`,
+   `buildPolicy`, masker build, and the license cap checks in `buildLanes`.
+   A config the caps refuse is logged and not applied, the same verdict
+   startup would reach. Lanes match by listener name; the topology guard
+   compares `name`, `protocol`, `network`, `listen`, `upstream`, and both
+   TLS blocks. Any mismatch, addition, or removal falls back to the restart
+   log.
+4. **Detector rebuild:** the entry points pass their `PluginBuilder` into
+   setup as a new `Option`, so a changed `pii` section rebuilds the detector
+   the way startup would. Without the option, a `pii` or `mask` drift falls
+   back to the restart log rather than swapping rules the old detector
+   cannot serve.
+5. **gRPC lanes stay on the restart path** in this iteration, with a log
+   line saying so. Their swap needs its own seam through the ADR-0013
+   callback injection and earns its own change.
+
+Swap semantics are connection-granular: a connection opened before the swap
+keeps the rules it started with until it closes; every connection accepted
+after the swap runs the new rules. Statement-granular semantics (a live
+session picks up new rules on its next statement) move the atomic load into
+the Gate's per-statement path and are deferred until connection-granular
+proves itself in the field.
+
+## Consequences
+
+Easier: a rule edited in the UI reaches every connected sidecar within one
+heartbeat, with zero dropped connections. Fleet-wide policy changes stop
+being restart campaigns.
+
+Harder: one process can run two rule generations at once, old Gates beside
+new ones. The admin `/config` and `/stats` endpoints must say which config
+generation is active, or an operator debugging "why did this not deny"
+reads rules a draining connection no longer runs. Session audit events need
+nothing: each Gate already records what it enforced.
+
+Committed: the reload pipeline and the startup pipeline stay one code path.
+A config startup would refuse, reload refuses for the same reason with the
+same message. The moment those diverge, the heartbeat becomes a side door
+past validation and the caps.
+
+Revisit if topology drift turns out to be common (connections re-pointed at
+new hosts as a matter of routine). That is option 2's territory: listener
+rebinding with a drain policy, and this ADR's guard becomes the fallback
+rather than the boundary. Revisit the connection-granular choice if
+customers expect an edited deny rule to bind existing sessions; that is the
+statement-granular follow-up, not a reason to hold this stage.

--- a/docs/adr/0014-sidecar-config-hot-reload.md
+++ b/docs/adr/0014-sidecar-config-hot-reload.md
@@ -86,11 +86,12 @@ We will implement option 3, in stages:
    compares `name`, `protocol`, `network`, `listen`, `upstream`, and both
    TLS blocks. Any mismatch, addition, or removal falls back to the restart
    log.
-4. **Detector rebuild:** the entry points pass their `PluginBuilder` into
-   setup as a new `Option`, so a changed `pii` section rebuilds the detector
-   the way startup would. Without the option, a `pii` or `mask` drift falls
-   back to the restart log rather than swapping rules the old detector
-   cannot serve.
+4. **Detector rebuild:** `SetupWith` already receives the entry point's
+   `PluginBuilder`; the control-plane state retains it for the reloader, so
+   a changed `pii` section rebuilds the detector the way startup would. A
+   caller that passed no builder keeps a drifted `pii` section on the
+   restart path rather than swapping in rules the old detector cannot
+   serve.
 5. **gRPC lanes stay on the restart path** in this iteration, with a log
    line saying so. Their swap needs its own seam through the ADR-0013
    callback injection and earns its own change.
@@ -101,6 +102,45 @@ after the swap runs the new rules. Statement-granular semantics (a live
 session picks up new rules on its next statement) move the atomic load into
 the Gate's per-statement path and are deferred until connection-granular
 proves itself in the field.
+
+The heartbeat's decision per fetched document:
+
+```mermaid
+flowchart TD
+    HB[heartbeat tick:<br/>POST /api/sidecars/handshake] --> CMP{bytes differ from<br/>running config?}
+    CMP -- no --> HB
+    CMP -- yes --> LOAD[LoadConfigBytes:<br/>strict decode + Validate]
+    LOAD -- refused --> KEEP[warn, keep running rules]
+    LOAD -- ok --> GUARD{non-rule doc identical?<br/>listeners, audit, admin,<br/>log_level, analyzer}
+    GUARD -- no --> RESTART[warn: restart to apply it]
+    GUARD -- yes --> DET{pii drifted?}
+    DET -- "builder retained" --> REBUILD[rebuild detector<br/>+ analyzer deps]
+    DET -- "no builder" --> RESTART
+    DET -- unchanged --> LANES
+    REBUILD --> LANES[buildLanes:<br/>caps + policy + masker,<br/>same path as startup]
+    LANES -- refused --> KEEP
+    LANES -- ok --> SWAP[atomic SwapRules<br/>per relay lane]
+    SWAP --> GRPC[grpc lanes with drifted rules:<br/>warn, restart path]
+```
+
+What each connection runs across a swap:
+
+```mermaid
+sequenceDiagram
+    participant A as psql (opened before swap)
+    participant S as proxy.Server
+    participant B as psql (opened after swap)
+    Note over S: rules v1
+    A->>S: connect
+    S->>A: Gate captures rules v1
+    Note over S: heartbeat swaps to rules v2
+    B->>S: connect
+    S->>B: Gate captures rules v2
+    A->>S: statement
+    Note over A,S: still evaluated under v1<br/>until this session closes
+    B->>S: statement
+    Note over B,S: evaluated under v2
+```
 
 ## Consequences
 

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -9972,6 +9972,54 @@ const docTemplate = `{
                 }
             }
         },
+        "/sidecars/configuration": {
+            "get": {
+                "description": "Authenticated with the hoop-sidecar-token header. Returns the configuration the sidecar must serve, rebuilt from the connections assigned to it. Unlike the handshake it records nothing, so a poll never overwrites what the sidecar last reported about itself.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sidecars"
+                ],
+                "summary": "Sidecar Configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The token returned when the sidecar was created",
+                        "name": "hoop-sidecar-token",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/sidecars/handshake": {
             "post": {
                 "description": "Authenticated with the hoop-sidecar-token header. Records the reported version and returns the configuration the sidecar must serve.",

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -21658,6 +21658,69 @@
         ]
       }
     },
+    "/sidecars/configuration": {
+      "get": {
+        "description": "Authenticated with the hoop-sidecar-token header. Returns the configuration the sidecar must serve, rebuilt from the connections assigned to it. Unlike the handshake it records nothing, so a poll never overwrites what the sidecar last reported about itself.",
+        "parameters": [
+          {
+            "description": "The token returned when the sidecar was created",
+            "in": "header",
+            "name": "hoop-sidecar-token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Sidecar Configuration",
+        "tags": [
+          "Sidecars"
+        ]
+      }
+    },
     "/sidecars/handshake": {
       "post": {
         "description": "Authenticated with the hoop-sidecar-token header. Records the reported version and returns the configuration the sidecar must serve.",

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -300,6 +300,7 @@ func (api *Api) buildSidecarRoutes(r *apiroutes.Router) {
 	// obvious ones to a reader. Post also refuses these two as resource
 	// names, so no sidecar can be shadowed by them.
 	r.POST("/sidecars/handshake", r.SidecarAuthMiddleware, apisidecar.Handshake)
+	r.GET("/sidecars/configuration", r.SidecarAuthMiddleware, apisidecar.Configuration)
 
 	r.GET("/sidecars/:nameOrID",
 		apiroutes.ReadOnlyAccessRole,

--- a/gateway/api/sidecar/sidecar.go
+++ b/gateway/api/sidecar/sidecar.go
@@ -171,6 +171,25 @@ func Handshake(c *gin.Context) {
 	respondConfig(c, sidecar)
 }
 
+// Sidecar Configuration
+//
+//	@Summary		Sidecar Configuration
+//	@Description	Authenticated with the hoop-sidecar-token header. Returns the configuration the sidecar must serve, rebuilt from the connections assigned to it. Unlike the handshake it records nothing, so a poll never overwrites what the sidecar last reported about itself.
+//	@Tags			Sidecars
+//	@Produce		json
+//	@Param			hoop-sidecar-token	header		string	true	"The token returned when the sidecar was created"
+//	@Success		200				{object}	map[string]interface{}
+//	@Failure		401,422,500		{object}	openapi.HTTPError
+//	@Router			/sidecars/configuration [get]
+func Configuration(c *gin.Context) {
+	sidecar := apiroutes.SidecarFromContext(c)
+	if sidecar == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"message": "access denied"})
+		return
+	}
+	respondConfig(c, sidecar)
+}
+
 // respondConfig is shared so the handshake and the poll can never drift.
 func respondConfig(c *gin.Context, sidecar *models.Sidecar) {
 	cfg, err := services.BuildSidecarConfig(models.DB, sidecar.OrgID, sidecar.ID)

--- a/gateway/services/sidecar.go
+++ b/gateway/services/sidecar.go
@@ -145,6 +145,7 @@ func buildConfig(conns []sidecarConnection) (*daemon.Config, error) {
 	var piiEntities []string
 	seenEntity := map[string]bool{}
 	var piiThreshold *float64
+	usedPorts := map[int]bool{}
 
 	for _, conn := range conns {
 		protocol, err := SidecarProtocol(conn.connType, conn.subType)
@@ -159,7 +160,7 @@ func buildConfig(conns []sidecarConnection) (*daemon.Config, error) {
 		listener := daemon.ListenerConfig{
 			Name:     conn.name,
 			Protocol: protocol,
-			Listen:   "0.0.0.0:" + port,
+			Listen:   "0.0.0.0:" + strconv.Itoa(allocateListenPort(usedPorts, port)),
 			Upstream: upstream,
 		}
 		// An empty, non-nil TLSConfig turns on upstream TLS with normal
@@ -297,6 +298,26 @@ func isValidPort(port string) bool {
 		return false
 	}
 	return strconv.Itoa(n) == port
+}
+
+// allocateListenPort binds each lane to its upstream's port, so an agent
+// pointed at the sidecar changes only the host in its connection string. On
+// a collision it walks upward to the next free port: two databases commonly
+// share 5432, and one wildcard listener cannot serve both. Connections
+// arrive ordered by name, so the allocation is deterministic for a given
+// set; the first name keeps the natural port, and the sidecar treats a
+// shifted port as topology drift, which is a restart, never a surprise.
+func allocateListenPort(used map[int]bool, natural string) int {
+	// natural passed isValidPort before reaching here.
+	p, _ := strconv.Atoi(natural)
+	for used[p] {
+		p++
+		if p > 65535 {
+			p = 1024
+		}
+	}
+	used[p] = true
+	return p
 }
 
 // decodeEnv reads a connection env-var secret, stored base64-encoded under

--- a/gateway/services/sidecar_test.go
+++ b/gateway/services/sidecar_test.go
@@ -90,13 +90,26 @@ func TestBuildConfigPostgresListener(t *testing.T) {
 	}
 }
 
-func TestBuildConfigDuplicateListenAddress(t *testing.T) {
-	_, err := buildConfig([]sidecarConnection{
+// Two databases commonly share an upstream port. The generated config must
+// still load in the sidecar, so the second lane (by name order) walks to the
+// next free listen port while both upstreams keep their own.
+func TestBuildConfigAllocatesDistinctListenPorts(t *testing.T) {
+	cfg, err := buildConfig([]sidecarConnection{
 		pgConn("pg-a", "a.internal", "5432"),
 		pgConn("pg-b", "b.internal", "5432"),
 	})
-	if err == nil || !strings.Contains(err.Error(), "duplicate listen address") {
-		t.Fatalf("want a duplicate listen address error, got %v", err)
+	if err != nil {
+		t.Fatalf("buildConfig: %v", err)
+	}
+	if got := cfg.Listeners[0].Listen; got != "0.0.0.0:5432" {
+		t.Errorf("first lane listen = %q, want the natural port", got)
+	}
+	if got := cfg.Listeners[1].Listen; got != "0.0.0.0:5433" {
+		t.Errorf("second lane listen = %q, want the next free port", got)
+	}
+	if cfg.Listeners[0].Upstream != "a.internal:5432" || cfg.Listeners[1].Upstream != "b.internal:5432" {
+		t.Errorf("upstreams moved with the listen allocation: %q, %q",
+			cfg.Listeners[0].Upstream, cfg.Listeners[1].Upstream)
 	}
 }
 

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -261,10 +261,14 @@ fact is the same mistake as a field written in two spellings. A first
 handshake that fails stops startup, since there is nothing to serve yet.
 
 Once running, a heartbeat repeats the handshake every minute. It keeps the
-plane's last-seen fresh and notices a config edited there: the process logs
-the change (`restart to apply it`) and keeps serving what it started with.
-A failed heartbeat also changes nothing, because losing the phone line home
-must not take the data path down with it.
+plane's last-seen fresh and picks up edits: a change that only touches rules
+(guardrails, masking, pii, OPA) is applied in place, logged as
+`configuration applied` with a generation number. Connections already open
+drain under the rules they were accepted with; new connections run the new
+rules, and nothing rebinds or drops. A change beyond the rules (listeners,
+audit, admin, log_level, analyzer) logs `restart to apply it` instead, and
+a failed heartbeat changes nothing, because losing the phone line home must
+not take the data path down with it. ADR-0014 records the boundary.
 
 ## Configuring it: config.yaml
 

--- a/sidecar/analyzer/evaluator.go
+++ b/sidecar/analyzer/evaluator.go
@@ -140,13 +140,22 @@ type Config struct {
 	CacheSize int
 	CacheTTL  time.Duration
 
-	// MaxCallsPerSession bounds classifications for one Evaluator's
-	// lifetime. Zero means unbounded.
+	// MaxCallsPerSession bounds classifications charged to this rule's
+	// budget. Zero means unbounded.
 	//
 	// An Evaluator is shared across connections, so this is a process-wide
 	// budget rather than a per-connection one. It is a backstop against a
-	// pathological workload, not a quota.
+	// pathological workload, not a quota. The counter it bounds may be
+	// shared through Budget, in which case it also spans evaluator
+	// generations.
 	MaxCalls int
+
+	// Budget optionally supplies the call counter itself. A hot reload
+	// that rebuilds an evaluator hands the replacement the SAME cell, so
+	// the draining generation and the new one together never exceed
+	// MaxCalls; independent counters would let each generation spend the
+	// full budget. Nil allocates a private counter.
+	Budget *atomic.Int64
 
 	// Redact rewrites content before it leaves the process. Nil sends the
 	// statement as-is.
@@ -173,7 +182,7 @@ type Evaluator struct {
 	// their change to take effect would see nothing.
 	promptKey string
 
-	calls  atomic.Int64
+	calls  *atomic.Int64
 	denied atomic.Int64
 	errs   atomic.Int64
 
@@ -212,11 +221,16 @@ func New(cfg Config) (*Evaluator, error) {
 		}
 	}
 	prompt := BuildSystemPrompt(cfg.Guidance)
+	calls := cfg.Budget
+	if calls == nil {
+		calls = new(atomic.Int64)
+	}
 	return &Evaluator{
 		cfg:       cfg,
 		cache:     newCache(cfg.CacheSize, cfg.CacheTTL),
 		prompt:    prompt,
 		promptKey: fingerprint(prompt),
+		calls:     calls,
 	}, nil
 }
 

--- a/sidecar/daemon/analyzer.go
+++ b/sidecar/daemon/analyzer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/hoophq/hoop/sidecar/inspect"
@@ -335,25 +336,40 @@ func splitAnalyzerRules(rules []policy.Rule) (local, ai []policy.Rule) {
 	return local, ai
 }
 
+// budgetFor returns the rule's process-lifetime call counter, creating it
+// on first sight. See analyzerDeps.budgets for the sharing contract.
+func (ac *analyzerDeps) budgetFor(rule string) *atomic.Int64 {
+	if ac.budgets == nil {
+		ac.budgets = map[string]*atomic.Int64{}
+	}
+	cell, ok := ac.budgets[rule]
+	if !ok {
+		cell = new(atomic.Int64)
+		ac.budgets[rule] = cell
+	}
+	return cell
+}
+
 // buildAnalyzerEvaluators turns ai_analysis rules into evaluators.
 //
 // Each rule becomes its own Evaluator, so two rules on one lane get their own
 // trigger, action map and denial message while sharing the provider and,
-// through the provider, the credential.
+// through the provider, the credential. The call BUDGET comes from ac's
+// per-rule registry, so a rebuilt evaluator (a hot reload that edited the
+// rule's lane) continues the running count instead of starting a fresh one.
 func buildAnalyzerEvaluators(
 	rules []policy.Rule,
-	cfg *AnalyzerConfig,
-	provider analyzer.Provider,
-	redact func(string) string,
+	ac *analyzerDeps,
 	hasOPA bool,
 ) ([]policy.Evaluator, error) {
 	if len(rules) == 0 {
 		return nil, nil
 	}
-	if cfg == nil || provider == nil {
+	if ac == nil || ac.cfg == nil || ac.provider == nil {
 		return nil, fmt.Errorf(
 			"ai_analysis rule %q needs an analyzer section, and none is configured", rules[0].Name)
 	}
+	cfg, provider, redact := ac.cfg, ac.provider, ac.redact
 
 	out := make([]policy.Evaluator, 0, len(rules))
 	for _, r := range rules {
@@ -379,6 +395,7 @@ func buildAnalyzerEvaluators(
 			CacheSize:     cfg.Cache.Size,
 			CacheTTL:      time.Duration(cfg.Cache.TTLSec) * time.Second,
 			MaxCalls:      cfg.MaxCalls,
+			Budget:        ac.budgetFor(r.Name),
 			Redact:        redact,
 		})
 		if err != nil {

--- a/sidecar/daemon/analyzer_test.go
+++ b/sidecar/daemon/analyzer_test.go
@@ -291,7 +291,8 @@ func TestPromptPrecedence(t *testing.T) {
 			r.Prompt = tc.rulePrompt
 			cfg := &AnalyzerConfig{Provider: "stub", Model: "m", Prompt: tc.cfgPrompt}
 
-			evs, err := buildAnalyzerEvaluators([]policy.Rule{r}, cfg, stubAnalyzerProvider{}, nil, true)
+			evs, err := buildAnalyzerEvaluators([]policy.Rule{r},
+				&analyzerDeps{cfg: cfg, provider: stubAnalyzerProvider{}}, true)
 			if err != nil {
 				t.Fatalf("buildAnalyzerEvaluators: %v", err)
 			}
@@ -322,6 +323,50 @@ func (stubAnalyzerProvider) Name() string { return "stub" }
 
 func (stubAnalyzerProvider) Classify(context.Context, string, string) (*analyzer.Result, error) {
 	return &analyzer.Result{RiskLevel: analyzer.RiskLow}, nil
+}
+
+// A hot reload that rebuilds a rule's evaluator must not re-arm its call
+// budget: the draining generation and the replacement pay from one purse.
+// Two builds against one analyzerDeps stand in for two generations.
+func TestTheCallBudgetSurvivesAnEvaluatorRebuild(t *testing.T) {
+	deps := &analyzerDeps{
+		cfg:      &AnalyzerConfig{Provider: "stub", Model: "m", MaxCalls: 1},
+		provider: stubAnalyzerProvider{},
+	}
+	stmt := inspect.Statement{
+		Protocol:  inspect.Postgres,
+		Direction: inspect.FromClient,
+		Text:      "DELETE FROM t",
+		Operation: inspect.OpDelete,
+	}
+
+	gen1, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("risky")}, deps, false)
+	if err != nil {
+		t.Fatalf("buildAnalyzerEvaluators: %v", err)
+	}
+	gen1[0].Evaluate(stmt) // spends the whole budget of 1
+
+	gen2, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("risky")}, deps, false)
+	if err != nil {
+		t.Fatalf("buildAnalyzerEvaluators: %v", err)
+	}
+	gen2[0].Evaluate(stmt)
+
+	// One purse: the second generation saw the budget already spent. The
+	// counter never exceeds MaxCalls across generations.
+	if got := gen2[0].(*analyzer.Evaluator).Stats().Calls; got != 1 {
+		t.Fatalf("calls across generations = %d, want the budget of 1", got)
+	}
+
+	// A DIFFERENT rule name is a different identity with its own purse.
+	other, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("other")}, deps, false)
+	if err != nil {
+		t.Fatalf("buildAnalyzerEvaluators: %v", err)
+	}
+	other[0].Evaluate(stmt)
+	if got := other[0].(*analyzer.Evaluator).Stats().Calls; got != 1 {
+		t.Fatalf("a fresh rule's budget = %d, want its own count of 1", got)
+	}
 }
 
 // An ai_analysis rule on an HTTP lane with no body capture classifies nothing:

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/hoophq/hoop/sidecar/analyzer"
@@ -1136,13 +1137,7 @@ func buildPolicy(gc GuardrailsConfig, opa *OPAConfig, det Plugin, ac *analyzerDe
 	}
 
 	if len(aiRules) > 0 {
-		var cfg *AnalyzerConfig
-		var provider analyzer.Provider
-		var redact func(string) string
-		if ac != nil {
-			cfg, provider, redact = ac.cfg, ac.provider, ac.redact
-		}
-		evs, err := buildAnalyzerEvaluators(aiRules, cfg, provider, redact, opa.enabled())
+		evs, err := buildAnalyzerEvaluators(aiRules, ac, opa.enabled())
 		if err != nil {
 			return nil, err
 		}
@@ -1196,6 +1191,15 @@ type analyzerDeps struct {
 	cfg      *AnalyzerConfig
 	provider analyzer.Provider
 	redact   func(string) string
+
+	// budgets hands every generation of a rule's evaluator the same call
+	// counter, so MaxCalls bounds the rule's spend across hot reloads: a
+	// draining generation and its replacement pay from one purse. Keyed
+	// by rule name, the identity an operator edits; two lanes naming one
+	// rule share a budget too, which is what "process-wide" already
+	// promised. Entries are never dropped, and single-goroutine access
+	// (startup builds, then only the heartbeat) needs no lock.
+	budgets map[string]*atomic.Int64
 }
 
 // BuildTLS turns a TLSConfig into a *tls.Config.

--- a/sidecar/daemon/controlplane.go
+++ b/sidecar/daemon/controlplane.go
@@ -59,6 +59,13 @@ type controlPlane struct {
 	urlSource string
 	token     string
 	lastRaw   []byte
+
+	// build is the PluginBuilder SetupWith received, retained so a reload
+	// can rebuild the detector when the pii section drifts. Nil means the
+	// entry point linked no detector; a drifted pii section then stays on
+	// the restart path instead of swapping in rules the running detector
+	// cannot serve.
+	build PluginBuilder
 }
 
 // WithControlPlaneToken supplies the sidecar token from the command line,
@@ -267,10 +274,10 @@ func controlPlaneMessage(raw []byte) string {
 //
 // Failures degrade and never stop the process: the lanes keep serving the
 // last good config, because killing a data-path proxy over a lost phone line
-// home is an outage. The heartbeat logs a changed config and applies
-// nothing; listeners can appear and disappear between fetches, and swapping
-// bound ports under live connections is a restart's job.
-func (cp *controlPlane) heartbeat(ctx context.Context, log *slog.Logger) {
+// home is an outage. A changed document goes to the reloader, which swaps
+// rule-only drift into the running lanes and answers "restart to apply it"
+// for everything a live process cannot change (ADR-0014).
+func (cp *controlPlane) heartbeat(ctx context.Context, log *slog.Logger, rl *reloader) {
 	t := time.NewTicker(heartbeatEvery)
 	defer t.Stop()
 	for {
@@ -285,8 +292,7 @@ func (cp *controlPlane) heartbeat(ctx context.Context, log *slog.Logger) {
 			log.Warn("control plane handshake failed; serving the last good config",
 				"url", cp.url, "error", err)
 		case changed:
-			log.Warn("the control plane configuration changed; restart to apply it",
-				"url", cp.url)
+			rl.apply(log, cp.lastRaw)
 		}
 	}
 }

--- a/sidecar/daemon/controlplane.go
+++ b/sidecar/daemon/controlplane.go
@@ -58,7 +58,10 @@ type controlPlane struct {
 	url       string
 	urlSource string
 	token     string
-	lastRaw   []byte
+	// lastRaw is the startup handshake's document. The reloader seeds its
+	// handled-tracking from it; the heartbeat itself keeps no compare
+	// state.
+	lastRaw []byte
 
 	// build is the PluginBuilder SetupWith received, retained so a reload
 	// can rebuild the detector when the pii section drifts. Nil means the
@@ -308,9 +311,11 @@ func controlPlaneMessage(raw []byte) string {
 //
 // Failures degrade and never stop the process: the lanes keep serving the
 // last good config, because killing a data-path proxy over a lost phone line
-// home is an outage. A changed document goes to the reloader, which swaps
-// rule-only drift into the running lanes and answers "restart to apply it"
-// for everything a live process cannot change (ADR-0014).
+// home is an outage. Every fetched document goes to the reloader, which
+// owns the seen/handled bookkeeping: it swaps rule-only drift into the
+// running lanes, answers "restart to apply it" for everything a live
+// process cannot change, and retries a document whose failure can clear
+// without another edit (ADR-0014).
 func (cp *controlPlane) heartbeat(ctx context.Context, log *slog.Logger, rl *reloader) {
 	t := time.NewTicker(heartbeatEvery)
 	defer t.Stop()
@@ -320,30 +325,12 @@ func (cp *controlPlane) heartbeat(ctx context.Context, log *slog.Logger, rl *rel
 			return
 		case <-t.C:
 		}
-		changed, err := cp.poll()
-		switch {
-		case err != nil:
+		raw, err := fetchControlPlaneConfig(cp.url, cp.token, Version)
+		if err != nil {
 			log.Warn("control plane handshake failed; serving the last good config",
 				"url", cp.url, "error", err)
-		case changed:
-			rl.apply(log, cp.lastRaw)
+			continue
 		}
+		rl.handle(log, raw)
 	}
-}
-
-// poll fetches the current config and reports whether it differs from what
-// this process is serving. lastRaw advances on change so one edit logs once,
-// not once per tick. The byte compare is sound because the gateway builds
-// the document with encoding/json, which orders struct fields by declaration
-// and map keys alphabetically.
-func (cp *controlPlane) poll() (changed bool, err error) {
-	raw, err := fetchControlPlaneConfig(cp.url, cp.token, Version)
-	if err != nil {
-		return false, err
-	}
-	if bytes.Equal(raw, cp.lastRaw) {
-		return false, nil
-	}
-	cp.lastRaw = raw
-	return true, nil
 }

--- a/sidecar/daemon/controlplane.go
+++ b/sidecar/daemon/controlplane.go
@@ -107,10 +107,20 @@ func resolveControlPlaneURL(fileValue string) (value, source string, err error) 
 	return "", "", nil
 }
 
+// checkControlPlaneURL admits only what the handshake can use: an http(s)
+// URL with a host, optionally a path prefix for a plane behind one. Query,
+// fragment and userinfo are refused rather than carried into a request
+// whose path would then not be the handshake's; the error names the source
+// the operator has to fix.
 func checkControlPlaneURL(value, source string) (string, string, error) {
 	u, err := url.Parse(value)
 	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
 		return "", "", fmt.Errorf("%s holds %q, which is not an http(s) URL", source, value)
+	}
+	if u.RawQuery != "" || u.Fragment != "" || u.User != nil {
+		return "", "", fmt.Errorf("%s holds %q; a control plane URL carries no query, "+
+			"fragment or user information, only a scheme, a host and an optional path prefix",
+			source, value)
 	}
 	return value, source, nil
 }
@@ -206,19 +216,38 @@ func fetchControlPlaneConfig(baseURL, token, version string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The base was validated by checkControlPlaneURL; JoinPath keeps a
+	// path prefix (a plane behind /hoop) and normalizes trailing slashes.
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("control plane URL %q: %w", baseURL, err)
+	}
 	req, err := http.NewRequest(http.MethodPost,
-		strings.TrimRight(baseURL, "/")+controlPlaneHandshakePath, bytes.NewReader(body))
+		u.JoinPath(controlPlaneHandshakePath).String(), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("control plane request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(sidecarTokenHeader, token)
 
-	resp, err := (&http.Client{Timeout: controlPlaneTimeout}).Do(req)
+	client := &http.Client{
+		Timeout: controlPlaneTimeout,
+		// Never follow a redirect: the token rides a custom header, which
+		// Go's redirect handling forwards even across origins (it strips
+		// only the headers it knows are credentials). Surfacing the 3xx
+		// turns a misdirected URL into an error naming the fix instead of
+		// a bearer token handed to whoever answered the Location.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("the control plane at %s is unreachable: %w", baseURL, err)
 	}
-	defer resp.Body.Close()
+	// The body is always read to completion below; a close error after a
+	// full read carries nothing actionable, so it is dropped on purpose.
+	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxControlPlaneConfig+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading the control plane response from %s: %w", baseURL, err)
@@ -244,10 +273,15 @@ func fetchControlPlaneConfig(baseURL, token, version string) ([]byte, error) {
 		// what to change.
 		return nil, fmt.Errorf("the control plane at %s cannot build this sidecar's config: %s",
 			baseURL, controlPlaneMessage(raw))
-	default:
-		return nil, fmt.Errorf("the control plane at %s answered %s: %s",
-			baseURL, resp.Status, controlPlaneMessage(raw))
 	}
+
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return nil, fmt.Errorf("the control plane at %s redirected to %q; the handshake "+
+			"never follows one, so the token was not re-sent. Configure the final URL",
+			baseURL, resp.Header.Get("Location"))
+	}
+	return nil, fmt.Errorf("the control plane at %s answered %s: %s",
+		baseURL, resp.Status, controlPlaneMessage(raw))
 }
 
 // controlPlaneMessage extracts the gateway's {"message": ...} error shape,

--- a/sidecar/daemon/controlplane_test.go
+++ b/sidecar/daemon/controlplane_test.go
@@ -343,18 +343,20 @@ func TestAnEmptyPlaneConfigIsRefused(t *testing.T) {
 	}
 }
 
-// One edit on the plane logs once, not once per tick: lastRaw advances when
-// a change is seen.
-func TestPollNoticesAChangeOnce(t *testing.T) {
-	srv, _ := planeServer(t, http.StatusOK, planeConfig)
-	cp := &controlPlane{url: srv.URL, token: "hsc_x", lastRaw: []byte(`{"old":true}`)}
+// One edit is handled once, not once per tick: the reloader remembers the
+// last document that reached a terminal outcome, and the same bytes on the
+// next tick do nothing. reload_test.go covers what handling decides.
+func TestTheSameDocumentIsHandledOnce(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
 
-	changed, err := cp.poll()
-	if err != nil || !changed {
-		t.Fatalf("first poll = %v, %v; want a change", changed, err)
+	drifted := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	if got := handleWith(rl, buf, drifted); got != reloadApplied {
+		t.Fatalf("first handle = %v, want applied; log:\n%s", got, buf)
 	}
-	changed, err = cp.poll()
-	if err != nil || changed {
-		t.Fatalf("second poll = %v, %v; want no change", changed, err)
+	if got := handleWith(rl, buf, drifted); got != reloadUnchanged {
+		t.Fatalf("second handle = %v, want unchanged; log:\n%s", got, buf)
+	}
+	if rl.gen != 1 {
+		t.Fatalf("generation = %d; the duplicate was re-applied", rl.gen)
 	}
 }

--- a/sidecar/daemon/controlplane_test.go
+++ b/sidecar/daemon/controlplane_test.go
@@ -112,6 +112,70 @@ func TestABrokenControlPlaneEnvDoesNotFallThrough(t *testing.T) {
 	}
 }
 
+// A URL carrying a query, fragment or userinfo would build a request whose
+// path is not the handshake's, so validation refuses each one and names the
+// source the operator has to fix.
+func TestAControlPlaneURLCarriesNoQueryFragmentOrUser(t *testing.T) {
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+	for _, bad := range []string{
+		"http://plane.example?tenant=a",
+		"http://plane.example#frag",
+		"http://user:pw@plane.example",
+	} {
+		t.Setenv(ControlPlaneURLEnv, bad)
+		_, _, err := SetupWith("", nil, nil)
+		if err == nil {
+			t.Fatalf("%q was accepted", bad)
+		}
+		if !strings.Contains(err.Error(), ControlPlaneURLEnv) {
+			t.Errorf("the error for %q does not name the source: %v", bad, err)
+		}
+	}
+}
+
+// A plane behind a path prefix keeps it: the handshake path joins the
+// configured base instead of replacing it.
+func TestAPathPrefixedPlaneURLKeepsItsPrefix(t *testing.T) {
+	srv, calls := planeServer(t, http.StatusOK, planeConfig)
+	t.Setenv(ControlPlaneURLEnv, srv.URL+"/hoop/")
+	t.Setenv(SidecarTokenEnv, "hsc_x")
+
+	if _, _, err := SetupWith("", nil, nil); err != nil {
+		t.Fatalf("SetupWith: %v", err)
+	}
+	if got := (*calls)[0].path; got != "/hoop"+controlPlaneHandshakePath {
+		t.Errorf("path = %q, want the prefix kept", got)
+	}
+}
+
+// The token rides a custom header, which Go forwards on redirects even
+// across origins. The handshake never follows one: the 3xx surfaces as an
+// error naming the Location, and the token goes nowhere else.
+func TestARedirectingPlaneIsRefusedWithoutResendingTheToken(t *testing.T) {
+	leaked := false
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		leaked = true
+	}))
+	t.Cleanup(sink.Close)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, sink.URL, http.StatusMovedPermanently)
+	}))
+	t.Cleanup(redirector.Close)
+	t.Setenv(ControlPlaneURLEnv, redirector.URL)
+	t.Setenv(SidecarTokenEnv, "hsc_secret")
+
+	_, _, err := SetupWith("", nil, nil)
+	if err == nil {
+		t.Fatal("a redirecting plane was accepted")
+	}
+	if !strings.Contains(err.Error(), "redirected") {
+		t.Errorf("the error does not say it was a redirect: %v", err)
+	}
+	if leaked {
+		t.Fatal("the redirect target was contacted; the token traveled")
+	}
+}
+
 func TestTheTokenFlagOutranksTheEnvironment(t *testing.T) {
 	srv, calls := planeServer(t, http.StatusOK, planeConfig)
 	t.Setenv(ControlPlaneURLEnv, srv.URL)

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -38,6 +38,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -639,6 +640,12 @@ func Run(cfg *Config, det Plugin) error {
 		}
 	}
 
+	// view is the generation the admin endpoints render. Startup publishes
+	// generation zero; every applied reload publishes the next, so /config
+	// answers for the rules the data path runs, not for a snapshot.
+	view := &atomic.Pointer[laneState]{}
+	view.Store(&laneState{lanes: lanes})
+
 	if cfg.cp != nil {
 		// The heartbeat keeps the plane's last-seen fresh and hands drift to
 		// the reloader: rule-only changes swap into the servers built above,
@@ -648,7 +655,7 @@ func Run(cfg *Config, det Plugin) error {
 		for i, srv := range servers {
 			byName[relayNames[i]] = srv
 		}
-		rl, rerr := newReloader(cfg, lanes, byName, det)
+		rl, rerr := newReloader(cfg, lanes, byName, det, analyzerDeps, view)
 		if rerr != nil {
 			return rerr
 		}
@@ -661,7 +668,7 @@ func Run(cfg *Config, det Plugin) error {
 
 	if cfg.Admin.Listen != "" {
 		go serveAdmin(ctx, cfg.Admin.Listen, servers, relayNames, grpcServers, grpcNames,
-			lanes, ac, cfg.Analyzer, cfg.lic, log)
+			view, ac, cfg.Analyzer, cfg.lic, log)
 	}
 
 	var wg sync.WaitGroup
@@ -1094,7 +1101,7 @@ func serveAdmin(
 	relayNames []string,
 	grpcServers []GRPCServer,
 	grpcNames []string,
-	lanes []lane,
+	view *atomic.Pointer[laneState],
 	ac auditChain,
 	analyzerCfg *AnalyzerConfig,
 	lic license.Status,
@@ -1188,8 +1195,12 @@ func serveAdmin(
 			AIRules     []string `json:"ai_rules,omitempty"`
 			CaptureBody bool     `json:"capture_body,omitempty"`
 		}
-		out := make([]laneView, 0, len(lanes))
-		for _, ln := range lanes {
+		// The generation the data path runs. A reload publishes new lanes
+		// and its generation as one store, so this render never mixes the
+		// two (ADR-0014).
+		st := view.Load()
+		out := make([]laneView, 0, len(st.lanes))
+		for _, ln := range st.lanes {
 			mode := ModeEnforce
 			if ln.observing {
 				mode = ModeObserve
@@ -1222,6 +1233,10 @@ func serveAdmin(
 		resp := map[string]any{
 			"version": Version,
 			"lanes":   out,
+			// Zero until a control-plane reload applies; each applied
+			// reload increments it, matching the "configuration applied"
+			// log line.
+			"config_generation": st.gen,
 			// Named in the payload rather than only in the README, so a
 			// control plane can warn its own developers without reading
 			// prose. These keys still carry correct values.

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -139,6 +139,11 @@ func SetupWith(path string, load Loader, build PluginBuilder, opts ...Option) (*
 	if err != nil {
 		return nil, nil, err
 	}
+	if cfg.cp != nil {
+		// Retained so a pii drift from the plane rebuilds the detector the
+		// way startup would. See reloader.
+		cfg.cp.build = build
+	}
 	cfg.lic = ResolveLicense(o.licenseFlag, cfg.License)
 	if cfg.lic.State() == license.StateInvalid {
 		return nil, nil, cfg.lic.Err
@@ -583,17 +588,6 @@ func Run(cfg *Config, det Plugin) error {
 		licenseExpired = watchLicense(ctx, cfg.lic, licenseCheckEvery, log)
 	}
 
-	if cfg.cp != nil {
-		// The heartbeat keeps the plane's last-seen fresh and logs when the
-		// config there no longer matches this process. It shares the run
-		// context, so shutdown stops it with everything else.
-		log.Info("control plane connected",
-			"url", cfg.cp.url,
-			"source", cfg.cp.urlSource,
-			"poll", heartbeatEvery.String())
-		go cfg.cp.heartbeat(ctx, log)
-	}
-
 	// Two server kinds, one loop of lane facts. Relay lanes run
 	// proxy.Server; grpc lanes run the transport the plugin registered
 	// (ADR-0013). The stats zip in serveAdmin pairs servers with
@@ -643,6 +637,26 @@ func Run(cfg *Config, det Plugin) error {
 				"listener", ln.name,
 				"hint", "add guardrails.rules at the top level or on this listener")
 		}
+	}
+
+	if cfg.cp != nil {
+		// The heartbeat keeps the plane's last-seen fresh and hands drift to
+		// the reloader: rule-only changes swap into the servers built above,
+		// everything else keeps the restart log (ADR-0014). It shares the
+		// run context, so shutdown stops it with everything else.
+		byName := make(map[string]*proxy.Server, len(servers))
+		for i, srv := range servers {
+			byName[relayNames[i]] = srv
+		}
+		rl, rerr := newReloader(cfg, lanes, byName, det)
+		if rerr != nil {
+			return rerr
+		}
+		log.Info("control plane connected",
+			"url", cfg.cp.url,
+			"source", cfg.cp.urlSource,
+			"poll", heartbeatEvery.String())
+		go cfg.cp.heartbeat(ctx, log, rl)
 	}
 
 	if cfg.Admin.Listen != "" {

--- a/sidecar/daemon/reload.go
+++ b/sidecar/daemon/reload.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"sync/atomic"
 
 	"github.com/hoophq/hoop/sidecar/license"
 	"github.com/hoophq/hoop/sidecar/proxy"
@@ -18,8 +19,13 @@ import (
 // The boundary is the non-rule document: listener topology, audit, admin,
 // log_level and the analyzer section are bound at startup (sockets, sinks,
 // loggers, provider credentials), so any drift there keeps the restart log.
+//
+// Everything here runs on the heartbeat goroutine alone. Run hands the
+// reloader over before starting it and never touches it again, which is why
+// no field needs a lock; the one cross-goroutine surface is laneState,
+// published through an atomic pointer the admin endpoints load.
 
-// reloadOutcome is what apply concluded, returned so a test asserts the
+// reloadOutcome is what handle concluded, returned so a test asserts the
 // decision rather than parsing log lines.
 type reloadOutcome int
 
@@ -31,64 +37,111 @@ const (
 	// reloadRefused kept the running rules because the new document failed
 	// the same checks startup runs.
 	reloadRefused
+	// reloadUnchanged is a document this reloader already handled; nothing
+	// is re-run and nothing is re-logged.
+	reloadUnchanged
+	// reloadRetry kept the running rules over a failure that may clear
+	// without another edit, so the same document is retried next tick.
+	reloadRetry
 )
+
+// laneState is one config generation as the admin endpoints see it: the
+// lanes serving traffic and the generation they came from. Published
+// atomically so /config renders what the data path runs, never the startup
+// snapshot of a process that reloaded since (ADR-0014's admin consequence).
+type laneState struct {
+	lanes []lane
+	gen   int
+}
 
 // reloader holds what a running process needs to rebuild and swap lane
 // rules. Run assembles one when a control plane is connected; the heartbeat
-// owns it afterwards, so nothing here needs a lock.
+// owns it afterwards.
 type reloader struct {
 	// baseline is the running config's non-rule document. A fetched config
 	// whose non-rule document differs needs a restart.
 	baseline []byte
-	// piiRaw is the pii section the running detector was built from. Only
-	// consulted when build is nil: with a builder the section is rebuilt
-	// into a new detector instead of compared.
+	// piiRaw is the pii section the running detector was built from. The
+	// detector is rebuilt only when this drifts, never per reload: a
+	// rebuilt detector forces every masker and pii rule to swap, and most
+	// reloads touch neither.
 	piiRaw []byte
-	// grpcRules maps each grpc lane to the rule document it started with.
-	// gRPC lanes stay on the restart path (ADR-0014), so drift there is
-	// reported, never swapped.
-	grpcRules map[string][]byte
+	// laneDocs maps every lane to the resolved rule document it is
+	// serving. A lane whose document is unchanged is skipped, keeping its
+	// evaluator instances alive: analyzer call budgets, verdict caches and
+	// counters survive every reload that does not edit that lane's rules.
+	laneDocs map[string][]byte
+	// prevLanes keeps the lane structs the skipped lanes still serve, so a
+	// published generation renders the truth for swapped and kept lanes
+	// alike.
+	prevLanes map[string]lane
 	// servers maps relay lane names to their running servers, the swap
 	// targets.
 	servers map[string]*proxy.Server
+	// view is where an applied generation is published for the admin
+	// endpoints.
+	view *atomic.Pointer[laneState]
 
-	lic   license.Status
-	det   Plugin
+	lic license.Status
+	det Plugin
+	// ac is the startup analyzer state, retained whole: the provider and
+	// its credential are restart-guarded, so a reload never rebuilds them.
+	// Only the redactor is replaced, and only when the detector changed.
+	ac    *analyzerDeps
 	build PluginBuilder
 
-	// gen counts applied reloads, so log lines can say which config
-	// generation the lanes accepted from.
-	gen int
+	// lastHandled is the last document that reached a terminal outcome.
+	// Tracked apart from the fetch dedupe in the heartbeat on purpose: a
+	// retryable failure leaves it alone, so the same bytes run again next
+	// tick instead of waiting for another edit.
+	lastHandled []byte
+	gen         int
 }
 
-// newReloader captures the startup state apply compares against. lanes are
-// the built startup lanes; servers pairs each relay lane name with its
-// server, in lane order.
-func newReloader(cfg *Config, lanes []lane, servers map[string]*proxy.Server, det Plugin) (*reloader, error) {
+// newReloader captures the startup state handle compares against.
+func newReloader(cfg *Config, lanes []lane, servers map[string]*proxy.Server,
+	det Plugin, ac *analyzerDeps, view *atomic.Pointer[laneState]) (*reloader, error) {
 	baseline, err := nonRuleDoc(cfg)
 	if err != nil {
 		return nil, err
 	}
-	grpcRules := map[string][]byte{}
+	laneDocs := make(map[string][]byte, len(lanes))
+	prevLanes := make(map[string]lane, len(lanes))
 	for _, ln := range lanes {
-		if !isGRPC(ln.cfg) {
-			continue
+		doc, derr := laneRuleDoc(cfg, ln.cfg)
+		if derr != nil {
+			return nil, derr
 		}
-		doc, err := laneRuleDoc(cfg, ln.cfg)
-		if err != nil {
-			return nil, err
-		}
-		grpcRules[ln.name] = doc
+		laneDocs[ln.name] = doc
+		prevLanes[ln.name] = ln
 	}
 	return &reloader{
-		baseline:  baseline,
-		piiRaw:    cfg.PII,
-		grpcRules: grpcRules,
-		servers:   servers,
-		lic:       cfg.lic,
-		det:       det,
-		build:     cfg.cp.build,
+		baseline:    baseline,
+		piiRaw:      cfg.PII,
+		laneDocs:    laneDocs,
+		prevLanes:   prevLanes,
+		servers:     servers,
+		view:        view,
+		lic:         cfg.lic,
+		det:         det,
+		ac:          ac,
+		build:       cfg.cp.build,
+		lastHandled: cfg.cp.lastRaw,
 	}, nil
+}
+
+// handle is the heartbeat's entry: it drops documents already handled and
+// remembers terminal outcomes, so one edit logs once while a retryable
+// failure runs again next tick.
+func (r *reloader) handle(log *slog.Logger, raw []byte) reloadOutcome {
+	if bytes.Equal(raw, r.lastHandled) {
+		return reloadUnchanged
+	}
+	out := r.apply(log, raw)
+	if out != reloadRetry {
+		r.lastHandled = raw
+	}
+	return out
 }
 
 // apply decides what a drifted document means for the running process and
@@ -106,52 +159,70 @@ func (r *reloader) apply(log *slog.Logger, raw []byte) reloadOutcome {
 
 	doc, err := nonRuleDoc(newCfg)
 	if err != nil {
+		// A marshal failure here is internal, not a fact about the
+		// document; retrying costs one compare and may clear.
 		log.Warn("config compare failed; keeping the running rules", "error", err)
-		return reloadRefused
+		return reloadRetry
 	}
 	if !bytes.Equal(doc, r.baseline) {
 		log.Warn("the control plane configuration changed beyond the rules; restart to apply it")
 		return reloadRestart
 	}
 
-	det := r.det
-	if r.build != nil {
+	det, detChanged := r.det, false
+	if !bytes.Equal(bytes.TrimSpace(r.piiRaw), bytes.TrimSpace(newCfg.PII)) {
+		if r.build == nil {
+			log.Warn("the pii section changed and this build retained no detector builder; restart to apply it")
+			return reloadRestart
+		}
 		det, err = r.build(newCfg.PII)
 		if err != nil {
 			log.Warn("detector rebuild failed; keeping the running rules", "error", err)
 			return reloadRefused
 		}
-	} else if !bytes.Equal(bytes.TrimSpace(r.piiRaw), bytes.TrimSpace(newCfg.PII)) {
-		log.Warn("the pii section changed and this build retained no detector builder; restart to apply it")
-		return reloadRestart
-	}
-
-	// The analyzer section is inside the baseline, so it is identical here;
-	// the deps still rebuild when a builder ran, because the redactor holds
-	// the detector. The startup credential probe is not repeated: the
-	// provider config cannot have changed.
-	ac, err := setupAnalyzer(newCfg, det)
-	if err != nil {
-		log.Warn("analyzer rebuild failed; keeping the running rules", "error", err)
-		return reloadRefused
+		detChanged = true
+		if r.ac != nil {
+			// The provider and its credential stay: the analyzer section
+			// is inside the baseline. Only the redactor holds the
+			// detector, so only it follows the rebuild.
+			r.ac.redact = redactorFor(r.ac.cfg.Send, det)
+		}
 	}
 
 	newCfg.lic = r.lic
-	lanes, err := buildLanes(newCfg, det, ac)
+	lanes, err := buildLanes(newCfg, det, r.ac)
 	if err != nil {
 		log.Warn("the control plane sent a config the rules or the caps refuse; keeping the running rules",
 			"error", err)
 		return reloadRefused
 	}
 
-	swapped := 0
+	swapped, kept := 0, 0
+	viewLanes := make([]lane, 0, len(lanes))
 	for _, ln := range lanes {
+		doc, derr := laneRuleDoc(newCfg, ln.cfg)
+		if derr != nil {
+			log.Warn("lane compare failed; keeping the running rules",
+				"listener", ln.name, "error", derr)
+			return reloadRetry
+		}
 		if isGRPC(ln.cfg) {
-			doc, derr := laneRuleDoc(newCfg, ln.cfg)
-			if derr == nil && !bytes.Equal(doc, r.grpcRules[ln.name]) {
+			// gRPC lanes stay on the restart path (ADR-0014); drift is
+			// reported, never swapped, and the view keeps the serving lane.
+			if !bytes.Equal(doc, r.laneDocs[ln.name]) {
 				log.Warn("grpc lane rules changed on the control plane; restart to apply them",
 					"listener", ln.name)
 			}
+			viewLanes = append(viewLanes, r.prevLanes[ln.name])
+			continue
+		}
+		if !detChanged && bytes.Equal(doc, r.laneDocs[ln.name]) {
+			// This lane's rules did not move, so its running evaluators
+			// keep serving: analyzer call budgets, verdict caches and
+			// per-rule counters survive the reload. Only an edit to THIS
+			// lane's rules re-arms them.
+			viewLanes = append(viewLanes, r.prevLanes[ln.name])
+			kept++
 			continue
 		}
 		srv, ok := r.servers[ln.name]
@@ -162,14 +233,18 @@ func (r *reloader) apply(log *slog.Logger, raw []byte) reloadOutcome {
 			continue
 		}
 		srv.SwapRules(ln.policy, ln.masker)
+		r.laneDocs[ln.name] = doc
+		r.prevLanes[ln.name] = ln
+		viewLanes = append(viewLanes, ln)
 		swapped++
 	}
 
 	r.det = det
 	r.piiRaw = newCfg.PII
 	r.gen++
+	r.view.Store(&laneState{lanes: viewLanes, gen: r.gen})
 	log.Info("control plane configuration applied",
-		"generation", r.gen, "lanes", swapped)
+		"generation", r.gen, "swapped", swapped, "kept", kept)
 	return reloadApplied
 }
 
@@ -196,8 +271,8 @@ func nonRuleDoc(c *Config) ([]byte, error) {
 	return json.Marshal(&cp)
 }
 
-// laneRuleDoc renders one listener's RESOLVED rule stack, for the per-lane
-// drift report on grpc lanes.
+// laneRuleDoc renders one listener's RESOLVED rule stack: the skip decision
+// per lane, and the drift report on grpc lanes.
 func laneRuleDoc(c *Config, lc ListenerConfig) ([]byte, error) {
 	gc, opa, mc := c.resolve(lc)
 	return json.Marshal(struct {

--- a/sidecar/daemon/reload.go
+++ b/sidecar/daemon/reload.go
@@ -1,0 +1,208 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/hoophq/hoop/sidecar/license"
+	"github.com/hoophq/hoop/sidecar/proxy"
+)
+
+// This file is the ADR-0014 hot reload: when the control plane's config
+// drifts in rule content only, the running relay lanes swap evaluators and
+// maskers atomically instead of asking for a restart. Connections already
+// open keep the Gate they captured at accept time; connections accepted
+// after the swap run the new rules.
+//
+// The boundary is the non-rule document: listener topology, audit, admin,
+// log_level and the analyzer section are bound at startup (sockets, sinks,
+// loggers, provider credentials), so any drift there keeps the restart log.
+
+// reloadOutcome is what apply concluded, returned so a test asserts the
+// decision rather than parsing log lines.
+type reloadOutcome int
+
+const (
+	// reloadApplied swapped the rules into the running lanes.
+	reloadApplied reloadOutcome = iota
+	// reloadRestart names drift a live process cannot absorb.
+	reloadRestart
+	// reloadRefused kept the running rules because the new document failed
+	// the same checks startup runs.
+	reloadRefused
+)
+
+// reloader holds what a running process needs to rebuild and swap lane
+// rules. Run assembles one when a control plane is connected; the heartbeat
+// owns it afterwards, so nothing here needs a lock.
+type reloader struct {
+	// baseline is the running config's non-rule document. A fetched config
+	// whose non-rule document differs needs a restart.
+	baseline []byte
+	// piiRaw is the pii section the running detector was built from. Only
+	// consulted when build is nil: with a builder the section is rebuilt
+	// into a new detector instead of compared.
+	piiRaw []byte
+	// grpcRules maps each grpc lane to the rule document it started with.
+	// gRPC lanes stay on the restart path (ADR-0014), so drift there is
+	// reported, never swapped.
+	grpcRules map[string][]byte
+	// servers maps relay lane names to their running servers, the swap
+	// targets.
+	servers map[string]*proxy.Server
+
+	lic   license.Status
+	det   Plugin
+	build PluginBuilder
+
+	// gen counts applied reloads, so log lines can say which config
+	// generation the lanes accepted from.
+	gen int
+}
+
+// newReloader captures the startup state apply compares against. lanes are
+// the built startup lanes; servers pairs each relay lane name with its
+// server, in lane order.
+func newReloader(cfg *Config, lanes []lane, servers map[string]*proxy.Server, det Plugin) (*reloader, error) {
+	baseline, err := nonRuleDoc(cfg)
+	if err != nil {
+		return nil, err
+	}
+	grpcRules := map[string][]byte{}
+	for _, ln := range lanes {
+		if !isGRPC(ln.cfg) {
+			continue
+		}
+		doc, err := laneRuleDoc(cfg, ln.cfg)
+		if err != nil {
+			return nil, err
+		}
+		grpcRules[ln.name] = doc
+	}
+	return &reloader{
+		baseline:  baseline,
+		piiRaw:    cfg.PII,
+		grpcRules: grpcRules,
+		servers:   servers,
+		lic:       cfg.lic,
+		det:       det,
+		build:     cfg.cp.build,
+	}, nil
+}
+
+// apply decides what a drifted document means for the running process and
+// swaps it in when it can. Every refusal runs the same checks startup runs
+// (LoadConfigBytes, the caps in buildLanes), so a config startup would
+// refuse is refused here with the same message; the heartbeat must never be
+// a side door past validation.
+func (r *reloader) apply(log *slog.Logger, raw []byte) reloadOutcome {
+	newCfg, err := LoadConfigBytes(raw)
+	if err != nil {
+		log.Warn("the control plane sent a config this build refuses; keeping the running rules",
+			"error", err)
+		return reloadRefused
+	}
+
+	doc, err := nonRuleDoc(newCfg)
+	if err != nil {
+		log.Warn("config compare failed; keeping the running rules", "error", err)
+		return reloadRefused
+	}
+	if !bytes.Equal(doc, r.baseline) {
+		log.Warn("the control plane configuration changed beyond the rules; restart to apply it")
+		return reloadRestart
+	}
+
+	det := r.det
+	if r.build != nil {
+		det, err = r.build(newCfg.PII)
+		if err != nil {
+			log.Warn("detector rebuild failed; keeping the running rules", "error", err)
+			return reloadRefused
+		}
+	} else if !bytes.Equal(bytes.TrimSpace(r.piiRaw), bytes.TrimSpace(newCfg.PII)) {
+		log.Warn("the pii section changed and this build retained no detector builder; restart to apply it")
+		return reloadRestart
+	}
+
+	// The analyzer section is inside the baseline, so it is identical here;
+	// the deps still rebuild when a builder ran, because the redactor holds
+	// the detector. The startup credential probe is not repeated: the
+	// provider config cannot have changed.
+	ac, err := setupAnalyzer(newCfg, det)
+	if err != nil {
+		log.Warn("analyzer rebuild failed; keeping the running rules", "error", err)
+		return reloadRefused
+	}
+
+	newCfg.lic = r.lic
+	lanes, err := buildLanes(newCfg, det, ac)
+	if err != nil {
+		log.Warn("the control plane sent a config the rules or the caps refuse; keeping the running rules",
+			"error", err)
+		return reloadRefused
+	}
+
+	swapped := 0
+	for _, ln := range lanes {
+		if isGRPC(ln.cfg) {
+			doc, derr := laneRuleDoc(newCfg, ln.cfg)
+			if derr == nil && !bytes.Equal(doc, r.grpcRules[ln.name]) {
+				log.Warn("grpc lane rules changed on the control plane; restart to apply them",
+					"listener", ln.name)
+			}
+			continue
+		}
+		srv, ok := r.servers[ln.name]
+		if !ok {
+			// The baseline compare guarantees the same listener set, so a
+			// miss is a bug worth a line, not a silent skip.
+			log.Warn("no running server for a reloaded lane", "listener", ln.name)
+			continue
+		}
+		srv.SwapRules(ln.policy, ln.masker)
+		swapped++
+	}
+
+	r.det = det
+	r.piiRaw = newCfg.PII
+	r.gen++
+	log.Info("control plane configuration applied",
+		"generation", r.gen, "lanes", swapped)
+	return reloadApplied
+}
+
+// nonRuleDoc renders everything a hot swap cannot change: the config with
+// every rule-bearing section removed. Two configs with equal documents
+// differ in rules alone.
+//
+// A JSON render rather than a field-by-field compare, so a new Config field
+// is restart-guarded by default; forgetting it here fails safe.
+func nonRuleDoc(c *Config) ([]byte, error) {
+	cp := *c
+	cp.Guardrails, cp.OPA, cp.Mask, cp.Policy = nil, nil, nil, nil
+	cp.PII = nil
+	// The running config carries the resolved URL and the file's license
+	// reference; the fetched one carries neither. Neither is a lane fact.
+	cp.License = ""
+	cp.ControlPlaneURL = ""
+	listeners := make([]ListenerConfig, len(c.Listeners))
+	for i, lc := range c.Listeners {
+		lc.Guardrails, lc.OPA, lc.Mask, lc.Policy = nil, nil, nil, nil
+		listeners[i] = lc
+	}
+	cp.Listeners = listeners
+	return json.Marshal(&cp)
+}
+
+// laneRuleDoc renders one listener's RESOLVED rule stack, for the per-lane
+// drift report on grpc lanes.
+func laneRuleDoc(c *Config, lc ListenerConfig) ([]byte, error) {
+	gc, opa, mc := c.resolve(lc)
+	return json.Marshal(struct {
+		G GuardrailsConfig `json:"g"`
+		O *OPAConfig       `json:"o"`
+		M MaskConfig       `json:"m"`
+	}{gc, opa, mc})
+}

--- a/sidecar/daemon/reload_test.go
+++ b/sidecar/daemon/reload_test.go
@@ -1,0 +1,201 @@
+package daemon
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/proxy"
+)
+
+// reloadBase is the running config every reload test starts from: one
+// postgres lane with one guardrail rule, the shape the gateway emits.
+const reloadBase = `{
+  "listeners": [{
+    "name": "appdb", "protocol": "postgres",
+    "listen": "127.0.0.1:0", "upstream": "h:5432",
+    "guardrails": {"mode": "enforce", "rules": [
+      {"name": "r0", "type": "deny_words_list", "words": ["drop table"]}
+    ]}
+  }],
+  "audit": {"file": "-"},
+  "log_level": "info"
+}`
+
+// editJSON applies a crude replacement so each case states only its drift.
+func editJSON(t *testing.T, doc, old, new string) string {
+	t.Helper()
+	if !strings.Contains(doc, old) {
+		t.Fatalf("test bug: %q not in the base document", old)
+	}
+	return strings.Replace(doc, old, new, 1)
+}
+
+// testReloader builds a reloader over a running-shaped config, with a real
+// (unserved) proxy.Server per relay lane so a swap has a target.
+func testReloader(t *testing.T, raw string) (*reloader, *bytes.Buffer) {
+	t.Helper()
+	cfg, err := LoadConfigBytes([]byte(raw))
+	if err != nil {
+		t.Fatalf("LoadConfigBytes: %v", err)
+	}
+	cfg.cp = &controlPlane{url: "http://plane", token: "hsc_x"}
+
+	lanes, err := buildLanes(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildLanes: %v", err)
+	}
+	servers := map[string]*proxy.Server{}
+	for _, ln := range lanes {
+		if isGRPC(ln.cfg) {
+			continue
+		}
+		srv, serr := buildServer(ln, cfg.Audit, nil, slog.Default())
+		if serr != nil {
+			t.Fatalf("buildServer: %v", serr)
+		}
+		servers[ln.name] = srv
+	}
+	rl, err := newReloader(cfg, lanes, servers, nil)
+	if err != nil {
+		t.Fatalf("newReloader: %v", err)
+	}
+	var buf bytes.Buffer
+	return rl, &buf
+}
+
+func applyWith(rl *reloader, buf *bytes.Buffer, raw string) reloadOutcome {
+	log := slog.New(slog.NewTextHandler(buf, nil))
+	return rl.apply(log, []byte(raw))
+}
+
+func TestARuleOnlyDriftIsApplied(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	if got := applyWith(rl, buf, drifted); got != reloadApplied {
+		t.Fatalf("outcome = %v, want applied; log:\n%s", got, buf)
+	}
+	if !strings.Contains(buf.String(), "configuration applied") {
+		t.Errorf("no applied log line:\n%s", buf)
+	}
+	if rl.gen != 1 {
+		t.Errorf("generation = %d, want 1", rl.gen)
+	}
+}
+
+// The generation advances per applied reload, so an operator can match a log
+// line to the config edit that produced it.
+func TestEachAppliedReloadAdvancesTheGeneration(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	first := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	second := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["delete from"]`)
+	applyWith(rl, buf, first)
+	applyWith(rl, buf, second)
+	if rl.gen != 2 {
+		t.Fatalf("generation = %d, want 2", rl.gen)
+	}
+}
+
+func TestATopologyDriftKeepsTheRestartPath(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase, `"upstream": "h:5432"`, `"upstream": "other:5432"`)
+	if got := applyWith(rl, buf, drifted); got != reloadRestart {
+		t.Fatalf("outcome = %v, want restart; log:\n%s", got, buf)
+	}
+	if !strings.Contains(buf.String(), "restart to apply it") {
+		t.Errorf("no restart log line:\n%s", buf)
+	}
+}
+
+// An added listener is topology, not rules: sockets would have to bind.
+func TestAnAddedListenerKeepsTheRestartPath(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase, `"listeners": [{`,
+		`"listeners": [{"name": "second", "protocol": "postgres", "listen": "127.0.0.1:1", "upstream": "h2:5432"}, {`)
+	if got := applyWith(rl, buf, drifted); got != reloadRestart {
+		t.Fatalf("outcome = %v, want restart; log:\n%s", got, buf)
+	}
+}
+
+// A document startup would refuse is refused on reload with the running
+// rules kept: the heartbeat must never be a side door past validation.
+func TestABrokenDocumentIsRefused(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	if got := applyWith(rl, buf, `{"listeners": [{"protocol": "nope"}]}`); got != reloadRefused {
+		t.Fatalf("outcome = %v, want refused; log:\n%s", got, buf)
+	}
+}
+
+// The caps bind on reload exactly as at startup: this process runs the free
+// tier, and the plane sending two guardrail rules must not lift it.
+func TestAnOverCapReloadIsRefused(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase,
+		`{"name": "r0", "type": "deny_words_list", "words": ["drop table"]}`,
+		`{"name": "r0", "type": "deny_words_list", "words": ["drop table"]},
+		 {"name": "r1", "type": "deny_words_list", "words": ["truncate"]}`)
+	if got := applyWith(rl, buf, drifted); got != reloadRefused {
+		t.Fatalf("outcome = %v, want refused; log:\n%s", got, buf)
+	}
+	if !strings.Contains(buf.String(), "keeping the running rules") {
+		t.Errorf("the refusal does not say the running rules survive:\n%s", buf)
+	}
+}
+
+// Without a retained detector builder, a pii drift cannot be swapped: the
+// running detector was built from the old section.
+func TestAPIIDriftWithoutABuilderKeepsTheRestartPath(t *testing.T) {
+	base := editJSON(t, reloadBase, `"log_level": "info"`,
+		`"log_level": "info", "pii": {"entities": ["EMAIL_ADDRESS"]}`)
+	// A pii section needs a detector at Run time, but the reloader only
+	// compares bytes when no builder exists; det stays nil in this harness.
+	rl, buf := testReloader(t, base)
+
+	drifted := editJSON(t, base, `["EMAIL_ADDRESS"]`, `["CREDIT_CARD"]`)
+	if got := applyWith(rl, buf, drifted); got != reloadRestart {
+		t.Fatalf("outcome = %v, want restart; log:\n%s", got, buf)
+	}
+	if !strings.Contains(buf.String(), "no detector builder") {
+		t.Errorf("the log does not name the missing builder:\n%s", buf)
+	}
+}
+
+// A reload that changes nothing but rules back and forth still applies: the
+// swap is idempotent and cheap, and refusing a revert would strand a fleet
+// on an edit the operator undid.
+func TestARevertToTheBaselineRulesStillApplies(t *testing.T) {
+	rl, buf := testReloader(t, reloadBase)
+
+	drifted := editJSON(t, reloadBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	applyWith(rl, buf, drifted)
+	if got := applyWith(rl, buf, reloadBase); got != reloadApplied {
+		t.Fatalf("outcome = %v, want applied; log:\n%s", got, buf)
+	}
+}
+
+func TestNonRuleDocIgnoresEveryRuleSection(t *testing.T) {
+	a, err := LoadConfigBytes([]byte(reloadBase))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := LoadConfigBytes([]byte(editJSON(t, reloadBase,
+		`"words": ["drop table"]`, `"words": ["truncate"]`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	docA, errA := nonRuleDoc(a)
+	docB, errB := nonRuleDoc(b)
+	if errA != nil || errB != nil {
+		t.Fatalf("nonRuleDoc: %v, %v", errA, errB)
+	}
+	if !bytes.Equal(docA, docB) {
+		t.Fatalf("rule drift leaked into the non-rule document:\n%s\n%s", docA, docB)
+	}
+}

--- a/sidecar/daemon/reload_test.go
+++ b/sidecar/daemon/reload_test.go
@@ -3,7 +3,9 @@ package daemon
 import (
 	"bytes"
 	"log/slog"
+	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hoophq/hoop/sidecar/proxy"
@@ -33,14 +35,15 @@ func editJSON(t *testing.T, doc, old, new string) string {
 }
 
 // testReloader builds a reloader over a running-shaped config, with a real
-// (unserved) proxy.Server per relay lane so a swap has a target.
+// (unserved) proxy.Server per relay lane so a swap has a target. It returns
+// the log buffer; startupLanes are reachable through rl.prevLanes.
 func testReloader(t *testing.T, raw string) (*reloader, *bytes.Buffer) {
 	t.Helper()
 	cfg, err := LoadConfigBytes([]byte(raw))
 	if err != nil {
 		t.Fatalf("LoadConfigBytes: %v", err)
 	}
-	cfg.cp = &controlPlane{url: "http://plane", token: "hsc_x"}
+	cfg.cp = &controlPlane{url: "http://plane", token: "hsc_x", lastRaw: []byte(raw)}
 
 	lanes, err := buildLanes(cfg, nil, nil)
 	if err != nil {
@@ -57,7 +60,9 @@ func testReloader(t *testing.T, raw string) (*reloader, *bytes.Buffer) {
 		}
 		servers[ln.name] = srv
 	}
-	rl, err := newReloader(cfg, lanes, servers, nil)
+	view := &atomic.Pointer[laneState]{}
+	view.Store(&laneState{lanes: lanes})
+	rl, err := newReloader(cfg, lanes, servers, nil, nil, view)
 	if err != nil {
 		t.Fatalf("newReloader: %v", err)
 	}
@@ -68,6 +73,11 @@ func testReloader(t *testing.T, raw string) (*reloader, *bytes.Buffer) {
 func applyWith(rl *reloader, buf *bytes.Buffer, raw string) reloadOutcome {
 	log := slog.New(slog.NewTextHandler(buf, nil))
 	return rl.apply(log, []byte(raw))
+}
+
+func handleWith(rl *reloader, buf *bytes.Buffer, raw string) reloadOutcome {
+	log := slog.New(slog.NewTextHandler(buf, nil))
+	return rl.handle(log, []byte(raw))
 }
 
 func TestARuleOnlyDriftIsApplied(t *testing.T) {
@@ -197,5 +207,64 @@ func TestNonRuleDocIgnoresEveryRuleSection(t *testing.T) {
 	}
 	if !bytes.Equal(docA, docB) {
 		t.Fatalf("rule drift leaked into the non-rule document:\n%s\n%s", docA, docB)
+	}
+}
+
+// A two-lane config where only one lane's rules drift: the untouched lane
+// keeps its RUNNING evaluator instances, so analyzer call budgets, verdict
+// caches and counters survive reloads that never edited it. The free tier
+// allows one guardrail rule per process, so lane A carries it and lane B
+// consults OPA, which gives B a non-nil evaluator without touching a cap.
+const twoLaneBase = `{
+  "listeners": [
+    {"name": "appdb", "protocol": "postgres",
+     "listen": "127.0.0.1:0", "upstream": "h:5432",
+     "guardrails": {"mode": "enforce", "rules": [
+       {"name": "r0", "type": "deny_words_list", "words": ["drop table"]}
+     ]}},
+    {"name": "webdb", "protocol": "postgres",
+     "listen": "127.0.0.1:1", "upstream": "h2:5432",
+     "opa": {"url": "http://opa.local/v1/data/hoop/allow"}}
+  ],
+  "audit": {"file": "-"},
+  "log_level": "info"
+}`
+
+func TestAnUntouchedLaneKeepsItsRunningEvaluators(t *testing.T) {
+	rl, buf := testReloader(t, twoLaneBase)
+	before, ok := rl.prevLanes["webdb"]
+	if !ok {
+		t.Fatal("test bug: no webdb lane")
+	}
+	if before.policy == nil {
+		t.Fatal("test bug: webdb built no evaluator, identity would compare nil to nil")
+	}
+
+	drifted := editJSON(t, twoLaneBase, `"words": ["drop table"]`, `"words": ["truncate"]`)
+	if got := handleWith(rl, buf, drifted); got != reloadApplied {
+		t.Fatalf("outcome = %v, want applied; log:\n%s", got, buf)
+	}
+
+	st := rl.view.Load()
+	if st.gen != 1 {
+		t.Fatalf("published generation = %d, want 1", st.gen)
+	}
+	var after *lane
+	for i := range st.lanes {
+		if st.lanes[i].name == "webdb" {
+			after = &st.lanes[i]
+		}
+	}
+	if after == nil {
+		t.Fatal("webdb missing from the published generation")
+	}
+	// Instance identity, not equality: a policy.Chain is a slice, so the
+	// underlying data pointer is what proves the running evaluator (and
+	// its budgets and counters) kept serving.
+	if reflect.ValueOf(after.policy).Pointer() != reflect.ValueOf(before.policy).Pointer() {
+		t.Error("webdb's evaluator was rebuilt by a drift that never touched it")
+	}
+	if !strings.Contains(buf.String(), "kept=1") {
+		t.Errorf("the applied line does not count the kept lane:\n%s", buf)
 	}
 }

--- a/sidecar/proxy/proxy.go
+++ b/sidecar/proxy/proxy.go
@@ -134,11 +134,25 @@ type Config struct {
 	Logger *slog.Logger
 }
 
+// laneRules bundles the enforcement facts a connection captures at accept
+// time, so a swap replaces them as one unit: a policy from one config
+// generation must never run beside a masker from another.
+type laneRules struct {
+	policy policy.Evaluator
+	masker gate.Masker
+}
+
 // Server accepts connections and relays them through a Gate.
 type Server struct {
 	cfg      Config
 	log      *slog.Logger
 	listener net.Listener
+
+	// rules is what handle reads instead of cfg.Policy/cfg.Masker, so a
+	// config reload can replace both without a restart. Loaded once per
+	// accepted connection: the Gate keeps what it captured, which is what
+	// makes a swap safe under live traffic.
+	rules atomic.Pointer[laneRules]
 
 	mu      sync.Mutex
 	conns   map[net.Conn]struct{}
@@ -175,11 +189,25 @@ func NewServer(cfg Config) (*Server, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
-	return &Server{
+	s := &Server{
 		cfg:   cfg,
 		log:   cfg.Logger,
 		conns: map[net.Conn]struct{}{},
-	}, nil
+	}
+	s.rules.Store(&laneRules{policy: cfg.Policy, masker: cfg.Masker})
+	return s, nil
+}
+
+// SwapRules replaces the policy evaluator and masker for every connection
+// accepted from now on. Connections already open keep the Gate they
+// captured at accept time and drain under the rules they started with;
+// nothing rebinds and nothing closes.
+//
+// This is the seam a control-plane config reload swaps through. Both fields
+// travel together on purpose: rules and masking come from one config
+// document, and mixing generations would enforce a config nobody wrote.
+func (s *Server) SwapRules(pol policy.Evaluator, masker gate.Masker) {
+	s.rules.Store(&laneRules{policy: pol, masker: masker})
 }
 
 // reclaimStaleSocket removes a leftover unix socket file so a restart can
@@ -348,11 +376,15 @@ func (s *Server) handle(ctx context.Context, client net.Conn) {
 
 	log := s.log.With("session", string(sess.ID), "principal", identity.Principal())
 
+	// One load for the whole connection: this Gate runs the rules current
+	// at accept time, however long the session lives. See SwapRules.
+	rules := s.rules.Load()
+
 	g, err := gate.New(sess, gate.Config{
 		Protocol:         s.cfg.Protocol,
-		Policy:           s.cfg.Policy,
+		Policy:           rules.policy,
 		Audit:            s.cfg.Audit,
-		Masker:           s.cfg.Masker,
+		Masker:           rules.masker,
 		FailOnAuditError: s.cfg.FailOnAuditError,
 		CodecFactory:     s.cfg.CodecFactory,
 	})

--- a/sidecar/proxy/proxy.go
+++ b/sidecar/proxy/proxy.go
@@ -298,9 +298,14 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 
 		s.track(conn)
+		// The rule generation is pinned HERE, at the accept boundary, not
+		// in the asynchronously scheduled handler: a swap landing between
+		// accept and the goroutine running must not blur which side of it
+		// this connection is on.
+		rules := s.rules.Load()
 		go func() {
 			defer s.untrack(conn)
-			s.handle(ctx, conn)
+			s.handle(ctx, conn, rules)
 		}()
 	}
 }
@@ -360,8 +365,9 @@ func (s *Server) untrack(c net.Conn) {
 	_ = c.Close()
 }
 
-// handle relays one connection.
-func (s *Server) handle(ctx context.Context, client net.Conn) {
+// handle relays one connection under rules, the immutable generation Serve
+// pinned at the accept boundary.
+func (s *Server) handle(ctx context.Context, client net.Conn, rules *laneRules) {
 	identity := session.Identity{PeerAddr: client.RemoteAddr().String()}
 	if s.cfg.IdentityFn != nil {
 		identity = s.cfg.IdentityFn(client)
@@ -375,10 +381,6 @@ func (s *Server) handle(ctx context.Context, client net.Conn) {
 	sess.Upstream = s.cfg.Upstream
 
 	log := s.log.With("session", string(sess.ID), "principal", identity.Principal())
-
-	// One load for the whole connection: this Gate runs the rules current
-	// at accept time, however long the session lives. See SwapRules.
-	rules := s.rules.Load()
 
 	g, err := gate.New(sess, gate.Config{
 		Protocol:         s.cfg.Protocol,

--- a/sidecar/proxy/swap_test.go
+++ b/sidecar/proxy/swap_test.go
@@ -1,0 +1,44 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/inspect"
+	"github.com/hoophq/hoop/sidecar/policy"
+)
+
+type stubEval struct{ name string }
+
+func (s stubEval) Evaluate(inspect.Statement) policy.Verdict { return policy.Verdict{} }
+
+// A connection captures the rules current at accept time, so the swap
+// contract is entirely in the pointer: what Load returns after SwapRules is
+// what the next accepted connection's Gate runs.
+func TestSwapRulesReplacesWhatTheNextConnectionCaptures(t *testing.T) {
+	before := stubEval{name: "before"}
+	s, err := NewServer(Config{
+		Listen:   "127.0.0.1:0",
+		Upstream: "h:5432",
+		Protocol: inspect.Postgres,
+		Policy:   before,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	got := s.rules.Load()
+	if got.policy != policy.Evaluator(before) {
+		t.Fatalf("the seeded policy is not what NewServer was given")
+	}
+
+	after := stubEval{name: "after"}
+	s.SwapRules(after, nil)
+
+	got = s.rules.Load()
+	if got.policy != policy.Evaluator(after) {
+		t.Fatalf("SwapRules did not replace the policy")
+	}
+	if got.masker != nil {
+		t.Fatalf("SwapRules kept a masker the new generation does not carry")
+	}
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Every PR MUST have **exactly one** of these labels, the merge is blocked otherwise:
> - `major` / `minor` / `patch` publishes a new release on merge with the corresponding semver bump.
> - `skip-release` merges without publishing a release (use for docs, CI changes, refactors, etc.).

<!-- label: minor -->

## 📝 Description

Hot reload for control-plane-connected sidecars (ADR-0014), plus the poll endpoint that feeds it:

- **Gateway**: `GET /sidecars/configuration` — same `hoop-sidecar-token` auth and same `respondConfig` as the handshake, so the two answers cannot drift. Unlike the handshake it records nothing: a poll never overwrites the version/last-seen the sidecar reported.
- **Sidecar**: the heartbeat no longer only logs config drift. Rule-only changes (guardrails, masking, pii, OPA) now swap into the running lanes atomically; in-flight connections drain under the rules they were accepted with, connections accepted after the swap run the new rules. No socket rebinds, no dropped sessions.
- The topology guard keeps everything a live process cannot absorb (listeners added/removed/re-pointed, audit, admin, log_level, analyzer) on today's `restart to apply it` path. The guard compares a rule-stripped JSON render of the config, so any future `Config` field is restart-guarded by default.
- Reload runs the exact startup pipeline — strict decode, detector rebuild via the retained `PluginBuilder`, `buildLanes` with the running license — so a config startup would refuse (including over-cap) is refused on reload with the same message. The heartbeat is not a side door past validation.
- gRPC lanes (ADR-0013) stay on the restart path this iteration; per-lane drift is detected and logged.
- `docs/adr/0014-sidecar-config-hot-reload.md`: the decision record, with mermaid diagrams of the heartbeat decision tree and the per-connection swap semantics.

## 📣 User-facing impact

Guardrail and data-masking rules edited in the Control Plane now reach connected sidecars within about a minute, without restarting them or dropping any active database connection.

## 🔗 Related Issue

Fixes DEP-197

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- `gateway/api/sidecar/sidecar.go`, `gateway/api/server.go`: `GET /sidecars/configuration` handler and route; OpenAPI specs regenerated (`make generate-openapi-docs`).
- `sidecar/proxy/proxy.go`: `laneRules` behind an `atomic.Pointer` on `Server`, loaded once per accepted connection; `SwapRules(policy, masker)` replaces both as one unit. This also removes the previously unsynchronized `cfg.Policy` read.
- `sidecar/daemon/reload.go` (new): `reloader` with `apply` → `applied | restart | refused`; `nonRuleDoc` topology guard; per-lane rule docs for gRPC drift reporting; generation counter in the applied log line.
- `sidecar/daemon/controlplane.go` / `daemon.go`: heartbeat hands drifted documents to the reloader; `Run` wires lane-name→server map; `SetupWith` retains the `PluginBuilder` for detector rebuilds.
- `docs/adr/0014-sidecar-config-hot-reload.md` (new): Status: Proposed, with diagrams.
- Tests: `sidecar/daemon/reload_test.go` (9 cases), `sidecar/proxy/swap_test.go`.

## 🧪 Testing

### How to test

**Setup**: dev postgres + control plane (per `DEV.md`):

```bash
make run-dev-postgres
make run-dev-control-plane      # API on the port it prints
export API=http://localhost:8009
```

**Steps**

1. Register a sidecar, assign a postgres connection to it, and start it:
   ```bash
   HOOP_CONTROL_PLANE_URL=$API hoop start sidecar --token hsc_...
   ```
   **Expected**: `control plane connected ... poll=1m0s`, one `lane ready` per connection.
2. Poll endpoint directly:
   ```bash
   curl -s -H "hoop-sidecar-token: hsc_..." $API/api/sidecars/configuration
   ```
   **Expected**: `200` with the same config document the handshake returns; `401 access denied` with a wrong/missing token. `GET /api/sidecars/<name>` still shows the version/last-seen from the last handshake — the poll does not touch them.
3. Open a `psql` session through the sidecar lane and keep it open.
4. Edit the guardrail rule attached to the connection (e.g. change the deny word).
   **Expected** within ~1 min, in the sidecar log: `control plane configuration applied generation=1 lanes=1`. The open `psql` session from step 3 is still connected.
5. Reconnect `psql` and trigger the new rule.
   **Expected**: the new deny fires on the fresh session. The session from step 3 keeps the old rules until it reconnects (connection-granular by design, see ADR-0014).
6. Re-point the connection's HOST (topology change).
   **Expected**: `the control plane configuration changed beyond the rules; restart to apply it` — nothing swaps, lanes keep serving.

**Negative paths**

- Add a second guardrail rule on a free-tier sidecar → reload refused with the startup cap message verbatim (`... enforces at most 1 ...; keeping the running rules`).
- Stop the gateway → `control plane handshake failed; serving the last good config`; lanes unaffected.

**Regression check**

- Standalone sidecar (`--config config.yaml`, no plane env) starts and enforces exactly as before.
- `POST /api/sidecars/handshake` still returns the config and records version/last-seen.

### Test Configuration:
- **Browser(s)**: n/a (CLI/daemon + REST)
- **OS**: macOS 15 arm64 (darwin/arm64)

### Tests performed:
- [x] Unit tests pass (9 new reload cases + proxy swap test; full sidecar module green; reload tests pass under `-race`)
- [x] Integration tests pass (`client/cmd`, `gateway/services`; endpoint smoked live against a control-plane gateway + dev postgres: 200/401/422 and handshake parity)
- [x] Manual testing completed (live sidecar against a plane: over-cap refusal, rule-only apply `generation=1 lanes=1`, topology restart log — three consecutive heartbeat ticks, one process, no restart)

## 📸 Screenshots (if applicable)

n/a — the ADR carries mermaid diagrams of the reload decision tree and swap semantics.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- Per `docs/adr/README.md`, the ADR normally ships as its own `docs(adr):` PR with `Status: Proposed` and a 1–3 day Slack window. If you split it out, drop the ADR file from this PR and link the ADR PR here instead; the code is the implementation of that decision.
- Deferred, recorded in the ADR: statement-granular swap semantics (open sessions picking up new rules mid-session), gRPC lane swaps, and surfacing the config generation on the admin `/config`–`/stats` endpoints (it lives in the applied log line today).
- Reviewers: start with `reloader.apply` in `sidecar/daemon/reload.go` — every reload decision is there — then `SwapRules`/`laneRules` in `sidecar/proxy/proxy.go` for the concurrency contract (one atomic load per accepted connection).

---

<!-- Thank you for contributing to our project! 🙏 -->
