### PR TITLE
feat(sidecar): first start no config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,15 @@ listeners:
 ## Run
 
 ```bash
+hoop start sidecar                                # no config: a built-in default
 hoop start sidecar --config config.yaml           # start
 hoop start sidecar --config config.yaml --validate # check the config, then exit
 ```
+
+With no config at all, the sidecar starts anyway: one loopback URL that
+forwards to the [getting-started guide](https://hoop.dev/docs). It inspects
+no traffic — it exists so your first run works — and the terminal says how
+to replace it with a real config.
 
 Point your agent at `127.0.0.1:15432` instead of the database. Your agents change one thing: the port in their connection string. The sidecar runs next to your database, not in place of it.
 

--- a/client/cmd/startsidecar.go
+++ b/client/cmd/startsidecar.go
@@ -53,6 +53,11 @@ Every capability is decided by the config file, so turning on PII detection
 does not require a different binary. The file may be YAML or JSON; the
 extension picks the parser.
 
+Run with nothing at all — no config, no flags — and a built-in default
+starts instead: one loopback URL that forwards to the getting-started
+guide. It inspects no traffic; it exists so the first run after the
+install works. Write a config to replace it.
+
 This command was named "inspect". That name still works as a deprecated
 alias.
 
@@ -76,7 +81,8 @@ the URL and passing the token, nothing else; once the plane holds a config
 it owns it, and listeners still in the file are ignored with a warning. The
 token is shown once when the sidecar is created; a lost one means
 registering a new sidecar.`,
-	Example: `  hoop start sidecar --config /etc/hoop-inspect/config.yaml
+	Example: `  hoop start sidecar
+  hoop start sidecar --config /etc/hoop-inspect/config.yaml
   hoop start sidecar --config config.yaml --license /etc/hoop-inspect/license.json
   hoop start sidecar --config config.yaml --validate
   hoop start sidecar --config config.yaml --validate --strict
@@ -88,6 +94,9 @@ registering a new sidecar.`,
 		warnDeprecatedSidecarAlias(os.Stderr, cmd.CalledAs())
 
 		if sidecarConfigFlag == "" && os.Getenv(daemon.ControlPlaneURLEnv) == "" {
+			if sidecarBareInvocation() {
+				return daemon.FirstRun(os.Stdout, "hoop start sidecar --config config.yaml")
+			}
 			// The one genuine usage error here, so let cobra show the flags.
 			cmd.SilenceUsage = false
 			return fmt.Errorf("--config is required (or set HOOP_SIDECAR_CONFIG or %s)",
@@ -137,6 +146,21 @@ func warnDeprecatedSidecarAlias(w io.Writer, calledAs string) {
 			"Use \"hoop start sidecar\"; the alias is removed in a future release.",
 		deprecatedSidecarAlias))
 	_, _ = fmt.Fprintf(w, "%s\n", msg)
+}
+
+// sidecarBareInvocation reports whether this invocation asked for nothing:
+// no config anywhere, no control plane, and no flag. That is the one case
+// that runs the first-run default (daemon.FirstRun) — a loopback URL
+// forwarding to the getting-started guide — instead of a usage error, so a
+// user's first contact after the install is a working URL. Any flag keeps
+// the error: --validate or --token without a config is a mistake to
+// report, not a request for the demo.
+//
+// The caller has already established that sidecarConfigFlag (whose default
+// comes from the environment) and the control plane env var are empty.
+func sidecarBareInvocation() bool {
+	return !sidecarValidateFlag && !sidecarStrictFlag &&
+		sidecarLicenseFlag == "" && sidecarTokenFlag == ""
 }
 
 // sidecarConfigFromEnv reads the config path from the environment. It prefers

--- a/client/cmd/startsidecar.go
+++ b/client/cmd/startsidecar.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hoophq/hoop/sidecar/license"
 	"github.com/hoophq/hoop/sidecar/pii/alcatraz"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // deprecatedSidecarAlias is the pre-rename name of this command. Cobra routes
@@ -94,7 +95,7 @@ registering a new sidecar.`,
 		warnDeprecatedSidecarAlias(os.Stderr, cmd.CalledAs())
 
 		if sidecarConfigFlag == "" && os.Getenv(daemon.ControlPlaneURLEnv) == "" {
-			if sidecarBareInvocation() {
+			if sidecarBareInvocation(cmd, args) {
 				return daemon.FirstRun(os.Stdout, "hoop start sidecar --config config.yaml")
 			}
 			// The one genuine usage error here, so let cobra show the flags.
@@ -149,18 +150,27 @@ func warnDeprecatedSidecarAlias(w io.Writer, calledAs string) {
 }
 
 // sidecarBareInvocation reports whether this invocation asked for nothing:
-// no config anywhere, no control plane, and no flag. That is the one case
-// that runs the first-run default (daemon.FirstRun) — a loopback URL
-// forwarding to the getting-started guide — instead of a usage error, so a
-// user's first contact after the install is a working URL. Any flag keeps
-// the error: --validate or --token without a config is a mistake to
-// report, not a request for the demo.
+// no config anywhere, no control plane, no flag, no argument. That is the
+// one case that runs the first-run default (daemon.FirstRun) — a loopback
+// URL forwarding to the getting-started guide — instead of a usage error,
+// so a user's first contact after the install is a working URL.
+//
+// The gate keys on what the user typed, not on resulting values: a flag
+// set to its default (--validate=false, --license=) or an inherited global
+// flag (--debug) still keeps the error, because typing anything without a
+// config is a mistake to report, not a request for the demo.
 //
 // The caller has already established that sidecarConfigFlag (whose default
 // comes from the environment) and the control plane env var are empty.
-func sidecarBareInvocation() bool {
-	return !sidecarValidateFlag && !sidecarStrictFlag &&
-		sidecarLicenseFlag == "" && sidecarTokenFlag == ""
+func sidecarBareInvocation(cmd *cobra.Command, args []string) bool {
+	if len(args) > 0 {
+		return false
+	}
+	changed := false
+	seen := func(f *pflag.Flag) { changed = changed || f.Changed }
+	cmd.Flags().VisitAll(seen)
+	cmd.InheritedFlags().VisitAll(seen)
+	return !changed
 }
 
 // sidecarConfigFromEnv reads the config path from the environment. It prefers

--- a/client/cmd/startsidecar_test.go
+++ b/client/cmd/startsidecar_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestStartSidecarCommandNames(t *testing.T) {
@@ -75,31 +77,36 @@ func TestSidecarConfigFromEnv(t *testing.T) {
 }
 
 func TestSidecarBareInvocation(t *testing.T) {
-	// The gate reads package-level flag variables; save and restore them so
-	// this test composes with any other that touches the command.
-	restore := func(validate, strict bool, lic, tok string) {
-		sidecarValidateFlag, sidecarStrictFlag = validate, strict
-		sidecarLicenseFlag, sidecarTokenFlag = lic, tok
-	}
-	defer restore(sidecarValidateFlag, sidecarStrictFlag, sidecarLicenseFlag, sidecarTokenFlag)
-
 	for _, tt := range []struct {
-		msg      string
-		validate bool
-		strict   bool
-		license  string
-		token    string
-		want     bool
+		msg  string
+		args []string
+		want bool
 	}{
 		{msg: "nothing at all is bare", want: true},
-		{msg: "--validate keeps the usage error", validate: true},
-		{msg: "--strict keeps the usage error", strict: true},
-		{msg: "--license keeps the usage error", license: "/lic.json"},
-		{msg: "--token keeps the usage error", token: "hsc_x"},
+		{msg: "--validate keeps the usage error", args: []string{"--validate"}},
+		{msg: "--strict keeps the usage error", args: []string{"--strict"}},
+		{msg: "--license keeps the usage error", args: []string{"--license", "/lic.json"}},
+		{msg: "--token keeps the usage error", args: []string{"--token", "hsc_x"}},
+		{msg: "an explicit default value still keeps the usage error", args: []string{"--validate=false"}},
+		{msg: "an explicit empty value still keeps the usage error", args: []string{"--license="}},
+		{msg: "an inherited global flag keeps the usage error", args: []string{"--debug"}},
+		{msg: "a positional argument keeps the usage error", args: []string{"extra"}},
 	} {
 		t.Run(tt.msg, func(t *testing.T) {
-			restore(tt.validate, tt.strict, tt.license, tt.token)
-			if got := sidecarBareInvocation(); got != tt.want {
+			// Fresh commands per case: pflag's Changed sticks once set, so
+			// reusing the package-level command would leak state across cases.
+			root := &cobra.Command{Use: "hoop"}
+			root.PersistentFlags().Bool("debug", false, "")
+			cmd := &cobra.Command{Use: "sidecar"}
+			cmd.Flags().Bool("validate", false, "")
+			cmd.Flags().Bool("strict", false, "")
+			cmd.Flags().String("license", "", "")
+			cmd.Flags().String("token", "", "")
+			root.AddCommand(cmd)
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := sidecarBareInvocation(cmd, cmd.Flags().Args()); got != tt.want {
 				t.Fatalf("got %v, want %v", got, tt.want)
 			}
 		})

--- a/client/cmd/startsidecar_test.go
+++ b/client/cmd/startsidecar_test.go
@@ -73,3 +73,35 @@ func TestSidecarConfigFromEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestSidecarBareInvocation(t *testing.T) {
+	// The gate reads package-level flag variables; save and restore them so
+	// this test composes with any other that touches the command.
+	restore := func(validate, strict bool, lic, tok string) {
+		sidecarValidateFlag, sidecarStrictFlag = validate, strict
+		sidecarLicenseFlag, sidecarTokenFlag = lic, tok
+	}
+	defer restore(sidecarValidateFlag, sidecarStrictFlag, sidecarLicenseFlag, sidecarTokenFlag)
+
+	for _, tt := range []struct {
+		msg      string
+		validate bool
+		strict   bool
+		license  string
+		token    string
+		want     bool
+	}{
+		{msg: "nothing at all is bare", want: true},
+		{msg: "--validate keeps the usage error", validate: true},
+		{msg: "--strict keeps the usage error", strict: true},
+		{msg: "--license keeps the usage error", license: "/lic.json"},
+		{msg: "--token keeps the usage error", token: "hsc_x"},
+	} {
+		t.Run(tt.msg, func(t *testing.T) {
+			restore(tt.validate, tt.strict, tt.license, tt.token)
+			if got := sidecarBareInvocation(); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -284,6 +284,15 @@ and the extension picks the parser: `.yaml` and `.yml` go through the nested
 `config/yaml` module, anything else is read as JSON. Decoding is strict, so a
 mistyped key fails the startup instead of silently disabling a control.
 
+Run with no config at all — no file, no flags, no control plane — and a
+built-in default starts instead of a usage error: one loopback HTTP
+listener (port 15321, or a free one when that is taken) answering every
+request with a redirect to the getting-started guide at
+https://hoop.dev/docs. It is not a relay lane: no codec, no policy, no
+audit. It exists so the first run after the install shows a working URL
+and a next step, and the banner says exactly that. Any flag keeps the
+usage error, and a config file replaces the default entirely.
+
 ### What this build limits, and the license that lifts it
 
 Unlicensed, one guardrail rule and one data masking rule, for the whole

--- a/sidecar/cmd/main.go
+++ b/sidecar/cmd/main.go
@@ -60,6 +60,8 @@
 //
 // Usage:
 //
+//	hoop-inspect                    (no config: a built-in default that serves
+//	                                 one loopback URL forwarding to the docs)
 //	hoop-inspect -config /etc/hoop-inspect/config.yaml
 //	hoop-inspect -validate -config config.yaml
 //	hoop-inspect -validate -strict -config config.yaml

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -236,14 +236,14 @@ func Main(version string, load Loader, build PluginBuilder) error {
 		return nil
 	}
 	if *configPath == "" && os.Getenv(ControlPlaneURLEnv) == "" {
-		// A truly bare invocation — no config source and no flag asking for
-		// anything — runs the first-run default instead of erroring, so a
-		// user's first contact after the install is a working URL rather
-		// than a usage message. Any flag at all keeps the old error: a
-		// -validate or -token without a config is a mistake to report, not
-		// a request for the demo.
-		if !*validate && !*strict && *grpcDiscover == "" && *grpcDiscoverOut == "" &&
-			*licenseRef == "" && *tokenRef == "" {
+		// A truly bare invocation — nothing typed at all — runs the
+		// first-run default instead of erroring, so a user's first contact
+		// after the install is a working URL rather than a usage message.
+		// Anything typed keeps the old error: a flag set even to its
+		// default (-validate=false, -license=) or a stray positional
+		// argument without a config is a mistake to report, not a request
+		// for the demo. -version returned above, so it never reaches this.
+		if bareInvocation(fs) {
 			return FirstRun(os.Stdout, "hoop-inspect -config config.yaml")
 		}
 		fs.Usage()
@@ -274,6 +274,14 @@ func Main(version string, load Loader, build PluginBuilder) error {
 	}
 
 	return Run(cfg, det)
+}
+
+// bareInvocation reports whether the parsed command line asked for nothing:
+// no flag was set (NFlag counts flags the user typed, so an explicit
+// default like -validate=false still counts) and no positional argument
+// was given. Only that invocation runs the first-run default.
+func bareInvocation(fs *flag.FlagSet) bool {
+	return fs.NFlag() == 0 && fs.NArg() == 0
 }
 
 // ReportDeprecations writes each deprecation notice to w, one per line.

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -190,10 +190,9 @@ var ErrUsage = errors.New("usage")
 //
 // Usage:
 //
+//	hoop-inspect                    (no config: first-run default, see FirstRun)
 //	hoop-inspect -config /etc/hoop-inspect/config.yaml
-//	hoop-inspect -config config.yaml -license /etc/hoop-inspect/license.json
-//	hoop-inspect -validate -config config.yaml   # check and exit
-//	hoop-inspect -grpc-discover api -grpc-discover-out api.pb -config config.yaml
+//	hoop-inspect -validate -config config.yaml
 //	hoop-inspect -version
 func Main(version string, load Loader, build PluginBuilder) error {
 	Version = version
@@ -237,6 +236,16 @@ func Main(version string, load Loader, build PluginBuilder) error {
 		return nil
 	}
 	if *configPath == "" && os.Getenv(ControlPlaneURLEnv) == "" {
+		// A truly bare invocation — no config source and no flag asking for
+		// anything — runs the first-run default instead of erroring, so a
+		// user's first contact after the install is a working URL rather
+		// than a usage message. Any flag at all keeps the old error: a
+		// -validate or -token without a config is a mistake to report, not
+		// a request for the demo.
+		if !*validate && !*strict && *grpcDiscover == "" && *grpcDiscoverOut == "" &&
+			*licenseRef == "" && *tokenRef == "" {
+			return FirstRun(os.Stdout, "hoop-inspect -config config.yaml")
+		}
 		fs.Usage()
 		return fmt.Errorf("%w: -config is required unless %s is set", ErrUsage, ControlPlaneURLEnv)
 	}

--- a/sidecar/daemon/daemon_test.go
+++ b/sidecar/daemon/daemon_test.go
@@ -1,0 +1,42 @@
+package daemon
+
+import (
+	"flag"
+	"testing"
+)
+
+// The first-run default engages only when the user typed nothing at all.
+// The gate keys on what was typed, not on resulting values: an explicit
+// -validate=false or -license= parses to the default value but is still a
+// mistake to report when no config exists, and a positional argument is
+// never a request for the demo.
+func TestBareInvocation(t *testing.T) {
+	for _, tt := range []struct {
+		msg  string
+		args []string
+		want bool
+	}{
+		{msg: "nothing at all is bare", want: true},
+		{msg: "a set flag is not bare", args: []string{"-validate"}},
+		{msg: "an explicit false flag is not bare", args: []string{"-validate=false"}},
+		{msg: "an explicit empty value is not bare", args: []string{"-license="}},
+		{msg: "a positional argument is not bare", args: []string{"extra"}},
+		{msg: "a flag and an argument are not bare", args: []string{"-strict", "extra"}},
+	} {
+		t.Run(tt.msg, func(t *testing.T) {
+			// The same flags Main declares, minus the ones the gate never
+			// sees (-config non-empty and -version return before it).
+			fs := flag.NewFlagSet("hoop-inspect", flag.ContinueOnError)
+			fs.Bool("validate", false, "")
+			fs.Bool("strict", false, "")
+			fs.String("license", "", "")
+			fs.String("token", "", "")
+			if err := fs.Parse(tt.args); err != nil {
+				t.Fatalf("parse %v: %v", tt.args, err)
+			}
+			if got := bareInvocation(fs); got != tt.want {
+				t.Errorf("bareInvocation(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/sidecar/daemon/firstrun.go
+++ b/sidecar/daemon/firstrun.go
@@ -1,0 +1,140 @@
+// First-run mode: what a bare `hoop start sidecar` or `hoop-inspect` does
+// when the operator supplied nothing at all — no config, no control plane,
+// no flags. It used to be a usage error, and a new user's first contact with
+// the product was that error. Now it is a working loopback URL and a next
+// step.
+//
+// This is NOT a relay lane. No codec runs, no policy evaluates, no audit row
+// is written, and the "an empty config cannot start" rule for real configs
+// (see resolveConfigSource) stands untouched: first-run is a separate path
+// that engages only when there is no config to resolve. The lane answers
+// every request with a redirect to the live getting-started guide — the
+// docs stay on the docs site, nothing is hosted here.
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// FirstRunDocsURL is where the default lane sends a browser. The site
+// resolves the root to the getting-started guide; the deep URL under it is
+// the docs site's to rearrange, so the redirect names the root that will
+// not rot.
+const FirstRunDocsURL = "https://hoop.dev/docs"
+
+// firstRunAddr is the preferred bind: loopback only, and a port unusual
+// enough that a laptop's usual suspects (5432, 8080, 3000) and our own
+// conventions (15432 for the demo Postgres lane, 19000 for /stats) never
+// sit on it. A preference, not a promise: firstRunListen falls back when
+// something holds it, and the banner prints what was actually bound.
+const firstRunAddr = "127.0.0.1:15321"
+
+// firstRunFallbackAddr lets the kernel assign a free port when the
+// preferred one is taken. No scan-for-the-next-port loop: between probing
+// a port and binding it somebody else can take it, and :0 has no such
+// window.
+const firstRunFallbackAddr = "127.0.0.1:0"
+
+// FirstRun binds one loopback HTTP listener, redirects every request to the
+// getting-started guide, prints where it bound and what to do next, and
+// blocks until SIGINT or SIGTERM, like Run.
+//
+// restartCmd is the command line the banner tells the user to run once they
+// have written a config; the CLI and the standalone binary spell it
+// differently.
+func FirstRun(out io.Writer, restartCmd string) error {
+	ctx, stop := signal.NotifyContext(context.Background(),
+		os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return firstRunServe(ctx, out, restartCmd)
+}
+
+// firstRunServe is FirstRun minus the signal wiring, so a test can stop it
+// with a context instead of a signal.
+func firstRunServe(ctx context.Context, out io.Writer, restartCmd string) error {
+	ln, fellBack, err := firstRunListen()
+	if err != nil {
+		return err
+	}
+
+	firstRunBanner(out, ln.Addr().String(), fellBack, restartCmd)
+
+	srv := &http.Server{
+		Handler:           firstRunRedirect(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	errc := make(chan error, 1)
+	go func() { errc <- srv.Serve(ln) }()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errc:
+		return err
+	}
+}
+
+// firstRunListen binds the preferred address, or a kernel-assigned free
+// port when it is taken. fellBack reports which one happened, so the banner
+// can say the port moved.
+func firstRunListen() (ln net.Listener, fellBack bool, err error) {
+	ln, err = net.Listen("tcp", firstRunAddr)
+	if err == nil {
+		return ln, false, nil
+	}
+	ln, fbErr := net.Listen("tcp", firstRunFallbackAddr)
+	if fbErr != nil {
+		return nil, false, fmt.Errorf("binding the default listener: %w", fbErr)
+	}
+	return ln, true, nil
+}
+
+// firstRunRedirect answers every path with a redirect to the guide.
+//
+// 302, never 301: a browser caches a 301 per host:port, and the next
+// process to bind this port on the same machine would inherit the redirect.
+func firstRunRedirect() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, FirstRunDocsURL, http.StatusFound)
+	})
+}
+
+// firstRunBanner is the whole first-run interface: one URL to open, the
+// fact that this is a default rather than a configuration, and the command
+// that replaces it. Prose to stdout on purpose — the operational JSON log
+// is for a sidecar that is running a config, and this mode exists for a
+// human at a terminal who has not written one yet.
+func firstRunBanner(out io.Writer, addr string, fellBack bool, restartCmd string) {
+	_, _ = fmt.Fprintf(out, "No config file given. Running with a built-in default.\n\n")
+	if fellBack {
+		_, _ = fmt.Fprintf(out, "  The default port (%s) was busy; a free one was bound instead.\n\n",
+			portOf(firstRunAddr))
+	}
+	_, _ = fmt.Fprintf(out, "  Open http://%s in your browser.\n", addr)
+	_, _ = fmt.Fprintf(out, "  It forwards to the getting-started guide at %s.\n\n", FirstRunDocsURL)
+	_, _ = fmt.Fprintf(out, "This default inspects no traffic. Write a config with your first\n")
+	_, _ = fmt.Fprintf(out, "listener and restart:\n\n")
+	_, _ = fmt.Fprintf(out, "  %s\n", restartCmd)
+}
+
+// portOf extracts the port from a host:port literal, for the banner's
+// port-was-busy line. The input is a package constant, so a split failure
+// is a compile-time-shaped bug; returning the input whole keeps the banner
+// printable anyway.
+func portOf(addr string) string {
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	return port
+}

--- a/sidecar/daemon/firstrun.go
+++ b/sidecar/daemon/firstrun.go
@@ -14,6 +14,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -88,13 +89,32 @@ func firstRunServe(ctx context.Context, out io.Writer, restartCmd string) error 
 // port when it is taken. fellBack reports which one happened, so the banner
 // can say the port moved.
 func firstRunListen() (ln net.Listener, fellBack bool, err error) {
-	ln, err = net.Listen("tcp", firstRunAddr)
+	return firstRunListenAt(firstRunAddr, firstRunFallbackAddr)
+}
+
+// firstRunListenAt is firstRunListen over caller-chosen addresses, so a
+// test can exercise the error classification without squatting on the
+// real port.
+//
+// Only a busy preferred port moves to the fallback: that is the one
+// failure a different port fixes. Anything else — no route, fd
+// exhaustion, a policy denying the bind — would fail again on the
+// fallback, and retrying would misreport it as "port busy" in the
+// banner, so it is returned as what it is. syscall.EADDRINUSE matches
+// both the bare errno and the wrapped net.OpError forms Go returns,
+// on POSIX and Windows alike (see tunnel/loginflow's isAddrInUse).
+func firstRunListenAt(preferred, fallback string) (ln net.Listener, fellBack bool, err error) {
+	ln, err = net.Listen("tcp", preferred)
 	if err == nil {
 		return ln, false, nil
 	}
-	ln, fbErr := net.Listen("tcp", firstRunFallbackAddr)
+	if !errors.Is(err, syscall.EADDRINUSE) {
+		return nil, false, fmt.Errorf("binding the default listener: %w", err)
+	}
+	ln, fbErr := net.Listen("tcp", fallback)
 	if fbErr != nil {
-		return nil, false, fmt.Errorf("binding the default listener: %w", fbErr)
+		return nil, false, fmt.Errorf("the preferred address %s is busy and the fallback bind failed: %w",
+			preferred, fbErr)
 	}
 	return ln, true, nil
 }

--- a/sidecar/daemon/firstrun_test.go
+++ b/sidecar/daemon/firstrun_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -63,6 +64,49 @@ func TestFirstRunListenFallsBackWhenThePortIsBusy(t *testing.T) {
 	}
 }
 
+// A preferred bind that fails for any reason other than a busy port must
+// surface as that failure, not as "port busy": the fallback would fail
+// the same way, and the banner's diagnosis would be false.
+func TestFirstRunListenReportsANonBusyBindFailure(t *testing.T) {
+	// 192.0.2.1 is TEST-NET-1: never a local address, so the bind fails
+	// with EADDRNOTAVAIL, which is not EADDRINUSE.
+	ln, fellBack, err := firstRunListenAt("192.0.2.1:0", firstRunFallbackAddr)
+	if err == nil {
+		ln.Close()
+		t.Fatal("binding a non-local address succeeded")
+	}
+	if fellBack {
+		t.Error("a non-busy bind failure reported fellBack = true")
+	}
+	if strings.Contains(err.Error(), "busy") {
+		t.Errorf("a non-busy failure was diagnosed as busy: %v", err)
+	}
+}
+
+// When the preferred port is genuinely busy AND the fallback bind fails,
+// the error must carry both facts, or the operator debugs blind.
+func TestFirstRunListenNamesBothFailuresWhenTheFallbackAlsoFails(t *testing.T) {
+	squatter, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("binding a loopback squatter: %v", err)
+	}
+	defer squatter.Close()
+
+	ln, fellBack, err := firstRunListenAt(squatter.Addr().String(), "192.0.2.1:0")
+	if err == nil {
+		ln.Close()
+		t.Fatal("both binds were doomed, yet firstRunListenAt succeeded")
+	}
+	if fellBack {
+		t.Error("an error return reported fellBack = true")
+	}
+	for _, want := range []string{"busy", "fallback"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
 // The banner is the interface: it must carry the URL that was actually
 // bound, say the config is a default, and name the command that replaces
 // it. When the port moved, it must say so.
@@ -99,7 +143,7 @@ func TestFirstRunServeAnswersAndStopsOnContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var buf bytes.Buffer
+	var buf syncBuffer
 	done := make(chan error, 1)
 	go func() {
 		done <- firstRunServe(ctx, &buf, "hoop start sidecar --config config.yaml")
@@ -137,12 +181,32 @@ func TestFirstRunServeAnswersAndStopsOnContextCancel(t *testing.T) {
 	}
 }
 
+// syncBuffer is a bytes.Buffer the banner writer (the firstRunServe
+// goroutine) and the test's poller can share: bytes.Buffer alone is not
+// safe for concurrent Write and String.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 // waitForBannerURL polls the banner buffer until the "Open http://..." line
 // lands and returns that URL. The banner is written before the server
 // starts accepting, so once the URL is visible the GET below may still race
 // the Serve goroutine by a scheduler tick; the poll in the caller's Get is
 // the client timeout.
-func waitForBannerURL(t *testing.T, buf *bytes.Buffer) string {
+func waitForBannerURL(t *testing.T, buf *syncBuffer) string {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {

--- a/sidecar/daemon/firstrun_test.go
+++ b/sidecar/daemon/firstrun_test.go
@@ -1,0 +1,178 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The redirect is the whole data path of first-run mode: every path answers
+// 302 toward the live guide. 302 and not 301, because a browser caches a
+// 301 per host:port and the next process on the port would inherit it.
+func TestFirstRunRedirectsEveryPathToTheGuide(t *testing.T) {
+	h := firstRunRedirect()
+	for _, path := range []string{"/", "/anything", "/favicon.ico"} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest("GET", path, nil))
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("%s: status = %d, want %d", path, rec.Code, http.StatusFound)
+		}
+		if loc := rec.Header().Get("Location"); loc != FirstRunDocsURL {
+			t.Errorf("%s: Location = %q, want %q", path, loc, FirstRunDocsURL)
+		}
+	}
+}
+
+// A busy preferred port must move the lane, not kill it: that is the
+// difference between "the demo works" and "the demo fails exactly when
+// something else is already running", which is most laptops.
+func TestFirstRunListenFallsBackWhenThePortIsBusy(t *testing.T) {
+	squatter, err := net.Listen("tcp", firstRunAddr)
+	if err != nil {
+		// Something on this machine already holds the port, which IS the
+		// busy case: firstRunListen must still land somewhere.
+		ln, fellBack, err := firstRunListen()
+		if err != nil {
+			t.Fatalf("with the port busy, firstRunListen failed: %v", err)
+		}
+		defer ln.Close()
+		if !fellBack {
+			t.Error("the preferred port is held by another process, yet fellBack is false")
+		}
+		return
+	}
+	defer squatter.Close()
+
+	ln, fellBack, err := firstRunListen()
+	if err != nil {
+		t.Fatalf("firstRunListen with %s busy: %v", firstRunAddr, err)
+	}
+	defer ln.Close()
+
+	if !fellBack {
+		t.Error("the preferred port was busy, yet fellBack is false")
+	}
+	if ln.Addr().String() == firstRunAddr {
+		t.Errorf("bound %s while it was already held", firstRunAddr)
+	}
+}
+
+// The banner is the interface: it must carry the URL that was actually
+// bound, say the config is a default, and name the command that replaces
+// it. When the port moved, it must say so.
+func TestFirstRunBannerNamesTheBoundURLAndTheNextStep(t *testing.T) {
+	var buf bytes.Buffer
+	firstRunBanner(&buf, "127.0.0.1:49152", false, "hoop start sidecar --config config.yaml")
+
+	out := buf.String()
+	for _, want := range []string{
+		"http://127.0.0.1:49152",
+		FirstRunDocsURL,
+		"default",
+		"hoop start sidecar --config config.yaml",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("banner is missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "busy") {
+		t.Errorf("no fallback happened, yet the banner mentions a busy port:\n%s", out)
+	}
+
+	buf.Reset()
+	firstRunBanner(&buf, "127.0.0.1:49153", true, "hoop-inspect -config config.yaml")
+	if out := buf.String(); !strings.Contains(out, "busy") {
+		t.Errorf("the port moved and the banner does not say so:\n%s", out)
+	}
+}
+
+// End to end minus the process: firstRunServe binds, answers a real HTTP
+// request with the redirect, and a cancelled context shuts it down cleanly
+// — the exit an operator's Ctrl-C takes, and it must be exit 0.
+func TestFirstRunServeAnswersAndStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- firstRunServe(ctx, &buf, "hoop start sidecar --config config.yaml")
+	}()
+
+	url := waitForBannerURL(t, &buf)
+
+	client := &http.Client{
+		// The response under test is the redirect itself.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+	if loc := resp.Header.Get("Location"); loc != FirstRunDocsURL {
+		t.Errorf("Location = %q, want %q", loc, FirstRunDocsURL)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("a cancelled first run returned %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("firstRunServe did not stop after the context was cancelled")
+	}
+}
+
+// waitForBannerURL polls the banner buffer until the "Open http://..." line
+// lands and returns that URL. The banner is written before the server
+// starts accepting, so once the URL is visible the GET below may still race
+// the Serve goroutine by a scheduler tick; the poll in the caller's Get is
+// the client timeout.
+func waitForBannerURL(t *testing.T, buf *bytes.Buffer) string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		out := buf.String()
+		if i := strings.Index(out, "http://"); i >= 0 {
+			end := strings.IndexAny(out[i:], " \n")
+			if end > 0 {
+				return out[i : i+end]
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("the banner never printed a URL")
+	return ""
+}
+
+// The default lane must never leave loopback: it is unauthenticated and
+// exists only for the human at this terminal.
+func TestFirstRunListenBindsLoopback(t *testing.T) {
+	ln, _, err := firstRunListen()
+	if err != nil {
+		t.Fatalf("firstRunListen: %v", err)
+	}
+	defer ln.Close()
+
+	host, _, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("bound address %q does not split: %v", ln.Addr(), err)
+	}
+	if host != "127.0.0.1" {
+		t.Errorf("bound host = %q, want 127.0.0.1", host)
+	}
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Label: `minor` — new user-facing behavior, no breaking change.

## 📝 Description

A sidecar started with no config used to exit with `--config is required`, so a new user's first contact after the install was an error. Now a truly bare `hoop start sidecar` (or `hoop-inspect`) starts a built-in default: one loopback HTTP listener that answers every request with a 302 to the getting-started guide at https://hoop.dev/docs, plus a terminal banner that names the URL, says the config is a default, and gives the exact restart command once a real config exists.

Mechanics and the reasoning behind them:

- **Preferred port `127.0.0.1:15321`, fallback `127.0.0.1:0`.** When the preferred port is busy the kernel assigns a free one — no next-port scan, because probe-then-bind has a race window and `:0` has none. The banner always prints the address that was actually bound.
- **302 redirect instead of a relay lane pointing at the docs.** The relay copies bytes verbatim and never rewrites `Host`; the docs CDN routes by `Host`, so a relay lane at `hoop.dev:443` would 404. 302 and never 301, so a browser can't cache the redirect against a port some other process binds tomorrow.
- **First-run engages only on a bare invocation.** Any flag — `--validate`, `--strict`, `--license`, `--token` — keeps the old usage error: those are mistakes to report, not requests for the demo. The env sources (`HOOP_SIDECAR_CONFIG`, `HOOP_CONTROL_PLANE_URL`) also suppress it.
- **Not a relay lane.** No codec, no policy, no audit, and the daemon's "an empty config cannot start" rule for real configs is untouched; first-run is a separate path, not a relaxation.

## 📣 User-facing impact

Running `hoop start sidecar` with no config now starts a working service on a localhost URL that opens the getting-started guide, instead of failing with an error. The terminal tells you it's a default and how to replace it with a real config.

## 🔗 Related Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🧹 Chore

## 📋 Changes Made

- `sidecar/daemon/firstrun.go` (new): `FirstRun` — binds the default lane, serves the redirect, prints the banner, blocks until SIGINT/SIGTERM like `Run`.
- `sidecar/daemon/daemon.go`: `Main` routes a bare invocation to `FirstRun`; any flag keeps the exit-2 usage error.
- `client/cmd/startsidecar.go`: same gate via `sidecarBareInvocation()`; command help and examples document the zero-config run.
- `sidecar/cmd/main.go`: package doc usage updated.
- `sidecar/daemon/firstrun_test.go` (new): redirect on every path (302 + `Location`), busy-port fallback, banner contract (bound URL, docs URL, "default", restart command, busy line only when it moved), serve-then-cancel returns nil, bind never leaves loopback.
- `client/cmd/startsidecar_test.go`: table test for the bare-invocation gate.
- `README.md`, `sidecar/README.md`: zero-config run documented.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a (curl against the bound URL; the redirect target is the live docs site)
- **OS**: macOS (darwin/arm64)

### Tests performed:
- [x] Unit tests pass
- [ ] Integration tests pass (n/a — `test-sidecar-e2e` covers relay lanes; first-run has no relay)
- [x] Manual testing completed

Manual runs, both binaries built from this branch:

1. Bare `hoop-inspect`: banner printed `http://127.0.0.1:15321`; `curl -si` returned `HTTP/1.1 302 Found` with `Location: https://hoop.dev/docs`; SIGINT exited 0.
2. With 15321 pre-bound: banner said the default port was busy, printed the fallback (`http://127.0.0.1:49912`), same 302, SIGINT exited 0.
3. `hoop-inspect -validate` with no config: usage error kept, exit 2.
4. Bare `hoop start sidecar` (hoop CLI): same banner and 302, graceful stop with exit 0.
5. `go test ./daemon/...` in `sidecar/` green; `client` and `sidecar/cmd` build clean.

## 📸 Screenshots (if applicable)

```
$ hoop start sidecar
No config file given. Running with a built-in default.

  Open http://127.0.0.1:15321 in your browser.
  It forwards to the getting-started guide at https://hoop.dev/docs.

This default inspects no traffic. Write a config with your first
listener and restart:

  hoop start sidecar --config config.yaml
```

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 📄 Additional Notes

- The docs URL is the root `https://hoop.dev/docs`, verified live to resolve to the getting-started guide; a deep link would rot when the docs site rearranges.
- Reviewers: the one behavioral seam worth scrutiny is the bare-invocation gate in `daemon.Main` and `startsidecar.go` — every flagged-but-configless combination must still hit the old usage error, and the tests pin each one.
