### PR TITLE
EVL-261: register a review a sidecar filed

### DIFF
--- a/gateway/analytics/events.go
+++ b/gateway/analytics/events.go
@@ -49,6 +49,9 @@ const (
 	EventCreateSidecar = "hoop-create-sidecar"
 	EventUpdateSidecar = "hoop-update-sidecar"
 	EventDeleteSidecar = "hoop-delete-sidecar"
+	// EventCreateSidecarReview is emitted with TrackEvent, not TrackRequest:
+	// a sidecar authenticates with its own token and carries no user.
+	EventCreateSidecarReview = "hoop-create-sidecar-review"
 
 	// plugins
 	EventCreatePlugin          = "hoop-create-plugin"

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -10206,6 +10206,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/openapi.HTTPError"
                         }
                     },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -19611,8 +19617,9 @@ const docTemplate = `{
             ],
             "properties": {
                 "listener_name": {
-                    "description": "The sidecar listener the statement arrived on",
+                    "description": "The sidecar listener the statement arrived on\n\nBounded because private.reviews.listener_name is VARCHAR(255): a longer\nname would reach Postgres and fail the write, rather than being told at\nthe door that it is too long.",
                     "type": "string",
+                    "maxLength": 255,
                     "example": "appdb"
                 },
                 "payload": {

--- a/gateway/api/openapi/autogen/docs.go
+++ b/gateway/api/openapi/autogen/docs.go
@@ -10150,6 +10150,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/sidecars/reviews": {
+            "post": {
+                "description": "Register a review for a statement a sidecar held. The sidecar is taken from the token, never the body.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sidecars"
+                ],
+                "summary": "Create Sidecar Review",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The token returned when the sidecar was created",
+                        "name": "hoop-sidecar-token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "The request body resource",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/openapi.SidecarReviewRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.Review"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "412": {
+                        "description": "Precondition Failed",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/openapi.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/sidecars/{nameOrID}": {
             "get": {
                 "description": "Get a sidecar by name or ID",
@@ -19535,6 +19600,25 @@ const docTemplate = `{
                     "description": "Version reported at the last handshake. Held in gateway memory, not\nstored, so it is empty until the sidecar calls and again after a\ngateway restart.",
                     "type": "string",
                     "example": "1.0.0"
+                }
+            }
+        },
+        "openapi.SidecarReviewRequest": {
+            "type": "object",
+            "required": [
+                "listener_name",
+                "payload"
+            ],
+            "properties": {
+                "listener_name": {
+                    "description": "The sidecar listener the statement arrived on",
+                    "type": "string",
+                    "example": "appdb"
+                },
+                "payload": {
+                    "description": "The statement to review, base64 encoded",
+                    "type": "string",
+                    "example": "REVMRVRFIEZST00gdXNlcnM7"
                 }
             }
         },

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -8493,6 +8493,25 @@
         },
         "type": "object"
       },
