### PR TITLE
feat(sidecar): Analyzer first class feature

### DIFF
--- a/client/cmd/startsidecar.go
+++ b/client/cmd/startsidecar.go
@@ -28,11 +28,13 @@ import (
 const deprecatedSidecarAlias = "inspect"
 
 var (
-	sidecarConfigFlag   string
-	sidecarLicenseFlag  string
-	sidecarTokenFlag    string
-	sidecarValidateFlag bool
-	sidecarStrictFlag   bool
+	sidecarConfigFlag     string
+	sidecarLicenseFlag    string
+	sidecarTokenFlag      string
+	sidecarValidateFlag   bool
+	sidecarStrictFlag     bool
+	sidecarMigrateFlag    bool
+	sidecarMigrateOutFlag string
 )
 
 var startSidecarCmd = &cobra.Command{
@@ -102,6 +104,33 @@ registering a new sidecar.`,
 			cmd.SilenceUsage = false
 			return fmt.Errorf("--config is required (or set HOOP_SIDECAR_CONFIG or %s)",
 				daemon.ControlPlaneURLEnv)
+		}
+		if sidecarMigrateFlag {
+			if sidecarConfigFlag == "" {
+				cmd.SilenceUsage = false
+				return fmt.Errorf("--migrate needs --config: it rewrites a file, " +
+					"and a control-plane config has no file to rewrite")
+			}
+			cfg, err := configyaml.Load(sidecarConfigFlag)
+			if err != nil {
+				return err
+			}
+			out := os.Stdout
+			if sidecarMigrateOutFlag != "" {
+				f, err := os.Create(sidecarMigrateOutFlag)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				out = f
+			}
+			// The destination's extension picks the syntax; stdout
+			// inherits the input's.
+			target := sidecarMigrateOutFlag
+			if target == "" {
+				target = sidecarConfigFlag
+			}
+			return daemon.WriteMigrated(cfg, configyaml.IsYAML(target), out, os.Stderr)
 		}
 
 		cfg, det, err := daemon.SetupWith(sidecarConfigFlag, configyaml.Load, buildSidecarPlugin,
@@ -202,6 +231,9 @@ func init() {
 	// operator reading either sees the hoop version that produced the binary
 	// rather than the library's "dev" default.
 	daemon.Version = version.Get().Version
+	// --migrate renders YAML through the same module that parses it; the
+	// daemon package cannot import it, so the renderer is injected.
+	daemon.YAMLFromJSON = configyaml.FromJSON
 
 	startSidecarCmd.Flags().StringVar(&sidecarConfigFlag, "config", sidecarConfigFromEnv(),
 		"Path to the inspection config file (YAML or JSON)")
@@ -222,6 +254,13 @@ func init() {
 	startSidecarCmd.Flags().BoolVar(&sidecarStrictFlag, "strict", false,
 		"Fail when the config uses a deprecated field, so a pipeline can catch it "+
 			"before the release that removes it")
+	startSidecarCmd.Flags().BoolVar(&sidecarMigrateFlag, "migrate", false,
+		"Rewrite the config onto the current schema, print it, and exit. Deprecated "+
+			"fields are folded and ai_analysis rules become listener analyzer blocks "+
+			"where the move is faithful")
+	startSidecarCmd.Flags().StringVar(&sidecarMigrateOutFlag, "migrate-out", "",
+		"File --migrate writes to instead of stdout; its extension picks the syntax, "+
+			"defaulting to the input's")
 
 	startCmd.AddCommand(startSidecarCmd)
 }

--- a/deploy/docker-compose/envoy-stack/README.md
+++ b/deploy/docker-compose/envoy-stack/README.md
@@ -284,9 +284,12 @@ Two producers sit commented out in `sidecar/config.yaml`:
   lane with no `opa.url` denies on a match instead of reporting it, so the
   rule on its own turns this lane into a hard block on those four entity
   classes.
-- **`ai_analysis`**: sends a statement to a language model and reports the
-  risk it comes back with. Needs a credential and spends money per statement,
-  so it also needs the `analyzer:` block.
+- **the analyzer**: a per-listener `analyzer:` block, beside `guardrails`,
+  that sends a statement to a language model and reports the risk it comes
+  back with. Needs a credential and spends money per statement, so it also
+  needs the top-level `analyzer:` section that holds the provider. (The old
+  spelling, a `type: ai_analysis` rule under `guardrails.rules`, still loads
+  but prints a deprecation and fails under `-strict`.)
 
 Either way nothing else in the stack changes: the Rego is already loaded and
 the OPA container is already running.
@@ -297,7 +300,7 @@ would put it in this YAML, a second place decisions live that nobody reviews.
 already owns:
 
 ```yaml
-analyzer:
+analyzer:                              # the provider, plus defaults every lane inherits
   provider: vertex                     # vertex | anthropic | openai
   model: claude-sonnet-4-5@20250929
   extra: {project: my-gcp-project, region: global}
@@ -317,31 +320,29 @@ listeners:
           type: pii
           action: defer                # report the classes, do not deny
           entities: [US_SSN, CREDIT_CARD, IBAN_CODE, EMAIL_ADDRESS]
-        - name: risky-writes
-          type: ai_analysis
-          high: defer                  # the analyzer classifies; Rego decides
-          medium: defer
-          low: defer
+    analyzer:                          # this lane's analyzer, beside guardrails
+      high: defer                      # the analyzer classifies; Rego decides
+      medium: defer
+      low: defer
 ```
 
 BR_CPF is missing from that entity list because `no-cpf-in-query` in the
 defaults already denies it outright, for free, before OPA is consulted.
 Taking the `pii` rule on its own means dropping `gate: true`, because a gate
-with no `ai_analysis` rule is a round trip that buys nothing and is refused at
-startup.
+with no analyzer is a round trip that buys nothing and is refused at startup.
 
 The lane then consults OPA twice, at the same URL, with `input.phase` saying
 which call it is. The **gate** phase runs before the producers and answers
 `request: {"ai_analysis": true}` or `false`, so the cost control is a Rego
-rule rather than a `trigger:` list. That is why the ai rule above has no
-trigger at all. The **decide** phase runs after, carrying what each producer
+rule rather than a `trigger:` list. That is why the analyzer block above has
+no trigger at all. The **decide** phase runs after, carrying what each producer
 established in `input.findings`, keyed by source:
 
 ```json
 {"findings": {
   "pii": {"rule": "sensitive-columns", "status": "ok",
           "values": {"entities": ["US_SSN"], "rules": ["sensitive-columns"]}},
-  "ai_analysis": {"rule": "risky-writes", "status": "ok",
+  "ai_analysis": {"rule": "appdb", "status": "ok",
                   "values": {"risk_level": "high"}}
 }}
 ```
@@ -379,7 +380,7 @@ with the word in `reason`:
 
 ```bash
 curl -s localhost:19000/api/stats | python3 -m json.tool   # by_risk
-curl -s localhost:19000/config    | python3 -m json.tool   # ai_rules per lane
+curl -s localhost:19000/config    | python3 -m json.tool   # each lane's resolved analyzer
 ```
 
 This evaluator **fails open** by default. It depends on a third-party API, and

--- a/deploy/docker-compose/envoy-stack/mssql/config-mssql.yaml
+++ b/deploy/docker-compose/envoy-stack/mssql/config-mssql.yaml
@@ -37,15 +37,17 @@ pii:
     - IBAN_CODE
 
 # ------------------------------------------------------------------ analyzer
-# Commented out because it needs a credential and spends money per statement.
-# Uncomment, add an ai_analysis rule to a lane below, and the relay classifies
-# what the trigger names.
+# The provider plus the DEFAULTS every lane inherits. Commented out because
+# it needs a credential and spends money per statement. Uncomment, give a
+# lane below its own analyzer: block, and the relay classifies what that
+# block's trigger names. (The old spelling, a `type: ai_analysis` rule under
+# guardrails.rules, still loads but prints a deprecation.)
 #
 # Three things bound the cost, and all three matter on a database lane where
 # an ORM repeats one statement shape thousands of times: the trigger decides
 # what is worth asking about, the cache keys on the statement SHAPE (literals
 # stripped, so `WHERE id = 1` and `WHERE id = 2` are one verdict), and the
-# rule runs last in the chain, after the free local rules and OPA.
+# analyzer runs last in the chain, after the free local rules and OPA.
 #
 # analyzer:
 #   provider: vertex            # vertex | anthropic | openai
@@ -65,12 +67,12 @@ pii:
 #   max_input_bytes: 8192
 #   cache: {size: 4096, ttl_sec: 900}
 #   max_calls: 500
-#   # PROCESS-WIDE: this reaches every ai_analysis rule on every lane, the
-#   # http one included, so keep it protocol-neutral. Protocol-specific
-#   # wording belongs on a rule's own `prompt:`, which beats this. Neither can
-#   # remove the output contract (call one tool, never quote a literal value
-#   # from the statement) -- the second keeps an identifier the model objected
-#   # to out of the audit trail.
+#   # PROCESS-WIDE: this reaches every lane's analyzer, the http one
+#   # included, so keep it protocol-neutral. Protocol-specific wording
+#   # belongs on a listener block's own `prompt:`, which wins for its lane.
+#   # Neither can remove the output contract (call one tool, never quote a
+#   # literal value from the statement) -- the second keeps an identifier the
+#   # model objected to out of the audit trail.
 #   prompt: |
 #     You are classifying traffic to a production environment holding
 #     customer records. Anything reading or modifying customer data is at
@@ -176,17 +178,16 @@ listeners:
           type: operation # lexer-derived, so SELECT 'DROP TABLE x' is a select
           operations: [drop, delete, truncate]
           message: destructive statements are not permitted on appdb
-        # Uncomment with the analyzer block above. The trigger excludes
-        # select, so an ORM's read traffic costs nothing; delete is already
-        # refused by the rule above, and Chain short-circuits on the first
-        # denial, so only an UPDATE actually reaches the model.
-        # - name: risky-writes
-        #   type: ai_analysis
-        #   trigger: {operations: [update]}
-        #   high: block
-        #   medium: warn
-        #   low: allow
-        #   message: refused by risk analysis
+    # Uncomment with the analyzer section above. The trigger excludes
+    # select, so an ORM's read traffic costs nothing; delete is already
+    # refused by the rule above, and Chain short-circuits on the first
+    # denial, so only an UPDATE actually reaches the model.
+    # analyzer:
+    #   trigger: {operations: [update]}
+    #   high: block
+    #   medium: warn
+    #   low: allow
+    #   message: refused by risk analysis
     mask:
       rules:
         # Column rules are only possible where the protocol names its values,
@@ -221,13 +222,12 @@ listeners:
           # this is a question Envoy structurally cannot ask.
           statuses: ["5xx"]
           message: upstream failure suppressed by policy
-        # Needs the http block below: without capture_body the analyzer sees
-        # "POST /anything" and no payload, which tells a model nothing.
-        # - name: risky-payloads
-        #   type: ai_analysis
-        #   trigger: {resources: ["/anything"]}
-        #   high: block
-        #   medium: warn
+    # Needs the http block below: without capture_body the analyzer sees
+    # "POST /anything" and no payload, which tells a model nothing.
+    # analyzer:
+    #   trigger: {resources: ["/anything"]}
+    #   high: block
+    #   medium: warn
     # Off by default: everything captured reaches policy, the audit trail and,
     # with an analyzer configured, a third party. authorization, cookie and
     # proxy-authorization cannot be allowlisted, and no header ever reaches

--- a/deploy/docker-compose/envoy-stack/opa/authz.rego
+++ b/deploy/docker-compose/envoy-stack/opa/authz.rego
@@ -130,7 +130,7 @@ inspect_phase := object.get(input, "phase", "decide")
 # ------------------------------------------------------------- gate phase
 # Runs BEFORE the producers and answers one question per source: is this
 # statement worth running that producer on? `request` overrides the source's
-# own configuration (the ai rule's `trigger` here), so the cost control
+# own configuration (the analyzer's `trigger` here), so the cost control
 # sits next to the policy that spends the money instead of in a YAML trigger
 # the Rego author never sees.
 #
@@ -160,7 +160,7 @@ inspect := {"allow": true, "request": {"ai_analysis": false}} if {
 # precedence order.
 inspect := inspect_decide if inspect_phase == "decide"
 
-# The ai_analysis producer. UNDEFINED on a lane carrying no ai_analysis rule,
+# The ai_analysis producer. UNDEFINED on a lane with no analyzer,
 # which is what separates "no analyzer here" from "the analyzer ran and could
 # not answer": a configured analyzer reports a finding even when it skips.
 inspect_ai := input.findings.ai_analysis
@@ -190,7 +190,7 @@ inspect_pii_hits := {e | some e in inspect_pii_entities; e in inspect_pii_protec
 inspect_decide := {"denied": true, "rule": "ai-unavailable", "message": msg} if {
 	# Fail closed on protected data nobody classified. A level-only
 	# contract cannot express this case, which is why status exists.
-	# Naming inspect_ai.status is also the presence check: with no ai rule
+	# Naming inspect_ai.status is also the presence check: with no analyzer
 	# on the lane this branch is undefined and the chain falls through,
 	# rather than denying everything because nothing classified.
 	inspect_touches_sensitive

--- a/deploy/docker-compose/envoy-stack/postgres/config-postgres.yaml
+++ b/deploy/docker-compose/envoy-stack/postgres/config-postgres.yaml
@@ -37,15 +37,17 @@ pii:
     - IBAN_CODE
 
 # ------------------------------------------------------------------ analyzer
-# Commented out because it needs a credential and spends money per statement.
-# Uncomment, add an ai_analysis rule to a lane below, and the relay classifies
-# what the trigger names.
+# The provider plus the DEFAULTS every lane inherits. Commented out because
+# it needs a credential and spends money per statement. Uncomment, give a
+# lane below its own analyzer: block, and the relay classifies what that
+# block's trigger names. (The old spelling, a `type: ai_analysis` rule under
+# guardrails.rules, still loads but prints a deprecation.)
 #
 # Three things bound the cost, and all three matter on a database lane where
 # an ORM repeats one statement shape thousands of times: the trigger decides
 # what is worth asking about, the cache keys on the statement SHAPE (literals
 # stripped, so `WHERE id = 1` and `WHERE id = 2` are one verdict), and the
-# rule runs last in the chain, after the free local rules and OPA.
+# analyzer runs last in the chain, after the free local rules and OPA.
 #
 # analyzer:
 #   provider: vertex            # vertex | anthropic | openai
@@ -65,12 +67,12 @@ pii:
 #   max_input_bytes: 8192
 #   cache: {size: 4096, ttl_sec: 900}
 #   max_calls: 500
-#   # PROCESS-WIDE: this reaches every ai_analysis rule on every lane, the
-#   # http one included, so keep it protocol-neutral. Protocol-specific
-#   # wording belongs on a rule's own `prompt:`, which beats this. Neither can
-#   # remove the output contract (call one tool, never quote a literal value
-#   # from the statement) -- the second keeps an identifier the model objected
-#   # to out of the audit trail.
+#   # PROCESS-WIDE: this reaches every lane's analyzer, the http one
+#   # included, so keep it protocol-neutral. Protocol-specific wording
+#   # belongs on a listener block's own `prompt:`, which wins for its lane.
+#   # Neither can remove the output contract (call one tool, never quote a
+#   # literal value from the statement) -- the second keeps an identifier the
+#   # model objected to out of the audit trail.
 #   prompt: |
 #     You are classifying traffic to a production environment holding
 #     customer records. Anything reading or modifying customer data is at
@@ -128,17 +130,16 @@ listeners:
           type: operation # lexer-derived, so SELECT 'DROP TABLE x' is a select
           operations: [drop, delete, truncate]
           message: destructive statements are not permitted on appdb
-        # Uncomment with the analyzer block above. The trigger excludes
-        # select, so an ORM's read traffic costs nothing; delete is already
-        # refused by the rule above, and Chain short-circuits on the first
-        # denial, so only an UPDATE actually reaches the model.
-        # - name: risky-writes
-        #   type: ai_analysis
-        #   trigger: {operations: [update]}
-        #   high: block
-        #   medium: warn
-        #   low: allow
-        #   message: refused by risk analysis
+    # Uncomment with the analyzer section above. The trigger excludes
+    # select, so an ORM's read traffic costs nothing; delete is already
+    # refused by the rule above, and Chain short-circuits on the first
+    # denial, so only an UPDATE actually reaches the model.
+    # analyzer:
+    #   trigger: {operations: [update]}
+    #   high: block
+    #   medium: warn
+    #   low: allow
+    #   message: refused by risk analysis
     mask:
       rules:
         # Column rules are only possible where the protocol names its values,
@@ -173,13 +174,12 @@ listeners:
           # this is a question Envoy structurally cannot ask.
           statuses: ["5xx"]
           message: upstream failure suppressed by policy
-        # Needs the http block below: without capture_body the analyzer sees
-        # "POST /anything" and no payload, which tells a model nothing.
-        # - name: risky-payloads
-        #   type: ai_analysis
-        #   trigger: {resources: ["/anything"]}
-        #   high: block
-        #   medium: warn
+    # Needs the http block below: without capture_body the analyzer sees
+    # "POST /anything" and no payload, which tells a model nothing.
+    # analyzer:
+    #   trigger: {resources: ["/anything"]}
+    #   high: block
+    #   medium: warn
     # Off by default: everything captured reaches policy, the audit trail and,
     # with an analyzer configured, a third party. authorization, cookie and
     # proxy-authorization cannot be allowlisted, and no header ever reaches

--- a/deploy/docker-compose/envoy-stack/sidecar-binary.md
+++ b/deploy/docker-compose/envoy-stack/sidecar-binary.md
@@ -290,12 +290,19 @@ in the audit stream on stdout as one JSON line:
 
 ## Turning on AI risk analysis
 
-A `type: ai_analysis` rule sends a statement to a language model and denies on
-the risk it reports. It works on both lane types: SQL on a postgres listener,
-request bodies on an HTTP one. The relay holds the provider credential; there
-is no gateway call.
+The AI analyzer is a per-listener component, declared beside `guardrails` and
+`mask`. It sends a statement to a language model and denies on the risk it
+reports. It works on both lane types: SQL on a postgres listener, request
+bodies on an HTTP one. The relay holds the provider credential; there is no
+gateway call.
 
-Add an `analyzer:` block and a rule:
+Two blocks share the work. The top-level `analyzer:` section holds the
+provider plus the defaults every listener inherits; each lane's own
+`analyzer:` block holds the trigger, the risk→action map and any default it
+overrides. (The old spelling — a `type: ai_analysis` rule under
+`guardrails.rules` — is deprecated but still loads: it builds the same
+evaluator, prints a deprecation naming the listener block, and `-strict`
+fails on it.)
 
 ```yaml
 analyzer:
@@ -313,15 +320,12 @@ analyzer:
 listeners:
   - name: appdb
     # ... as above
-    guardrails:
-      rules:
-        - name: risky-writes
-          type: ai_analysis
-          trigger: {operations: [update, delete]}
-          high: block
-          medium: warn
-          low: allow
-          message: refused by risk analysis
+    analyzer:                        # this lane's analyzer, beside guardrails
+      trigger: {operations: [update, delete]}
+      high: block
+      medium: warn
+      low: allow
+      message: refused by risk analysis
 ```
 
 `--validate` reports it, and for Vertex it mints one token so a bad key or a
@@ -332,7 +336,7 @@ risky statement:
 config OK: 1 listener(s)
   license: missing, running the free tier. Add one with the license flag, the HOOP_LICENSE environment variable, or the "license" key in the config file
   limits: 1 guardrail rule(s), 1 data masking rule(s)
-  appdb            postgres  enforcing 1 rule(s) + masking + 1 ai rule(s)
+  appdb            postgres  enforcing 1 rule(s) + masking + ai analyzer
 ```
 
 ### Three knobs decide what it costs
@@ -342,9 +346,13 @@ these are not optimizations you can skip:
 
 | Knob | Effect |
 |---|---|
-| `trigger` | Only these operations, tables or resources are classified. Everything else is free. An empty trigger classifies nothing and is a startup error. |
+| `trigger` | Only these operations, tables or resources are classified. Everything else is free. An empty trigger classifies nothing and is a startup error, except under `opa.gate: true`, where it means Rego decides. |
 | `cache` | Keys on the statement SHAPE. `WHERE id = 1` and `WHERE id = 2` are one verdict. |
-| `max_calls` | Process-lifetime budget. Past it, statements fall through to the local rules. |
+| `max_calls` | Call budget, keyed on the listener name. Past it, statements fall through to the local rules. |
+
+All three default to the top-level `analyzer:` value; a block that names one
+overrides it for that lane alone, as do `send`, `fail_open`, `timeout_sec`
+and `max_input_bytes`.
 
 Read the hit rate before you enable `block` anywhere:
 
@@ -369,16 +377,13 @@ The HTTP codec exposes nothing by default. Without a body the model sees `POST
       capture_body: true
       max_body_bytes: 8192
       headers: [Content-Type]      # authorization is refused at startup
-    guardrails:
-      rules:
-        - name: risky-payloads
-          type: ai_analysis
-          trigger: {resources: ["/orders/**"]}
-          high: block
+    analyzer:
+      trigger: {resources: ["/orders/**"]}
+      high: block
 ```
 
 A request with no body is skipped rather than classified, so a forgotten
-`capture_body` looks like a rule that never fires.
+`capture_body` looks like an analyzer that never fires.
 
 ### Reading the verdicts
 
@@ -468,13 +473,14 @@ is a compliance requirement.
 
 ### Writing your own prompt
 
-`analyzer.prompt` sets the risk guidance for every rule; a rule's own
-`prompt:` beats it.
+`analyzer.prompt` at the top level sets the risk guidance for every lane; a
+listener block's own `prompt:` beats it for that lane.
 
-`analyzer.prompt` reaches **every lane**, so keep it protocol-neutral and put
-SQL- or HTTP-specific wording on the rule. Guidance reading "you are
-classifying SQL against a customer database" follows an HTTP statement to the
-model and has it reasoning about `DROP` while it looks at a JSON body.
+The top-level prompt reaches **every lane**, so keep it protocol-neutral and
+put SQL- or HTTP-specific wording on the listener's block. Guidance reading
+"you are classifying SQL against a customer database" follows an HTTP
+statement to the model and has it reasoning about `DROP` while it looks at a
+JSON body.
 
 Either way, two instructions are appended and cannot be removed: call exactly
 one risk tool, and never quote a literal value from the statement. The second
@@ -523,10 +529,10 @@ recognizing the value, and the detector deliberately refuses obvious fixtures
 like `123-45-6789`. Use a column rule when the protocol names the value, an
 entity rule when it does not.
 
-**An `ai_analysis` rule on an HTTP lane needs `capture_body: true`.** The HTTP
-codec exposes no body by default, and a request with no body is skipped rather
-than classified, so the symptom is a rule that does not fire rather than an
-error. The same rule on a postgres lane needs nothing extra, because the
+**The analyzer on an HTTP lane needs `capture_body: true`.** The HTTP codec
+exposes no body by default, and a request with no body is skipped rather than
+classified, so the symptom is an analyzer that does not fire rather than an
+error. The same block on a postgres lane needs nothing extra, because the
 statement text is there either way.
 
 ---

--- a/deploy/docker-compose/envoy-stack/sidecar-binary.md
+++ b/deploy/docker-compose/envoy-stack/sidecar-binary.md
@@ -346,7 +346,7 @@ these are not optimizations you can skip:
 
 | Knob | Effect |
 |---|---|
-| `trigger` | Only these operations, tables or resources are classified. Everything else is free. An empty trigger classifies nothing and is a startup error, except under `opa.gate: true`, where it means Rego decides. |
+| `trigger` | Only these operations, tables or resources are classified. Everything else is free. Omit it and EVERY statement on the lane is classified (a model call per statement shape; `-validate` prints a note); under `opa.gate: true` an omitted trigger means Rego decides instead. |
 | `cache` | Keys on the statement SHAPE. `WHERE id = 1` and `WHERE id = 2` are one verdict. |
 | `max_calls` | Call budget, keyed on the listener name. Past it, statements fall through to the local rules. |
 

--- a/deploy/docker-compose/envoy-stack/sidecar/config.yaml
+++ b/deploy/docker-compose/envoy-stack/sidecar/config.yaml
@@ -208,9 +208,10 @@ listeners:
     # No trigger, on purpose. `gate: true` below consults OPA BEFORE the
     # analyzer (phase: gate) and it answers request: {ai_analysis:
     # true|false}, so Rego decides what is worth a model call. Without
-    # gate: true an analyzer block with no trigger is refused at startup,
-    # and without the gate at all the model runs first: a statement Rego
-    # would have refused for free has already been paid for.
+    # gate: true an analyzer block with no trigger classifies EVERY
+    # statement (a model call per statement shape; -validate prints a
+    # note), and without the gate at all the model runs first: a statement
+    # Rego would have refused for free has already been paid for.
     # analyzer:
     #   high: defer
     #   medium: defer

--- a/deploy/docker-compose/envoy-stack/sidecar/config.yaml
+++ b/deploy/docker-compose/envoy-stack/sidecar/config.yaml
@@ -42,16 +42,18 @@ pii:
     - IBAN_CODE
 
 # ------------------------------------------------------------------ analyzer
-# Commented out because it needs a credential and spends money per statement.
-# Uncomment, add an ai_analysis rule to a lane below, and the relay classifies
-# what the trigger names.
+# The provider plus the DEFAULTS every lane inherits. Commented out because
+# it needs a credential and spends money per statement. Uncomment, give a
+# lane below its own analyzer: block, and the relay classifies what that
+# block's trigger names. (The old spelling, a `type: ai_analysis` rule under
+# guardrails.rules, still loads but prints a deprecation.)
 #
 # Three things bound the cost, and all three matter on a database lane where
 # an ORM repeats one statement shape thousands of times: the trigger decides
 # what is worth asking about, the cache keys on the statement SHAPE (literals
 # stripped, so `WHERE id = 1` and `WHERE id = 2` are one verdict), and the
-# rule runs after the free local rules, so nothing already refused is paid
-# for. The appdb lane below moves the first of the three into Rego with
+# analyzer runs after the free local rules, so nothing already refused is
+# paid for. The appdb lane below moves the first of the three into Rego with
 # `opa.gate`, which is the same cost control asked of the policy engine
 # instead of a YAML trigger.
 #
@@ -73,12 +75,12 @@ pii:
 #   max_input_bytes: 8192
 #   cache: {size: 4096, ttl_sec: 900}
 #   max_calls: 500
-#   # PROCESS-WIDE: this reaches every ai_analysis rule on every lane, the
-#   # http one included, so keep it protocol-neutral. Protocol-specific
-#   # wording belongs on a rule's own `prompt:`, which beats this. Neither can
-#   # remove the output contract (call one tool, never quote a literal value
-#   # from the statement); the second keeps an identifier the model objected
-#   # to out of the audit trail.
+#   # PROCESS-WIDE: this reaches every lane's analyzer, the http one
+#   # included, so keep it protocol-neutral. Protocol-specific wording
+#   # belongs on a listener block's own `prompt:`, which wins for its lane.
+#   # Neither can remove the output contract (call one tool, never quote a
+#   # literal value from the statement); the second keeps an identifier the
+#   # model objected to out of the audit trail.
 #   prompt: |
 #     You are classifying traffic to a production environment holding
 #     customer records. Anything reading or modifying customer data is at
@@ -179,8 +181,8 @@ listeners:
         # This one needs the `pii:` section above (already there) and the
         # `opa:` block below, and nothing else: no model, no credential,
         # no per-statement cost. It is the cheapest way to see two-phase
-        # evaluation in this stack. Taking it WITHOUT the ai rule means
-        # dropping `gate: true`: a gate with no ai_analysis rule is a round
+        # evaluation in this stack. Taking it WITHOUT the analyzer below
+        # means dropping `gate: true`: a gate with no analyzer is a round
         # trip that buys nothing and is refused at startup.
         #
         # OPA sees input.findings.pii.values.entities, the entity CLASSES
@@ -191,38 +193,35 @@ listeners:
         #   type: pii
         #   action: defer
         #   entities: [US_SSN, CREDIT_CARD, IBAN_CODE, EMAIL_ADDRESS]
-        # ---- AI verdict -> Rego (off; needs a model credential) ---------
-        # Uncommenting the rest of this block and the analyzer: section
-        # above is the ONLY step needed to turn it on. The Rego is already
-        # in opa/authz.rego and the OPA container is already running, so
-        # nothing else in the stack changes.
-        #
-        # `defer` means the analyzer does not decide. It classifies, and
-        # the level travels to OPA as input.findings.ai_analysis on a
-        # second call carrying phase: decide, where rule `inspect` in
-        # opa/authz.rego blocks or allows. A shop that already reviews Rego
-        # has one place decisions live; a `high: block` line here would be
-        # a second one nobody reviews.
-        #
-        # No trigger, on purpose. `gate: true` below consults OPA BEFORE
-        # the analyzer (phase: gate) and it answers request: {ai_analysis:
-        # true|false}, so Rego decides what is worth a model call. Without
-        # gate: true an ai_analysis rule with no trigger is refused at
-        # startup, and without the gate at all the model runs first: a
-        # statement Rego would have refused for free has already been paid
-        # for.
-        # - name: risky-writes
-        #   type: ai_analysis
-        #   high: defer
-        #   medium: defer
-        #   low: defer
+    # ---- AI verdict -> Rego (off; needs a model credential) ------------
+    # Uncommenting this block and the analyzer: section above is the ONLY
+    # step needed to turn it on. The Rego is already in opa/authz.rego and
+    # the OPA container is already running, so nothing else in the stack
+    # changes.
+    #
+    # `defer` means the analyzer does not decide. It classifies, and the
+    # level travels to OPA as input.findings.ai_analysis on a second call
+    # carrying phase: decide, where rule `inspect` in opa/authz.rego blocks
+    # or allows. A shop that already reviews Rego has one place decisions
+    # live; a `high: block` line here would be a second one nobody reviews.
+    #
+    # No trigger, on purpose. `gate: true` below consults OPA BEFORE the
+    # analyzer (phase: gate) and it answers request: {ai_analysis:
+    # true|false}, so Rego decides what is worth a model call. Without
+    # gate: true an analyzer block with no trigger is refused at startup,
+    # and without the gate at all the model runs first: a statement Rego
+    # would have refused for free has already been paid for.
+    # analyzer:
+    #   high: defer
+    #   medium: defer
+    #   low: defer
     # opa:
     #   # The same OPA container the fat gate uses, a different rule:
     #   # ext_authz answers Envoy at envoy/authz/result, this answers the
-    #   # sidecar over the Data API. Required by either deferring rule
+    #   # sidecar over the Data API. Wanted by either deferring block
     #   # above: `defer` with no OPA endpoint defers to a decision that
-    #   # does not exist, which allows everything, so it is refused at
-    #   # startup.
+    #   # does not exist, so the lane loads with a startup note and DENIES
+    #   # on a match instead of allowing it.
     #   url: http://opa:8181/v1/data/envoy/authz/inspect
     #   # A policy engine outage stops appdb rather than silently
     #   # disabling enforcement. The gate phase is exempt by design: an
@@ -286,13 +285,12 @@ listeners:
         #   type: http_status
         #   statuses: ["5xx"]
         #   message: upstream failure suppressed by policy
-        # Needs the http block below: without capture_body the analyzer sees
-        # "POST /anything" and no payload, which tells a model nothing.
-        # - name: risky-payloads
-        #   type: ai_analysis
-        #   trigger: {resources: ["/anything"]}
-        #   high: block
-        #   medium: warn
+    # Needs the http block below: without capture_body the analyzer sees
+    # "POST /anything" and no payload, which tells a model nothing.
+    # analyzer:
+    #   trigger: {resources: ["/anything"]}
+    #   high: block
+    #   medium: warn
     # Off by default: everything captured reaches policy, the audit trail and,
     # with an analyzer configured, a third party. authorization, cookie and
     # proxy-authorization cannot be allowlisted, and no header ever reaches

--- a/docs/adr/0008-analyzer-enforces-without-opa.md
+++ b/docs/adr/0008-analyzer-enforces-without-opa.md
@@ -1,11 +1,21 @@
 # ADR-0008: The AI analyzer decides for itself; OPA is the opt-in second decider
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-09-11: omitted trigger classifies everything, see note below)
 - **Date:** 2026-08-27
 - **Author:** @matheusfrancisco
 - **Code:** [`sidecar/analyzer/`](../../sidecar/analyzer), [`sidecar/daemon/config.go`](../../sidecar/daemon/config.go), [`sidecar/daemon/analyzer.go`](../../sidecar/daemon/analyzer.go), [`sidecar/policy/`](../../sidecar/policy)
 - **Related:** [ADR-0005](0005-sidecar-flow.md) (request flow, current state), [ADR-0006](0006-sidecar-config-defaults-and-overrides.md) (the refusal table this ADR explains the other half of), [ADR-0009](0009-guardrails-and-masking-architecture.md) (the enforcement points this chain sits in)
 - **Supersedes / Superseded by:** —
+
+> **Amendment (2026-09-11):** the trigger is no longer load-bearing as a
+> refusal. "The trigger is the cost control" below stands, but an OMITTED
+> trigger on an ungated lane now classifies everything instead of being
+> refused at startup: declaring the analyzer is the opt-in, the cache and
+> `max_calls` bound the bill, and `-validate` prints the per-statement cost
+> as a note. Gated lanes are unchanged — the zero trigger stays, so a
+> gate-phase policy's silence keeps meaning "skip". See
+> [ADR-0015](0015-listener-analyzer-block.md) for the listener block this
+> applies to.
 
 ## Context
 

--- a/docs/adr/0015-listener-analyzer-block.md
+++ b/docs/adr/0015-listener-analyzer-block.md
@@ -1,0 +1,157 @@
+# ADR-0015: The analyzer is a listener component, not a guardrail rule
+
+- **Status:** Proposed
+- **Date:** 2026-09-11
+- **Author:** @matheusfrancisco
+- **Code:** [`sidecar/daemon/analyzer.go`](../../sidecar/daemon/analyzer.go), [`sidecar/daemon/config.go`](../../sidecar/daemon/config.go), [`sidecar/daemon/reload.go`](../../sidecar/daemon/reload.go)
+- **Related:** [ADR-0008](0008-analyzer-enforces-without-opa.md) (the analyzer decides for itself; every row of its action table survives this ADR), [ADR-0011](0011-sidecar-config-schema.md) (the guardrails/opa split this extends to the analyzer), [ADR-0006](0006-sidecar-config-defaults-and-overrides.md) (the merge table the new block joins), [ADR-0014](0014-sidecar-config-hot-reload.md) (the reload boundary the block sits inside)
+- **Supersedes / Superseded by:** amends the config surface of ADR-0008; the decision semantics there stand.
+
+## Context
+
+The AI analyzer shipped spelled as a guardrail rule: `type: ai_analysis`
+under `guardrails.rules`, beside `deny_words_list` and `pattern_match`. The
+spelling was never true. A guardrail rule is a local matcher — microseconds,
+no network, denies or defers on match through one `action`. The analyzer
+leaves the process, costs money per statement, can take a second, and maps
+`high`/`medium`/`low` onto actions instead of carrying one. The code always
+knew: `splitAnalyzerRules` lifted these rules out before `policy.NewRules`
+could see them, `Rules` rejected one that reached it anyway, and prompt
+precedence already read rule → analyzer section → built-in, which is
+component behaviour wearing a rule's clothes.
+
+The costume had a price in every layer that touched it:
+
+- Startup carried refusals that only exist because a component was forced
+  into a rule shape: `action:` on an `ai_analysis` rule (the field is read
+  by nobody), `opa.gate: true` with no `ai_analysis` rule, an `ai_analysis`
+  rule with no `analyzer` section.
+- The config could not say where the analyzer runs. The root had
+  `analyzer:` (provider, send, cache, budget) but a listener had no analyzer
+  block, so per-lane variation squeezed through rule fields while the
+  tunables an operator actually varies per lane — `send`, `fail_open`,
+  `max_calls` — were stuck process-wide.
+- `-validate` reported the component as a rule count (`+ 1 ai rule(s)`),
+  and the docs taught the analyzer through the guardrails page.
+
+The feature's intended role is a per-lane decision engine over the wire, a
+peer of guardrails and masking that can one day apply both at runtime. A
+rule shape blocks that: peers get blocks, subtypes get rows in someone
+else's list.
+
+## Options considered
+
+1. **Keep the rule shape and document it harder.** Zero migration cost.
+   Rejected: every startup refusal above stays load-bearing, per-lane
+   tunables stay impossible, and the next capability (the analyzer applying
+   guardrails the user never wrote) has no place to hang config.
+2. **A listener `analyzer:` block, and normalize() folds old rules into
+   it.** One canonical representation in memory. Rejected on faithfulness: a
+   lane carrying two `ai_analysis` rules (different triggers, different
+   prompts) cannot fold into one block, and a top-level rule reaches every
+   lane while a block is per listener. A fold that is sometimes lossy is
+   worse than no fold.
+3. **A listener `analyzer:` block beside the rule form, both building
+   through one path.** The block is canonical; the rule converts to the
+   block's shape (`specFromRule`) and builds through the same
+   `buildAnalyzerEvaluator`, so the two spellings cannot drift. The rule
+   form warns at load and keeps working. Chosen.
+
+## Decision
+
+Each listener takes its own `analyzer:` block — trigger, `high`/`medium`/
+`low`, `prompt`, `message` — plus per-lane overrides of the root defaults:
+`send`, `fail_open`, `timeout_sec`, `max_input_bytes`, `max_calls`, `cache`.
+A zero field inherits the root value, so the block overrides exactly what it
+names.
+
+The root `analyzer:` section keeps what is genuinely process-wide — the
+provider, the model, the endpoint, the credential, and one credential read —
+and becomes the defaults every lane inherits. Provider settings are NOT per
+lane: a second provider per lane doubles the credential surface for a case
+nobody has asked for, which is the same line ADR-0008 drew.
+
+`type: ai_analysis` still loads, still enforces, and records a deprecation
+through the same `Config.Deprecations` funnel every other renamed field uses
+(`-strict` turns it into a non-zero exit). Both spellings can serve one lane
+during a migration, each as its own evaluator: block first, then the rules
+in concatenation order, all after the local rules and the gate/single-call
+OPA position.
+
+Identity follows the shape. A block's evaluator is named after the LANE —
+`Finding.Rule`, the `ai_rule` audit key and the `max_calls` budget all carry
+it — because a component has no rule name and the listener name is the
+identity an operator edits. The field NAMES in findings, audit metadata and
+`/stats` do not change, so dashboards and Rego keyed on
+`findings.ai_analysis` keep working unmodified.
+
+The block sits inside the ADR-0014 hot-reload boundary: it builds
+evaluators, not sockets, so editing it swaps like a rule edit
+(`laneRuleDoc` carries it, `nonRuleDoc` strips it), while the root section
+stays restart-bound with the provider credential it holds. Budgets key on
+the evaluator name, so a reloaded block continues its lane's running count.
+
+`-validate` reports the component: `+ ai analyzer`, with
+`(N deprecated ai rule(s))` counting what is left to migrate on that lane.
+
+Nothing in ADR-0008 moves. The action table, `defer`'s degradation to
+`block` on OPA-less lanes, `require_review`'s refusal, fail-open-by-default
+and the trigger-as-cost-control all apply to the block verbatim, because the
+block and the rule build the same evaluator.
+
+## Consequences
+
+**The refusal table reads the same, one shape earlier.** A block with no
+trigger on an ungated lane, no action for any level, or no root `analyzer`
+section refuses at startup with the same reasoning the rule form had — those
+were never symptoms of the rule shape, only phrased as if they were. The one
+refusal that WAS a costume artifact, `action:` on an `ai_analysis` rule,
+survives only on the deprecated form and dies with it.
+
+**Two spellings exist until the rule form is removed.** That is the price of
+"the old version must not stop working", and it is bounded: both compile to
+one evaluator through one builder, validation shares `validateRiskActions`,
+and the deprecation warning names the replacement per rule, per lane. The
+removal release deletes `specFromRule`, `splitAnalyzerRules` and the
+`ai_analysis` arms of validation, and nothing else.
+
+**`ai_rule` changes value, not name, on migration.** A migrated lane reports
+the listener name where it reported the rule name. Anyone keying dashboards
+on the VALUE (not the field) sees the switch; the migration section in the
+sidecar README says so out loud. Findings were already keyed by source
+(`ai_analysis`), which does not move.
+
+**A lane with several ai rules has no block equivalent yet.** Different
+triggers with different prompts on one lane stay on the deprecated form
+until the block grows a list or the lane splits. `-validate` counts them per
+lane, so the leftover is visible rather than folklore.
+
+**The seam for "the analyzer applies guardrails" now exists.** A per-lane
+component block is where a future `apply: {guardrails: ..., mask: ...}`
+hangs without touching the rule set. That capability is unwritten and out of
+scope here; this ADR only guarantees it has an address.
+
+### How this was verified
+
+Against `sidecar/` at 2026-09-11, with the stub provider and no OPA
+anywhere. `go test ./...` passes across the module; `daemon/laneanalyzer_test.go`
+pins the contract:
+
+- A postgres lane with `analyzer: {trigger: {operations: [delete]}, high: block}`
+  validates, builds, and `-validate` reports `+ ai analyzer` with
+  `LaneInfo.Analyzer` set and no rule count.
+- The block without a root `analyzer` section, without a trigger on an
+  ungated lane, without any risk action, with `high: require_review`, with
+  an unknown action, an unknown `send`, or any negative numeric: each
+  refused, naming the lane.
+- Prompt precedence block → root → built-in, and the output contract
+  survives all three.
+- `max_calls: 1` on a block bounds the lane across evaluator rebuilds (one
+  purse per lane name; a second lane spends its own).
+- `high: defer` on the block builds the two-phase chain with the decide
+  OPA last, same as the rule form.
+- A config carrying `type: ai_analysis` validates, works, and lists a
+  deprecation naming the `analyzer` block; a lane carrying both spellings
+  builds both evaluators and reports both in its summary.
+- Editing only the block leaves `nonRuleDoc` byte-identical and changes
+  `laneRuleDoc`, which is the hot-swap condition.

--- a/docs/adr/0015-listener-analyzer-block.md
+++ b/docs/adr/0015-listener-analyzer-block.md
@@ -1,6 +1,6 @@
 # ADR-0015: The analyzer is a listener component, not a guardrail rule
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-09-11
 - **Author:** @matheusfrancisco
 - **Code:** [`sidecar/daemon/analyzer.go`](../../sidecar/daemon/analyzer.go), [`sidecar/daemon/config.go`](../../sidecar/daemon/config.go), [`sidecar/daemon/reload.go`](../../sidecar/daemon/reload.go)

--- a/docs/adr/0015-listener-analyzer-block.md
+++ b/docs/adr/0015-listener-analyzer-block.md
@@ -140,10 +140,12 @@ pins the contract:
 - A postgres lane with `analyzer: {trigger: {operations: [delete]}, high: block}`
   validates, builds, and `-validate` reports `+ ai analyzer` with
   `LaneInfo.Analyzer` set and no rule count.
-- The block without a root `analyzer` section, without a trigger on an
-  ungated lane, without any risk action, with `high: require_review`, with
-  an unknown action, an unknown `send`, or any negative numeric: each
-  refused, naming the lane.
+- The block without a root `analyzer` section, without any risk action,
+  with `high: require_review`, with an unknown action, an unknown `send`,
+  or any negative numeric: each refused, naming the lane. An omitted
+  trigger is accepted and classifies everything on an ungated lane (with a
+  `-validate` note naming the cost); on a gated lane the gate keeps
+  deciding, so Rego's silence still means "skip".
 - Prompt precedence block → root → built-in, and the output contract
   survives all three.
 - `max_calls: 1` on a block bounds the lane across evaluator rebuilds (one

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -494,6 +494,23 @@ that already holds every entity type. Nothing that worked stops working.
 `hoop-inspect -validate -strict` exits non-zero on any deprecation, so a
 pipeline can fail on the old spelling before the release that removes it does.
 
+`hoop-inspect -migrate` rewrites the file for you:
+
+```bash
+hoop-inspect -migrate -config config.yaml -migrate-out config-new.yaml
+```
+
+It loads the config through the same strict decoder the daemon uses, folds
+every renamed field above onto its replacement, moves `type: ai_analysis`
+rules onto listener `analyzer` blocks where the move is faithful (see
+"Migrating from `type: ai_analysis` rules" below), and emits a document that
+passes `-validate -strict`. The report on stderr names everything it moved
+and everything it left for you: a lane carrying two ai rules, or a top-level
+rule some lane cannot absorb, keeps the rule form with a note instead of a
+guess. The output's extension picks the syntax (stdout inherits the input's),
+and comments and key order from the original are not preserved — review the
+diff before deploying. `hoop start sidecar --migrate` is the same command.
+
 ### 1. Write the file
 
 Top-level `policy` and `mask` are DEFAULTS. Each listener is one upstream, and
@@ -1006,8 +1023,10 @@ path, and prints a deprecation naming its replacement (`-strict` turns the
 warning into a non-zero exit). Both spellings can serve one lane while you
 migrate, each as its own evaluator.
 
-Move the rule's fields onto the listener's `analyzer` block; they keep their
-names:
+`hoop-inspect -migrate -config old.yaml -migrate-out new.yaml` does the move
+below mechanically, refuses to guess where it would be lossy, and reports
+what is left; the rest of this section is what it does and why. Move the
+rule's fields onto the listener's `analyzer` block; they keep their names:
 
 ```yaml
 # before

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -654,7 +654,9 @@ it under `guardrails.would_deny`. A lane that should skip the work sets
 `-validate` also prints a note where a resolved lane behaves in a way the file
 does not show. A rule carrying `action: defer`, or an analyzer block deferring
 a risk level, on a lane with no `opa.url` gets one, because that match or
-level denies rather than reporting a finding.
+level denies rather than reporting a finding. An analyzer with no trigger on
+an ungated lane gets one too, naming the model call per statement shape it
+implies.
 
 Validation builds every lane, so it catches what a syntax check cannot, and it
 reports every problem in one run rather than one per restart. It refuses these
@@ -674,8 +676,11 @@ outright:
 - A key typo, in YAML or JSON.
 - A bad regex in any lane's rules, naming the lane.
 - An analyzer (a listener's block, or a deprecated `ai_analysis` rule) with
-  no top-level `analyzer` section, no trigger, or no action for any risk
-  level. All three would load and classify nothing.
+  no top-level `analyzer` section, or with no action for any risk level.
+  Both would load and classify nothing. An OMITTED trigger is legal and
+  classifies everything on an ungated lane — a note, not a refusal, because
+  declaring the analyzer is already the opt-in — and `-validate` prints the
+  per-statement cost it implies.
 - An analyzer on a lane whose protocol has no content builder, naming the
   protocol. That lane classifies nothing and says nothing while doing it: the
   analyzer returns before it has a status, so there is no finding and no
@@ -904,13 +909,15 @@ answer what the level means. Both calls hit the same URL and carry
 `input.phase`, so a policy that ignores the field answers both identically,
 and turning the gate on costs one round trip rather than a rewrite.
 
-Three configs are refused at startup. `gate: true` on a lane with no analyzer
-is a round trip that buys nothing. An analyzer block with no `trigger` is
-refused too, except under `gate: true`, where an empty trigger is how you say
-Rego decides. So is a block naming no action for any risk level, because
-every verdict would then allow while looking like enforcement.
+Two configs are refused at startup. `gate: true` on a lane with no analyzer
+is a round trip that buys nothing. A block naming no action for any risk
+level is refused too, because every verdict would then allow while looking
+like enforcement. An omitted `trigger` is NOT a refusal: on a plain lane it
+classifies everything (a model call per statement shape, bounded by the
+cache and `max_calls`, and `-validate` says so in a note), and under
+`gate: true` it is how you say Rego decides.
 
-`defer` on a lane with no `opa.url` used to be a fourth refusal. It now
+`defer` on a lane with no `opa.url` used to be a refusal too. It now
 loads, warns at startup, and DENIES on a match. Deferring to a decision that
 does not exist has to fail closed somewhere, and moving that from startup to
 runtime lets one file serve a deployment with OPA and a deployment without

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -858,10 +858,12 @@ A classifier that denies whenever its provider has an outage takes the
 database down with it. Set it false where the classification is a compliance
 requirement, and accept that a provider outage then stops traffic.
 
-**`send: redacted` uses the in-process detector** to name entities instead of
-transmitting their values. A relay whose job is keeping taxpayer ids out of a
-database's query log should not post them to a model vendor. `send: refuse`
-denies locally instead of transmitting. Neither one needs a `pii` section any
+**`send: redacted` rewrites every detected value as its entity class** before
+the statement leaves the process. A relay whose job is keeping taxpayer ids
+out of a database's query log should not post them to a model vendor, and a
+model judging `pan = '<CREDIT_CARD>'` classifies the same as one shown the
+number. `send: refuse` denies locally instead of transmitting. Neither one
+needs a `pii` section any
 more: a detector always exists once the plugin is linked, and the section only
 narrows which entity types it scans for.
 

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -268,13 +268,14 @@ startup, since there is nothing to serve yet.
 
 Once running, a heartbeat repeats the handshake every minute. It keeps the
 plane's last-seen fresh and picks up edits: a change that only touches rules
-(guardrails, masking, pii, OPA) is applied in place, logged as
-`configuration applied` with a generation number. Connections already open
-drain under the rules they were accepted with; new connections run the new
-rules, and nothing rebinds or drops. A change beyond the rules (listeners,
-audit, admin, log_level, analyzer) logs `restart to apply it` instead, and
-a failed heartbeat changes nothing, because losing the phone line home must
-not take the data path down with it. ADR-0014 records the boundary.
+(guardrails, masking, pii, OPA, a listener's analyzer block) is applied in
+place, logged as `configuration applied` with a generation number.
+Connections already open drain under the rules they were accepted with; new
+connections run the new rules, and nothing rebinds or drops. A change beyond
+the rules (listeners, audit, admin, log_level, the top-level analyzer
+section) logs `restart to apply it` instead, and a failed heartbeat changes
+nothing, because losing the phone line home must not take the data path down
+with it. ADR-0014 records the boundary.
 
 ## Configuring it: config.yaml
 
@@ -299,9 +300,9 @@ Unlicensed, one guardrail rule and one data masking rule, for the whole
 process. The count is what the file AUTHORS, not what each lane resolves: a
 rule in the top-level `guardrails` block is one rule however many listeners
 inherit it, and a lane that overrides `mask.rules` with `[]` spends nothing.
-`ai_analysis` rules are counted apart and are not capped, because their
-controls are the trigger and `analyzer.max_calls` rather than a number of
-rules.
+The analyzer is not a rule and is not capped — its controls are the trigger
+and `max_calls` — and neither are any deprecated `ai_analysis` rules still in
+a guardrails block.
 
 A config over either cap is refused at startup, naming every block that
 authored rules and how many each holds, so the message reads as a map of what
@@ -450,6 +451,7 @@ example below. Every config written against the old reference needs a pass.
 | `listeners[].connection` | `listeners[].name` | maps onto `name` when `name` is empty, warns |
 | `audit.fail_closed: <x>` | `audit.fail_open: <the opposite of x>` | works, warns |
 | `pii` omitted | still omitted | the detector gains all 54 entity types |
+| `guardrails.rules[].type: ai_analysis` | the listener's own `analyzer` block | works, warns; see [Migrating from `type: ai_analysis` rules](#migrating-from-type-ai_analysis-rules) |
 
 Three of those move traffic on the upgrade, and each one deserves a read
 before the restart:
@@ -603,7 +605,8 @@ concurrency.
 | `guardrails.mode` | replace when set | A lane rolling out behind an enforcing default has to be able to say observe. |
 | `opa` | replace when set | One lane has one decision endpoint. An explicitly empty `opa: {}` on a listener drops an inherited one. |
 | `mask.rules` | replace when set | A rule owns an entity or a column, and two concatenated lists leave two rewrites of one value. `mask.rules: []` is how a lane opts out of an inherited set. |
-| `pii`, `analyzer`, `audit`, `admin` | process-wide | One detector engine and one analyzer per process. |
+| `analyzer` (listener block) | listener-only; fields inherit the top-level `analyzer` defaults | The trigger, risk actions and prompt are per lane; the provider, model and credential stay in the top-level section, whose `send`/`fail_open`/`timeout_sec`/`max_input_bytes`/`max_calls`/`cache` values the block overrides field by field. |
+| `pii`, `analyzer` (top level), `audit`, `admin` | process-wide | One detector engine and one provider per process. |
 
 ### 3. Validate before you deploy
 
@@ -632,8 +635,9 @@ it under `guardrails.would_deny`. A lane that should skip the work sets
 `guardrails: {rules: []}`.
 
 `-validate` also prints a note where a resolved lane behaves in a way the file
-does not show. A rule carrying `action: defer` on a lane with no `opa.url`
-gets one, because that match denies rather than reporting a finding.
+does not show. A rule carrying `action: defer`, or an analyzer block deferring
+a risk level, on a lane with no `opa.url` gets one, because that match or
+level denies rather than reporting a finding.
 
 Validation builds every lane, so it catches what a syntax check cannot, and it
 reports every problem in one run rather than one per restart. It refuses these
@@ -652,12 +656,13 @@ outright:
   [Deprecated fields](#deprecated-fields).
 - A key typo, in YAML or JSON.
 - A bad regex in any lane's rules, naming the lane.
-- An `ai_analysis` rule with no `analyzer` section, no trigger, or no action
-  for any risk level. All three would load and classify nothing.
-- An `ai_analysis` rule on a lane whose protocol has no content builder,
-  naming the protocol. That rule classifies nothing and says nothing while
-  doing it: the analyzer returns before it has a status, so there is no
-  finding and no annotation to notice.
+- An analyzer (a listener's block, or a deprecated `ai_analysis` rule) with
+  no top-level `analyzer` section, no trigger, or no action for any risk
+  level. All three would load and classify nothing.
+- An analyzer on a lane whose protocol has no content builder, naming the
+  protocol. That lane classifies nothing and says nothing while doing it: the
+  analyzer returns before it has a status, so there is no finding and no
+  annotation to notice.
 - An `analyzer.provider` the binary does not link, naming what it does link.
 - A credential file readable by group or other, naming its mode.
 - An `http` block on a non-HTTP lane, or `authorization` in its header
@@ -737,8 +742,8 @@ jq -r 'select(.metadata["guardrails.would_deny"]) | .metadata["guardrails.would_
 ```
 
 A dry run costs what enforcement costs, because nothing can report what would
-have been denied without evaluating it. An observe lane with `ai_analysis`
-rules makes model calls and one with OPA makes round trips. Set
+have been denied without evaluating it. An observe lane with an analyzer
+makes model calls and one with OPA makes round trips. Set
 `guardrails: {rules: []}` on a lane that wants the cheap off switch instead.
 Observe switches off nothing else: `ErrStreamUnsafe` still denies, a failed
 audit write still denies while `audit.fail_open` is false, and startup
@@ -747,25 +752,34 @@ validation runs in full. A lane in observe says so in the startup log and in
 
 ### Analyzing statements with a model
 
-An `ai_analysis` rule sends a statement to a language model and denies on the
-risk it reports. It is the only rule type that leaves the process, costs money
-and can be slow, so three things bound it: a trigger decides what is worth
-asking about, a cache collapses repeated statement shapes onto one verdict,
-and the rule runs LAST in the chain, after the free local rules and OPA.
+The AI analyzer is a per-listener component, declared beside `guardrails`,
+`opa` and `mask` rather than inside them. It sends a statement to a language
+model and denies on the risk it reports. It is the only evaluator that leaves
+the process, costs money and can be slow, so three things bound it: a trigger
+decides what is worth asking about, a cache collapses repeated statement
+shapes onto one verdict, and it runs LAST in the chain, after the free local
+rules and OPA.
 
-It runs wherever a content builder renders the statement for a model:
-`postgres`, `mysql` and `mssql` send the statement text with the operation,
-tables and database the codec derived; `http` sends the method, normalized
-resource and body. A lane whose protocol has no builder is refused at startup
-rather than left classifying nothing, which is what a relay-only protocol
-would otherwise get: no statements to render means no verdict, silently.
+Two config blocks share the work. The top-level `analyzer` section holds what
+is genuinely process-wide — the provider, the model, the credential — plus
+the defaults every lane inherits. Each listener's own `analyzer` block holds
+what is per lane: the trigger, the risk→action map, the prompt, and any
+default it wants to override.
+
+The analyzer runs wherever a content builder renders the statement for a
+model: `postgres`, `mysql` and `mssql` send the statement text with the
+operation, tables and database the codec derived; `http` sends the method,
+normalized resource and body. A lane whose protocol has no builder is refused
+at startup rather than left classifying nothing, which is what a relay-only
+protocol would otherwise get: no statements to render means no verdict,
+silently.
 
 ```yaml
 pii:                           # optional; omitting it activates all 54 types
   entities: [EMAIL_ADDRESS, US_SSN, BR_CPF]
 
-analyzer:                      # one provider serves every lane
-  provider: vertex             # vertex | anthropic | openai
+analyzer:                      # one provider serves every lane; the rest are
+  provider: vertex             #   defaults each listener inherits
   model: claude-sonnet-4-5@20250929
   extra: {project: my-gcp-project, region: global}
   # credentials_file omitted -> Application Default Credentials.
@@ -782,15 +796,12 @@ listeners:
     protocol: postgres
     listen: 0.0.0.0:15432
     upstream: appdb:5432
-    guardrails:
-      rules:
-        - name: risky-writes
-          type: ai_analysis
-          trigger: {operations: [delete, update]}
-          high: block
-          medium: warn
-          low: allow
-          message: refused by risk analysis
+    analyzer:                  # this lane's analyzer, beside guardrails
+      trigger: {operations: [delete, update]}
+      high: block
+      medium: warn
+      low: allow
+      message: refused by risk analysis
 
   - name: api
     protocol: http
@@ -800,13 +811,20 @@ listeners:
       capture_body: true
       max_body_bytes: 8192
       headers: [Content-Type]
-    guardrails:
-      rules:
-        - name: risky-payloads
-          type: ai_analysis
-          trigger: {resources: ["/anything", "/users/*/orders"]}
-          high: block
+    analyzer:
+      trigger: {resources: ["/anything", "/users/*/orders"]}
+      high: block
+      send: refuse             # overrides the inherited redacted, this lane only
 ```
+
+**What the block may override.** `send`, `fail_open`, `timeout_sec`,
+`max_input_bytes`, `max_calls` and `cache` all default to the top-level value
+and replace it when the block names them. `max_calls` on a block bounds that
+LANE's spend, and its budget keys on the listener name, so a hot reload that
+edits the block continues the running count rather than re-arming it.
+Provider, model, endpoint and credential are not per lane: a second provider
+per lane would double the credential surface, so those stay in the top-level
+section.
 
 **An HTTP lane needs `capture_body: true`.** The codec exposes nothing by
 default, so without it the analyzer sees `POST /anything` and no body, which
@@ -842,10 +860,10 @@ opa:
   fail_open: false
   gate: true
 
-guardrails:
-  rules:
-    - name: risky-writes
-      type: ai_analysis
+listeners:
+  - name: appdb
+    # ...
+    analyzer:
       # no trigger: with the gate on, Rego decides what is worth classifying
       high: defer
       medium: defer
@@ -854,9 +872,9 @@ guardrails:
 
 The level then travels to OPA as `input.findings.ai_analysis`, one entry in a
 map every producer on the lane reports into. `defer` is not analyzer-only:
-any rule type takes `action: defer` and reports the same way (see
-[Reporting instead of denying](#reporting-instead-of-denying)), so one
-statement can hand Rego a risk level and a set of PII entity classes at once.
+any rule type takes `action: defer` and reports the same way (see [Reporting
+instead of denying](#reporting-instead-of-denying)), so one statement can
+hand Rego a risk level and a set of PII entity classes at once.
 
 `defer` reorders the chain. A decision that reads the risk level has to run
 after the thing that fills it, so OPA moves from before the analyzer to after
@@ -867,28 +885,27 @@ answer what the level means. Both calls hit the same URL and carry
 `input.phase`, so a policy that ignores the field answers both identically,
 and turning the gate on costs one round trip rather than a rewrite.
 
-Three configs are refused at startup. `gate: true` on a lane with no
-`ai_analysis` rule is a round trip that buys nothing. An `ai_analysis` rule
-with no `trigger` is refused too, except under `gate: true`, where an empty
-trigger is how you say Rego decides. So is `action: defer` on an `ai_analysis`
-rule: that type defers per level through `high`/`medium`/`low`, and a rule
-saying both would leave two answers to one question.
+Three configs are refused at startup. `gate: true` on a lane with no analyzer
+is a round trip that buys nothing. An analyzer block with no `trigger` is
+refused too, except under `gate: true`, where an empty trigger is how you say
+Rego decides. So is a block naming no action for any risk level, because
+every verdict would then allow while looking like enforcement.
 
-`defer` on a lane with no `opa.url` used to be the fourth refusal. It now
+`defer` on a lane with no `opa.url` used to be a fourth refusal. It now
 loads, warns at startup, and DENIES on a match. Deferring to a decision that
 does not exist has to fail closed somewhere, and moving that from startup to
 runtime lets one file serve a deployment with OPA and a deployment without
-one. [Guardrails and OPA](#guardrails-and-opa) covers what the two phases send
-and what the gate may answer.
+one. See [Guardrails and OPA](#guardrails-and-opa) for what the two phases
+send and what the gate may answer.
 
 **Writing your own prompt.** Risk depends on what you are protecting, so the
 risk guidance is replaceable at two levels.
 
-`analyzer.prompt` is **process-wide**: it applies to every `ai_analysis` rule
-on every lane, database and HTTP alike. Put deployment-wide facts there and
-nothing protocol-specific, because the same words reach the model judging a
-SQL statement and the model judging a JSON body. A rule's own `prompt:` is
-where protocol- and lane-specific wording belongs, and it wins:
+`analyzer.prompt` at the top level is **process-wide**: it reaches every lane,
+database and HTTP alike. Put deployment-wide facts there and nothing
+protocol-specific, because the same words reach the model judging a SQL
+statement and the model judging a JSON body. The listener block's own
+`prompt:` is where protocol- and lane-specific wording belongs, and it wins:
 
 ```yaml
 analyzer:
@@ -899,34 +916,31 @@ analyzer:
 
 listeners:
   - name: appdb
-    guardrails:
-      rules:
-        - name: risky-writes
-          type: ai_analysis
-          trigger: {operations: [update]}
-          high: block
-          prompt: |
-            You are classifying SQL against the customer ledger. An UPDATE
-            with no WHERE clause is always high risk, and so is any schema
-            change.
+    # ...
+    analyzer:
+      trigger: {operations: [update]}
+      high: block
+      prompt: |
+        You are classifying SQL against the customer ledger. An UPDATE
+        with no WHERE clause is always high risk, and so is any schema
+        change.
 
   - name: api
-    guardrails:
-      rules:
-        - name: risky-payloads
-          type: ai_analysis
-          trigger: {resources: ["/orders/**"]}
-          high: block
-          prompt: |
-            You are classifying HTTP request bodies to the orders API. A
-            payload that cancels or refunds in bulk, or that edits another
-            tenant's records, is high risk.
+    # ...
+    analyzer:
+      trigger: {resources: ["/orders/**"]}
+      high: block
+      prompt: |
+        You are classifying HTTP request bodies to the orders API. A
+        payload that cancels or refunds in bulk, or that edits another
+        tenant's records, is high risk.
 ```
 
-Setting only `analyzer.prompt` is fine: the built-in guidance it replaces
-covers SQL, HTTP and gRPC payloads, with separate high-risk examples for each.
-Overriding it with database-only wording is the easy mistake: an HTTP or gRPC
-lane then classifies JSON bodies against advice about `DROP` and `TRUNCATE`.
+Setting only the top-level `analyzer.prompt` is fine: the built-in guidance it
+replaces covers SQL, HTTP and gRPC payloads, with separate high-risk examples
+for each. Overriding it with database-only wording is the easy mistake: an
+HTTP or gRPC lane then classifies JSON bodies against advice about `DROP` and
+`TRUNCATE`.
 
 A prompt replaces the **guidance** only. Two instructions are appended after
 whatever you write and cannot be removed:
@@ -939,7 +953,7 @@ whatever you write and cannot be removed:
   title repeating the identifier it objected to has published that
   identifier.
 
-Changing a prompt invalidates cached verdicts for the rules it applies to, so
+Changing a prompt invalidates cached verdicts for the lanes it applies to, so
 a reworded prompt takes effect on the next statement rather than after the
 cache TTL. `/config` reports `custom_prompt: true` and never the text, for the
 same reason it reports rule names and not their `pattern_regex`.
@@ -958,10 +972,12 @@ Verdicts land in the audit trail as `metadata.risk_level`, which rolls up to a
 session's highest risk in `GET /api/sessions` and `GET /api/stats`. Beside it,
 `metadata.ai_status` records what the analyzer did: `ok`, `cached`, `skipped`,
 `budget_exhausted`, `refused` or `error`. It merges most-degraded-wins across
-rules, so a second `ai_analysis` rule that succeeded cannot hide the first
-one's outage. `metadata.ai_rule` names the rule that produced the level and
+evaluators, so a second analyzer that succeeded cannot hide the first one's
+outage. `metadata.ai_rule` names what produced the level — the LISTENER name
+for an analyzer block, the rule name for the deprecated rule form — and
 merges as a unit with `risk_level`, so the name always belongs to the level
-shown.
+shown. All three field names are unchanged from the rule-form era, so
+dashboards and policies keyed on them keep working.
 
 `ai_status` and `ai_rule` are the analyzer's OWN audit vocabulary, not the
 finding it publishes to policy. The trail keeps the specific word, because an
@@ -981,6 +997,60 @@ to the audit trail.
 account and refreshed automatically, so `-validate` mints one token to prove
 the credential, the `roles/aiplatform.user` binding and the host clock before
 anything serves traffic. Prefer Workload Identity and omit `credentials_file`.
+
+#### Migrating from `type: ai_analysis` rules
+
+The analyzer used to be spelled as a guardrail rule. That form is DEPRECATED
+and still works: it loads, builds the same evaluator through the same code
+path, and prints a deprecation naming its replacement (`-strict` turns the
+warning into a non-zero exit). Both spellings can serve one lane while you
+migrate, each as its own evaluator.
+
+Move the rule's fields onto the listener's `analyzer` block; they keep their
+names:
+
+```yaml
+# before
+listeners:
+  - name: appdb
+    guardrails:
+      rules:
+        - name: risky-writes
+          type: ai_analysis
+          trigger: {operations: [delete]}
+          high: block
+          medium: warn
+          message: refused by risk analysis
+
+# after
+listeners:
+  - name: appdb
+    analyzer:
+      trigger: {operations: [delete]}
+      high: block
+      medium: warn
+      message: refused by risk analysis
+```
+
+Three things change with the move, all visible rather than behavioral traps:
+
+- `metadata.ai_rule` and the finding's `rule` carry the LISTENER name instead
+  of the rule name, because a component has no rule name. The field names and
+  everything else in findings, audit metadata and `/stats` stay the same.
+- The call budget keys on the listener name. Two lanes that shared one rule
+  name used to pay from one purse; two analyzer blocks never do.
+- A rule in the TOP-LEVEL guardrails block used to reach every lane; the
+  analyzer block is per listener, so write one on each lane that wants it.
+  What was genuinely process-wide about the analyzer already lives in the
+  top-level `analyzer` section.
+
+A lane with several `ai_analysis` rules (say, different triggers with
+different prompts) keeps them until it can express itself as one block;
+`-validate` counts what is left to migrate on each lane:
+
+```
+appdb            postgres  enforcing 2 rule(s) + ai analyzer (and 1 deprecated ai rule(s))
+```
 
 ## Overlap with Envoy
 
@@ -1285,7 +1355,7 @@ the decoder is keyed by protocol and each omitted piece fails differently:
 | the registration seam | `sidecar/codec/<name>`, and its import in `codec/all` | `inspect.New` refuses the protocol, so the lane will not start |
 | classification | a SQL `lexer.Dialect` selected by `inspect.AnalyzeSQL`, or the wire codec's native command classifier | operations and relations stay `unknown` |
 | a deny frame | `proxy/deny.go`; include request correlation when the protocol requires it | a denial closes the socket with no useful message |
-| an analyzer content builder | `analyzer/content.go` | `ai_analysis` rules on the lane classify nothing; startup refuses the lane rather than let it run silent |
+| an analyzer content builder | `analyzer/content.go` | an analyzer on the lane classifies nothing; startup refuses the lane rather than let it run silent |
 
 Masking needs no registration: the gate asks the codec for a `Reframer`, so a
 decoder that can rebuild its rows masks, and one that cannot has its
@@ -1507,10 +1577,11 @@ opa}` so a statement the local rules already forbid costs no network round
 trip. The Go package is still `policy`; the config keys are what split.
 
 **Guardrails are Hoop's own rules**, written under `guardrails` and evaluated
-in-process against a decoded statement. Eight rule types, all local except the
-`ai_analysis` one, and `guardrails.mode` decides whether a match denies or
-lands in the audit record as `guardrails.would_deny`. Nothing here needs a
-policy engine, a network hop or a second team.
+in-process against a decoded statement. Seven local rule types, plus the
+DEPRECATED `ai_analysis` one that the listener `analyzer` block replaced, and
+`guardrails.mode` decides whether a match denies or lands in the audit record
+as `guardrails.would_deny`. Nothing here needs a policy engine, a network hop
+or a second team.
 
 **OPA is someone else's Rego**, wired under `opa`. sidecar owns no policy
 there; it owns the *input document* it posts and the two phases it may post
@@ -1524,10 +1595,10 @@ hands every statement to Rego.
 
 **The local rule types.** SQL: `deny_words_list`, `pattern_match` (RE2),
 `operation`, `table`. HTTP: `http_resource`, `http_status`. Cross-protocol:
-`pii` (see [Masking and PII](#masking-and-pii)) and `ai_analysis` (see
-[Analyzing statements with a
-model](#analyzing-statements-with-a-model)). One ordered set can mix them, so
-a deployment fronting a database and an API needs one evaluator:
+`pii` (see [Masking and PII](#masking-and-pii)). The AI analyzer joins the
+same chain from its own listener block (see [Analyzing statements with a
+model](#analyzing-statements-with-a-model)). One ordered set can mix the rule
+types, so a deployment fronting a database and an API needs one evaluator:
 
 ```go
 policy.NewRules([]policy.Rule{
@@ -1628,7 +1699,8 @@ keys as `ai_analysis`. Every entry has one shape:
 - `values` is the producer's own: `risk_level` under `ai_analysis`,
   `entities` under `pii`, `words` under `deny_words_list`. Read a key only
   under a source you know writes it.
-- `rule` names the first configured rule that produced the entry.
+- `rule` names what produced the entry: the first configured rule of that
+  type, or the listener for its analyzer block.
 
 **A source that ran and could not answer still appears**, carrying a status
 and no values, and that is the whole reason `status` exists. An absent
@@ -1705,7 +1777,7 @@ a copy of everything you send it, so only the closed vocabulary above goes.
 
 **The gate answers `request`** beside its allow/deny: a map from source to
 bool. `true` runs a producer its own configuration would have skipped,
-overriding an `ai_analysis` rule's `trigger`; `false` vetoes one that
+overriding the analyzer's `trigger`; `false` vetoes one that
 configuration would have run; an absent key means no opinion, leaving that
 source in charge of itself. It is read on the gate phase only, so a policy
 that returns it on the decide phase is ignored rather than half-honored.

--- a/sidecar/analyzer/evaluator.go
+++ b/sidecar/analyzer/evaluator.go
@@ -22,12 +22,18 @@ const DefaultMaxInputBytes = 8 << 10
 
 // Trigger decides whether a statement is worth classifying.
 //
-// It is the first and cheapest cost control. A lane with no trigger
-// classifies everything, which on a database lane means paying for every
-// SELECT an ORM emits. An empty Trigger matches nothing, so a rule must state
-// what it cares about; that is the safe default, because the failure mode of
-// "matches everything by accident" is a bill.
+// It is the first and cheapest cost control. A zero Trigger matches
+// NOTHING; All matches everything. The split exists because the two
+// callers mean different things by an absent trigger: the sidecar sets All
+// for an ungated lane that omitted its trigger (the operator asked for
+// everything, out loud, and max_calls and the cache bound the bill), while
+// a gated lane keeps the zero trigger so the gate-phase policy stays the
+// only thing that spends money — Rego's silence must keep meaning "skip",
+// or a policy that answers nothing would start paying for every statement.
 type Trigger struct {
+	// All classifies every statement, overriding the three lists below.
+	All bool
+
 	// Operations matches the statement's normalized verb.
 	Operations []inspect.Operation
 
@@ -45,11 +51,14 @@ type Trigger struct {
 
 // IsZero reports whether the trigger names nothing.
 func (t Trigger) IsZero() bool {
-	return len(t.Operations) == 0 && len(t.Tables) == 0 && len(t.Resources) == 0
+	return !t.All && len(t.Operations) == 0 && len(t.Tables) == 0 && len(t.Resources) == 0
 }
 
 // matches reports whether stmt should be classified.
 func (t Trigger) matches(stmt inspect.Statement) bool {
+	if t.All {
+		return true
+	}
 	for _, op := range t.Operations {
 		if stmt.Operation == op {
 			return true

--- a/sidecar/analyzer/evaluator.go
+++ b/sidecar/analyzer/evaluator.go
@@ -450,17 +450,25 @@ func (e *Evaluator) classify(
 		return Result{}, StatusSkipped, nil
 	}
 
-	cacheKey := e.promptKey + ":" + content.CacheKey
-	if cached, hit := e.cache.get(cacheKey); hit {
-		return cached, StatusCached, nil
-	}
-
+	// Redaction runs BEFORE the cache, deliberately. The cache keys on the
+	// statement's SHAPE (literals stripped for SQL), so a sensitive literal
+	// can share a key with a clean statement that already seeded a verdict.
+	// send: refuse promises that content carrying a detected entity is
+	// refused in-process — every statement, not every cache miss — so the
+	// scan is the one per-statement cost a cache hit cannot skip. For
+	// redacted mode a hit transmits nothing, but the same ordering keeps
+	// one rule for where the callback runs.
 	text := content.Text
 	if e.cfg.Redact != nil {
 		text = e.cfg.Redact(text)
 		if text == RefuseSentinel {
 			return Result{}, StatusRefused, nil
 		}
+	}
+
+	cacheKey := e.promptKey + ":" + content.CacheKey
+	if cached, hit := e.cache.get(cacheKey); hit {
+		return cached, StatusCached, nil
 	}
 	// Reserve a slot atomically.
 	//

--- a/sidecar/cmd/main.go
+++ b/sidecar/cmd/main.go
@@ -93,6 +93,11 @@ import (
 var version = "0.1.0"
 
 func main() {
+	// -migrate renders YAML through the same nested module that parses it;
+	// the daemon package cannot import it, so the renderer is injected the
+	// same way the Loader is.
+	daemon.YAMLFromJSON = configyaml.FromJSON
+
 	err := daemon.Main(version, configyaml.Load, func(raw json.RawMessage) (daemon.Plugin, error) {
 		// An absent "pii" section no longer means no detector: the plugin
 		// builds one over every entity type it knows and the section

--- a/sidecar/config/yaml/fromjson_test.go
+++ b/sidecar/config/yaml/fromjson_test.go
@@ -1,0 +1,84 @@
+package yaml
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// FromJSON must preserve the document's key order: -migrate emits a file a
+// person maintains, and json.Marshal ordered the keys by struct
+// declaration, which is the order the docs teach.
+func TestFromJSONPreservesKeyOrder(t *testing.T) {
+	in := `{"analyzer":{"provider":"vertex","model":"m"},"listeners":[{"name":"appdb","protocol":"postgres","listen":":1","upstream":"h:1"}]}`
+	out, err := FromJSON([]byte(in))
+	if err != nil {
+		t.Fatalf("FromJSON: %v", err)
+	}
+	s := string(out)
+	for _, pair := range [][2]string{
+		{"analyzer:", "listeners:"},
+		{"provider:", "model:"},
+		{"name:", "protocol:"},
+		{"protocol:", "listen:"},
+		{"listen:", "upstream:"},
+	} {
+		if strings.Index(s, pair[0]) > strings.Index(s, pair[1]) {
+			t.Errorf("%s does not precede %s:\n%s", pair[0], pair[1], s)
+		}
+	}
+}
+
+// What FromJSON emits must read back through ToJSON as the same document:
+// the migration's output is this package's own input.
+func TestFromJSONRoundTripsThroughToJSON(t *testing.T) {
+	in := `{"listeners":[{"name":"appdb","protocol":"postgres","listen":":1","upstream":"h:1",` +
+		`"max_conns":10,"analyzer":{"trigger":{"operations":["delete"]},"high":"block",` +
+		`"fail_open":false,"prompt":"line one\nline two"}}],` +
+		`"guardrails":{"rules":[]},"opa":{"url":"http://opa:8181/v1/data/hoop"}}`
+
+	y, err := FromJSON([]byte(in))
+	if err != nil {
+		t.Fatalf("FromJSON: %v", err)
+	}
+	back, err := ToJSON(y)
+	if err != nil {
+		t.Fatalf("ToJSON of the render: %v\n%s", err, y)
+	}
+	// Compare semantically: ToJSON's key order comes from a map walk.
+	if got, want := canonical(t, back), canonical(t, []byte(in)); got != want {
+		t.Errorf("round trip drifted:\n got %s\nwant %s\nyaml:\n%s", got, want, y)
+	}
+}
+
+// Strings that look like other scalar types must come back as strings: a
+// deny word "true" or a message "123" cannot change type on the way through.
+func TestFromJSONQuotesAmbiguousStrings(t *testing.T) {
+	in := `{"a":"true","b":"123","c":"null","d":"03:04"}`
+	y, err := FromJSON([]byte(in))
+	if err != nil {
+		t.Fatalf("FromJSON: %v", err)
+	}
+	back, err := ToJSON(y)
+	if err != nil {
+		t.Fatalf("ToJSON: %v", err)
+	}
+	if got, want := canonical(t, back), canonical(t, []byte(in)); got != want {
+		t.Errorf("scalar types drifted:\n got %s\nwant %s\nyaml:\n%s", got, want, y)
+	}
+}
+
+// canonical renders JSON bytes with sorted keys so two documents compare by
+// content rather than by key order.
+func canonical(t *testing.T, data []byte) string {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("unmarshal %s: %v", data, err)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(out)
+}

--- a/sidecar/config/yaml/yaml.go
+++ b/sidecar/config/yaml/yaml.go
@@ -129,6 +129,105 @@ func ToJSON(data []byte) ([]byte, error) {
 	return out, nil
 }
 
+// FromJSON renders a JSON document as YAML, preserving the document's key
+// order.
+//
+// It exists for -migrate, which rebuilds a config from the parsed struct
+// and owes the operator a file in the syntax they wrote. Order matters for
+// a file a person maintains, and yaml.Marshal of a decoded map would
+// scramble it (Go maps carry no order), so this walks the JSON token
+// stream and builds a yaml.Node tree instead: the encoder then emits keys
+// exactly as json.Marshal ordered them, which is struct declaration order.
+func FromJSON(data []byte) ([]byte, error) {
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.UseNumber()
+	node, err := nodeFromJSON(dec)
+	if err != nil {
+		return nil, fmt.Errorf("convert json to yaml: %w", err)
+	}
+	var buf strings.Builder
+	enc := yamlv3.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(node); err != nil {
+		return nil, fmt.Errorf("convert json to yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("convert json to yaml: %w", err)
+	}
+	return []byte(buf.String()), nil
+}
+
+// nodeFromJSON consumes one JSON value from dec as a yaml.Node.
+func nodeFromJSON(dec *json.Decoder) (*yamlv3.Node, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	return nodeFromToken(dec, tok)
+}
+
+// nodeFromToken builds the node a token opens: a container's children are
+// consumed from the decoder, a scalar is complete in the token itself.
+func nodeFromToken(dec *json.Decoder, tok json.Token) (*yamlv3.Node, error) {
+	switch t := tok.(type) {
+	case json.Delim:
+		switch t {
+		case '{':
+			node := &yamlv3.Node{Kind: yamlv3.MappingNode, Tag: "!!map"}
+			for dec.More() {
+				keyTok, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				key, ok := keyTok.(string)
+				if !ok {
+					return nil, fmt.Errorf("object key %v is not a string", keyTok)
+				}
+				keyNode := &yamlv3.Node{}
+				keyNode.SetString(key)
+				valNode, err := nodeFromJSON(dec)
+				if err != nil {
+					return nil, err
+				}
+				node.Content = append(node.Content, keyNode, valNode)
+			}
+			_, err := dec.Token() // consume '}'
+			return node, err
+		case '[':
+			node := &yamlv3.Node{Kind: yamlv3.SequenceNode, Tag: "!!seq"}
+			for dec.More() {
+				child, err := nodeFromJSON(dec)
+				if err != nil {
+					return nil, err
+				}
+				node.Content = append(node.Content, child)
+			}
+			_, err := dec.Token() // consume ']'
+			return node, err
+		}
+		return nil, fmt.Errorf("unexpected delimiter %v", t)
+	case string:
+		// SetString picks the safe style: plain where possible, quoted
+		// where the value would otherwise read as a number or a bool,
+		// literal for multiline. That is exactly the round-trip rule
+		// ToJSON needs to hold in the other direction.
+		node := &yamlv3.Node{}
+		node.SetString(t)
+		return node, nil
+	case json.Number:
+		tag := "!!int"
+		if strings.ContainsAny(t.String(), ".eE") {
+			tag = "!!float"
+		}
+		return &yamlv3.Node{Kind: yamlv3.ScalarNode, Tag: tag, Value: t.String()}, nil
+	case bool:
+		return &yamlv3.Node{Kind: yamlv3.ScalarNode, Tag: "!!bool", Value: fmt.Sprintf("%t", t)}, nil
+	case nil:
+		return &yamlv3.Node{Kind: yamlv3.ScalarNode, Tag: "!!null", Value: "null"}, nil
+	}
+	return nil, fmt.Errorf("unexpected token %v", tok)
+}
+
 // normalize rewrites a decoded YAML value into something encoding/json can
 // marshal.
 //

--- a/sidecar/daemon/analyzer.go
+++ b/sidecar/daemon/analyzer.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hoophq/hoop/sidecar/inspect"
 	"github.com/hoophq/hoop/sidecar/analyzer"
+	"github.com/hoophq/hoop/sidecar/inspect"
 
 	"github.com/hoophq/hoop/sidecar/policy"
 )
@@ -191,10 +191,12 @@ type AnalyzerCacheConfig struct {
 // deprecation naming this block), because removing it would break every
 // deployed config on upgrade rather than warning about it.
 type LaneAnalyzerConfig struct {
-	// Trigger narrows which statements this lane classifies. A block with
-	// an empty trigger classifies nothing and is refused, unless opa.gate
-	// is on and the policy decides what gets classified: the failure mode
-	// of "matches everything by accident" is a bill rather than an error.
+	// Trigger narrows which statements this lane classifies. OMITTED, the
+	// lane classifies everything: declaring the analyzer is the opt-in,
+	// max_calls and the cache bound the bill, and -validate prints the
+	// per-statement cost as a note. On a lane with opa.gate the gate-phase
+	// policy decides instead, and an omitted trigger leaves it fully in
+	// charge.
 	Trigger *policy.AITrigger `json:"trigger,omitempty"`
 
 	// HighRisk, MediumRisk and LowRisk map a verdict onto an action:
@@ -442,7 +444,7 @@ const (
 func buildAnalyzerEvaluators(
 	rules []policy.Rule,
 	ac *analyzerDeps,
-	hasOPA bool,
+	hasOPA, gated bool,
 ) ([]policy.Evaluator, error) {
 	if len(rules) == 0 {
 		return nil, nil
@@ -454,7 +456,7 @@ func buildAnalyzerEvaluators(
 	out := make([]policy.Evaluator, 0, len(rules))
 	for _, r := range rules {
 		ev, err := buildAnalyzerEvaluator(r.Name, budgetRulePrefix+r.Name,
-			specFromRule(r), ac, hasOPA)
+			specFromRule(r), ac, hasOPA, gated)
 		if err != nil {
 			return nil, fmt.Errorf("rule %q: %w", r.Name, err)
 		}
@@ -474,7 +476,7 @@ func buildLaneAnalyzer(
 	lane string,
 	la *LaneAnalyzerConfig,
 	ac *analyzerDeps,
-	hasOPA bool,
+	hasOPA, gated bool,
 ) (policy.Evaluator, error) {
 	if la == nil {
 		return nil, nil
@@ -484,7 +486,7 @@ func buildLaneAnalyzer(
 			"listener %q has an analyzer block, and the config has no top-level "+
 				"analyzer section to supply the provider", lane)
 	}
-	ev, err := buildAnalyzerEvaluator(lane, budgetLanePrefix+lane, *la, ac, hasOPA)
+	ev, err := buildAnalyzerEvaluator(lane, budgetLanePrefix+lane, *la, ac, hasOPA, gated)
 	if err != nil {
 		return nil, fmt.Errorf("analyzer block: %w", err)
 	}
@@ -499,13 +501,25 @@ func buildLaneAnalyzer(
 // budgetKey is its purse in ac's registry. They differ because the report
 // name is an operator-facing identity and the purse must not collide across
 // the two analyzer forms — see the budget key prefixes above.
+//
+// An OMITTED trigger classifies everything — on an ungated lane. Declaring
+// an analyzer is already the opt-in, so the absence of a narrower means
+// "all of it", bounded by the cache and max_calls; buildLanes leaves a
+// startup note naming the cost. A GATED lane keeps the zero trigger, so a
+// gate-phase policy stays the only spender and Rego's silence keeps
+// meaning "skip" for every deployed two-phase config.
 func buildAnalyzerEvaluator(
 	name, budgetKey string,
 	la LaneAnalyzerConfig,
 	ac *analyzerDeps,
-	hasOPA bool,
+	hasOPA, gated bool,
 ) (policy.Evaluator, error) {
 	cfg := ac.cfg
+
+	trigger := triggerFrom(la.Trigger)
+	if trigger.IsZero() && !gated {
+		trigger.All = true
+	}
 
 	actions, err := actionMap(la, hasOPA)
 	if err != nil {
@@ -567,7 +581,7 @@ func buildAnalyzerEvaluator(
 		Provider:      ac.provider,
 		Guidance:      guidance,
 		Actions:       actions,
-		Trigger:       triggerFrom(la.Trigger),
+		Trigger:       trigger,
 		Message:       la.Message,
 		Timeout:       time.Duration(timeout) * time.Second,
 		FailOpen:      failOpen,
@@ -770,23 +784,13 @@ func validateLaneAnalysis(rules []policy.Rule, la *LaneAnalyzerConfig,
 	}
 
 	if la != nil {
-		problems = append(problems, validateLaneBlock(la, gated, lane)...)
+		problems = append(problems, validateLaneBlock(la, lane)...)
 	}
 
 	for _, r := range rules {
-		if r.Trigger.IsZero() && !gated {
-			// An empty trigger classifies nothing. Silently accepting
-			// it leaves an operator believing a guardrail is running.
-			//
-			// A gated lane is the exception: there the gate decides
-			// what gets classified, and an empty trigger is how an
-			// operator says so.
-			problems = append(problems, fmt.Sprintf(
-				"%s: ai_analysis rule %q has no trigger, so it would classify nothing; "+
-					"name operations, tables or resources, or turn on opa.gate "+
-					"and let the policy decide", lane, r.Name))
-		}
-
+		// An omitted trigger is legal on either lane kind: an ungated
+		// lane classifies everything (buildLanes leaves a cost note), a
+		// gated one hands the question to the gate-phase policy.
 		if r.Action != "" {
 			// policy.newRules refuses this, but an ai_analysis rule
 			// never reaches it: splitAnalyzerRules lifts these out
@@ -811,17 +815,9 @@ func validateLaneAnalysis(rules []policy.Rule, la *LaneAnalyzerConfig,
 // checks mirror the rule-form ones — same failure, same message shape — plus
 // the numeric bounds a rule never carried, which get the same negative
 // refusal AnalyzerConfig.validate applies to the defaults they override.
-func validateLaneBlock(la *LaneAnalyzerConfig, gated bool, lane string) []string {
+func validateLaneBlock(la *LaneAnalyzerConfig, lane string) []string {
 	var problems []string
 	where := lane + ": analyzer block"
-
-	if la.Trigger.IsZero() && !gated {
-		problems = append(problems, fmt.Sprintf(
-			"%s has no trigger, so it would classify nothing; name operations, "+
-				"tables or resources, or turn on opa.gate and let the policy decide",
-			where))
-	}
-
 	problems = append(problems, validateRiskActions(
 		la.HighRisk, la.MediumRisk, la.LowRisk, where)...)
 

--- a/sidecar/daemon/analyzer.go
+++ b/sidecar/daemon/analyzer.go
@@ -403,19 +403,32 @@ func splitAnalyzerRules(rules []policy.Rule) (local, ai []policy.Rule) {
 	return local, ai
 }
 
-// budgetFor returns the rule's process-lifetime call counter, creating it
-// on first sight. See analyzerDeps.budgets for the sharing contract.
-func (ac *analyzerDeps) budgetFor(rule string) *atomic.Int64 {
+// budgetFor returns the process-lifetime call counter for one budget key,
+// creating it on first sight. Keys are namespaced by analyzer form — see
+// the budget key prefixes — and the sharing contract lives on
+// analyzerDeps.budgets.
+func (ac *analyzerDeps) budgetFor(key string) *atomic.Int64 {
 	if ac.budgets == nil {
 		ac.budgets = map[string]*atomic.Int64{}
 	}
-	cell, ok := ac.budgets[rule]
+	cell, ok := ac.budgets[key]
 	if !ok {
 		cell = new(atomic.Int64)
-		ac.budgets[rule] = cell
+		ac.budgets[key] = cell
 	}
 	return cell
 }
+
+// budget key prefixes. The map in analyzerDeps is process-wide and keyed by
+// name, and the two analyzer forms draw their names from different
+// namespaces: a rule is named by the operator, a block by its listener. A
+// rule that happens to carry a listener's name must not spend that lane's
+// allowance, so each form prefixes its keys and the collision cannot be
+// spelled.
+const (
+	budgetRulePrefix = "rule:"
+	budgetLanePrefix = "lane:"
+)
 
 // buildAnalyzerEvaluators turns DEPRECATED ai_analysis rules into
 // evaluators.
@@ -424,7 +437,8 @@ func (ac *analyzerDeps) budgetFor(rule string) *atomic.Int64 {
 // trigger, action map and denial message while sharing the provider and,
 // through the provider, the credential. The call BUDGET comes from ac's
 // per-name registry, so a rebuilt evaluator (a hot reload that edited the
-// rule's lane) continues the running count instead of starting a fresh one.
+// rule's lane) continues the running count instead of starting a fresh one,
+// and two lanes naming one rule still pay from one purse.
 func buildAnalyzerEvaluators(
 	rules []policy.Rule,
 	ac *analyzerDeps,
@@ -439,7 +453,8 @@ func buildAnalyzerEvaluators(
 	}
 	out := make([]policy.Evaluator, 0, len(rules))
 	for _, r := range rules {
-		ev, err := buildAnalyzerEvaluator(r.Name, specFromRule(r), ac, hasOPA)
+		ev, err := buildAnalyzerEvaluator(r.Name, budgetRulePrefix+r.Name,
+			specFromRule(r), ac, hasOPA)
 		if err != nil {
 			return nil, fmt.Errorf("rule %q: %w", r.Name, err)
 		}
@@ -469,7 +484,7 @@ func buildLaneAnalyzer(
 			"listener %q has an analyzer block, and the config has no top-level "+
 				"analyzer section to supply the provider", lane)
 	}
-	ev, err := buildAnalyzerEvaluator(lane, *la, ac, hasOPA)
+	ev, err := buildAnalyzerEvaluator(lane, budgetLanePrefix+lane, *la, ac, hasOPA)
 	if err != nil {
 		return nil, fmt.Errorf("analyzer block: %w", err)
 	}
@@ -479,8 +494,13 @@ func buildLaneAnalyzer(
 // buildAnalyzerEvaluator is the one place an evaluator is assembled, for
 // both spellings. Every zero field in la inherits the top-level analyzer
 // default, so the block overrides exactly what it names and nothing else.
+//
+// name is what the evaluator reports (Finding.Rule, the ai_rule audit key);
+// budgetKey is its purse in ac's registry. They differ because the report
+// name is an operator-facing identity and the purse must not collide across
+// the two analyzer forms — see the budget key prefixes above.
 func buildAnalyzerEvaluator(
-	name string,
+	name, budgetKey string,
 	la LaneAnalyzerConfig,
 	ac *analyzerDeps,
 	hasOPA bool,
@@ -512,13 +532,35 @@ func buildAnalyzerEvaluator(
 	if maxCalls == 0 {
 		maxCalls = cfg.MaxCalls
 	}
+	// Cache fields merge INDIVIDUALLY, like every other override here: a
+	// block naming only ttl_sec keeps the inherited size. Replacing the
+	// struct wholesale would zero the field the block did not write, and a
+	// zero on either side disables caching — the opposite of what a partial
+	// override asked for.
 	cache := cfg.Cache
 	if la.Cache != nil {
-		cache = *la.Cache
+		if la.Cache.Size != 0 {
+			cache.Size = la.Cache.Size
+		}
+		if la.Cache.TTLSec != 0 {
+			cache.TTLSec = la.Cache.TTLSec
+		}
 	}
 	send := la.Send
 	if send == "" {
 		send = cfg.Send
+	}
+	// The EFFECTIVE mode is what has to be checked against the detector,
+	// because a lane can override the top-level send. The top-level check
+	// in AnalyzerConfig.validate cannot see overrides, and a nil redactor
+	// under redacted or refuse would transmit the original text under a
+	// name that promises otherwise.
+	switch send {
+	case SendRedacted, SendRefuse:
+		if ac.det == nil {
+			return nil, fmt.Errorf(
+				"send: %s needs a detector, and this build has none", send)
+		}
 	}
 	return analyzer.New(analyzer.Config{
 		Rule:          name,
@@ -533,7 +575,7 @@ func buildAnalyzerEvaluator(
 		CacheSize:     cache.Size,
 		CacheTTL:      time.Duration(cache.TTLSec) * time.Second,
 		MaxCalls:      maxCalls,
-		Budget:        ac.budgetFor(name),
+		Budget:        ac.budgetFor(budgetKey),
 		Redact:        redactorFor(send, ac.det),
 	})
 }
@@ -651,19 +693,18 @@ func redactorFor(mode SendMode, det Plugin) func(string) string {
 	switch mode {
 	case SendRedacted:
 		return func(s string) string {
-			// ScanText returns entity NAMES and never values or
-			// offsets, so the only redaction it supports is naming
-			// what was found. That is the right shape here anyway: a
-			// model asked to judge "a statement containing a
-			// taxpayer id" gives the same verdict as one shown the
-			// number, and the number never leaves.
-			entities := det.ScanText(s)
+			// RedactText rewrites every detected span as its entity
+			// class, so the value itself never leaves the process. The
+			// note tells the model what it is looking at: a statement
+			// judged as "contains <US_SSN>" classifies the same as one
+			// shown the number, and the number stays here.
+			redacted, entities := det.RedactText(s)
 			if len(entities) == 0 {
 				return s
 			}
-			return s + "\n\n[proxy: this statement contains " +
+			return redacted + "\n\n[proxy: this statement contained " +
 				strings.Join(entities, ", ") +
-				"; the values were withheld]"
+				"; each value was replaced with its entity class]"
 		}
 	case SendRefuse:
 		return func(s string) string {

--- a/sidecar/daemon/analyzer.go
+++ b/sidecar/daemon/analyzer.go
@@ -67,12 +67,13 @@ func (h *HTTPCodecConfig) validate(lane string) []string {
 	return problems
 }
 
-// AnalyzerConfig configures the AI risk analyzer for the whole process.
+// AnalyzerConfig configures the AI risk analyzer: the provider for the whole
+// process, and the defaults every listener's analyzer block inherits.
 //
-// One provider serves every lane. Per-lane variation lives in the rules,
-// which is where an operator already expresses per-lane policy; a second
-// provider per lane would double the credential surface for a case nobody
-// has asked for.
+// One provider serves every lane. Provider, model, endpoint and credential
+// are process-wide because a second provider per lane would double the
+// credential surface for a case nobody has asked for; everything else here
+// is a DEFAULT a listener's own analyzer block overrides per lane.
 type AnalyzerConfig struct {
 	// Provider names a registered provider: anthropic, openai, vertex.
 	// Availability depends on what the binary links.
@@ -173,6 +174,72 @@ type AnalyzerCacheConfig struct {
 	// TTLSec expires an entry. Zero disables the cache, because an entry
 	// that never expires outlives a prompt or model change.
 	TTLSec int `json:"ttl_sec,omitempty"`
+}
+
+// LaneAnalyzerConfig is one listener's own analyzer block: what this lane
+// classifies, what each risk level does, and which process defaults it
+// overrides.
+//
+// The analyzer is a per-lane component, a peer of guardrails and mask,
+// not a guardrail rule. The block holds what is genuinely per lane — the
+// trigger, the risk-to-action map, the prompt — and inherits everything
+// else from the top-level analyzer section, which keeps the provider, the
+// model and the credential: one provider, one credential read per process.
+//
+// The DEPRECATED spelling is a `type: ai_analysis` rule under
+// guardrails.rules. It still loads and still works (normalize records a
+// deprecation naming this block), because removing it would break every
+// deployed config on upgrade rather than warning about it.
+type LaneAnalyzerConfig struct {
+	// Trigger narrows which statements this lane classifies. A block with
+	// an empty trigger classifies nothing and is refused, unless opa.gate
+	// is on and the policy decides what gets classified: the failure mode
+	// of "matches everything by accident" is a bill rather than an error.
+	Trigger *policy.AITrigger `json:"trigger,omitempty"`
+
+	// HighRisk, MediumRisk and LowRisk map a verdict onto an action:
+	// allow, warn, block or defer. An unset level defaults to allow, so an
+	// operator opts into blocking a tier by naming it.
+	HighRisk   string `json:"high,omitempty"`
+	MediumRisk string `json:"medium,omitempty"`
+	LowRisk    string `json:"low,omitempty"`
+
+	// Prompt replaces the inherited risk guidance for this lane. This is
+	// where protocol-specific wording belongs: analyzer.prompt reaches
+	// every lane, so SQL advice written there follows an HTTP body to the
+	// model. The output contract (call exactly one tool, never quote a
+	// literal value) is appended after it and cannot be removed.
+	Prompt string `json:"prompt,omitempty"`
+
+	// Message reaches the user on denial. Empty falls back to the model's
+	// own title.
+	Message string `json:"message,omitempty"`
+
+	// The rest override the top-level analyzer defaults for this lane.
+	// A zero value inherits; see the field of the same name on
+	// AnalyzerConfig for what each bounds.
+	TimeoutSec    int                  `json:"timeout_sec,omitempty"`
+	FailOpen      *bool                `json:"fail_open,omitempty"`
+	Send          SendMode             `json:"send,omitempty"`
+	MaxInputBytes int                  `json:"max_input_bytes,omitempty"`
+	MaxCalls      int                  `json:"max_calls,omitempty"`
+	Cache         *AnalyzerCacheConfig `json:"cache,omitempty"`
+}
+
+// specFromRule maps a DEPRECATED ai_analysis rule onto the lane block
+// shape, which is how the rule form "keeps working": both spellings build
+// through buildAnalyzerEvaluator, so they cannot drift apart. A rule
+// carries no per-lane overrides, so every zero field inherits the
+// top-level defaults exactly as it always did.
+func specFromRule(r policy.Rule) LaneAnalyzerConfig {
+	return LaneAnalyzerConfig{
+		Trigger:    r.Trigger,
+		HighRisk:   r.HighRisk,
+		MediumRisk: r.MediumRisk,
+		LowRisk:    r.LowRisk,
+		Prompt:     r.Prompt,
+		Message:    r.Message,
+	}
 }
 
 // failOpen resolves the pointer default.
@@ -350,12 +417,13 @@ func (ac *analyzerDeps) budgetFor(rule string) *atomic.Int64 {
 	return cell
 }
 
-// buildAnalyzerEvaluators turns ai_analysis rules into evaluators.
+// buildAnalyzerEvaluators turns DEPRECATED ai_analysis rules into
+// evaluators.
 //
 // Each rule becomes its own Evaluator, so two rules on one lane get their own
 // trigger, action map and denial message while sharing the provider and,
 // through the provider, the credential. The call BUDGET comes from ac's
-// per-rule registry, so a rebuilt evaluator (a hot reload that edited the
+// per-name registry, so a rebuilt evaluator (a hot reload that edited the
 // rule's lane) continues the running count instead of starting a fresh one.
 func buildAnalyzerEvaluators(
 	rules []policy.Rule,
@@ -369,41 +437,105 @@ func buildAnalyzerEvaluators(
 		return nil, fmt.Errorf(
 			"ai_analysis rule %q needs an analyzer section, and none is configured", rules[0].Name)
 	}
-	cfg, provider, redact := ac.cfg, ac.provider, ac.redact
-
 	out := make([]policy.Evaluator, 0, len(rules))
 	for _, r := range rules {
-		actions, err := actionMap(r, hasOPA)
-		if err != nil {
-			return nil, err
-		}
-		// Rule prompt beats the analyzer default beats the built-in.
-		guidance := r.Prompt
-		if guidance == "" {
-			guidance = cfg.Prompt
-		}
-		ev, err := analyzer.New(analyzer.Config{
-			Rule:          r.Name,
-			Provider:      provider,
-			Guidance:      guidance,
-			Actions:       actions,
-			Trigger:       triggerFrom(r.Trigger),
-			Message:       r.Message,
-			Timeout:       time.Duration(cfg.TimeoutSec) * time.Second,
-			FailOpen:      cfg.failOpen(),
-			MaxInputBytes: cfg.MaxInputBytes,
-			CacheSize:     cfg.Cache.Size,
-			CacheTTL:      time.Duration(cfg.Cache.TTLSec) * time.Second,
-			MaxCalls:      cfg.MaxCalls,
-			Budget:        ac.budgetFor(r.Name),
-			Redact:        redact,
-		})
+		ev, err := buildAnalyzerEvaluator(r.Name, specFromRule(r), ac, hasOPA)
 		if err != nil {
 			return nil, fmt.Errorf("rule %q: %w", r.Name, err)
 		}
 		out = append(out, ev)
 	}
 	return out, nil
+}
+
+// buildLaneAnalyzer turns a listener's analyzer block into its evaluator.
+//
+// The evaluator is named after the LANE, because the block is a per-lane
+// component rather than a named rule: that name is what Finding.Rule, the
+// ai_rule audit key and the call budget all carry, and it is the identity
+// an operator edits. Two lanes therefore never share a budget, which is
+// what "per lane" promises.
+func buildLaneAnalyzer(
+	lane string,
+	la *LaneAnalyzerConfig,
+	ac *analyzerDeps,
+	hasOPA bool,
+) (policy.Evaluator, error) {
+	if la == nil {
+		return nil, nil
+	}
+	if ac == nil || ac.cfg == nil || ac.provider == nil {
+		return nil, fmt.Errorf(
+			"listener %q has an analyzer block, and the config has no top-level "+
+				"analyzer section to supply the provider", lane)
+	}
+	ev, err := buildAnalyzerEvaluator(lane, *la, ac, hasOPA)
+	if err != nil {
+		return nil, fmt.Errorf("analyzer block: %w", err)
+	}
+	return ev, nil
+}
+
+// buildAnalyzerEvaluator is the one place an evaluator is assembled, for
+// both spellings. Every zero field in la inherits the top-level analyzer
+// default, so the block overrides exactly what it names and nothing else.
+func buildAnalyzerEvaluator(
+	name string,
+	la LaneAnalyzerConfig,
+	ac *analyzerDeps,
+	hasOPA bool,
+) (policy.Evaluator, error) {
+	cfg := ac.cfg
+
+	actions, err := actionMap(la, hasOPA)
+	if err != nil {
+		return nil, err
+	}
+	// Lane prompt beats the analyzer default beats the built-in.
+	guidance := la.Prompt
+	if guidance == "" {
+		guidance = cfg.Prompt
+	}
+	timeout := la.TimeoutSec
+	if timeout == 0 {
+		timeout = cfg.TimeoutSec
+	}
+	failOpen := cfg.failOpen()
+	if la.FailOpen != nil {
+		failOpen = *la.FailOpen
+	}
+	maxInput := la.MaxInputBytes
+	if maxInput == 0 {
+		maxInput = cfg.MaxInputBytes
+	}
+	maxCalls := la.MaxCalls
+	if maxCalls == 0 {
+		maxCalls = cfg.MaxCalls
+	}
+	cache := cfg.Cache
+	if la.Cache != nil {
+		cache = *la.Cache
+	}
+	send := la.Send
+	if send == "" {
+		send = cfg.Send
+	}
+	return analyzer.New(analyzer.Config{
+		Rule:          name,
+		Provider:      ac.provider,
+		Guidance:      guidance,
+		Actions:       actions,
+		Trigger:       triggerFrom(la.Trigger),
+		Message:       la.Message,
+		Timeout:       time.Duration(timeout) * time.Second,
+		FailOpen:      failOpen,
+		MaxInputBytes: maxInput,
+		CacheSize:     cache.Size,
+		CacheTTL:      time.Duration(cache.TTLSec) * time.Second,
+		MaxCalls:      maxCalls,
+		Budget:        ac.budgetFor(name),
+		Redact:        redactorFor(send, ac.det),
+	})
 }
 
 func triggerFrom(t *policy.AITrigger) analyzer.Trigger {
@@ -417,7 +549,7 @@ func triggerFrom(t *policy.AITrigger) analyzer.Trigger {
 	}
 }
 
-// actionMap turns a rule's high/medium/low strings into the analyzer's
+// actionMap turns the block's high/medium/low strings into the analyzer's
 // action vocabulary.
 //
 // hasOPA false degrades `defer` to `block`. Deferring names a decision-maker,
@@ -426,19 +558,19 @@ func triggerFrom(t *policy.AITrigger) analyzer.Trigger {
 // which allows the statement: the opposite of what the operator asked for.
 // The lane keeps a startup note saying so, because a config that reads
 // `high: defer` and behaves as `high: block` has to say which one it did.
-func actionMap(r policy.Rule, hasOPA bool) (analyzer.ActionMap, error) {
+func actionMap(la LaneAnalyzerConfig, hasOPA bool) (analyzer.ActionMap, error) {
 	m := analyzer.ActionMap{}
 	for level, raw := range map[analyzer.RiskLevel]string{
-		analyzer.RiskHigh:   r.HighRisk,
-		analyzer.RiskMedium: r.MediumRisk,
-		analyzer.RiskLow:    r.LowRisk,
+		analyzer.RiskHigh:   la.HighRisk,
+		analyzer.RiskMedium: la.MediumRisk,
+		analyzer.RiskLow:    la.LowRisk,
 	} {
 		if raw == "" {
 			continue
 		}
 		a := analyzer.Action(raw)
 		if !a.Valid() {
-			return nil, fmt.Errorf("rule %q: unknown action %q for %s risk", r.Name, raw, level)
+			return nil, fmt.Errorf("unknown action %q for %s risk", raw, level)
 		}
 		if a == analyzer.ActionDefer && !hasOPA {
 			a = analyzer.ActionBlock
@@ -469,7 +601,7 @@ func setupAnalyzer(cfg *Config, det Plugin) (*analyzerDeps, error) {
 	return &analyzerDeps{
 		cfg:      cfg.Analyzer,
 		provider: provider,
-		redact:   redactorFor(cfg.Analyzer.Send, det),
+		det:      det,
 	}, nil
 }
 
@@ -562,22 +694,24 @@ func httpCodecFactory(proto inspect.Protocol, h *HTTPCodecConfig) func() inspect
 	return newHTTPCodec(*h)
 }
 
-// validateAIRules checks each ai_analysis rule against the analyzer section
-// and against the lane's OPA settings.
+// validateLaneAnalysis checks a lane's analyzer surface — its own analyzer
+// block and any DEPRECATED ai_analysis rules — against the top-level
+// analyzer section and the lane's OPA settings.
 //
 // Every refusal here is a control that would otherwise load, evaluate and do
 // nothing: the exact failure the pii-entity check exists to prevent, applied
 // to a feature that also costs money when it does fire.
-func validateAIRules(rules []policy.Rule, cfg *AnalyzerConfig, opa *OPAConfig, lane string) []string {
+func validateLaneAnalysis(rules []policy.Rule, la *LaneAnalyzerConfig,
+	cfg *AnalyzerConfig, opa *OPAConfig, lane string) []string {
 	gated := opa.enabled() && opa.Gate
 
-	if len(rules) == 0 {
+	if len(rules) == 0 && la == nil {
 		if gated {
 			// A gate answers "is this worth a model call" for an
 			// analyzer that is not there. It would cost a round trip
 			// per statement and change nothing.
 			return []string{fmt.Sprintf(
-				"%s: opa.gate is on but the lane has no ai_analysis rule, "+
+				"%s: opa.gate is on but the lane has no analyzer block, "+
 					"so the extra decision would gate nothing", lane)}
 		}
 		return nil
@@ -585,8 +719,17 @@ func validateAIRules(rules []policy.Rule, cfg *AnalyzerConfig, opa *OPAConfig, l
 	var problems []string
 
 	if cfg == nil {
+		what := "has ai_analysis rule(s)"
+		if la != nil {
+			what = "has an analyzer block"
+		}
 		problems = append(problems, fmt.Sprintf(
-			"%s: has ai_analysis rule(s) but the config has no \"analyzer\" section", lane))
+			"%s: %s but the config has no top-level \"analyzer\" section "+
+				"(the provider, the model and the credential live there)", lane, what))
+	}
+
+	if la != nil {
+		problems = append(problems, validateLaneBlock(la, gated, lane)...)
 	}
 
 	for _, r := range rules {
@@ -616,41 +759,95 @@ func validateAIRules(rules []policy.Rule, cfg *AnalyzerConfig, opa *OPAConfig, l
 				lane, r.Name, r.Action))
 		}
 
-		named := false
-		for level, raw := range map[string]string{
-			"high": r.HighRisk, "medium": r.MediumRisk, "low": r.LowRisk,
-		} {
-			if raw == "" {
-				continue
-			}
-			named = true
-			a := analyzer.Action(raw)
-			if !a.Valid() {
-				problems = append(problems, fmt.Sprintf(
-					"%s: ai_analysis rule %q: unknown action %q for %s risk "+
-						"(allow, warn, block or defer)", lane, r.Name, raw, level))
-				continue
-			}
-			// `defer` with no OPA is no longer a refusal. actionMap
-			// degrades it to block, so the statement is denied rather
-			// than allowed, and one config file can serve a deployment
-			// with OPA and a deployment without one.
-			if a == analyzer.ActionRequireReview {
-				// The action is declared in the enum so the schema is
-				// stable when review lands, and refused here so nobody
-				// ships a config that looks like it holds statements
-				// for approval and quietly does not.
-				problems = append(problems, fmt.Sprintf(
-					"%s: ai_analysis rule %q asks for %q on %s risk, and this build "+
-						"cannot hold a statement for human approval; use block, warn "+
-						"or defer to an OPA policy", lane, r.Name, raw, level))
-			}
+		problems = append(problems, validateRiskActions(
+			r.HighRisk, r.MediumRisk, r.LowRisk,
+			fmt.Sprintf("%s: ai_analysis rule %q", lane, r.Name))...)
+	}
+	return problems
+}
+
+// validateLaneBlock checks one listener's analyzer block in isolation. The
+// checks mirror the rule-form ones — same failure, same message shape — plus
+// the numeric bounds a rule never carried, which get the same negative
+// refusal AnalyzerConfig.validate applies to the defaults they override.
+func validateLaneBlock(la *LaneAnalyzerConfig, gated bool, lane string) []string {
+	var problems []string
+	where := lane + ": analyzer block"
+
+	if la.Trigger.IsZero() && !gated {
+		problems = append(problems, fmt.Sprintf(
+			"%s has no trigger, so it would classify nothing; name operations, "+
+				"tables or resources, or turn on opa.gate and let the policy decide",
+			where))
+	}
+
+	problems = append(problems, validateRiskActions(
+		la.HighRisk, la.MediumRisk, la.LowRisk, where)...)
+
+	switch la.Send {
+	case "", SendRaw, SendRedacted, SendRefuse:
+	default:
+		problems = append(problems, fmt.Sprintf(
+			"%s: unknown send mode %q (raw, redacted or refuse)", where, la.Send))
+	}
+	if la.TimeoutSec < 0 {
+		problems = append(problems, where+": timeout_sec is negative")
+	}
+	if la.MaxInputBytes < 0 {
+		problems = append(problems, where+": max_input_bytes is negative")
+	}
+	if la.MaxCalls < 0 {
+		problems = append(problems, where+": max_calls is negative")
+	}
+	if la.Cache != nil {
+		if la.Cache.Size < 0 {
+			problems = append(problems, where+": cache.size is negative")
 		}
-		if !named {
+		if la.Cache.TTLSec < 0 {
+			problems = append(problems, where+": cache.ttl_sec is negative")
+		}
+	}
+	return problems
+}
+
+// validateRiskActions checks a high/medium/low action map, shared by the
+// block and the rule form so the two spellings refuse identically.
+func validateRiskActions(high, medium, low, where string) []string {
+	var problems []string
+	named := false
+	for level, raw := range map[string]string{
+		"high": high, "medium": medium, "low": low,
+	} {
+		if raw == "" {
+			continue
+		}
+		named = true
+		a := analyzer.Action(raw)
+		if !a.Valid() {
 			problems = append(problems, fmt.Sprintf(
-				"%s: ai_analysis rule %q names no action for any risk level, "+
-					"so every verdict would allow", lane, r.Name))
+				"%s: unknown action %q for %s risk "+
+					"(allow, warn, block or defer)", where, raw, level))
+			continue
 		}
+		// `defer` with no OPA is not a refusal. actionMap degrades it
+		// to block, so the statement is denied rather than allowed,
+		// and one config file can serve a deployment with OPA and a
+		// deployment without one.
+		if a == analyzer.ActionRequireReview {
+			// The action is declared in the enum so the schema is
+			// stable when review lands, and refused here so nobody
+			// ships a config that looks like it holds statements
+			// for approval and quietly does not.
+			problems = append(problems, fmt.Sprintf(
+				"%s asks for %q on %s risk, and this build "+
+					"cannot hold a statement for human approval; use block, warn "+
+					"or defer to an OPA policy", where, raw, level))
+		}
+	}
+	if !named {
+		problems = append(problems, fmt.Sprintf(
+			"%s names no action for any risk level, "+
+				"so every verdict would allow", where))
 	}
 	return problems
 }

--- a/sidecar/daemon/analyzer_test.go
+++ b/sidecar/daemon/analyzer_test.go
@@ -42,20 +42,27 @@ func TestAIRuleWithoutAnalyzerSectionIsRefused(t *testing.T) {
 	}
 }
 
-// An empty trigger classifies nothing, so the rule is a guardrail that does
-// not run. Accepting it silently is the pii-entity failure again.
-func TestAIRuleWithoutTriggerIsRefused(t *testing.T) {
+// An omitted trigger now means "classify everything" on an ungated lane:
+// declaring the analyzer is the opt-in, and the resolved lane carries a
+// startup note naming the per-statement cost.
+func TestAIRuleWithoutTriggerClassifiesEverything(t *testing.T) {
 	r := aiRule("risky")
 	r.Trigger = nil
 	cfg := pgLane(r)
 	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
 
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("an ai_analysis rule with no trigger was accepted")
+	lanes, err := Validate(cfg, nil)
+	if err != nil {
+		t.Fatalf("an untriggered ai_analysis rule was refused: %v", err)
 	}
-	if !strings.Contains(err.Error(), "trigger") {
-		t.Errorf("the error does not name the trigger: %v", err)
+	var noted bool
+	for _, n := range lanes[0].Notes {
+		if strings.Contains(n, "no trigger") && strings.Contains(n, "every statement") {
+			noted = true
+		}
+	}
+	if !noted {
+		t.Errorf("no startup note names the classify-everything cost: %v", lanes[0].Notes)
 	}
 }
 
@@ -292,7 +299,7 @@ func TestPromptPrecedence(t *testing.T) {
 			cfg := &AnalyzerConfig{Provider: "stub", Model: "m", Prompt: tc.cfgPrompt}
 
 			evs, err := buildAnalyzerEvaluators([]policy.Rule{r},
-				&analyzerDeps{cfg: cfg, provider: stubAnalyzerProvider{}}, true)
+				&analyzerDeps{cfg: cfg, provider: stubAnalyzerProvider{}}, true, false)
 			if err != nil {
 				t.Fatalf("buildAnalyzerEvaluators: %v", err)
 			}
@@ -340,13 +347,13 @@ func TestTheCallBudgetSurvivesAnEvaluatorRebuild(t *testing.T) {
 		Operation: inspect.OpDelete,
 	}
 
-	gen1, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("risky")}, deps, false)
+	gen1, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("risky")}, deps, false, false)
 	if err != nil {
 		t.Fatalf("buildAnalyzerEvaluators: %v", err)
 	}
 	gen1[0].Evaluate(stmt) // spends the whole budget of 1
 
-	gen2, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("risky")}, deps, false)
+	gen2, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("risky")}, deps, false, false)
 	if err != nil {
 		t.Fatalf("buildAnalyzerEvaluators: %v", err)
 	}
@@ -359,7 +366,7 @@ func TestTheCallBudgetSurvivesAnEvaluatorRebuild(t *testing.T) {
 	}
 
 	// A DIFFERENT rule name is a different identity with its own purse.
-	other, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("other")}, deps, false)
+	other, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("other")}, deps, false, false)
 	if err != nil {
 		t.Fatalf("buildAnalyzerEvaluators: %v", err)
 	}

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -259,6 +259,24 @@ type ListenerConfig struct {
 	// a lane switches inherited masking off.
 	Mask *MaskConfig `json:"mask,omitempty"`
 
+	// Analyzer is this listener's own AI analyzer block: the trigger, the
+	// risk-to-action map and the prompt for this lane, plus overrides of
+	// the top-level analyzer defaults (send, fail_open, timeout_sec,
+	// max_input_bytes, max_calls, cache).
+	//
+	// It sits beside Guardrails and Mask as a peer, not inside them: the
+	// analyzer is a per-lane component that leaves the process and costs
+	// money, and modelling it as a guardrail rule hid both facts. The
+	// top-level analyzer section stays process-wide for what genuinely is
+	// (provider, model, credential) and supplies the defaults this block
+	// inherits.
+	//
+	// The DEPRECATED spelling — a `type: ai_analysis` rule under
+	// guardrails.rules — still loads and still works; normalize records a
+	// deprecation naming this block. Both can coexist on one lane during a
+	// migration, each becoming its own evaluator.
+	Analyzer *LaneAnalyzerConfig `json:"analyzer,omitempty"`
+
 	// HTTP configures what this lane's HTTP codec captures. Only valid on
 	// an http lane.
 	HTTP *HTTPCodecConfig `json:"http,omitempty"`
@@ -612,6 +630,16 @@ func (c *Config) normalize() error {
 	// mask.enabled -> the presence of mask.rules.
 	c.Mask = normalizeMask("mask", c.Mask, warn)
 
+	// A `type: ai_analysis` rule is the deprecated spelling of the
+	// listener analyzer block. It is warned about rather than folded:
+	// folding could not be faithful (two rules on one lane cannot become
+	// one block, and a top-level rule reaches lanes that have their own
+	// block), so the rule form keeps working through its own path and the
+	// warning names the replacement.
+	if c.Guardrails != nil {
+		warnAIRules("guardrails", c.Guardrails.Rules, warn)
+	}
+
 	for i := range c.Listeners {
 		lc := &c.Listeners[i]
 		where := lc.Name
@@ -648,12 +676,33 @@ func (c *Config) normalize() error {
 		lc.Policy = nil
 
 		lc.Mask = normalizeMask(where+": mask", lc.Mask, warn)
+		if lc.Guardrails != nil {
+			warnAIRules(where+": guardrails", lc.Guardrails.Rules, warn)
+		}
 	}
 
 	if len(conflicts) > 0 {
 		return fmt.Errorf("invalid config:\n  - %s", strings.Join(conflicts, "\n  - "))
 	}
 	return nil
+}
+
+// warnAIRules records a deprecation for every ai_analysis rule in one
+// guardrails block. Top-level rules point at each listener's block, because
+// a top-level analyzer block does not exist: what is process-wide about the
+// analyzer already lives in the top-level analyzer section.
+func warnAIRules(where string, rules []policy.Rule, warn func(string, ...any)) {
+	for _, r := range rules {
+		if r.Type != policy.MatchAIAnalysis {
+			continue
+		}
+		warn("%s: rule %q: type: ai_analysis is deprecated; the analyzer is a "+
+			"per-listener component, not a guardrail rule. Move trigger, "+
+			"high/medium/low, prompt and message to the listener's own "+
+			"\"analyzer\" block, which inherits the top-level analyzer "+
+			"defaults and overrides them per lane. The rule form keeps "+
+			"working for now", where, r.Name)
+	}
 }
 
 // foldPolicy maps one deprecated policy block onto a guardrails block and an
@@ -913,7 +962,7 @@ func (c *Config) validateLane(lc ListenerConfig, name string) []string {
 	}
 
 	localRules, aiRules := splitAnalyzerRules(gc.Rules)
-	problems = append(problems, validateAIRules(aiRules, c.Analyzer, opa, name)...)
+	problems = append(problems, validateLaneAnalysis(aiRules, lc.Analyzer, c.Analyzer, opa, name)...)
 
 	if opa != nil && opa.URL == "" && !opa.off() {
 		problems = append(problems, name+
@@ -972,28 +1021,30 @@ func (c *Config) validateLane(lc ListenerConfig, name string) []string {
 				"\"grpc\" block with capture_payload: true and descriptors", name))
 	}
 
-	// An ai_analysis rule on an HTTP lane with no body capture classifies
-	// nothing: HTTPBuilder.Build returns ok=false on an empty body, and the
-	// codec leaves Body empty unless the lane asked for it. The rule would
-	// load, evaluate and never fire: the same silent failure the config
-	// refuses everywhere else, on a control that also costs money when it
-	// does work.
+	// A lane's analyzer — the block or a DEPRECATED ai_analysis rule — on
+	// an HTTP lane with no body capture classifies nothing:
+	// HTTPBuilder.Build returns ok=false on an empty body, and the codec
+	// leaves Body empty unless the lane asked for it. It would load,
+	// evaluate and never fire: the same silent failure the config refuses
+	// everywhere else, on a control that also costs money when it does
+	// work.
 	//
 	// This asserts only that the proxy COULD capture a body. A request that
 	// carries no body is still skipped at runtime, deliberately: paying for
 	// a verdict on "POST /orders" with no payload is what that skip avoids.
-	if len(aiRules) > 0 && inspect.Protocol(lc.Protocol) == inspect.HTTP &&
+	analyzing := len(aiRules) > 0 || lc.Analyzer != nil
+	if analyzing && inspect.Protocol(lc.Protocol) == inspect.HTTP &&
 		(lc.HTTP == nil || !lc.HTTP.CaptureBody) {
 		problems = append(problems, fmt.Sprintf(
-			"%s: has ai_analysis rule(s) on an http listener but http.capture_body "+
+			"%s: has an analyzer on an http listener but http.capture_body "+
 				"is not set, so every request would be skipped; add an \"http\" "+
 				"block with capture_body: true", name))
 	}
 
-	if len(aiRules) > 0 && isGRPCTransport(lc) &&
+	if analyzing && isGRPCTransport(lc) &&
 		(lc.GRPC == nil || !lc.GRPC.CapturePayload) {
 		problems = append(problems, fmt.Sprintf(
-			"%s: has ai_analysis rule(s) on a %s listener but grpc.capture_payload "+
+			"%s: has an analyzer on a %s listener but grpc.capture_payload "+
 				"is not set, so every RPC would be skipped; add a \"grpc\" block "+
 				"with capture_payload: true and descriptors", name, lc.Protocol))
 	}
@@ -1002,12 +1053,13 @@ func (c *Config) validateLane(lc ListenerConfig, name string) []string {
 	// does so more quietly than any other failure here: Evaluator.classify
 	// returns before it has a status, so there is no skipped finding and no
 	// annotation, and an operator watching the trail sees a lane behaving
-	// exactly as if the rule were absent. That is the mssql case this check
-	// exists for, and it covers any protocol that relays without decoding.
-	if p := inspect.Protocol(lc.Protocol); len(aiRules) > 0 && p != "" {
+	// exactly as if the analyzer were absent. That is the mssql case this
+	// check exists for, and it covers any protocol that relays without
+	// decoding.
+	if p := inspect.Protocol(lc.Protocol); analyzing && p != "" {
 		if _, ok := analyzer.BuilderFor(p); !ok {
 			problems = append(problems, fmt.Sprintf(
-				"%s: has ai_analysis rule(s) on a listener with protocol %q, and this "+
+				"%s: has an analyzer on a listener with protocol %q, and this "+
 					"build has no content builder for it, so every statement would be "+
 					"skipped without leaving a finding", name, p))
 		}
@@ -1126,13 +1178,17 @@ type Plugin interface {
 // the config at startup stopped one file from serving a deployment with OPA
 // and a deployment without one.
 //
+// lane names the listener; it is what the analyzer block's evaluator, its
+// findings and its call budget carry, since a component has no rule name.
+//
 // Returns nil when nothing would evaluate. det may be nil, and a lane with pii
 // rules then fails to build by design: a guardrail that cannot see must not
 // start.
-func buildPolicy(gc GuardrailsConfig, opa *OPAConfig, det Plugin, ac *analyzerDeps) (policy.Evaluator, error) {
-	// ai_analysis rules are lifted out before Rules sees them: they need a
-	// provider and a deadline, which a local matcher has no business
-	// holding, and Rules refuses one that reaches it.
+func buildPolicy(lane string, gc GuardrailsConfig, la *LaneAnalyzerConfig,
+	opa *OPAConfig, det Plugin, ac *analyzerDeps) (policy.Evaluator, error) {
+	// DEPRECATED ai_analysis rules are lifted out before Rules sees them:
+	// they need a provider and a deadline, which a local matcher has no
+	// business holding, and Rules refuses one that reaches it.
 	localRules, aiRules := splitAnalyzerRules(gc.Rules)
 
 	var chain policy.Chain
@@ -1157,7 +1213,7 @@ func buildPolicy(gc GuardrailsConfig, opa *OPAConfig, det Plugin, ac *analyzerDe
 	// ai_analysis risk level or a local rule reporting a match. Both need a
 	// decision placed AFTER them, because a policy reading input.findings
 	// has to run after the thing that fills it.
-	twoPhase := opa.enabled() && (opa.Gate || anyDeferred(gc.Rules))
+	twoPhase := opa.enabled() && (opa.Gate || anyDeferred(gc.Rules) || analyzerDefers(la))
 
 	switch {
 	case !opa.enabled():
@@ -1170,6 +1226,17 @@ func buildPolicy(gc GuardrailsConfig, opa *OPAConfig, det Plugin, ac *analyzerDe
 		chain = append(chain, opa.client(policy.PhaseGate))
 	}
 
+	// The lane's own analyzer block runs first, then any DEPRECATED
+	// rule-form analyzers in concatenation order. All of them sit after
+	// the local rules and the single-call/gate OPA position, so a
+	// statement a free evaluator already refused never costs a model call.
+	if la != nil {
+		ev, err := buildLaneAnalyzer(lane, la, ac, opa.enabled())
+		if err != nil {
+			return nil, err
+		}
+		chain = append(chain, ev)
+	}
 	if len(aiRules) > 0 {
 		evs, err := buildAnalyzerEvaluators(aiRules, ac, opa.enabled())
 		if err != nil {
@@ -1219,20 +1286,43 @@ func anyDeferred(rules []policy.Rule) bool {
 	return false
 }
 
+// analyzerDefers reports whether a lane's analyzer block hands any risk
+// level to a later evaluator: the block's spelling of what anyDeferred
+// reads off the rule set.
+func analyzerDefers(la *LaneAnalyzerConfig) bool {
+	if la == nil {
+		return false
+	}
+	for _, raw := range [...]string{la.HighRisk, la.MediumRisk, la.LowRisk} {
+		if analyzer.Action(raw) == analyzer.ActionDefer {
+			return true
+		}
+	}
+	return false
+}
+
 // analyzerDeps carries the process-wide analyzer to each lane's policy build.
 // One provider serves every lane, so the credential is read once.
 type analyzerDeps struct {
 	cfg      *AnalyzerConfig
 	provider analyzer.Provider
-	redact   func(string) string
 
-	// budgets hands every generation of a rule's evaluator the same call
-	// counter, so MaxCalls bounds the rule's spend across hot reloads: a
+	// det builds each evaluator's redactor from its EFFECTIVE send mode:
+	// a lane overriding `send` gets its own rewrite function while every
+	// other lane keeps the default. Held here rather than a prebuilt
+	// redactor because the mode is per lane now. Nil in a build with no
+	// detector, which sends raw.
+	det Plugin
+
+	// budgets hands every generation of an evaluator the same call
+	// counter, so MaxCalls bounds the spend across hot reloads: a
 	// draining generation and its replacement pay from one purse. Keyed
-	// by rule name, the identity an operator edits; two lanes naming one
-	// rule share a budget too, which is what "process-wide" already
-	// promised. Entries are never dropped, and single-goroutine access
-	// (startup builds, then only the heartbeat) needs no lock.
+	// by the evaluator's name — the rule name for the DEPRECATED rule
+	// form, the LANE name for an analyzer block — which is the identity
+	// an operator edits. Two lanes naming one rule share a budget too,
+	// which is what "process-wide" already promised. Entries are never
+	// dropped, and single-goroutine access (startup builds, then only
+	// the heartbeat) needs no lock.
 	budgets map[string]*atomic.Int64
 }
 

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -348,7 +348,12 @@ type GuardrailsConfig struct {
 
 	// Rules is the local rule set, evaluated first so a statement the
 	// local rules already forbid costs no network round trip.
-	Rules []policy.Rule `json:"rules,omitempty"`
+	//
+	// No omitempty: an explicitly empty list is a listener's opt-out from
+	// inherited rules (resolve reads nil and [] differently), and omitempty
+	// would marshal both as absence. A nil set marshals as null, which every
+	// consumer reads back as nil.
+	Rules []policy.Rule `json:"rules"`
 }
 
 // enforcing reports whether a resolved lane denies what its rules match.

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -1155,6 +1155,12 @@ type Plugin interface {
 	// published it into the audit trail.
 	ScanText(text string) []string
 
+	// RedactText rewrites every detected value in text as its entity class
+	// and names the classes found. The returned text carries NO detected
+	// value: it is what the analyzer's send: redacted mode transmits, so a
+	// value surviving here has left the process.
+	RedactText(text string) (string, []string)
+
 	// Entities lists what this detector was configured to find, for the
 	// startup log and for a config error that has to say what is available.
 	Entities() []string

--- a/sidecar/daemon/config.go
+++ b/sidecar/daemon/config.go
@@ -1241,15 +1241,19 @@ func buildPolicy(lane string, gc GuardrailsConfig, la *LaneAnalyzerConfig,
 	// rule-form analyzers in concatenation order. All of them sit after
 	// the local rules and the single-call/gate OPA position, so a
 	// statement a free evaluator already refused never costs a model call.
+	//
+	// gated tells the builders what an OMITTED trigger means: everything
+	// on a plain lane, gate-decided on a gated one.
+	gated := opa.enabled() && opa.Gate
 	if la != nil {
-		ev, err := buildLaneAnalyzer(lane, la, ac, opa.enabled())
+		ev, err := buildLaneAnalyzer(lane, la, ac, opa.enabled(), gated)
 		if err != nil {
 			return nil, err
 		}
 		chain = append(chain, ev)
 	}
 	if len(aiRules) > 0 {
-		evs, err := buildAnalyzerEvaluators(aiRules, ac, opa.enabled())
+		evs, err := buildAnalyzerEvaluators(aiRules, ac, opa.enabled(), gated)
 		if err != nil {
 			return nil, err
 		}

--- a/sidecar/daemon/config_test.go
+++ b/sidecar/daemon/config_test.go
@@ -245,7 +245,7 @@ func TestEnforceIsTheDefault(t *testing.T) {
 	if !gc.enforcing() {
 		t.Fatal("an unset mode did not enforce")
 	}
-	pol, err := buildPolicy(gc, opa, nil, nil)
+	pol, err := buildPolicy("lane", gc, nil, opa, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestObserveModeWrapsTheChainInsteadOfSkippingIt(t *testing.T) {
 		},
 	}
 	gc, opa, _ := cfg.resolve(cfg.Listeners[0])
-	pol, err := buildPolicy(gc, opa, nil, nil)
+	pol, err := buildPolicy("lane", gc, nil, opa, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestObserveModeWrapsTheChainInsteadOfSkippingIt(t *testing.T) {
 
 // A lane with nothing to enforce relays normally rather than failing.
 func TestEnforceWithNoRulesIsAPassThrough(t *testing.T) {
-	pol, err := buildPolicy(GuardrailsConfig{Mode: ModeEnforce}, nil, nil, nil)
+	pol, err := buildPolicy("lane", GuardrailsConfig{Mode: ModeEnforce}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestEnforceWithNoRulesIsAPassThrough(t *testing.T) {
 // Observe over an empty chain must stay nil too, or the gate loses its
 // short-circuit and every statement walks a wrapper that does nothing.
 func TestObserveWithNoRulesStaysNil(t *testing.T) {
-	pol, err := buildPolicy(GuardrailsConfig{Mode: ModeObserve}, nil, nil, nil)
+	pol, err := buildPolicy("lane", GuardrailsConfig{Mode: ModeObserve}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -325,7 +325,7 @@ func TestBuildPolicyChainsLocalRulesThenOPA(t *testing.T) {
 			Operations: []inspect.Operation{inspect.OpDrop},
 		}},
 	}
-	pol, err := buildPolicy(gc, &OPAConfig{URL: "http://opa:8181/v1/data/hoop"}, nil, nil)
+	pol, err := buildPolicy("lane", gc, nil, &OPAConfig{URL: "http://opa:8181/v1/data/hoop"}, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}
@@ -357,7 +357,7 @@ func TestDeferDeniesOnALaneWithNoOPA(t *testing.T) {
 			Message:    "no drops",
 		}},
 	}
-	pol, err := buildPolicy(gc, nil, nil, nil)
+	pol, err := buildPolicy("lane", gc, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("a deferring rule with no OPA was refused: %v", err)
 	}
@@ -382,7 +382,7 @@ func TestDeferReportsOnALaneWithOPA(t *testing.T) {
 			Action:     policy.ActionDefer,
 		}},
 	}
-	pol, err := buildPolicy(gc, &OPAConfig{URL: "http://opa:8181/v1/data/hoop"}, nil, nil)
+	pol, err := buildPolicy("lane", gc, nil, &OPAConfig{URL: "http://opa:8181/v1/data/hoop"}, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPolicy: %v", err)
 	}

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -367,10 +367,12 @@ type LaneInfo struct {
 	// shows. See lane.notes.
 	Notes []string
 
-	// Analyzed counts the ai_analysis rules on this lane. They are
-	// reported apart from Rules because they behave differently in the way
-	// that matters to whoever is reading a validate output: they leave the
-	// process, they cost money, and they can be slow.
+	// Analyzer reports the lane's own analyzer block, and Analyzed counts
+	// any DEPRECATED ai_analysis rules still on the lane. Both are
+	// reported apart from Rules because the analyzer is a component, not
+	// a rule count: it leaves the process, it costs money, and it can be
+	// slow.
+	Analyzer bool
 	Analyzed int
 }
 
@@ -392,8 +394,17 @@ func (l LaneInfo) Summary() string {
 	if l.Masking {
 		mode += " + masking"
 	}
-	if l.Analyzed > 0 {
-		mode += fmt.Sprintf(" + %d ai rule(s)", l.Analyzed)
+	// The analyzer is a component of the lane, not a rule count. The
+	// deprecated rule form is still named — with its count, since two
+	// rules are two evaluators — so an operator can see what is left to
+	// migrate.
+	switch {
+	case l.Analyzer && l.Analyzed > 0:
+		mode += fmt.Sprintf(" + ai analyzer (and %d deprecated ai rule(s))", l.Analyzed)
+	case l.Analyzer:
+		mode += " + ai analyzer"
+	case l.Analyzed > 0:
+		mode += fmt.Sprintf(" + ai analyzer (%d deprecated ai rule(s))", l.Analyzed)
 	}
 	return mode
 }
@@ -442,6 +453,7 @@ func Validate(cfg *Config, det Plugin) ([]LaneInfo, error) {
 			Rules:     len(ln.rules),
 			OPA:       ln.opaURL != "",
 			Masking:   ln.masker != nil,
+			Analyzer:  ln.cfg.Analyzer != nil,
 			Analyzed:  len(ln.analyzed),
 			Notes:     notes,
 		})
@@ -813,9 +825,11 @@ type lane struct {
 	rules  []string
 	opaURL string
 
-	// analyzed names the ai_analysis rules on this lane, reported the same
-	// way and for the same reason: the Chain cannot say what is in it, and
-	// an operator needs to see that a lane is sending statements to a model.
+	// analyzed names any DEPRECATED ai_analysis rules on this lane,
+	// reported the same way and for the same reason: the Chain cannot say
+	// what is in it, and an operator needs to see that a lane is sending
+	// statements to a model. The lane's own analyzer block is reported
+	// through cfg.Analyzer instead.
 	analyzed []string
 
 	// captureBody reports whether this lane's codec exposes request bodies,
@@ -861,7 +875,7 @@ func buildLanes(cfg *Config, det Plugin, ac *analyzerDeps) ([]lane, error) {
 			continue
 		}
 
-		pol, err := buildPolicy(gc, opa, det, ac)
+		pol, err := buildPolicy(name, gc, lc.Analyzer, opa, det, ac)
 		if err != nil {
 			problems = append(problems, name+": "+err.Error())
 			continue
@@ -901,10 +915,10 @@ func buildLanes(cfg *Config, det Plugin, ac *analyzerDeps) ([]lane, error) {
 				"observe mode: every rule is evaluated and nothing is denied. "+
 					"Matches are recorded on the audit line as "+policy.AnnotationWouldDeny)
 		}
-		if !opa.enabled() && anyDeferred(gc.Rules) {
+		if !opa.enabled() && (anyDeferred(gc.Rules) || analyzerDefers(lc.Analyzer)) {
 			ln.notes = append(ln.notes,
-				"rule(s) defer to a decision this lane has no opa.url for, so a match "+
-					"denies instead of reporting a finding")
+				"defer names a decision this lane has no opa.url for, so a deferred "+
+					"match or risk level denies instead of reporting a finding")
 		}
 		out = append(out, ln)
 	}
@@ -1225,11 +1239,13 @@ func serveAdmin(
 			OPAGate    bool     `json:"opa_gate,omitempty"`
 			Notes      []string `json:"notes,omitempty"`
 
-			// AIRules names the ai_analysis rules and CaptureBody says
-			// whether this lane's codec exposes request bodies. Both
-			// are here because they answer "what leaves this process",
-			// which is the question an operator has about an analyzer
-			// and cannot answer from the config file alone.
+			// Analyzer reports the lane's own analyzer block, AIRules
+			// names any DEPRECATED ai_analysis rules, and CaptureBody
+			// says whether this lane's codec exposes request bodies.
+			// All three are here because they answer "what leaves this
+			// process", which is the question an operator has about an
+			// analyzer and cannot answer from the config file alone.
+			Analyzer    bool     `json:"analyzer,omitempty"`
 			AIRules     []string `json:"ai_rules,omitempty"`
 			CaptureBody bool     `json:"capture_body,omitempty"`
 		}
@@ -1252,6 +1268,7 @@ func serveAdmin(
 				Rules:       ln.rules,
 				OPA:         ln.opaURL,
 				Masking:     ln.masker != nil,
+				Analyzer:    ln.cfg.Analyzer != nil,
 				AIRules:     ln.analyzed,
 				CaptureBody: ln.captureBody,
 				Observing:   ln.observing,

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -214,10 +214,10 @@ func Main(version string, load Loader, build PluginBuilder) error {
 			`"license" key`)
 		tokenRef = fs.String("token", "", "the token identifying this sidecar to the "+
 			"control plane; overrides "+SidecarTokenEnv)
-		validate     = fs.Bool("validate", false, "validate the config and exit")
-		strict       = fs.Bool("strict", false, "treat a deprecated config field as an error")
-		showVer      = fs.Bool("version", false, "print the version and exit")
-		migrate = fs.Bool("migrate", false, "rewrite the config onto the current schema, "+
+		validate = fs.Bool("validate", false, "validate the config and exit")
+		strict   = fs.Bool("strict", false, "treat a deprecated config field as an error")
+		showVer  = fs.Bool("version", false, "print the version and exit")
+		migrate  = fs.Bool("migrate", false, "rewrite the config onto the current schema, "+
 			"print it, and exit; deprecated fields are folded and ai_analysis rules "+
 			"become listener analyzer blocks where the move is faithful")
 		migrateOut = fs.String("migrate-out", "", "file -migrate writes to instead of "+
@@ -955,6 +955,26 @@ func buildLanes(cfg *Config, det Plugin, ac *analyzerDeps) ([]lane, error) {
 			ln.notes = append(ln.notes,
 				"defer names a decision this lane has no opa.url for, so a deferred "+
 					"match or risk level denies instead of reporting a finding")
+		}
+		// An omitted trigger on an ungated lane classifies EVERYTHING.
+		// That is what the operator wrote, and it is also a model call
+		// per statement shape, so the resolved lane says it out loud
+		// where a validate run and the startup log both read it.
+		if !(opa.enabled() && opa.Gate) {
+			if lc.Analyzer != nil && lc.Analyzer.Trigger.IsZero() {
+				ln.notes = append(ln.notes,
+					"the analyzer block has no trigger, so every statement on this "+
+						"lane is classified: a model call per statement shape, bounded "+
+						"only by the cache and max_calls. Add a trigger to narrow it")
+			}
+			for _, r := range gc.Rules {
+				if r.Type == policy.MatchAIAnalysis && r.Trigger.IsZero() {
+					ln.notes = append(ln.notes, fmt.Sprintf(
+						"ai_analysis rule %q has no trigger, so every statement on this "+
+							"lane is classified: a model call per statement shape, bounded "+
+							"only by the cache and max_calls. Add a trigger to narrow it", r.Name))
+				}
+			}
 		}
 		out = append(out, ln)
 	}

--- a/sidecar/daemon/daemon.go
+++ b/sidecar/daemon/daemon.go
@@ -193,6 +193,7 @@ var ErrUsage = errors.New("usage")
 //	hoop-inspect                    (no config: first-run default, see FirstRun)
 //	hoop-inspect -config /etc/hoop-inspect/config.yaml
 //	hoop-inspect -validate -config config.yaml
+//	hoop-inspect -migrate -config config.yaml -migrate-out config-new.yaml
 //	hoop-inspect -version
 func Main(version string, load Loader, build PluginBuilder) error {
 	Version = version
@@ -216,6 +217,11 @@ func Main(version string, load Loader, build PluginBuilder) error {
 		validate     = fs.Bool("validate", false, "validate the config and exit")
 		strict       = fs.Bool("strict", false, "treat a deprecated config field as an error")
 		showVer      = fs.Bool("version", false, "print the version and exit")
+		migrate = fs.Bool("migrate", false, "rewrite the config onto the current schema, "+
+			"print it, and exit; deprecated fields are folded and ai_analysis rules "+
+			"become listener analyzer blocks where the move is faithful")
+		migrateOut = fs.String("migrate-out", "", "file -migrate writes to instead of "+
+			"stdout; its extension picks the syntax, defaulting to the input's")
 		grpcDiscover = fs.String("grpc-discover", "", "name of a grpc or spanner listener: "+
 			"fetch its upstream's descriptor set over gRPC server reflection, print every "+
 			"method with its maskable field paths, and exit")
@@ -234,6 +240,36 @@ func Main(version string, load Loader, build PluginBuilder) error {
 	if *showVer {
 		fmt.Println("hoop-inspect", version)
 		return nil
+	}
+
+	if *migrate {
+		if *configPath == "" {
+			fs.Usage()
+			return fmt.Errorf("%w: -migrate needs -config", ErrUsage)
+		}
+		if load == nil {
+			load = LoadConfig
+		}
+		cfg, err := load(*configPath)
+		if err != nil {
+			return err
+		}
+		out := os.Stdout
+		if *migrateOut != "" {
+			f, err := os.Create(*migrateOut)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			out = f
+		}
+		// The destination's extension picks the syntax; stdout inherits
+		// the input's, so `-migrate -config config.yaml` prints YAML.
+		target := *migrateOut
+		if target == "" {
+			target = *configPath
+		}
+		return WriteMigrated(cfg, isYAMLPath(target), out, os.Stderr)
 	}
 	if *configPath == "" && os.Getenv(ControlPlaneURLEnv) == "" {
 		// A truly bare invocation — nothing typed at all — runs the

--- a/sidecar/daemon/lane_test.go
+++ b/sidecar/daemon/lane_test.go
@@ -27,6 +27,16 @@ func (s stubPlugin) ScanText(text string) []string {
 	return nil
 }
 
+// RedactText mirrors the real plugin's contract: the found literal is
+// replaced with its entity class, never appended to.
+func (s stubPlugin) RedactText(text string) (string, []string) {
+	if s.find != "" && strings.Contains(text, s.find) {
+		return strings.ReplaceAll(text, s.find, "<"+s.entities[0]+">"),
+			[]string{s.entities[0]}
+	}
+	return text, nil
+}
+
 // BuildMasker mirrors the real plugin: a rule naming an entity it does not
 // detect is a config error, so it cannot become a rule that silently never
 // fires.

--- a/sidecar/daemon/laneanalyzer_test.go
+++ b/sidecar/daemon/laneanalyzer_test.go
@@ -1,11 +1,13 @@
 package daemon
 
 import (
+	"context"
 	"strings"
+	"sync"
 	"testing"
 
-	"github.com/hoophq/hoop/sidecar/inspect"
 	"github.com/hoophq/hoop/sidecar/analyzer"
+	"github.com/hoophq/hoop/sidecar/inspect"
 	"github.com/hoophq/hoop/sidecar/policy"
 )
 
@@ -376,5 +378,191 @@ func TestLaneAnalyzerBlockIsInsideTheReloadBoundary(t *testing.T) {
 	}
 	if string(d1) == string(d2) {
 		t.Error("an analyzer block edit did not change the lane's rule document")
+	}
+}
+
+// recordingProvider captures what actually leaves the process, which is the
+// only honest way to test redaction: an assertion on the redactor alone
+// cannot notice a caller that skipped it.
+type recordingProvider struct {
+	mu    sync.Mutex
+	texts []string
+}
+
+func (r *recordingProvider) Name() string { return "recording" }
+
+func (r *recordingProvider) Classify(_ context.Context, _ string, text string) (*analyzer.Result, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.texts = append(r.texts, text)
+	return &analyzer.Result{RiskLevel: analyzer.RiskLow}, nil
+}
+
+func (r *recordingProvider) sent() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.texts...)
+}
+
+func deleteStmt(text string) inspect.Statement {
+	return inspect.Statement{
+		Protocol:  inspect.Postgres,
+		Direction: inspect.FromClient,
+		Text:      text,
+		Operation: inspect.OpDelete,
+	}
+}
+
+// A block naming ONE cache field keeps the other's inherited value, like
+// every other override. Replacing the struct wholesale would zero the
+// unnamed field, and a zero on either side disables caching.
+func TestLaneCacheOverrideMergesFieldWise(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		cache *AnalyzerCacheConfig
+	}{
+		{"ttl only keeps the inherited size", &AnalyzerCacheConfig{TTLSec: 60}},
+		{"size only keeps the inherited ttl", &AnalyzerCacheConfig{Size: 8}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingProvider{}
+			deps := &analyzerDeps{
+				cfg: &AnalyzerConfig{Provider: "stub", Model: "m",
+					Cache: AnalyzerCacheConfig{Size: 128, TTLSec: 900}},
+				provider: rec,
+			}
+			la := laneBlock()
+			la.Cache = tc.cache
+			ev, err := buildLaneAnalyzer("appdb", la, deps, false)
+			if err != nil {
+				t.Fatalf("buildLaneAnalyzer: %v", err)
+			}
+			ev.Evaluate(deleteStmt("DELETE FROM t WHERE id = 1"))
+			ev.Evaluate(deleteStmt("DELETE FROM t WHERE id = 1"))
+			if calls := len(rec.sent()); calls != 1 {
+				t.Fatalf("provider calls = %d, want 1: a partial cache override "+
+					"disabled the cache instead of merging", calls)
+			}
+		})
+	}
+}
+
+// A lane's block and a DEPRECATED rule that happens to carry the lane's
+// name must not share a purse: the two forms draw names from different
+// namespaces, and coexistence is supported during migration.
+func TestBlockAndRuleBudgetsDoNotCollideOnOneName(t *testing.T) {
+	rec := &recordingProvider{}
+	deps := &analyzerDeps{
+		cfg:      &AnalyzerConfig{Provider: "stub", Model: "m", MaxCalls: 1},
+		provider: rec,
+	}
+
+	block, err := buildLaneAnalyzer("appdb", laneBlock(), deps, false)
+	if err != nil {
+		t.Fatalf("buildLaneAnalyzer: %v", err)
+	}
+	rules, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("appdb")}, deps, false)
+	if err != nil {
+		t.Fatalf("buildAnalyzerEvaluators: %v", err)
+	}
+
+	block.Evaluate(deleteStmt("DELETE FROM a"))    // spends the lane's budget of 1
+	rules[0].Evaluate(deleteStmt("DELETE FROM b")) // must spend the RULE's own budget
+
+	if calls := len(rec.sent()); calls != 2 {
+		t.Fatalf("provider calls = %d, want 2: the rule named after the lane "+
+			"paid from the lane's purse", calls)
+	}
+}
+
+// send: redacted must never transmit a detected value. The provider sees
+// the entity class where the value stood, and never the value.
+func TestRedactedSendTransmitsNoValues(t *testing.T) {
+	const pan = "4111111111111111"
+	rec := &recordingProvider{}
+	deps := &analyzerDeps{
+		cfg:      &AnalyzerConfig{Provider: "stub", Model: "m", Send: SendRedacted},
+		provider: rec,
+		det:      stubPlugin{entities: []string{"CREDIT_CARD"}, find: pan},
+	}
+	ev, err := buildLaneAnalyzer("appdb", laneBlock(), deps, false)
+	if err != nil {
+		t.Fatalf("buildLaneAnalyzer: %v", err)
+	}
+
+	ev.Evaluate(deleteStmt("DELETE FROM cards WHERE pan = '" + pan + "'"))
+
+	sent := rec.sent()
+	if len(sent) != 1 {
+		t.Fatalf("provider calls = %d, want 1", len(sent))
+	}
+	if strings.Contains(sent[0], pan) {
+		t.Fatalf("the detected value left the process:\n%s", sent[0])
+	}
+	if !strings.Contains(sent[0], "<CREDIT_CARD>") {
+		t.Errorf("the entity class did not replace the value:\n%s", sent[0])
+	}
+}
+
+// A lane overriding send to redacted or refuse in a build with no detector
+// would get a nil redactor and transmit raw text under a name that promises
+// otherwise. The build refuses instead, exactly like the top-level check.
+func TestLanePrivacySendWithoutDetectorIsRefused(t *testing.T) {
+	for _, mode := range []SendMode{SendRedacted, SendRefuse} {
+		t.Run(string(mode), func(t *testing.T) {
+			deps := &analyzerDeps{
+				cfg:      &AnalyzerConfig{Provider: "stub", Model: "m"}, // send: raw default
+				provider: stubAnalyzerProvider{},
+			}
+			la := laneBlock()
+			la.Send = mode
+			_, err := buildLaneAnalyzer("appdb", la, deps, false)
+			if err == nil || !strings.Contains(err.Error(), "detector") {
+				t.Fatalf("a %s override with no detector was accepted: %v", mode, err)
+			}
+
+			// The same refusal through the front door.
+			cfg := blockLane(la)
+			if _, verr := Validate(cfg, nil); verr == nil {
+				t.Fatalf("Validate accepted a %s lane with no detector", mode)
+			}
+		})
+	}
+}
+
+// send: refuse runs on EVERY statement, cache hit or not. The cache keys on
+// the statement's shape, so a clean statement must not open a hole for a
+// sensitive literal with the same shape.
+func TestRefuseRunsOnCacheHits(t *testing.T) {
+	const pan = "4111111111111111"
+	rec := &recordingProvider{}
+	deps := &analyzerDeps{
+		cfg: &AnalyzerConfig{Provider: "stub", Model: "m", Send: SendRefuse,
+			Cache: AnalyzerCacheConfig{Size: 16, TTLSec: 900}},
+		provider: rec,
+		det:      stubPlugin{entities: []string{"CREDIT_CARD"}, find: pan},
+	}
+	ev, err := buildLaneAnalyzer("appdb", laneBlock(), deps, false)
+	if err != nil {
+		t.Fatalf("buildLaneAnalyzer: %v", err)
+	}
+
+	// A clean statement seeds the cache for this SQL shape.
+	if v := ev.Evaluate(deleteStmt("DELETE FROM cards WHERE pan = '1'")); v.Denied {
+		t.Fatalf("the clean statement was denied: %+v", v)
+	}
+	// The same shape carrying the sensitive literal must be refused
+	// locally, not served the cached verdict.
+	v := ev.Evaluate(deleteStmt("DELETE FROM cards WHERE pan = '" + pan + "'"))
+	if !v.Denied {
+		t.Fatal("a sensitive literal rode a cached shape past send: refuse")
+	}
+	if calls := len(rec.sent()); calls != 1 {
+		t.Fatalf("provider calls = %d, want 1: the refusal must not cost a call", calls)
+	}
+	for _, sent := range rec.sent() {
+		if strings.Contains(sent, pan) {
+			t.Fatalf("the detected value left the process:\n%s", sent)
+		}
 	}
 }

--- a/sidecar/daemon/laneanalyzer_test.go
+++ b/sidecar/daemon/laneanalyzer_test.go
@@ -51,9 +51,10 @@ func TestLaneAnalyzerWithoutTopLevelSectionIsRefused(t *testing.T) {
 	}
 }
 
-// An empty trigger classifies nothing on an ungated lane, exactly as it did
-// on the rule form, and is the correct spelling on a gated one.
-func TestLaneAnalyzerTriggerIsRequiredUnlessGated(t *testing.T) {
+// An omitted trigger means "classify everything" on an ungated lane and
+// "the gate decides" on a gated one. Both spellings are accepted; the
+// difference is who spends the money.
+func TestOmittedTriggerClassifiesEverythingUnlessGated(t *testing.T) {
 	build := func(gate bool) error {
 		cfg := blockLane(&LaneAnalyzerConfig{HighRisk: "block"})
 		if gate {
@@ -63,11 +64,49 @@ func TestLaneAnalyzerTriggerIsRequiredUnlessGated(t *testing.T) {
 		}
 		return cfg.Validate()
 	}
-	if err := build(false); err == nil {
-		t.Error("an untriggered block on an ungated lane was accepted")
+	if err := build(false); err != nil {
+		t.Errorf("an untriggered block on an ungated lane was refused: %v", err)
 	}
 	if err := build(true); err != nil {
 		t.Errorf("an untriggered block on a gated lane was refused: %v", err)
+	}
+
+	// The runtime split. Ungated: everything is classified, a SELECT
+	// included. Gated: the zero trigger stays, so with no gate request the
+	// statement is skipped and nothing is spent — Rego's silence keeps
+	// meaning "skip" for deployed two-phase configs.
+	stmt := inspect.Statement{
+		Protocol:  inspect.Postgres,
+		Direction: inspect.FromClient,
+		Text:      "SELECT id FROM t",
+		Operation: inspect.OpSelect,
+	}
+
+	rec := &recordingProvider{}
+	deps := &analyzerDeps{
+		cfg:      &AnalyzerConfig{Provider: "stub", Model: "m"},
+		provider: rec,
+	}
+	ungated, err := buildLaneAnalyzer("appdb", &LaneAnalyzerConfig{HighRisk: "block"},
+		deps, false, false)
+	if err != nil {
+		t.Fatalf("buildLaneAnalyzer: %v", err)
+	}
+	ungated.Evaluate(stmt)
+	if calls := len(rec.sent()); calls != 1 {
+		t.Fatalf("ungated untriggered block made %d provider calls, want 1: "+
+			"an omitted trigger classifies everything", calls)
+	}
+
+	gated, err := buildLaneAnalyzer("payments", &LaneAnalyzerConfig{HighRisk: "block"},
+		deps, true, true)
+	if err != nil {
+		t.Fatalf("buildLaneAnalyzer: %v", err)
+	}
+	gated.Evaluate(stmt)
+	if calls := len(rec.sent()); calls != 1 {
+		t.Fatalf("a gated untriggered block classified without a gate request "+
+			"(provider calls = %d)", calls)
 	}
 }
 
@@ -167,7 +206,7 @@ func TestLaneAnalyzerPromptPrecedence(t *testing.T) {
 				cfg:      &AnalyzerConfig{Provider: "stub", Model: "m", Prompt: tc.cfgPrompt},
 				provider: stubAnalyzerProvider{},
 			}
-			ev, err := buildLaneAnalyzer("appdb", la, deps, true)
+			ev, err := buildLaneAnalyzer("appdb", la, deps, true, false)
 			if err != nil {
 				t.Fatalf("buildLaneAnalyzer: %v", err)
 			}
@@ -199,13 +238,13 @@ func TestLaneAnalyzerOverridesAndBudgetKeyOnTheLane(t *testing.T) {
 		Operation: inspect.OpDelete,
 	}
 
-	gen1, err := buildLaneAnalyzer("appdb", la, deps, false)
+	gen1, err := buildLaneAnalyzer("appdb", la, deps, false, false)
 	if err != nil {
 		t.Fatalf("buildLaneAnalyzer: %v", err)
 	}
 	gen1.Evaluate(stmt) // spends the whole lane budget of 1
 
-	gen2, err := buildLaneAnalyzer("appdb", la, deps, false)
+	gen2, err := buildLaneAnalyzer("appdb", la, deps, false, false)
 	if err != nil {
 		t.Fatalf("buildLaneAnalyzer: %v", err)
 	}
@@ -215,7 +254,7 @@ func TestLaneAnalyzerOverridesAndBudgetKeyOnTheLane(t *testing.T) {
 	}
 
 	// A different lane is a different identity with its own purse.
-	other, err := buildLaneAnalyzer("payments", la, deps, false)
+	other, err := buildLaneAnalyzer("payments", la, deps, false, false)
 	if err != nil {
 		t.Fatalf("buildLaneAnalyzer: %v", err)
 	}
@@ -433,7 +472,7 @@ func TestLaneCacheOverrideMergesFieldWise(t *testing.T) {
 			}
 			la := laneBlock()
 			la.Cache = tc.cache
-			ev, err := buildLaneAnalyzer("appdb", la, deps, false)
+			ev, err := buildLaneAnalyzer("appdb", la, deps, false, false)
 			if err != nil {
 				t.Fatalf("buildLaneAnalyzer: %v", err)
 			}
@@ -457,11 +496,11 @@ func TestBlockAndRuleBudgetsDoNotCollideOnOneName(t *testing.T) {
 		provider: rec,
 	}
 
-	block, err := buildLaneAnalyzer("appdb", laneBlock(), deps, false)
+	block, err := buildLaneAnalyzer("appdb", laneBlock(), deps, false, false)
 	if err != nil {
 		t.Fatalf("buildLaneAnalyzer: %v", err)
 	}
-	rules, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("appdb")}, deps, false)
+	rules, err := buildAnalyzerEvaluators([]policy.Rule{aiRule("appdb")}, deps, false, false)
 	if err != nil {
 		t.Fatalf("buildAnalyzerEvaluators: %v", err)
 	}
@@ -485,7 +524,7 @@ func TestRedactedSendTransmitsNoValues(t *testing.T) {
 		provider: rec,
 		det:      stubPlugin{entities: []string{"CREDIT_CARD"}, find: pan},
 	}
-	ev, err := buildLaneAnalyzer("appdb", laneBlock(), deps, false)
+	ev, err := buildLaneAnalyzer("appdb", laneBlock(), deps, false, false)
 	if err != nil {
 		t.Fatalf("buildLaneAnalyzer: %v", err)
 	}
@@ -516,7 +555,7 @@ func TestLanePrivacySendWithoutDetectorIsRefused(t *testing.T) {
 			}
 			la := laneBlock()
 			la.Send = mode
-			_, err := buildLaneAnalyzer("appdb", la, deps, false)
+			_, err := buildLaneAnalyzer("appdb", la, deps, false, false)
 			if err == nil || !strings.Contains(err.Error(), "detector") {
 				t.Fatalf("a %s override with no detector was accepted: %v", mode, err)
 			}
@@ -542,7 +581,7 @@ func TestRefuseRunsOnCacheHits(t *testing.T) {
 		provider: rec,
 		det:      stubPlugin{entities: []string{"CREDIT_CARD"}, find: pan},
 	}
-	ev, err := buildLaneAnalyzer("appdb", laneBlock(), deps, false)
+	ev, err := buildLaneAnalyzer("appdb", laneBlock(), deps, false, false)
 	if err != nil {
 		t.Fatalf("buildLaneAnalyzer: %v", err)
 	}

--- a/sidecar/daemon/laneanalyzer_test.go
+++ b/sidecar/daemon/laneanalyzer_test.go
@@ -1,0 +1,380 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/inspect"
+	"github.com/hoophq/hoop/sidecar/analyzer"
+	"github.com/hoophq/hoop/sidecar/policy"
+)
+
+// laneBlock is a minimal valid listener analyzer block.
+func laneBlock() *LaneAnalyzerConfig {
+	return &LaneAnalyzerConfig{
+		Trigger: &policy.AITrigger{
+			Operations: []inspect.Operation{inspect.OpDelete},
+		},
+		HighRisk: "block",
+	}
+}
+
+// blockLane is a postgres lane carrying its own analyzer block.
+func blockLane(la *LaneAnalyzerConfig) *Config {
+	cfg := pgLane()
+	cfg.Listeners[0].Analyzer = la
+	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
+	return cfg
+}
+
+// The analyzer is a per-lane component now: a listener declares it beside
+// guardrails and mask, with no rule wrapper.
+func TestLaneAnalyzerBlockIsAccepted(t *testing.T) {
+	if err := blockLane(laneBlock()).Validate(); err != nil {
+		t.Fatalf("a listener analyzer block was refused: %v", err)
+	}
+}
+
+// The block needs the top-level section the same way the rule form did: the
+// provider, the model and the credential live there.
+func TestLaneAnalyzerWithoutTopLevelSectionIsRefused(t *testing.T) {
+	cfg := blockLane(laneBlock())
+	cfg.Analyzer = nil
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("an analyzer block with no top-level analyzer section was accepted")
+	}
+	if !strings.Contains(err.Error(), "analyzer") {
+		t.Errorf("the error does not name the missing section: %v", err)
+	}
+}
+
+// An empty trigger classifies nothing on an ungated lane, exactly as it did
+// on the rule form, and is the correct spelling on a gated one.
+func TestLaneAnalyzerTriggerIsRequiredUnlessGated(t *testing.T) {
+	build := func(gate bool) error {
+		cfg := blockLane(&LaneAnalyzerConfig{HighRisk: "block"})
+		if gate {
+			cfg.Listeners[0].OPA = &OPAConfig{
+				URL: "http://opa:8181/v1/data/hoop", Gate: true,
+			}
+		}
+		return cfg.Validate()
+	}
+	if err := build(false); err == nil {
+		t.Error("an untriggered block on an ungated lane was accepted")
+	}
+	if err := build(true); err != nil {
+		t.Errorf("an untriggered block on a gated lane was refused: %v", err)
+	}
+}
+
+// A block naming no action for any risk level would allow every verdict,
+// which looks like enforcement and is not.
+func TestLaneAnalyzerWithoutAnyActionIsRefused(t *testing.T) {
+	cfg := blockLane(&LaneAnalyzerConfig{
+		Trigger: &policy.AITrigger{Operations: []inspect.Operation{inspect.OpDelete}},
+	})
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("an analyzer block with no risk actions was accepted")
+	}
+	if !strings.Contains(err.Error(), "no action for any risk level") {
+		t.Errorf("the error does not explain the allow-everything failure: %v", err)
+	}
+}
+
+// The block refuses the same action values the rule form refuses, through
+// the same shared check.
+func TestLaneAnalyzerActionVocabulary(t *testing.T) {
+	for _, tc := range []struct {
+		name, action, want string
+	}{
+		{"unknown", "explode", "unknown action"},
+		{"require_review", "require_review", "hold a statement"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			la := laneBlock()
+			la.HighRisk = tc.action
+			err := blockLane(la).Validate()
+			if err == nil {
+				t.Fatalf("action %q was accepted", tc.action)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %v does not contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// The numeric bounds a block overrides get the same negative refusal the
+// top-level defaults get: a negative reads as "off" while looking set.
+func TestLaneAnalyzerNegativeNumericsAreRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		la   LaneAnalyzerConfig
+	}{
+		{"timeout_sec", LaneAnalyzerConfig{TimeoutSec: -1}},
+		{"max_input_bytes", LaneAnalyzerConfig{MaxInputBytes: -1}},
+		{"max_calls", LaneAnalyzerConfig{MaxCalls: -1}},
+		{"cache.size", LaneAnalyzerConfig{Cache: &AnalyzerCacheConfig{Size: -1}}},
+		{"cache.ttl_sec", LaneAnalyzerConfig{Cache: &AnalyzerCacheConfig{TTLSec: -1}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			la := laneBlock()
+			base := tc.la
+			base.Trigger, base.HighRisk = la.Trigger, la.HighRisk
+			err := blockLane(&base).Validate()
+			if err == nil {
+				t.Fatalf("a negative %s was accepted", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.name) {
+				t.Errorf("error %v does not name %s", err, tc.name)
+			}
+		})
+	}
+}
+
+// An unknown send mode on the block is refused, not downgraded to raw.
+func TestLaneAnalyzerUnknownSendModeIsRefused(t *testing.T) {
+	la := laneBlock()
+	la.Send = "plaintext"
+	if err := blockLane(la).Validate(); err == nil {
+		t.Fatal("an unknown send mode on the block was accepted")
+	}
+}
+
+// The block's prompt beats the top-level default, which beats the built-in:
+// the same precedence the rule form has, because both build through one
+// path.
+func TestLaneAnalyzerPromptPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		blockPrompt string
+		cfgPrompt   string
+		want        string
+	}{
+		{"block wins", "lane text", "cfg text", "lane text"},
+		{"top-level default applies", "", "cfg text", "cfg text"},
+		{"built-in when neither", "", "", "Risk levels:"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			la := laneBlock()
+			la.Prompt = tc.blockPrompt
+			deps := &analyzerDeps{
+				cfg:      &AnalyzerConfig{Provider: "stub", Model: "m", Prompt: tc.cfgPrompt},
+				provider: stubAnalyzerProvider{},
+			}
+			ev, err := buildLaneAnalyzer("appdb", la, deps, true)
+			if err != nil {
+				t.Fatalf("buildLaneAnalyzer: %v", err)
+			}
+			got := ev.(*analyzer.Evaluator).SystemPrompt()
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("prompt = %q, want it to contain %q", got, tc.want)
+			}
+			if !strings.Contains(got, "Never quote a literal value") {
+				t.Error("the output contract was dropped")
+			}
+		})
+	}
+}
+
+// The block overrides only what it names. max_calls is the observable one:
+// a lane cap of 1 must beat an unbounded default, and the budget must key on
+// the LANE name so a rebuilt block continues the running count.
+func TestLaneAnalyzerOverridesAndBudgetKeyOnTheLane(t *testing.T) {
+	deps := &analyzerDeps{
+		cfg:      &AnalyzerConfig{Provider: "stub", Model: "m"},
+		provider: stubAnalyzerProvider{},
+	}
+	la := laneBlock()
+	la.MaxCalls = 1
+	stmt := inspect.Statement{
+		Protocol:  inspect.Postgres,
+		Direction: inspect.FromClient,
+		Text:      "DELETE FROM t",
+		Operation: inspect.OpDelete,
+	}
+
+	gen1, err := buildLaneAnalyzer("appdb", la, deps, false)
+	if err != nil {
+		t.Fatalf("buildLaneAnalyzer: %v", err)
+	}
+	gen1.Evaluate(stmt) // spends the whole lane budget of 1
+
+	gen2, err := buildLaneAnalyzer("appdb", la, deps, false)
+	if err != nil {
+		t.Fatalf("buildLaneAnalyzer: %v", err)
+	}
+	gen2.Evaluate(stmt)
+	if got := gen2.(*analyzer.Evaluator).Stats().Calls; got != 1 {
+		t.Fatalf("calls across generations = %d, want the lane budget of 1", got)
+	}
+
+	// A different lane is a different identity with its own purse.
+	other, err := buildLaneAnalyzer("payments", la, deps, false)
+	if err != nil {
+		t.Fatalf("buildLaneAnalyzer: %v", err)
+	}
+	other.Evaluate(stmt)
+	if got := other.(*analyzer.Evaluator).Stats().Calls; got != 1 {
+		t.Fatalf("a second lane's budget = %d, want its own count of 1", got)
+	}
+}
+
+// A deferring block makes the lane two-phase exactly as a deferring rule
+// does: the decision that reads the finding has to run after the block that
+// fills it.
+func TestLaneAnalyzerDeferMakesTheLaneTwoPhase(t *testing.T) {
+	la := laneBlock()
+	la.HighRisk = "defer"
+	s := laneStack{la: la, opa: &OPAConfig{URL: "http://opa:8181/v1/data/hoop"}}
+	pol, err := buildLane(s, nil, stubDeps())
+	if err != nil {
+		t.Fatalf("buildPolicy: %v", err)
+	}
+	got := phases(t, pol)
+	if len(got) != 1 || got[0] != policy.PhaseDecide {
+		t.Fatalf("phases = %v, want exactly one decide-phase OPA after the analyzer", got)
+	}
+}
+
+// A block that reads `high: defer` and behaves as `high: block` — the
+// OPA-less degradation — has to say which one it did, so the lane carries
+// the same startup note a deferring local rule gets.
+func TestLaneAnalyzerDeferWithoutOPALeavesANote(t *testing.T) {
+	la := laneBlock()
+	la.HighRisk = "defer"
+	lanes, err := Validate(blockLane(la), nil)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	var found bool
+	for _, n := range lanes[0].Notes {
+		if strings.Contains(n, "no opa.url") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no startup note explains the defer degradation: %v", lanes[0].Notes)
+	}
+}
+
+// The rule form still loads, still works, and now says what replaced it.
+func TestAIAnalysisRuleLoadsWithADeprecation(t *testing.T) {
+	cfg := pgLane(aiRule("risky"))
+	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("the deprecated rule form was refused: %v", err)
+	}
+	if err := cfg.normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	var found bool
+	for _, d := range cfg.Deprecations {
+		if strings.Contains(d, "ai_analysis is deprecated") &&
+			strings.Contains(d, `"analyzer" block`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no deprecation names the analyzer block: %v", cfg.Deprecations)
+	}
+}
+
+// Both spellings can serve one lane during a migration, each as its own
+// evaluator; neither silently displaces the other.
+func TestBlockAndRuleFormCoexist(t *testing.T) {
+	cfg := blockLane(laneBlock())
+	cfg.Listeners[0].Guardrails = &GuardrailsConfig{Rules: []policy.Rule{aiRule("risky")}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("a migrating lane carrying both spellings was refused: %v", err)
+	}
+	lanes, err := Validate(cfg, nil)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	sum := lanes[0].Summary()
+	if !strings.Contains(sum, "ai analyzer") || !strings.Contains(sum, "1 deprecated ai rule(s)") {
+		t.Errorf("summary %q does not report the component and the leftover rule", sum)
+	}
+}
+
+// -validate reports the analyzer as a component of the lane, never a rule
+// count.
+func TestValidateReportsTheAnalyzerAsAComponent(t *testing.T) {
+	lanes, err := Validate(blockLane(laneBlock()), nil)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !lanes[0].Analyzer {
+		t.Error("LaneInfo does not report the analyzer block")
+	}
+	sum := lanes[0].Summary()
+	if !strings.Contains(sum, "+ ai analyzer") {
+		t.Errorf("summary %q does not report the analyzer component", sum)
+	}
+	if strings.Contains(sum, "ai rule") {
+		t.Errorf("summary %q still reports a rule count for a block-only lane", sum)
+	}
+}
+
+// The block on an HTTP lane needs body capture for the same reason the rule
+// form did: a bodiless request is skipped, so the analyzer would never fire.
+func TestHTTPLaneAnalyzerWithoutCaptureBodyIsRefused(t *testing.T) {
+	cfg := &Config{
+		Analyzer: &AnalyzerConfig{Provider: "stub", Model: "m"},
+		Listeners: []ListenerConfig{{
+			Name: "api", Protocol: "http", Listen: ":1", Upstream: "h:1",
+			Analyzer: &LaneAnalyzerConfig{
+				Trigger:  &policy.AITrigger{Resources: []string{"/orders/**"}},
+				HighRisk: "block",
+			},
+		}},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("an http lane analyzer with no capture_body was accepted")
+	}
+	if !strings.Contains(err.Error(), "capture_body") {
+		t.Errorf("the error does not name capture_body: %v", err)
+	}
+
+	cfg.Listeners[0].HTTP = &HTTPCodecConfig{CaptureBody: true}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("the same lane with capture_body was refused: %v", err)
+	}
+}
+
+// Editing only a lane's analyzer block must swap on a hot reload rather
+// than demand a restart: the block builds evaluators, not sockets.
+func TestLaneAnalyzerBlockIsInsideTheReloadBoundary(t *testing.T) {
+	before := blockLane(laneBlock())
+	after := blockLane(laneBlock())
+	after.Listeners[0].Analyzer.HighRisk = "warn"
+
+	b1, err := nonRuleDoc(before)
+	if err != nil {
+		t.Fatalf("nonRuleDoc: %v", err)
+	}
+	b2, err := nonRuleDoc(after)
+	if err != nil {
+		t.Fatalf("nonRuleDoc: %v", err)
+	}
+	if string(b1) != string(b2) {
+		t.Error("an analyzer block edit changed the restart-guarded document")
+	}
+
+	d1, err := laneRuleDoc(before, before.Listeners[0])
+	if err != nil {
+		t.Fatalf("laneRuleDoc: %v", err)
+	}
+	d2, err := laneRuleDoc(after, after.Listeners[0])
+	if err != nil {
+		t.Fatalf("laneRuleDoc: %v", err)
+	}
+	if string(d1) == string(d2) {
+		t.Error("an analyzer block edit did not change the lane's rule document")
+	}
+}

--- a/sidecar/daemon/migrate.go
+++ b/sidecar/daemon/migrate.go
@@ -1,0 +1,426 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/hoophq/hoop/sidecar/policy"
+)
+
+// This file is the -migrate command: it rewrites a config that uses
+// deprecated spellings onto the canonical schema and emits the result.
+//
+// Most of the migration is not here. LoadConfigBytes already folds every
+// renamed field (policy -> guardrails/opa, connection -> name, mask.enabled,
+// audit.fail_closed) through normalize, so by the time a Config reaches this
+// file those fields are canonical and only the one deprecation normalize
+// cannot fold remains: `type: ai_analysis` rules, whose faithful home is a
+// listener's analyzer block. normalize does not fold them because the fold
+// is not always faithful — two rules on one lane cannot become one block —
+// so it lives here, where a partial move can be reported instead of guessed.
+
+// YAMLFromJSON renders a JSON document as YAML, for -migrate output.
+//
+// A package variable rather than a parameter for the same reason Loader is
+// injected: the root module carries no YAML dependency, so a main that
+// links github.com/hoophq/hoop/sidecar/config/yaml assigns its FromJSON
+// here. Nil means -migrate emits JSON whatever the file extension says.
+var YAMLFromJSON func(jsonDoc []byte) ([]byte, error)
+
+// MigrateDeprecated rewrites c in place onto the canonical schema and
+// returns operator-facing notes describing what moved and what could not.
+//
+// It expects a NORMALIZED config (anything from a Loader or LoadConfigBytes
+// qualifies): the renamed fields are already folded, and only ai_analysis
+// rules remain. The move is attempted only where it is faithful:
+//
+//   - A listener's own ai_analysis rule becomes the listener's analyzer
+//     block when the lane has exactly one and no block yet.
+//   - A single TOP-LEVEL ai_analysis rule reached every lane through rule
+//     concatenation, so it becomes a block on every listener — but only
+//     when every listener is free to take it, because a lane that already
+//     has a block cannot absorb a second trigger/action map.
+//
+// Everything else stays as rules, keeps working, and is named in the notes
+// with the reason, so the operator finishes by hand instead of the tool
+// guessing.
+func (c *Config) MigrateDeprecated() []string {
+	var notes []string
+	note := func(format string, args ...any) {
+		notes = append(notes, fmt.Sprintf(format, args...))
+	}
+
+	// Listener-scope rules first: the lane's own spelling has the
+	// strongest claim on the lane's block.
+	for i := range c.Listeners {
+		lc := &c.Listeners[i]
+		if lc.Guardrails == nil {
+			continue
+		}
+		local, ai := splitAnalyzerRules(lc.Guardrails.Rules)
+		if len(ai) == 0 {
+			continue
+		}
+		name := lc.displayName(i)
+		switch {
+		case lc.Analyzer != nil:
+			note("%s: %d ai_analysis rule(s) left in place: the listener already has "+
+				"an analyzer block, and a lane runs one block", name, len(ai))
+		case len(ai) > 1:
+			note("%s: %d ai_analysis rules left in place: they carry separate triggers, "+
+				"actions or prompts, and one block cannot hold two; merge them or keep "+
+				"the rule form until you can", name, len(ai))
+		default:
+			la := specFromRule(ai[0])
+			lc.Analyzer = &la
+			lc.Guardrails.Rules = local
+			if len(local) == 0 && lc.Guardrails.Mode == "" {
+				lc.Guardrails = nil
+			}
+			note("%s: rule %q became the listener's analyzer block. Its audit ai_rule "+
+				"and its max_calls budget now key on the listener name %q instead of "+
+				"the rule name", name, ai[0].Name, name)
+		}
+	}
+
+	// A top-level rule reached every lane. It moves only when every lane
+	// can take it, because a partial move would change which lanes run it.
+	if c.Guardrails == nil {
+		return notes
+	}
+	local, ai := splitAnalyzerRules(c.Guardrails.Rules)
+	switch {
+	case len(ai) == 0:
+	case len(ai) > 1:
+		note("guardrails: %d top-level ai_analysis rules left in place: each lane "+
+			"runs one analyzer block, and one lane cannot take %d", len(ai), len(ai))
+	default:
+		occupied := make([]string, 0, len(c.Listeners))
+		for i := range c.Listeners {
+			lc := &c.Listeners[i]
+			if lc.Analyzer != nil || hasAIRules(lc.Guardrails) {
+				occupied = append(occupied, lc.displayName(i))
+			}
+		}
+		if len(occupied) > 0 {
+			note("guardrails: top-level ai_analysis rule %q left in place: %s already "+
+				"carry an analyzer, and moving it to the free lanes only would change "+
+				"which lanes run it", ai[0].Name, strings.Join(occupied, ", "))
+			break
+		}
+		for i := range c.Listeners {
+			la := specFromRule(ai[0])
+			c.Listeners[i].Analyzer = &la
+		}
+		c.Guardrails.Rules = local
+		if len(local) == 0 && c.Guardrails.Mode == "" {
+			c.Guardrails = nil
+		}
+		note("guardrails: top-level rule %q became an analyzer block on every "+
+			"listener. Each lane now pays from its own max_calls budget, keyed on "+
+			"the listener name, where the shared rule paid from one purse named %q",
+			ai[0].Name, ai[0].Name)
+	}
+	return notes
+}
+
+// hasAIRules reports whether a guardrails block still authors ai_analysis
+// rules after the listener-scope pass.
+func hasAIRules(gc *GuardrailsConfig) bool {
+	if gc == nil {
+		return false
+	}
+	for _, r := range gc.Rules {
+		if r.Type == policy.MatchAIAnalysis {
+			return true
+		}
+	}
+	return false
+}
+
+// RenderMigrated marshals a migrated config as a JSON document fit to be a
+// config file.
+//
+// A plain json.Marshal of Config is correct but noisy: fields with no
+// omitempty render their zero values ("network": "", "upstream_tls": null),
+// which an operator would have to clean by hand. So the render prunes
+// zero-ish values from the document and then PROVES the prune changed
+// nothing: the pruned document is loaded through LoadConfigBytes and
+// re-marshaled, and only a byte-identical result ships. A prune that moved
+// semantics — an explicit `fail_open: false` pointer, an `opa: {}` opt-out —
+// fails that comparison and the noisy-but-exact document ships instead.
+//
+// The prune walks an ORDER-PRESERVING decode of the document rather than a
+// Go map, because the output is a file a person maintains: json.Marshal
+// ordered the keys by struct declaration — the order the docs teach — and
+// a map round-trip would alphabetize them.
+func RenderMigrated(c *Config) ([]byte, error) {
+	exact, err := json.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(exact))
+	dec.UseNumber()
+	doc, err := decodeOrdered(dec)
+	if err != nil {
+		return nil, err
+	}
+	pruned, err := json.MarshalIndent(prune(doc, "", ""), "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	reloaded, err := LoadConfigBytes(pruned)
+	if err == nil {
+		remarshal, merr := json.Marshal(reloaded)
+		if merr == nil && bytes.Equal(remarshal, exact) {
+			return append(pruned, '\n'), nil
+		}
+	}
+	// The prune was not provably lossless for this config; ship the exact
+	// document. Indented so it is still a file a person maintains.
+	exact, err = json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(exact, '\n'), nil
+}
+
+// prune drops zero values a strict decode reads back identically: null,
+// empty strings, zero numbers, false, and empty containers. The exceptions
+// are the spellings where presence itself is the meaning:
+//
+//   - `opa`, `guardrails`, `mask` and `analyzer` objects stay even empty,
+//     because an empty block can be an opt-out (`opa: {}`) or an explicit
+//     scope an operator wrote.
+//   - `rules: []` stays, because an empty list is how a lane switches an
+//     inherited rule set off.
+//   - `fail_open: false` stays under `analyzer` and `audit` blocks, where
+//     the field is a pointer and explicit false is not the same marshal as
+//     absent. Under `opa` it is a plain bool whose zero is absence, so it
+//     drops like any other zero.
+//
+// RenderMigrated verifies the result round-trips byte-identically, so a
+// miss here degrades output cosmetics, never semantics.
+func prune(v any, key, parent string) any {
+	switch t := v.(type) {
+	case *orderedMap:
+		out := &orderedMap{}
+		for _, kv := range t.pairs {
+			p := prune(kv.val, kv.key, key)
+			if p == nil && !keepEmpty(kv.key, kv.val) {
+				continue
+			}
+			if p == nil {
+				p = kv.val
+			}
+			out.pairs = append(out.pairs, pair{kv.key, p})
+		}
+		if len(out.pairs) == 0 && !keepEmpty(key, t) {
+			return nil
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(t))
+		for _, child := range t {
+			p := prune(child, "", key)
+			if p == nil {
+				continue
+			}
+			out = append(out, p)
+		}
+		if len(out) == 0 && !keepEmpty(key, t) {
+			return nil
+		}
+		return out
+	case string:
+		if t == "" {
+			return nil
+		}
+	case json.Number:
+		if f, err := t.Float64(); err == nil && f == 0 {
+			return nil
+		}
+	case bool:
+		if !t && !(key == "fail_open" && (parent == "analyzer" || parent == "audit")) {
+			return nil
+		}
+	case nil:
+		return nil
+	}
+	return v
+}
+
+// keepEmpty names the keys whose empty value is a meaning, not noise.
+func keepEmpty(key string, v any) bool {
+	switch key {
+	case "opa", "guardrails", "mask", "analyzer":
+		_, isMap := v.(*orderedMap)
+		return isMap
+	case "rules":
+		_, isList := v.([]any)
+		return isList
+	}
+	return false
+}
+
+// orderedMap is a JSON object that remembers its key order, so the pruned
+// document keeps the order json.Marshal gave it. The stdlib map would
+// alphabetize on re-marshal.
+type orderedMap struct {
+	pairs []pair
+}
+
+type pair struct {
+	key string
+	val any
+}
+
+// MarshalJSON renders the object with its remembered order.
+// json.MarshalIndent re-indents this output, so the render stays readable.
+func (m *orderedMap) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, kv := range m.pairs {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		k, err := json.Marshal(kv.key)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(k)
+		buf.WriteByte(':')
+		v, err := json.Marshal(kv.val)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(v)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// decodeOrdered consumes one JSON value from dec, decoding objects into
+// orderedMaps and everything else into the stdlib shapes.
+func decodeOrdered(dec *json.Decoder) (any, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	return orderedFromToken(dec, tok)
+}
+
+func orderedFromToken(dec *json.Decoder, tok json.Token) (any, error) {
+	switch t := tok.(type) {
+	case json.Delim:
+		switch t {
+		case '{':
+			m := &orderedMap{}
+			for dec.More() {
+				keyTok, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				key, ok := keyTok.(string)
+				if !ok {
+					return nil, fmt.Errorf("object key %v is not a string", keyTok)
+				}
+				val, err := decodeOrdered(dec)
+				if err != nil {
+					return nil, err
+				}
+				m.pairs = append(m.pairs, pair{key, val})
+			}
+			_, err := dec.Token() // consume '}'
+			return m, err
+		case '[':
+			var list []any
+			for dec.More() {
+				child, err := decodeOrdered(dec)
+				if err != nil {
+					return nil, err
+				}
+				list = append(list, child)
+			}
+			_, err := dec.Token() // consume ']'
+			if list == nil {
+				list = []any{}
+			}
+			return list, err
+		}
+		return nil, fmt.Errorf("unexpected delimiter %v", t)
+	default:
+		// string, json.Number, bool or nil, all complete in the token.
+		return tok, nil
+	}
+}
+
+// WriteMigrated runs the migration and writes the document to w and the
+// report to errw. Shared by hoop-inspect -migrate and
+// `hoop start sidecar --migrate`, so the two front ends cannot drift.
+//
+// yamlOut asks for YAML; it is honored only when the main injected
+// YAMLFromJSON, and falls back to JSON with a line on the report otherwise.
+// Comments and key order from the original file are not preserved — the
+// document is rebuilt from the parsed config — which the report says out
+// loud because an operator diffing the two files will notice first.
+func WriteMigrated(cfg *Config, yamlOut bool, w, errw io.Writer) error {
+	notes := cfg.MigrateDeprecated()
+
+	jsonDoc, err := RenderMigrated(cfg)
+	if err != nil {
+		return fmt.Errorf("rendering the migrated config: %w", err)
+	}
+
+	// Prove the emitted document loads before anyone deploys it, and count
+	// what it still warns about. JSON is what LoadConfigBytes reads; a YAML
+	// render comes from this verified JSON, so verifying it covers both.
+	reloaded, err := LoadConfigBytes(jsonDoc)
+	if err != nil {
+		return fmt.Errorf("the migrated config does not load, which is a bug worth "+
+			"reporting: %w", err)
+	}
+	if n := len(reloaded.Deprecations); n > 0 {
+		notes = append(notes, fmt.Sprintf(
+			"the migrated config still uses %d deprecated field(s); the notes above "+
+				"say which lanes to finish by hand", n))
+	}
+
+	doc := jsonDoc
+	if yamlOut {
+		if YAMLFromJSON == nil {
+			fmt.Fprintln(errw, "migrate: this build renders JSON only; the document below is JSON")
+		} else {
+			doc, err = YAMLFromJSON(jsonDoc)
+			if err != nil {
+				return fmt.Errorf("rendering the migrated config as YAML: %w", err)
+			}
+		}
+	}
+
+	for _, n := range notes {
+		fmt.Fprintln(errw, "migrate:", n)
+	}
+	fmt.Fprintln(errw, "migrate: comments and key order from the original file are not preserved; "+
+		"review the diff before deploying")
+
+	_, err = w.Write(doc)
+	return err
+}
+
+// isYAMLPath reports whether a path's extension asks for YAML. It mirrors
+// config/yaml.IsYAML without the import: the root module cannot depend on
+// the nested one, and two lines do not earn an interface.
+func isYAMLPath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml":
+		return true
+	}
+	return false
+}

--- a/sidecar/daemon/migrate_test.go
+++ b/sidecar/daemon/migrate_test.go
@@ -1,0 +1,263 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hoophq/hoop/sidecar/policy"
+)
+
+// One listener-scope ai_analysis rule is the clean case: it becomes the
+// lane's block, field for field, and the rule disappears.
+func TestMigrateMovesAListenerRuleOntoTheBlock(t *testing.T) {
+	r := aiRule("risky")
+	r.MediumRisk = "warn"
+	r.Prompt = "judge the ledger"
+	r.Message = "refused"
+	cfg := pgLane(r)
+	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
+
+	notes := cfg.MigrateDeprecated()
+
+	lc := cfg.Listeners[0]
+	if lc.Analyzer == nil {
+		t.Fatal("no analyzer block was created")
+	}
+	if lc.Analyzer.HighRisk != "block" || lc.Analyzer.MediumRisk != "warn" ||
+		lc.Analyzer.Prompt != "judge the ledger" || lc.Analyzer.Message != "refused" ||
+		lc.Analyzer.Trigger.IsZero() {
+		t.Errorf("block lost fields: %+v", lc.Analyzer)
+	}
+	// The rule was the guardrails block's only content, so the block goes
+	// too rather than leaving an empty stub.
+	if lc.Guardrails != nil {
+		t.Errorf("an emptied guardrails block was kept: %+v", lc.Guardrails)
+	}
+	if len(notes) == 0 || !strings.Contains(notes[0], "ai_rule") {
+		t.Errorf("the notes do not warn about the identity change: %v", notes)
+	}
+}
+
+// Local rules survive the move untouched, in order.
+func TestMigrateKeepsLocalRules(t *testing.T) {
+	local := policy.Rule{Name: "no-drop", Type: policy.MatchDenyWords, Words: []string{"drop"}}
+	cfg := pgLane(local, aiRule("risky"))
+	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
+
+	cfg.MigrateDeprecated()
+
+	lc := cfg.Listeners[0]
+	if lc.Guardrails == nil || len(lc.Guardrails.Rules) != 1 || lc.Guardrails.Rules[0].Name != "no-drop" {
+		t.Fatalf("local rules did not survive: %+v", lc.Guardrails)
+	}
+	if lc.Analyzer == nil {
+		t.Fatal("the ai rule did not become a block")
+	}
+}
+
+// Two rules on one lane cannot become one block, so the tool leaves them and
+// says why instead of guessing which one wins.
+func TestMigrateLeavesAMultiRuleLaneAlone(t *testing.T) {
+	cfg := pgLane(aiRule("writes"), aiRule("reads"))
+	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
+
+	notes := cfg.MigrateDeprecated()
+
+	lc := cfg.Listeners[0]
+	if lc.Analyzer != nil {
+		t.Fatal("a lossy move was made")
+	}
+	if len(lc.Guardrails.Rules) != 2 {
+		t.Fatalf("rules were dropped: %+v", lc.Guardrails.Rules)
+	}
+	if len(notes) != 1 || !strings.Contains(notes[0], "2 ai_analysis rules left in place") {
+		t.Errorf("notes = %v", notes)
+	}
+}
+
+// A lane that already has a block keeps its rules: the block is occupied and
+// a second trigger cannot be absorbed.
+func TestMigrateLeavesAnOccupiedLaneAlone(t *testing.T) {
+	cfg := pgLane(aiRule("risky"))
+	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
+	la := LaneAnalyzerConfig{HighRisk: "block"}
+	cfg.Listeners[0].Analyzer = &la
+
+	notes := cfg.MigrateDeprecated()
+
+	if len(cfg.Listeners[0].Guardrails.Rules) != 1 {
+		t.Fatal("the rule was moved onto an occupied lane")
+	}
+	if len(notes) != 1 || !strings.Contains(notes[0], "already has") {
+		t.Errorf("notes = %v", notes)
+	}
+}
+
+// A single top-level rule reached every lane through concatenation, so the
+// faithful move is a block on every listener.
+func TestMigrateCopiesATopLevelRuleToEveryFreeLane(t *testing.T) {
+	cfg := &Config{
+		Analyzer:   &AnalyzerConfig{Provider: "stub", Model: "m"},
+		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{aiRule("risky")}},
+		Listeners: []ListenerConfig{
+			{Name: "appdb", Protocol: "postgres", Listen: ":1", Upstream: "h:1"},
+			{Name: "payments", Protocol: "postgres", Listen: ":2", Upstream: "h:2"},
+		},
+	}
+
+	notes := cfg.MigrateDeprecated()
+
+	if cfg.Guardrails != nil {
+		t.Errorf("the emptied top-level guardrails block was kept: %+v", cfg.Guardrails)
+	}
+	for _, lc := range cfg.Listeners {
+		if lc.Analyzer == nil || lc.Analyzer.HighRisk != "block" {
+			t.Fatalf("%s did not receive the block: %+v", lc.Name, lc.Analyzer)
+		}
+	}
+	// Copies must not share memory: one lane's later edit is not the
+	// other's.
+	if cfg.Listeners[0].Analyzer == cfg.Listeners[1].Analyzer {
+		t.Fatal("two lanes share one block pointer")
+	}
+	if len(notes) != 1 || !strings.Contains(notes[0], "own max_calls budget") {
+		t.Errorf("notes = %v", notes)
+	}
+}
+
+// A top-level rule with one occupied lane stays put: moving it to the free
+// lanes only would change which lanes run it.
+func TestMigrateLeavesATopLevelRuleWhenALaneIsOccupied(t *testing.T) {
+	la := LaneAnalyzerConfig{HighRisk: "block"}
+	cfg := &Config{
+		Analyzer:   &AnalyzerConfig{Provider: "stub", Model: "m"},
+		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{aiRule("risky")}},
+		Listeners: []ListenerConfig{
+			{Name: "appdb", Protocol: "postgres", Listen: ":1", Upstream: "h:1"},
+			{Name: "payments", Protocol: "postgres", Listen: ":2", Upstream: "h:2",
+				Analyzer: &la},
+		},
+	}
+
+	notes := cfg.MigrateDeprecated()
+
+	if cfg.Guardrails == nil || len(cfg.Guardrails.Rules) != 1 {
+		t.Fatal("the top-level rule was moved despite an occupied lane")
+	}
+	if cfg.Listeners[0].Analyzer != nil {
+		t.Fatal("a partial move reached the free lane")
+	}
+	if len(notes) != 1 || !strings.Contains(notes[0], "payments") {
+		t.Errorf("the note does not name the occupied lane: %v", notes)
+	}
+}
+
+// A config with nothing deprecated migrates to itself: no notes, no moves.
+func TestMigrateIsANoOpOnACanonicalConfig(t *testing.T) {
+	cfg := blockLane(laneBlock())
+	before, _ := json.Marshal(cfg)
+
+	notes := cfg.MigrateDeprecated()
+
+	after, _ := json.Marshal(cfg)
+	if !bytes.Equal(before, after) {
+		t.Error("a canonical config was rewritten")
+	}
+	if len(notes) != 0 {
+		t.Errorf("notes on a canonical config: %v", notes)
+	}
+}
+
+// The rendered document must load, carry no zero-value noise, and mean
+// exactly what the in-memory config means.
+func TestRenderMigratedIsCleanAndLossless(t *testing.T) {
+	cfg := pgLane(aiRule("risky"))
+	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
+	cfg.MigrateDeprecated()
+
+	doc, err := RenderMigrated(cfg)
+	if err != nil {
+		t.Fatalf("RenderMigrated: %v", err)
+	}
+
+	reloaded, err := LoadConfigBytes(doc)
+	if err != nil {
+		t.Fatalf("the rendered document does not load: %v\n%s", err, doc)
+	}
+	if len(reloaded.Deprecations) != 0 {
+		t.Errorf("the rendered document still warns: %v", reloaded.Deprecations)
+	}
+	if reloaded.Listeners[0].Analyzer == nil {
+		t.Fatal("the block did not survive the render")
+	}
+
+	for _, noise := range []string{`"network"`, `"upstream_tls"`, `"idle_timeout_sec"`, `"log_level"`} {
+		if bytes.Contains(doc, []byte(noise)) {
+			t.Errorf("zero-value noise %s in the render:\n%s", noise, doc)
+		}
+	}
+}
+
+// The prune must not eat the spellings whose presence is the meaning: an
+// opt-out opa block, an empty rules override, an explicit fail_open: false.
+func TestRenderMigratedKeepsMeaningfulEmptiness(t *testing.T) {
+	off := false
+	cfg := &Config{
+		Analyzer: &AnalyzerConfig{Provider: "stub", Model: "m", FailOpen: &off},
+		OPA:      &OPAConfig{URL: "http://opa:8181/v1/data/hoop"},
+		Guardrails: &GuardrailsConfig{Rules: []policy.Rule{
+			{Name: "no-drop", Type: policy.MatchDenyWords, Words: []string{"drop"}},
+		}},
+		Listeners: []ListenerConfig{{
+			Name: "appdb", Protocol: "postgres", Listen: ":1", Upstream: "h:1",
+			OPA:        &OPAConfig{},
+			Guardrails: &GuardrailsConfig{Rules: []policy.Rule{}},
+		}},
+	}
+
+	doc, err := RenderMigrated(cfg)
+	if err != nil {
+		t.Fatalf("RenderMigrated: %v", err)
+	}
+	reloaded, err := LoadConfigBytes(doc)
+	if err != nil {
+		t.Fatalf("the rendered document does not load: %v\n%s", err, doc)
+	}
+
+	if gc, opa, _ := reloaded.resolve(reloaded.Listeners[0]); opa.enabled() {
+		t.Errorf("the lane's opa opt-out was pruned away:\n%s", doc)
+	} else if len(gc.Rules) != 0 {
+		t.Errorf("the lane's empty rules override was pruned away:\n%s", doc)
+	}
+	if reloaded.Analyzer.failOpen() {
+		t.Errorf("the explicit fail_open: false was pruned away:\n%s", doc)
+	}
+}
+
+// WriteMigrated is the whole command: document out, notes and the diff
+// warning on the report, and the leftover count when a lane could not move.
+func TestWriteMigratedReportsLeftovers(t *testing.T) {
+	cfg := pgLane(aiRule("writes"), aiRule("reads"))
+	cfg.Analyzer = &AnalyzerConfig{Provider: "stub", Model: "m"}
+
+	var out, report bytes.Buffer
+	if err := WriteMigrated(cfg, false, &out, &report); err != nil {
+		t.Fatalf("WriteMigrated: %v", err)
+	}
+
+	if _, err := LoadConfigBytes(out.Bytes()); err != nil {
+		t.Fatalf("the emitted document does not load: %v", err)
+	}
+	r := report.String()
+	if !strings.Contains(r, "left in place") {
+		t.Errorf("the report does not name the unmovable rules: %s", r)
+	}
+	if !strings.Contains(r, "still uses 2 deprecated field(s)") {
+		t.Errorf("the report does not count the leftovers: %s", r)
+	}
+	if !strings.Contains(r, "comments and key order") {
+		t.Errorf("the report does not warn about the rebuild: %s", r)
+	}
+}

--- a/sidecar/daemon/reload.go
+++ b/sidecar/daemon/reload.go
@@ -181,26 +181,38 @@ func (r *reloader) apply(log *slog.Logger, raw []byte) reloadOutcome {
 			return reloadRefused
 		}
 		detChanged = true
-		if r.ac != nil {
-			// The provider and its credential stay: the analyzer section
-			// is inside the baseline. Only the redactors hold the
-			// detector, and each evaluator builds its own from ac.det
-			// at swap time, so handing the rebuilt detector over is
-			// all a pii edit needs.
-			r.ac.det = det
-		}
+	}
+
+	// The candidate detector is STAGED, never written into r.ac before the
+	// document is accepted: a refusal below must leave the running
+	// dependencies exactly as they were, or a later reload would combine
+	// this uncommitted detector with the running maskers and pii rules.
+	// The copy shares the budgets map on purpose — budget continuity is
+	// per name, not per generation.
+	ac := r.ac
+	if detChanged && r.ac != nil {
+		staged := *r.ac
+		staged.det = det
+		ac = &staged
 	}
 
 	newCfg.lic = r.lic
-	lanes, err := buildLanes(newCfg, det, r.ac)
+	lanes, err := buildLanes(newCfg, det, ac)
 	if err != nil {
 		log.Warn("the control plane sent a config the rules or the caps refuse; keeping the running rules",
 			"error", err)
 		return reloadRefused
 	}
 
-	swapped, kept := 0, 0
-	viewLanes := make([]lane, 0, len(lanes))
+	// Pre-pass: render every lane's rule document BEFORE anything swaps.
+	// Two reasons. A gRPC-transport lane cannot swap (ADR-0013 binds its
+	// callbacks at server construction), so drift there makes the whole
+	// document restart-bound: swapping the relay lanes and reporting the
+	// generation applied would leave a lane silently serving old rules
+	// under a log line that says otherwise. And a render failure must
+	// surface before any lane swapped, so a retry re-runs the whole
+	// document rather than half of it.
+	docs := make(map[string][]byte, len(lanes))
 	for _, ln := range lanes {
 		doc, derr := laneRuleDoc(newCfg, ln.cfg)
 		if derr != nil {
@@ -208,14 +220,21 @@ func (r *reloader) apply(log *slog.Logger, raw []byte) reloadOutcome {
 				"listener", ln.name, "error", derr)
 			return reloadRetry
 		}
+		docs[ln.name] = doc
+		if isGRPCTransport(ln.cfg) && !bytes.Equal(doc, r.laneDocs[ln.name]) {
+			log.Warn("grpc lane rules changed on the control plane; restart to apply them",
+				"listener", ln.name)
+			return reloadRestart
+		}
+	}
+
+	swapped, kept := 0, 0
+	viewLanes := make([]lane, 0, len(lanes))
+	for _, ln := range lanes {
+		doc := docs[ln.name]
 		if isGRPCTransport(ln.cfg) {
-			// gRPC-transport lanes (grpc, spanner) stay on the restart path
-			// (ADR-0014); drift is reported, never swapped, and the view
-			// keeps the serving lane.
-			if !bytes.Equal(doc, r.laneDocs[ln.name]) {
-				log.Warn("grpc lane rules changed on the control plane; restart to apply them",
-					"listener", ln.name)
-			}
+			// Unchanged by the pre-pass check above; the view keeps the
+			// serving lane.
 			viewLanes = append(viewLanes, r.prevLanes[ln.name])
 			continue
 		}
@@ -242,6 +261,12 @@ func (r *reloader) apply(log *slog.Logger, raw []byte) reloadOutcome {
 		swapped++
 	}
 
+	// Commit, all together: the detector, the pii section it came from and
+	// the analyzer dependencies move as one, only on a document that
+	// applied.
+	if detChanged && r.ac != nil {
+		r.ac.det = det
+	}
 	r.det = det
 	r.piiRaw = newCfg.PII
 	r.gen++

--- a/sidecar/daemon/reload.go
+++ b/sidecar/daemon/reload.go
@@ -183,9 +183,11 @@ func (r *reloader) apply(log *slog.Logger, raw []byte) reloadOutcome {
 		detChanged = true
 		if r.ac != nil {
 			// The provider and its credential stay: the analyzer section
-			// is inside the baseline. Only the redactor holds the
-			// detector, so only it follows the rebuild.
-			r.ac.redact = redactorFor(r.ac.cfg.Send, det)
+			// is inside the baseline. Only the redactors hold the
+			// detector, and each evaluator builds its own from ac.det
+			// at swap time, so handing the rebuilt detector over is
+			// all a pii edit needs.
+			r.ac.det = det
 		}
 	}
 
@@ -266,6 +268,10 @@ func nonRuleDoc(c *Config) ([]byte, error) {
 	listeners := make([]ListenerConfig, len(c.Listeners))
 	for i, lc := range c.Listeners {
 		lc.Guardrails, lc.OPA, lc.Mask, lc.Policy = nil, nil, nil, nil
+		// The lane's analyzer block swaps with the rules: it builds
+		// evaluators, not sockets, and its provider lives in the
+		// top-level analyzer section, which stays in the baseline.
+		lc.Analyzer = nil
 		listeners[i] = lc
 	}
 	cp.Listeners = listeners
@@ -277,8 +283,9 @@ func nonRuleDoc(c *Config) ([]byte, error) {
 func laneRuleDoc(c *Config, lc ListenerConfig) ([]byte, error) {
 	gc, opa, mc := c.resolve(lc)
 	return json.Marshal(struct {
-		G GuardrailsConfig `json:"g"`
-		O *OPAConfig       `json:"o"`
-		M MaskConfig       `json:"m"`
-	}{gc, opa, mc})
+		G GuardrailsConfig    `json:"g"`
+		O *OPAConfig          `json:"o"`
+		M MaskConfig          `json:"m"`
+		A *LaneAnalyzerConfig `json:"a"`
+	}{gc, opa, mc, lc.Analyzer})
 }

--- a/sidecar/daemon/reload_test.go
+++ b/sidecar/daemon/reload_test.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"reflect"
 	"strings"
@@ -266,5 +268,127 @@ func TestAnUntouchedLaneKeepsItsRunningEvaluators(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "kept=1") {
 		t.Errorf("the applied line does not count the kept lane:\n%s", buf)
+	}
+}
+
+// An analyzer edit on a gRPC-transport lane cannot swap (its callbacks bind
+// at server construction), so the whole document keeps the restart path:
+// swapping the other lanes and logging "applied" would leave the gRPC lane
+// serving old rules under a log line that says otherwise.
+func TestAGRPCLaneAnalyzerEditKeepsTheRestartPath(t *testing.T) {
+	desc := writeGRPCTestDescriptors(t)
+	base := fmt.Sprintf(`{
+  "analyzer": {"provider": "stub", "model": "m"},
+  "listeners": [{
+    "name": "g", "protocol": "grpc",
+    "listen": "127.0.0.1:0", "upstream": "h:50051",
+    "grpc": {"capture_payload": true, "descriptors": [%q]},
+    "analyzer": {"trigger": {"operations": ["delete"]}, "high": "block"}
+  }],
+  "audit": {"file": "-"}
+}`, desc)
+
+	cfg, err := LoadConfigBytes([]byte(base))
+	if err != nil {
+		t.Fatalf("LoadConfigBytes: %v", err)
+	}
+	cfg.cp = &controlPlane{url: "http://plane", token: "hsc_x", lastRaw: []byte(base)}
+	ac, err := setupAnalyzer(cfg, nil)
+	if err != nil {
+		t.Fatalf("setupAnalyzer: %v", err)
+	}
+	lanes, err := buildLanes(cfg, nil, ac)
+	if err != nil {
+		t.Fatalf("buildLanes: %v", err)
+	}
+	view := &atomic.Pointer[laneState]{}
+	view.Store(&laneState{lanes: lanes})
+	rl, err := newReloader(cfg, lanes, map[string]*proxy.Server{}, nil, ac, view)
+	if err != nil {
+		t.Fatalf("newReloader: %v", err)
+	}
+	var buf bytes.Buffer
+
+	drifted := editJSON(t, base, `"high": "block"`, `"high": "warn"`)
+	if got := handleWith(rl, &buf, drifted); got != reloadRestart {
+		t.Fatalf("outcome = %v, want restart; log:\n%s", got, &buf)
+	}
+	if !strings.Contains(buf.String(), "restart to apply them") {
+		t.Errorf("no restart log line:\n%s", &buf)
+	}
+	if strings.Contains(buf.String(), "configuration applied") {
+		t.Errorf("a document a grpc lane cannot absorb was reported applied:\n%s", &buf)
+	}
+	if rl.gen != 0 {
+		t.Errorf("generation = %d, want 0: nothing was applied", rl.gen)
+	}
+}
+
+// A refused reload must not leak its candidate detector into the running
+// analyzer dependencies: the pii section was not committed, so a later
+// reload must not combine the uncommitted redaction behavior with the
+// running maskers and pii evaluators.
+func TestARefusedReloadDoesNotLeakTheDetector(t *testing.T) {
+	cfg, err := LoadConfigBytes([]byte(reloadBase))
+	if err != nil {
+		t.Fatalf("LoadConfigBytes: %v", err)
+	}
+	det0 := &stubPlugin{entities: []string{"US_SSN"}}
+	det1 := &stubPlugin{entities: []string{"CREDIT_CARD"}}
+	cfg.cp = &controlPlane{
+		url: "http://plane", token: "hsc_x", lastRaw: []byte(reloadBase),
+		build: func(json.RawMessage) (Plugin, error) { return det1, nil },
+	}
+	ac := &analyzerDeps{
+		cfg:      &AnalyzerConfig{Provider: "stub", Model: "m"},
+		provider: stubAnalyzerProvider{},
+		det:      det0,
+	}
+	lanes, err := buildLanes(cfg, det0, ac)
+	if err != nil {
+		t.Fatalf("buildLanes: %v", err)
+	}
+	servers := map[string]*proxy.Server{}
+	for _, ln := range lanes {
+		srv, serr := buildServer(ln, cfg.Audit, nil, slog.Default())
+		if serr != nil {
+			t.Fatalf("buildServer: %v", serr)
+		}
+		servers[ln.name] = srv
+	}
+	view := &atomic.Pointer[laneState]{}
+	view.Store(&laneState{lanes: lanes})
+	rl, err := newReloader(cfg, lanes, servers, det0, ac, view)
+	if err != nil {
+		t.Fatalf("newReloader: %v", err)
+	}
+	var buf bytes.Buffer
+
+	// A pii drift plus a second guardrail rule: the document decodes and
+	// validates, the detector rebuilds, and then the free-tier cap refuses
+	// the lanes. The candidate detector must go down with the document.
+	refused := editJSON(t, reloadBase, `"audit"`, `"pii": {"entities": ["US_SSN"]}, "audit"`)
+	refused = editJSON(t, refused,
+		`{"name": "r0", "type": "deny_words_list", "words": ["drop table"]}`,
+		`{"name": "r0", "type": "deny_words_list", "words": ["drop table"]},
+		 {"name": "r1", "type": "deny_words_list", "words": ["truncate"]}`)
+	if got := applyWith(rl, &buf, refused); got != reloadRefused {
+		t.Fatalf("outcome = %v, want refused; log:\n%s", got, &buf)
+	}
+	if rl.ac.det != Plugin(det0) {
+		t.Fatal("a refused reload leaked its candidate detector into the running deps")
+	}
+	if rl.det != Plugin(det0) {
+		t.Fatal("a refused reload committed its detector")
+	}
+
+	// The same pii drift without the extra rule applies, and everything
+	// moves together.
+	applied := editJSON(t, reloadBase, `"audit"`, `"pii": {"entities": ["US_SSN"]}, "audit"`)
+	if got := applyWith(rl, &buf, applied); got != reloadApplied {
+		t.Fatalf("outcome = %v, want applied; log:\n%s", got, &buf)
+	}
+	if rl.ac.det != Plugin(det1) || rl.det != Plugin(det1) {
+		t.Fatal("an applied pii drift did not commit the detector everywhere")
 	}
 }

--- a/sidecar/daemon/twophase_test.go
+++ b/sidecar/daemon/twophase_test.go
@@ -53,10 +53,12 @@ func denyWordsRule(name, action string) policy.Rule {
 }
 
 // lanePolicy is an enforcing lane policy, whatever produces on it.
-// laneStack is the pair buildPolicy takes now that the old policy block is
-// two config sections. Bundling them keeps each test below a single call.
+// laneStack is what buildPolicy takes now that the old policy block is
+// separate config sections. Bundling them keeps each test below a single
+// call.
 type laneStack struct {
 	gc  GuardrailsConfig
+	la  *LaneAnalyzerConfig
 	opa *OPAConfig
 }
 
@@ -66,7 +68,7 @@ func lanePolicy(opa *OPAConfig, rules ...policy.Rule) laneStack {
 }
 
 func buildLane(s laneStack, det Plugin, ac *analyzerDeps) (policy.Evaluator, error) {
-	return buildPolicy(s.gc, s.opa, det, ac)
+	return buildPolicy("lane", s.gc, s.la, s.opa, det, ac)
 }
 
 // A lane with no defer and no gate must build exactly the chain it built
@@ -139,7 +141,7 @@ func TestAIDeferWithoutOPABlocks(t *testing.T) {
 		t.Fatalf("a rule deferring on a lane with no opa was refused: %v", err)
 	}
 
-	m, err := actionMap(deferRule("risky"), false)
+	m, err := actionMap(specFromRule(deferRule("risky")), false)
 	if err != nil {
 		t.Fatalf("actionMap: %v", err)
 	}
@@ -149,7 +151,7 @@ func TestAIDeferWithoutOPABlocks(t *testing.T) {
 	}
 
 	// With a consumer, the same rule defers as written.
-	m, err = actionMap(deferRule("risky"), true)
+	m, err = actionMap(specFromRule(deferRule("risky")), true)
 	if err != nil {
 		t.Fatalf("actionMap: %v", err)
 	}

--- a/sidecar/daemon/twophase_test.go
+++ b/sidecar/daemon/twophase_test.go
@@ -175,9 +175,11 @@ func TestGateWithoutAIRulesIsRefused(t *testing.T) {
 	}
 }
 
-// An empty trigger is a broken rule on an ungated lane and the correct
-// configuration on a gated one, where the policy decides what gets analyzed.
-func TestEmptyTriggerIsAllowedOnlyWhenGated(t *testing.T) {
+// An empty trigger loads on both lane kinds. On an ungated lane it
+// classifies everything; on a gated one the policy decides what gets
+// analyzed. The runtime split is pinned in
+// TestOmittedTriggerClassifiesEverythingUnlessGated.
+func TestEmptyTriggerLoadsOnBothLaneKinds(t *testing.T) {
 	build := func(gate bool) error {
 		r := aiRule("risky")
 		r.Trigger = nil
@@ -189,8 +191,8 @@ func TestEmptyTriggerIsAllowedOnlyWhenGated(t *testing.T) {
 		return cfg.Validate()
 	}
 
-	if err := build(false); err == nil {
-		t.Error("an untriggered rule on an ungated lane was accepted")
+	if err := build(false); err != nil {
+		t.Errorf("an untriggered rule on an ungated lane was refused: %v", err)
 	}
 	if err := build(true); err != nil {
 		t.Errorf("an untriggered rule on a gated lane was refused: %v", err)

--- a/sidecar/pii/alcatraz/alcatraz.go
+++ b/sidecar/pii/alcatraz/alcatraz.go
@@ -399,6 +399,74 @@ func (d *Detector) ScanText(text string) []string {
 	return out
 }
 
+// RedactText rewrites every detected value as its entity class, returning
+// the rewritten text and the sorted class names found.
+//
+// It backs the analyzer's send: redacted mode, whose contract is that no
+// detected VALUE reaches a model vendor. Each span becomes "<ENTITY_TYPE>":
+// the class tells the model what kind of value stood there, which is all a
+// risk verdict needs, and the value itself never leaves the process.
+// Overlapping detections collapse onto the earliest-starting span, the same
+// resolution order Find publishes.
+func (d *Detector) RedactText(text string) (string, []string) {
+	if text == "" {
+		return text, nil
+	}
+	results := d.eng.Analyze(text, d.opts)
+	if len(results) == 0 {
+		return text, nil
+	}
+
+	type span struct {
+		start, end int
+		entity     string
+	}
+	spans := make([]span, 0, len(results))
+	seen := make(map[string]bool, len(results))
+	names := make([]string, 0, len(results))
+	for _, r := range results {
+		if r.Start < 0 || r.End > len(text) || r.Start >= r.End {
+			continue
+		}
+		spans = append(spans, span{r.Start, r.End, r.EntityType})
+		if !seen[r.EntityType] {
+			seen[r.EntityType] = true
+			names = append(names, r.EntityType)
+		}
+	}
+	if len(spans) == 0 {
+		return text, nil
+	}
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start != spans[j].start {
+			return spans[i].start < spans[j].start
+		}
+		// The longer span wins a tie so a value detected as two classes
+		// is removed whole.
+		return spans[i].end > spans[j].end
+	})
+
+	var b strings.Builder
+	b.Grow(len(text))
+	pos := 0
+	for _, s := range spans {
+		if s.start < pos {
+			// Overlap with an already-replaced span: extend the cut so
+			// no tail of the value survives, but write no second label.
+			if s.end > pos {
+				pos = s.end
+			}
+			continue
+		}
+		b.WriteString(text[pos:s.start])
+		b.WriteString("<" + s.entity + ">")
+		pos = s.end
+	}
+	b.WriteString(text[pos:])
+	sort.Strings(names)
+	return b.String(), names
+}
+
 // ScanTextFor is ScanText restricted to the entity classes the caller can act
 // on, implementing the root module's optional policy.ScopedScanner.
 //

--- a/sidecar/pii/alcatraz/config.go
+++ b/sidecar/pii/alcatraz/config.go
@@ -16,6 +16,7 @@ import (
 // would make the sidecar believe detection is on and call through it.
 type Plugin interface {
 	ScanText(text string) []string
+	RedactText(text string) (string, []string)
 	Entities() []string
 	BuildMasker(rawRules []byte) (gate.Masker, error)
 }

--- a/sidecar/pii/alcatraz/redact_test.go
+++ b/sidecar/pii/alcatraz/redact_test.go
@@ -1,0 +1,66 @@
+package alcatraz_test
+
+import (
+	"strings"
+	"testing"
+
+	alcz "github.com/hoophq/alcatraz/entities"
+	"github.com/hoophq/hoop/sidecar/pii/alcatraz"
+)
+
+// RedactText backs the analyzer's send: redacted mode, whose contract is
+// that no detected VALUE leaves the process. The value must be gone from
+// the rewrite, replaced by its class, with the classes named beside it.
+func TestRedactTextRemovesValues(t *testing.T) {
+	d := newDet(t, alcatraz.Options{
+		Entities: []string{alcz.CreditCard, alcz.EmailAddress},
+	})
+	const card, mail = "4111111111111111", "ada@example.com"
+
+	out, names := d.RedactText("card " + card + " mail " + mail)
+
+	if strings.Contains(out, card) || strings.Contains(out, mail) {
+		t.Fatalf("a detected value survived the rewrite: %q", out)
+	}
+	if !strings.Contains(out, "<"+alcz.CreditCard+">") ||
+		!strings.Contains(out, "<"+alcz.EmailAddress+">") {
+		t.Errorf("classes did not replace the values: %q", out)
+	}
+	want := []string{alcz.CreditCard, alcz.EmailAddress}
+	if len(names) != 2 || names[0] != want[0] || names[1] != want[1] {
+		t.Errorf("names = %v, want %v sorted", names, want)
+	}
+}
+
+// Clean text comes back untouched with no names: the common case costs one
+// scan and no rewrite.
+func TestRedactTextCleanAndEmpty(t *testing.T) {
+	d := newDet(t, alcatraz.Options{Entities: []string{alcz.CreditCard}})
+
+	const clean = "SELECT id FROM orders WHERE status = 'open'"
+	if out, names := d.RedactText(clean); out != clean || names != nil {
+		t.Errorf("clean text changed: %q, names %v", out, names)
+	}
+	if out, names := d.RedactText(""); out != "" || names != nil {
+		t.Errorf("empty text changed: %q, names %v", out, names)
+	}
+}
+
+// A value two recognizers claim is removed whole: overlapping spans
+// collapse onto one replacement, and no tail of the value survives.
+func TestRedactTextOverlappingSpans(t *testing.T) {
+	d := newDet(t, alcatraz.Options{}) // permissive: every class active
+	const card = "4111111111111111"
+
+	out, _ := d.RedactText("pay with " + card + " today")
+
+	if strings.Contains(out, card) {
+		t.Fatalf("the value survived overlapping detections: %q", out)
+	}
+	// However many classes claimed it, the digits are gone.
+	for i := 0; i+8 <= len(card); i++ {
+		if strings.Contains(out, card[i:i+8]) {
+			t.Fatalf("a fragment of the value survived: %q", out)
+		}
+	}
+}

--- a/sidecar/policy/policy.go
+++ b/sidecar/policy/policy.go
@@ -432,9 +432,9 @@ type Rule struct {
 	Entities []string `json:"entities,omitempty"`
 
 	// Trigger narrows which statements a MatchAIAnalysis rule classifies.
-	// A rule with an empty trigger classifies nothing, because the failure
-	// mode of "matches everything by accident" is a bill rather than an
-	// error.
+	// A rule with an empty trigger classifies EVERYTHING on an ungated
+	// lane (the resolved lane carries a startup note naming the cost) and
+	// leaves a gate-phase policy in charge on a gated one.
 	Trigger *AITrigger `json:"trigger,omitempty"`
 
 	// HighRisk, MediumRisk and LowRisk map a MatchAIAnalysis verdict onto


### PR DESCRIPTION
## 📝 Description

The AI analyzer is now a first-class, per-listener component instead of a guardrail rule (`type: ai_analysis`). Each listener takes its own `analyzer:` block — trigger, `high`/`medium`/`low` actions, `prompt`, `message` — beside `guardrails`, `opa` and `mask`. The top-level `analyzer:` section keeps what is genuinely process-wide (provider, model, credential) and becomes the defaults every lane inherits and overrides field by field (`send`, `fail_open`, `timeout_sec`, `max_input_bytes`, `max_calls`, `cache`).

The old rule spelling **keeps working**: it loads, builds the same evaluator through the same code path (`specFromRule` → `buildAnalyzerEvaluator`), and prints a deprecation naming the block. `-strict` turns the warning into a non-zero exit. Both spellings can serve one lane during migration, each as its own evaluator.

`hoop-inspect -migrate -config config.yaml -migrate-out config-new.yaml` (also `hoop start sidecar --migrate`) rewrites any old config onto the current schema: it folds every deprecated field through the same strict decoder the daemon uses, moves `ai_analysis` rules onto listener blocks only where the move is faithful (one rule per lane; a top-level rule only when every lane is free), reports what it left for you on stderr, and emits a document — in the input's syntax, keys in the documented order — that passes `-validate -strict`.

Hardening that landed with the review of this branch:

- **`send: redacted` now actually redacts.** New `Plugin.RedactText` (alcatraz implements it from engine offsets) replaces each detected value with `<ENTITY_CLASS>` before the statement leaves the process. The previous behavior appended a note while transmitting the values.
- **`send: refuse` runs on cache hits.** The redact/refuse callback moved ahead of the verdict cache, so a sensitive literal can no longer ride a cached SQL shape past the local denial.
- **Effective `redacted`/`refuse` refused without a detector** — a lane-level override can no longer produce a nil redactor that transmits raw text.
- **Call budgets namespaced by form** (`rule:<name>` / `lane:<name>`): a deprecated rule named after a lane no longer spends that lane's `max_calls`.
- **Cache overrides merge field-wise** — `cache: {ttl_sec: 60}` keeps the inherited size instead of disabling caching.
- **Reload honesty:** gRPC-transport lane drift now returns the restart outcome from a pre-pass before any swap (previously warned and reported "applied" with the stale lane), and a refused reload no longer leaks its candidate PII detector into the running analyzer deps — detector, `piiRaw` and deps commit together only on applied documents.

**Trigger default changed:** an analyzer with an omitted `trigger` now classifies **everything** on an ungated lane instead of being refused at startup (declaring the analyzer is the opt-in; the cache and `max_calls` bound the bill, and `-validate` prints a per-lane note naming the cost). Gated lanes are unchanged: the gate-phase policy stays the only spender and Rego's silence still means skip, so deployed two-phase configs move no traffic. ADR-0008 carries an amendment note for this.

Unchanged on purpose: `findings.ai_analysis`, `risk_level` / `ai_status` / `ai_rule` field names, `/stats`, and the whole ADR-0008 action table (`defer` degradation, `require_review` refusal, fail-open default, trigger as cost control). For a migrated lane `ai_rule` carries the **listener name** (a component has no rule name); the field name itself does not move.

Design record: `docs/adr/0015-listener-analyzer-block.md`. Companion docs-site PR (hoophq/documentation) rewrites the analyzer pages around the listener block.

## 📣 User-facing impact

Sidecar AI analysis is now configured per listener with an `analyzer` block that inherits process-wide defaults, replacing the `type: ai_analysis` guardrail rule (which still works but is deprecated). A new `hoop-inspect -migrate` command rewrites old config files automatically. `send: redacted` now removes detected values from what reaches the model provider.

## 🔗 Related Issue

DEP-198

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update

## 📋 Changes Made

- `sidecar/daemon/analyzer.go` — `LaneAnalyzerConfig`, unified evaluator builder for both spellings, field-wise default inheritance, namespaced budgets, detector-gated send modes, offset-based redaction
- `sidecar/daemon/config.go` — `listeners[].analyzer`, deprecation warning in `normalize`, block-aware validation/build; `guardrails.rules` lost `omitempty` (nil→`null`, `[]` stays `[]`, so the empty-list override survives marshal)
- `sidecar/daemon/daemon.go` — `-validate` prints `+ ai analyzer` (`(N deprecated ai rule(s))` counts leftovers); `/config` lanes gain `analyzer: true`; defer-without-OPA startup note covers the block
- `sidecar/daemon/reload.go` — lane analyzer block hot-reloads with rules; top-level analyzer stays restart-bound; gRPC drift pre-pass; staged detector commit
- `sidecar/daemon/migrate.go` + `sidecar/config/yaml` `FromJSON` — the `-migrate` command with a provably lossless render (prune → reload → byte-compare, order-preserving)
- `sidecar/analyzer/evaluator.go` — redact/refuse before the cache
- `sidecar/pii/alcatraz` — `RedactText` on the detector and both Plugin interfaces
- Docs: `sidecar/README.md` rewritten around the block + migration section, ADR-0015, envoy-stack guides and example configs converted

## 🧪 Testing

### How to test

**Setup** — only the sidecar binary is needed, no gateway or agent:

```bash
cd sidecar/cmd && go build -o /tmp/hoop-inspect .
printf 'sk-test-dummy' > /tmp/key && chmod 600 /tmp/key
```

**1. The new listener block validates as a component:**

```bash
cat > /tmp/new.yaml <<'EOF'
analyzer: {provider: anthropic, model: claude-sonnet-4-5, credentials_file: /tmp/key}
listeners:
  - name: appdb
    protocol: postgres
    listen: 127.0.0.1:15499
    upstream: localhost:5432
    guardrails: {rules: [{name: no-drop, type: deny_words_list, words: [drop]}]}
    analyzer:
      trigger: {operations: [delete, update]}
      high: block
      medium: warn
EOF
/tmp/hoop-inspect -validate -config /tmp/new.yaml
```

Expected: exit 0 and the lane line `appdb  postgres  enforcing 1 rule(s) + ai analyzer` — a component, not a rule count.

**2. The deprecated rule form still loads, warns, and migrates:**

```bash
cat > /tmp/old.yaml <<'EOF'
analyzer: {provider: anthropic, model: claude-sonnet-4-5, credentials_file: /tmp/key}
listeners:
  - name: appdb
    connection: appdb-legacy
    protocol: postgres
    listen: 127.0.0.1:15499
    upstream: localhost:5432
    policy:
      enforce: true
      rules:
        - {name: risky-writes, type: ai_analysis, trigger: {operations: [delete]}, high: block}
EOF
/tmp/hoop-inspect -validate -config /tmp/old.yaml
```

Expected: exit 0, a stderr deprecation naming the `analyzer` block, and `+ ai analyzer (1 deprecated ai rule(s))` in the lane line.

**3. Migration produces a strict-clean file:**

```bash
/tmp/hoop-inspect -migrate -config /tmp/old.yaml -migrate-out /tmp/migrated.yaml
/tmp/hoop-inspect -validate -strict -config /tmp/migrated.yaml && echo STRICT-CLEAN
```

Expected: the migrate report says rule `risky-writes` became the listener's block (and that `ai_rule`/budget now key on `appdb`); the second command exits 0 and prints `STRICT-CLEAN`. Inspect `/tmp/migrated.yaml`: `policy`/`connection` folded, the rule now a listener `analyzer:` block, keys in documented order.

**Negative paths:**

```bash
# strict fails on the deprecated form (exit 1):
/tmp/hoop-inspect -validate -strict -config /tmp/old.yaml; echo "exit=$?"
# a block with no risk actions is refused, naming the failure:
sed 's/high: block/low: allow/; s/medium: warn//' /tmp/new.yaml > /tmp/bad.yaml
```

Also refused (unit-covered, reproducible by editing `/tmp/new.yaml`): a block with no top-level `analyzer` section, `require_review`, an unknown `send`, and `send: redacted`/`refuse` in a build without a detector. An OMITTED `trigger` is not refused: on an ungated lane it classifies every statement and `-validate` prints a note naming the per-statement cost (delete the trigger line from `/tmp/new.yaml` to see it); under `opa.gate: true` it means Rego decides.

**Regression check:** run any pre-existing config unchanged — behavior is identical (`go test ./...` in `sidecar/` passes with the entire pre-block suite unmodified in behavior). A two-rule lane keeps both evaluators and reports them as deprecated leftovers.

Control-plane hot reload of a gRPC lane's analyzer edit (now `restart to apply`) needs a control plane and is covered by `TestAGRPCLaneAnalyzerEditKeepsTheRestartPath` rather than a local flow.

### Tests performed:
- [x] Unit tests pass (`go test ./...` in `sidecar/`, `sidecar/config/yaml`, `sidecar/pii/alcatraz`; `gateway`/`client` builds)
- [x] Integration tests pass (reload/two-phase/lane suites in `sidecar/daemon`)
- [x] Manual testing completed (the `-validate`/`-migrate` flows above)

## 📄 Additional Notes

- Reviewers: the redaction fix (`RedactText`) and the refuse-before-cache ordering are the security-relevant hunks; both were latent in the pre-existing rule form.
- One behavior change to be aware of: control-plane edits touching a gRPC-transport lane's rules now return the restart outcome for the whole document instead of swapping the relay lanes and logging "applied".
- ADR-0015 should go up per the ADR process (own `docs(adr):` PR + Slack broadcast) if we want to be strict about it; it is included here so the code and its record land together.