+      "openapi.SidecarReviewRequest": {
+        "properties": {
+          "listener_name": {
+            "description": "The sidecar listener the statement arrived on",
+            "example": "appdb",
+            "type": "string"
+          },
+          "payload": {
+            "description": "The statement to review, base64 encoded",
+            "example": "REVMRVRFIEZST00gdXNlcnM7",
+            "type": "string"
+          }
+        },
+        "required": [
+          "listener_name",
+          "payload"
+        ],
+        "type": "object"
+      },
       "openapi.SidecarUpdateRequest": {
         "properties": {
           "configuration": {
@@ -21898,6 +21917,90 @@
           }
         },
         "summary": "Sidecar Handshake",
+        "tags": [
+          "Sidecars"
+        ]
+      }
+    },
+    "/sidecars/reviews": {
+      "post": {
+        "description": "Register a review for a statement a sidecar held. The sidecar is taken from the token, never the body.",
+        "parameters": [
+          {
+            "description": "The token returned when the sidecar was created",
+            "in": "header",
+            "name": "hoop-sidecar-token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi.SidecarReviewRequest"
+              }
+            }
+          },
+          "description": "The request body resource",
+          "required": true,
+          "x-originalParamName": "request"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.Review"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Precondition Failed"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Create Sidecar Review",
         "tags": [
           "Sidecars"
         ]

--- a/gateway/api/openapi/openapiv3.json
+++ b/gateway/api/openapi/openapiv3.json
@@ -8496,8 +8496,9 @@
       "openapi.SidecarReviewRequest": {
         "properties": {
           "listener_name": {
-            "description": "The sidecar listener the statement arrived on",
+            "description": "The sidecar listener the statement arrived on\n\nBounded because private.reviews.listener_name is VARCHAR(255): a longer\nname would reach Postgres and fail the write, rather than being told at\nthe door that it is too long.",
             "example": "appdb",
+            "maxLength": 255,
             "type": "string"
           },
           "payload": {
@@ -21988,6 +21989,16 @@
               }
             },
             "description": "Precondition Failed"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi.HTTPError"
+                }
+              }
+            },
+            "description": "Request Entity Too Large"
           },
           "500": {
             "content": {

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -327,6 +327,17 @@ type SidecarCreateResponse struct {
 	Token string `json:"token" example:"hsc_Ab3fX9kL..."`
 }
 
+// SidecarReviewRequest registers a statement a sidecar held for human approval.
+//
+// The sidecar is not in the body and must not be: the token identifies it, so a
+// field here would let one sidecar file a review as another.
+type SidecarReviewRequest struct {
+	// The sidecar listener the statement arrived on
+	ListenerName string `json:"listener_name" binding:"required" example:"appdb"`
+	// The statement to review, base64 encoded
+	Payload string `json:"payload" binding:"required" example:"REVMRVRFIEZST00gdXNlcnM7"`
+}
+
 type SidecarHandshakeRequest struct {
 	// Version of the sidecar binary
 	Version string `json:"version" binding:"required" example:"1.0.0"`

--- a/gateway/api/openapi/types.go
+++ b/gateway/api/openapi/types.go
@@ -333,7 +333,11 @@ type SidecarCreateResponse struct {
 // field here would let one sidecar file a review as another.
 type SidecarReviewRequest struct {
 	// The sidecar listener the statement arrived on
-	ListenerName string `json:"listener_name" binding:"required" example:"appdb"`
+	//
+	// Bounded because private.reviews.listener_name is VARCHAR(255): a longer
+	// name would reach Postgres and fail the write, rather than being told at
+	// the door that it is too long.
+	ListenerName string `json:"listener_name" binding:"required,max=255" example:"appdb"`
 	// The statement to review, base64 encoded
 	Payload string `json:"payload" binding:"required" example:"REVMRVRFIEZST00gdXNlcnM7"`
 }

--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -287,6 +287,10 @@ func (a *Api) StartAPI() {
 func (api *Api) buildSidecarRoutes(r *apiroutes.Router) {
 	r.POST("/sidecars/handshake", r.SidecarAuthMiddleware, apisidecar.Handshake)
 	r.GET("/sidecars/configuration", r.SidecarAuthMiddleware, apisidecar.Configuration)
+	// No TrackRequest: SidecarAuthMiddleware installs an org context with no
+	// user, and TrackRequest requires a user email, so it would be a no-op
+	// that reads as an emitted event.
+	r.POST("/sidecars/reviews", r.SidecarAuthMiddleware, apisidecar.PostReview)
 	r.PUT("/sidecars/configuration", r.SidecarAuthMiddleware, apisidecar.ImportConfiguration)
 
 	r.POST("/sidecars",

--- a/gateway/api/sidecar/reviews.go
+++ b/gateway/api/sidecar/reviews.go
@@ -1,0 +1,201 @@
+package apisidecar
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/hoophq/hoop/common/log"
+	pb "github.com/hoophq/hoop/common/proto"
+	"github.com/hoophq/hoop/gateway/analytics"
+	"github.com/hoophq/hoop/gateway/api/apiroutes"
+	"github.com/hoophq/hoop/gateway/api/httputils"
+	"github.com/hoophq/hoop/gateway/api/openapi"
+	"github.com/hoophq/hoop/gateway/appconfig"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2/types"
+)
+
+const (
+	// reviewOwnerEmail stands in for the requester a sidecar review does not
+	// have. The control plane registers no ordinary users, so nothing here
+	// identifies a person. Known debt: every sidecar review shows the same
+	// requester until there is something real to record, which is where the
+	// database user or the source address behind the statement will go.
+	reviewOwnerEmail = "hoop@hoop.dev"
+
+	// reviewConnectionType is what a session must declare. private.sessions
+	// requires one and enum_connection_type has no label for a listener, so a
+	// sidecar session takes the catch-all rather than the enum taking a new
+	// value it would carry forever.
+	reviewConnectionType = "custom"
+)
+
+// PostReview
+//
+//	@Summary		Create Sidecar Review
+//	@Description	Register a review for a statement a sidecar held. The sidecar is taken from the token, never the body.
+//	@Tags			Sidecars
+//	@Accept			json
+//	@Produce		json
+//	@Param			hoop-sidecar-token	header		string							true	"The token returned when the sidecar was created"
+//	@Param			request				body		openapi.SidecarReviewRequest	true	"The request body resource"
+//	@Success		201					{object}	openapi.Review
+//	@Failure		400,401,412,500		{object}	openapi.HTTPError
+//	@Router			/sidecars/reviews [post]
+func PostReview(c *gin.Context) {
+	sidecar := apiroutes.SidecarFromContext(c)
+	if sidecar == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"message": "access denied"})
+		return
+	}
+
+	// A gateway would take the review and then never be able to settle it:
+	// approval there resolves a connection, and this review has none. Refuse
+	// rather than write a row nobody can act on. Checked after authentication,
+	// so an unauthenticated caller learns nothing about the deployment.
+	if !appconfig.Get().IsControlPlane() {
+		c.JSON(http.StatusPreconditionFailed, gin.H{
+			"message": "sidecar reviews are served by the control plane",
+		})
+		return
+	}
+
+	var req openapi.SidecarReviewRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	// Decoded here so a human never sees base64. The statement is stored as
+	// text and read back verbatim into the Slack message a reviewer approves
+	// from, and nothing further down this path decodes anything.
+	statement, err := base64.StdEncoding.DecodeString(req.Payload)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": fmt.Sprintf("payload is not valid base64: %v", err)})
+		return
+	}
+
+	rev, err := createSidecarReview(sidecar, req.ListenerName, string(statement))
+	if err != nil {
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating sidecar review: %v", err)
+		return
+	}
+
+	log.With("sid", rev.SessionID, "review-id", rev.ID, "sidecar", sidecar.Name, "listener", req.ListenerName).
+		Infof("registered a sidecar review")
+
+	// TrackEvent, not TrackRequest: this request has no user, and TrackRequest
+	// answers an empty user email by doing nothing at all.
+	analytics.New().TrackEvent(analytics.EventCreateSidecarReview, map[string]any{
+		"org-id":   sidecar.OrgID,
+		"sidecar":  sidecar.Name,
+		"listener": req.ListenerName,
+	})
+
+	c.JSON(http.StatusCreated, toOpenApiSidecarReview(rev))
+}
+
+// createSidecarReview writes the session and the review one statement needs to
+// wait for a human.
+func createSidecarReview(sidecar *models.Sidecar, listenerName, statement string) (*models.Review, error) {
+	now := time.Now().UTC()
+	sessionID := uuid.NewString()
+
+	// A review is one per session (private.reviews is UNIQUE on org and
+	// session), and UpdateReview syncs the session's status when the review
+	// settles, so the session is not optional bookkeeping.
+	err := models.UpsertSession(models.Session{
+		ID:             sessionID,
+		OrgID:          sidecar.OrgID,
+		BlobInput:      models.BlobInputType(statement),
+		Connection:     "",
+		ConnectionType: reviewConnectionType,
+		Verb:           pb.ClientVerbExec,
+		Status:         string(openapi.SessionStatusOpen),
+		UserID:         sidecar.ID,
+		UserName:       sidecar.Name,
+		UserEmail:      reviewOwnerEmail,
+		CreatedAt:      now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed creating session: %w", err)
+	}
+
+	rev := &models.Review{
+		ID:        uuid.NewString(),
+		OrgID:     sidecar.OrgID,
+		Type:      models.ReviewTypeOneTime,
+		Status:    models.ReviewStatusPending,
+		SessionID: sessionID,
+
+		// The listener this statement arrived on, in place of a connection.
+		// connection_name is NOT NULL and stays empty: a sidecar review never
+		// resolves one, and a listener name in that column could collide with
+		// a real connection of the same name.
+		SidecarID:    sql.NullString{String: sidecar.ID, Valid: true},
+		ListenerName: sql.NullString{String: listenerName, Valid: listenerName != ""},
+
+		OwnerID:    sidecar.ID,
+		OwnerEmail: reviewOwnerEmail,
+		OwnerName:  ptr.String(sidecar.Name),
+
+		MinApprovals: ptr.Int(1),
+		ReviewGroups: eligibleReviewGroups(sidecar.OrgID),
+
+		CreatedAt: now,
+	}
+
+	if err := models.CreateReview(rev, statement); err != nil {
+		return nil, fmt.Errorf("failed creating review: %w", err)
+	}
+	return rev, nil
+}
+
+// eligibleReviewGroups is the fixed policy: an admin or an approver, whichever
+// gets there first. Read from types rather than spelled, because an
+// organization can rename its admin group through the environment and a
+// hardcoded name would produce a row nobody is in.
+func eligibleReviewGroups(orgID string) []models.ReviewGroups {
+	groups := []string{types.GroupAdmin, types.GroupApprover}
+	reviewGroups := make([]models.ReviewGroups, 0, len(groups))
+	for _, name := range groups {
+		reviewGroups = append(reviewGroups, models.ReviewGroups{
+			ID:        uuid.NewString(),
+			OrgID:     orgID,
+			GroupName: name,
+			Status:    models.ReviewStatusPending,
+		})
+	}
+	return reviewGroups
+}
+
+// toOpenApiSidecarReview renders what the sidecar needs to recognise the review
+// later. The connection fields are left out rather than sent empty: this review
+// has none, and an empty string invites a client to read meaning into it.
+func toOpenApiSidecarReview(r *models.Review) *openapi.Review {
+	groups := make([]openapi.ReviewGroup, 0, len(r.ReviewGroups))
+	for _, rg := range r.ReviewGroups {
+		groups = append(groups, openapi.ReviewGroup{
+			ID:     rg.ID,
+			Group:  rg.GroupName,
+			Status: openapi.ReviewRequestStatusType(rg.Status),
+		})
+	}
+	return &openapi.Review{
+		ID:               r.ID,
+		Session:          r.SessionID,
+		Type:             openapi.ReviewType(r.Type),
+		Status:           openapi.ReviewStatusType(r.Status),
+		CreatedAt:        r.CreatedAt,
+		ReviewGroupsData: groups,
+		MinApprovals:     r.MinApprovals,
+		SidecarID:        ptr.String(r.SidecarID.String),
+		ListenerName:     ptr.String(r.ListenerName.String),
+	}
+}

--- a/gateway/api/sidecar/reviews.go
+++ b/gateway/api/sidecar/reviews.go
@@ -29,6 +29,12 @@ const (
 	// database user or the source address behind the statement will go.
 	reviewOwnerEmail = "hoop@hoop.dev"
 
+	// maxStatementBytes caps the decoded statement. It is stored twice, as the
+	// session blob and the review blob, and a token holder could otherwise fill
+	// the database one request at a time. A statement a human is expected to
+	// read has no business being larger.
+	maxStatementBytes = 100000 // 0.1MB, the ceiling plugin config already uses
+
 	// reviewConnectionType is what a session must declare. private.sessions
 	// requires one and enum_connection_type has no label for a listener, so a
 	// sidecar session takes the catch-all rather than the enum taking a new
@@ -46,7 +52,7 @@ const (
 //	@Param			hoop-sidecar-token	header		string							true	"The token returned when the sidecar was created"
 //	@Param			request				body		openapi.SidecarReviewRequest	true	"The request body resource"
 //	@Success		201					{object}	openapi.Review
-//	@Failure		400,401,412,500		{object}	openapi.HTTPError
+//	@Failure		400,401,412,413,500	{object}	openapi.HTTPError
 //	@Router			/sidecars/reviews [post]
 func PostReview(c *gin.Context) {
 	sidecar := apiroutes.SidecarFromContext(c)
@@ -81,9 +87,19 @@ func PostReview(c *gin.Context) {
 		return
 	}
 
+	if len(statement) > maxStatementBytes {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{
+			"message": fmt.Sprintf("statement is larger than %d bytes", maxStatementBytes),
+		})
+		return
+	}
+
 	rev, err := createSidecarReview(sidecar, req.ListenerName, string(statement))
 	if err != nil {
-		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating sidecar review: %v", err)
+		// The error is logged and sent to Sentry by AbortWithErr; the caller
+		// gets none of it. A database message names constraints, tables and
+		// columns, and a token holder has no use for any of that.
+		httputils.AbortWithErr(c, http.StatusInternalServerError, err, "failed creating sidecar review")
 		return
 	}
 
@@ -92,7 +108,9 @@ func PostReview(c *gin.Context) {
 
 	// TrackEvent, not TrackRequest: this request has no user, and TrackRequest
 	// answers an empty user email by doing nothing at all.
-	analytics.New().TrackEvent(analytics.EventCreateSidecarReview, map[string]any{
+	trackClient := analytics.New()
+	defer trackClient.Close()
+	trackClient.TrackEvent(analytics.EventCreateSidecarReview, map[string]any{
 		"org-id":   sidecar.OrgID,
 		"sidecar":  sidecar.Name,
 		"listener": req.ListenerName,
@@ -127,7 +145,19 @@ func createSidecarReview(sidecar *models.Sidecar, listenerName, statement string
 		return nil, fmt.Errorf("failed creating session: %w", err)
 	}
 
-	rev := &models.Review{
+	rev := newSidecarReview(sidecar, listenerName, sessionID, now)
+	if err := models.CreateReview(rev, statement); err != nil {
+		return nil, fmt.Errorf("failed creating review: %w", err)
+	}
+	return rev, nil
+}
+
+// newSidecarReview builds the row, and with it the whole approval policy: a
+// group per eligible role and a minimum of one. Nothing in the review path
+// spells that out, so an omission here is silent — without the minimum the
+// review needs BOTH groups, and without a row a role cannot approve at all.
+func newSidecarReview(sidecar *models.Sidecar, listenerName, sessionID string, now time.Time) *models.Review {
+	return &models.Review{
 		ID:        uuid.NewString(),
 		OrgID:     sidecar.OrgID,
 		Type:      models.ReviewTypeOneTime,
@@ -150,11 +180,6 @@ func createSidecarReview(sidecar *models.Sidecar, listenerName, statement string
 
 		CreatedAt: now,
 	}
-
-	if err := models.CreateReview(rev, statement); err != nil {
-		return nil, fmt.Errorf("failed creating review: %w", err)
-	}
-	return rev, nil
 }
 
 // eligibleReviewGroups is the fixed policy: an admin or an approver, whichever

--- a/gateway/api/sidecar/reviews_test.go
+++ b/gateway/api/sidecar/reviews_test.go
@@ -2,11 +2,13 @@ package apisidecar
 
 import (
 	"database/sql"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -25,6 +27,27 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	os.Exit(m.Run())
+}
+
+// The minimum is half the policy and nothing downstream restates it. Without
+// it reviewsCountNeeded falls back to the number of group rows, so the review
+// would quietly need BOTH an admin and an approver.
+func TestNewSidecarReviewCarriesTheWholePolicy(t *testing.T) {
+	sc := &models.Sidecar{ID: "sidecar-1", OrgID: "org-1", Name: "sc-a"}
+
+	rev := newSidecarReview(sc, "appdb", "session-1", time.Now().UTC())
+
+	assert.NotNil(t, rev.MinApprovals, "no minimum means both groups must approve")
+	assert.Equal(t, 1, *rev.MinApprovals, "one approval settles a sidecar review")
+	assert.Len(t, rev.ReviewGroups, 2)
+
+	assert.Equal(t, "sidecar-1", rev.SidecarID.String)
+	assert.Equal(t, "appdb", rev.ListenerName.String)
+	assert.Empty(t, rev.ConnectionName, "a sidecar review resolves no connection")
+	assert.Equal(t, reviewOwnerEmail, rev.OwnerEmail)
+	assert.Equal(t, models.ReviewStatusPending, rev.Status)
+	assert.Equal(t, models.ReviewTypeOneTime, rev.Type)
+	assert.Nil(t, rev.AccessRequestRuleName, "the policy is fixed, not carried by a rule")
 }
 
 // The whole approval policy lives in these rows. EVL-273 put none of it in
@@ -119,4 +142,22 @@ func TestPostReviewRefusesAPayloadThatIsNotBase64(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "not valid base64")
+}
+
+// The statement is stored twice, as the session blob and the review blob, so a
+// token holder could otherwise fill the database one request at a time.
+func TestPostReviewRefusesAStatementOverTheCap(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Set("sidecar-auth", &models.Sidecar{ID: "sidecar-1", OrgID: "org-1", Name: "sc-a"})
+	oversized := base64.StdEncoding.EncodeToString([]byte(strings.Repeat("a", maxStatementBytes+1)))
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/sidecars/reviews",
+		strings.NewReader(`{"listener_name":"appdb","payload":"`+oversized+`"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	PostReview(c)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Contains(t, rec.Body.String(), "larger than")
 }

--- a/gateway/api/sidecar/reviews_test.go
+++ b/gateway/api/sidecar/reviews_test.go
@@ -1,0 +1,122 @@
+package apisidecar
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/hoophq/hoop/gateway/appconfig"
+	"github.com/hoophq/hoop/gateway/models"
+	"github.com/hoophq/hoop/gateway/storagev2/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// The handler refuses outside the control plane, so a test reaching past that
+// guard has to run as one. appconfig.Load is one-shot (it returns early once
+// loaded), so a test binary gets a single mode and the gateway-mode refusal is
+// covered by booting a real gateway rather than from here.
+func TestMain(m *testing.M) {
+	if err := appconfig.Load(appconfig.AppModeControlPlane); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+// The whole approval policy lives in these rows. EVL-273 put none of it in
+// code, so if this drifts a sidecar review silently becomes unapprovable by
+// one of the two roles, and nothing says so at the time.
+func TestEligibleReviewGroups(t *testing.T) {
+	groups := eligibleReviewGroups("org-1")
+
+	names := make([]string, 0, len(groups))
+	for _, rg := range groups {
+		names = append(names, rg.GroupName)
+		assert.Equal(t, models.ReviewStatusPending, rg.Status)
+		assert.Equal(t, "org-1", rg.OrgID)
+		assert.NotEmpty(t, rg.ID, "a group row needs its own id: CreateReview inserts it verbatim")
+	}
+
+	assert.ElementsMatch(t, []string{types.GroupAdmin, types.GroupApprover}, names,
+		"an admin or an approver settles a sidecar review, so both need a row")
+}
+
+// The admin group name is read from the environment, so spelling it would
+// produce a row nobody is in for an organization that renamed it.
+func TestEligibleReviewGroupsDoesNotHardcodeAdmin(t *testing.T) {
+	for _, rg := range eligibleReviewGroups("org-1") {
+		if rg.GroupName == types.GroupApprover {
+			continue
+		}
+		assert.Equal(t, types.GroupAdmin, rg.GroupName)
+	}
+}
+
+// A sidecar review has no connection. Sending the fields empty would invite a
+// client to read meaning into an empty string, so they are absent instead.
+func TestToOpenApiSidecarReviewOmitsConnectionFields(t *testing.T) {
+	rev := &models.Review{
+		ID:           "review-1",
+		SessionID:    "session-1",
+		Type:         models.ReviewTypeOneTime,
+		Status:       models.ReviewStatusPending,
+		SidecarID:    sql.NullString{String: "sidecar-1", Valid: true},
+		ListenerName: sql.NullString{String: "appdb", Valid: true},
+		ReviewGroups: eligibleReviewGroups("org-1"),
+	}
+
+	got := toOpenApiSidecarReview(rev)
+
+	assert.Equal(t, "review-1", got.ID)
+	assert.Equal(t, "session-1", got.Session)
+	assert.Equal(t, "sidecar-1", *got.SidecarID)
+	assert.Equal(t, "appdb", *got.ListenerName)
+	assert.Len(t, got.ReviewGroupsData, 2)
+	assert.Equal(t, models.ReviewStatusPending.Str(), string(got.Status))
+
+	// openapi.Review carries no connection field at all, so the absence is
+	// structural. This pins the response the sidecar actually reads.
+	assert.Nil(t, got.RevokeAt, "a sidecar review is granted no access window")
+	assert.Nil(t, got.TimeWindow)
+	assert.Nil(t, got.AccessRequestRuleName, "the policy is fixed, not carried by a rule")
+}
+
+// Without the middleware there is no sidecar, and the handler must say so
+// rather than read a nil row: the difference between 401 and a panic.
+func TestPostReviewRefusesARequestThatSkippedTheMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/sidecars/reviews",
+		strings.NewReader(`{"listener_name":"appdb","payload":"c2VsZWN0IDE7"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	PostReview(c)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "access denied")
+}
+
+// A statement that is not valid base64 never reaches the database, so this
+// refuses before any write. The reviewer would otherwise be shown whatever
+// arrived, because nothing further down this path decodes anything.
+func TestPostReviewRefusesAPayloadThatIsNotBase64(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	// The same key SidecarAuthMiddleware sets, so the handler gets past its
+	// first guard without a middleware or a database.
+	c.Set("sidecar-auth", &models.Sidecar{ID: "sidecar-1", OrgID: "org-1", Name: "sc-a"})
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/sidecars/reviews",
+		strings.NewReader(`{"listener_name":"appdb","payload":"!!!not-base64!!!"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	PostReview(c)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "not valid base64")
+}


### PR DESCRIPTION
## 📝 Description

A sidecar holds a statement for human approval and posts it here. The control plane records a session and a `onetime` review at `PENDING`, and returns the review so the sidecar can recognise it later.

Create was the only review verb the control plane was missing: `GET /reviews`, `GET /reviews/:id` and `PUT /reviews/:id` already served there, and EVL-273 made a listener-bound review approvable. This closes the loop — a sidecar can now file one, and a human can settle it from Slack or the web app.

**The approval policy is carried entirely by the rows this endpoint writes**, the way every other review carries it: one `review_groups` row for `types.GroupAdmin`, one for `types.GroupApprover`, and `min_approvals = 1`. Nothing in the review path spells it out, which is why `eligibleReviewGroups` is pinned by tests — omit the minimum and the review silently needs *both* groups; omit a row and that role cannot approve at all.

## 📣 User-facing impact

A sidecar can register a statement for human approval in the control plane. Approvers see it in the reviews list, and one approval from an admin or an approver settles it.

## 🔗 Related Issue

EVL-261. Contract settled in EVL-271, approval shipped in EVL-273 (#1804).

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

- `gateway/api/sidecar/reviews.go`: the handler, the session and review writes, the fixed policy, and the response mapping.
- `openapi.SidecarReviewRequest`: `listener_name` and `payload`, both required. The sidecar is **not** in the body — `SidecarAuthMiddleware` resolves it from the token, so a field here would let one sidecar file a review as another.
- `analytics.EventCreateSidecarReview`, emitted with `TrackEvent`.
- One route in `buildSidecarRoutes`, behind `SidecarAuthMiddleware`.

### Four decisions worth naming

**Base64 is decoded at the door.** Nothing downstream decodes anything: `CreateReview` stores the input verbatim and the Slack plugin reads it straight back into the message a human approves from (`slack.go:205`). Storing it encoded would show the reviewer a wall of base64. Invalid base64 is a 400.

**The session takes `custom` + `exec`.** `private.sessions` requires a `connection_type` and a `verb`, both Postgres enums. `enum_connection_type` has no label for a listener, so a sidecar session takes the existing catch-all rather than the enum taking a value it would carry forever. `enum_session_verb` is only `connect` or `exec`.

**Any listener name is accepted.** A sidecar may run from its own config file rather than the control plane's, so validating against the stored `Configuration` would refuse listeners that are working as designed. Which source wins is its own project.

**Duplicate submits create duplicate reviews.** `CreateReview` is a plain insert and there is no idempotency key. Nothing polls yet, so nothing depends on dedupe; recorded rather than solved.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a
- **OS**: macOS 15.6, PostgreSQL 17

### Tests performed:
- [x] Unit tests pass
- [x] Manual testing completed

`make test-oss` green, 0 failures.

Five unit tests covering the fixed policy, the response shape, and the two guards reachable without a database.

End to end against a real Postgres, booting **both** modes from one binary. A sidecar was registered through the API and its real token used to file the review:

| Check | Result |
|---|---|
| Control plane: `POST /sidecars/reviews` | `201`, review with `sidecar_id`, `listener_name`, `min_approvals=1`, two PENDING group rows |
| Statement at rest | `["DELETE FROM users WHERE id = 42;"]` — decoded, not base64 |
| Admin approves it | `200`, `APPROVED`, no access window |
| Group rows after | `admin=APPROVED`, `approver=PENDING` |
| Session row | `status=ready`, `verb=exec`, `type=custom` |
| `GET /reviews` | listed, with its listener and sidecar |
| Gateway: same request | `412`, and **zero rows written** |
| Gateway: unauthenticated | `401` |
| Bad base64 / missing `listener_name` | `400` / `400` |

## 📄 Additional Notes

**The endpoint refuses outside the control plane.** `buildSidecarRoutes` is in the shared route tree, so this route is served by a gateway too — and a review filed there could never be settled, because approval in gateway mode resolves a connection this review does not have. It returns `412` rather than writing a row nobody can act on. Caught in review; without it the feature quietly manufactures dead reviews on the majority deployment shape.

**Authentication is checked before the mode.** An unauthenticated caller gets `401` and learns nothing about the deployment topology.

**Analytics uses `TrackEvent`, not `TrackRequest`.** `TrackRequest` returns early on an empty user email, and `SidecarAuthMiddleware` installs an org context with no user, so it would have been a no-op that reads like an emitted event. `TrackEvent` is the repo's existing path for user-less org events (`UserId: "Gateway"`, org-grouped, respects the org's analytics mode).

**`appconfig.Load` is one-shot**, returning early once loaded (`appconfig.go:124`), so a test binary gets a single app mode. The gateway-mode refusal is therefore covered by booting a real gateway rather than by a unit test that would silently fail to switch modes. The test file records this rather than leaving the gap implied.

**Known debt, carried deliberately:** `owner_email` is the placeholder `hoop@hoop.dev`. The control plane registers no ordinary users, so nothing here identifies a person. This is where the database user or the source address behind the statement will go.

https://claude.ai/code/session_017sx9jEmnE7kqHjUSQxJ91L
