### PR TITLE
EVL-272: tell a human a sidecar filed a review

### DIFF
--- a/gateway/api/sidecar/reviews.go
+++ b/gateway/api/sidecar/reviews.go
@@ -165,7 +165,7 @@ func notifySlack(sidecar *models.Sidecar, rev *models.Review, listenerName, stat
 	}
 
 	result := slackSvc.SendMessageReview(req)
-	log.With("sid", rev.SessionID, "review-id", rev.ID).Infof("sent slack review message, %v", result)
+	log.With("sid", rev.SessionID, "review-id", rev.ID).Infof("slack review message, %v", result)
 }
 
 // newSlackReviewRequest is what a reviewer ends up reading. Split out so the
@@ -191,10 +191,11 @@ func newSlackReviewRequest(sidecar *models.Sidecar, rev *models.Review, listener
 		ApprovalGroups: slackplugin.ParseGroups(rev.ReviewGroups),
 		Script:         statement,
 
-		// The control plane serves no page for a single review yet, so this
-		// points at its home rather than at a link that would 404. Replace it
-		// once there is a layout to point at.
-		WebappURL: appconfig.Get().ApiURL(),
+		// /reviews/<sid> exists in the router but renders a placeholder, so
+		// this points at the home page until there is a layout to point at.
+		// FullApiURL, not ApiURL: the latter drops the configured path prefix,
+		// which lands the approver outside the app wherever one is set.
+		WebappURL: appconfig.Get().FullApiURL(),
 	}
 }
 

--- a/gateway/api/sidecar/reviews.go
+++ b/gateway/api/sidecar/reviews.go
@@ -18,7 +18,9 @@ import (
 	"github.com/hoophq/hoop/gateway/api/openapi"
 	"github.com/hoophq/hoop/gateway/appconfig"
 	"github.com/hoophq/hoop/gateway/models"
+	slackservice "github.com/hoophq/hoop/gateway/slack"
 	"github.com/hoophq/hoop/gateway/storagev2/types"
+	slackplugin "github.com/hoophq/hoop/gateway/transport/plugins/slack"
 )
 
 const (
@@ -34,6 +36,10 @@ const (
 	// the database one request at a time. A statement a human is expected to
 	// read has no business being larger.
 	maxStatementBytes = 100000 // 0.1MB, the ceiling plugin config already uses
+
+	// reviewSlackType labels the review in Slack, where the message renders a
+	// "Type" line for what a gateway review calls its connection type.
+	reviewSlackType = "sidecar"
 
 	// reviewConnectionType is what a session must declare. private.sessions
 	// requires one and enum_connection_type has no label for a listener, so a
@@ -116,7 +122,80 @@ func PostReview(c *gin.Context) {
 		"listener": req.ListenerName,
 	})
 
+	// Detached, and deliberately after the review exists. SendMessageReview
+	// sleeps 1200ms per channel and the Slack client carries no timeout, so on
+	// the request path this would hold the sidecar for at least that long and
+	// potentially forever, while it waits on a statement it is blocking. A
+	// sidecar that gives up and retries would then file the review twice.
+	//
+	// Nothing in the response depends on it: the review is already persisted
+	// and visible to an approver either way.
+	go notifySlack(sidecar, rev, req.ListenerName, string(statement))
+
 	c.JSON(http.StatusCreated, toOpenApiSidecarReview(rev))
+}
+
+// notifySlack posts the review to the org's Slack channel, so a human learns it
+// exists rather than finding it by looking.
+//
+// Slack is optional everywhere else in this codebase and stays optional here:
+// an org that has not configured it gets no message and no error.
+func notifySlack(sidecar *models.Sidecar, rev *models.Review, listenerName, statement string) {
+	slackSvc := slackservice.GetServiceInstance(sidecar.OrgID)
+	if slackSvc == nil {
+		return
+	}
+
+	// A sidecar review has no connection to take channels from, so the org
+	// default is its only destination. Said out loud because otherwise a
+	// misconfigured org gets silence that looks like success.
+	if slackSvc.DefaultChannel() == "" {
+		log.With("sid", rev.SessionID, "review-id", rev.ID).
+			Warnf("the org has no default slack channel, nobody was notified of this review")
+		return
+	}
+
+	req := newSlackReviewRequest(sidecar, rev, listenerName, statement)
+	// The same ceiling both existing senders apply. Two groups today, but a
+	// message with no buttons is a notification nobody can act on.
+	if len(req.ApprovalGroups) == 0 || len(req.ApprovalGroups) >= slackplugin.SlackMaxButtons {
+		log.With("review-id", rev.ID).Warnf("not sending a review message with %d approval groups",
+			len(req.ApprovalGroups))
+		return
+	}
+
+	result := slackSvc.SendMessageReview(req)
+	log.With("sid", rev.SessionID, "review-id", rev.ID).Infof("sent slack review message, %v", result)
+}
+
+// newSlackReviewRequest is what a reviewer ends up reading. Split out so the
+// message can be asserted without a Slack workspace.
+func newSlackReviewRequest(sidecar *models.Sidecar, rev *models.Review, listenerName, statement string) *slackservice.MessageReviewRequest {
+	return &slackservice.MessageReviewRequest{
+		// ID is load bearing: it becomes the message metadata and the button
+		// ids, and it is how a click finds its way back to this review.
+		ID:        rev.ID,
+		SessionID: rev.SessionID,
+
+		// The message renders these labels whether or not they mean anything
+		// here, so each carries what a sidecar review does know rather than a
+		// blank that reads as broken. Groups repeats the eligible roles the
+		// buttons are labelled with: a sidecar has no groups of its own, and
+		// saying who may act beats an empty field.
+		Name:           sidecar.Name,
+		UserGroups:     slackplugin.ParseGroups(rev.ReviewGroups),
+		Email:          reviewOwnerEmail,
+		Connection:     listenerName,
+		ConnectionType: reviewSlackType,
+
+		ApprovalGroups: slackplugin.ParseGroups(rev.ReviewGroups),
+		Script:         statement,
+
+		// The control plane serves no page for a single review yet, so this
+		// points at its home rather than at a link that would 404. Replace it
+		// once there is a layout to point at.
+		WebappURL: appconfig.Get().ApiURL(),
+	}
 }
 
 // createSidecarReview writes the session and the review one statement needs to

--- a/gateway/api/sidecar/reviews_test.go
+++ b/gateway/api/sidecar/reviews_test.go
@@ -23,6 +23,10 @@ import (
 // loaded), so a test binary gets a single mode and the gateway-mode refusal is
 // covered by booting a real gateway rather than from here.
 func TestMain(m *testing.M) {
+	// With a bare origin the two url accessors return the same string, so the
+	// WebappURL assertion below would hold whichever one the code calls. The
+	// path prefix is what makes it mean something.
+	os.Setenv("API_URL", "http://localhost:8009/hoop")
 	if err := appconfig.Load(appconfig.AppModeControlPlane); err != nil {
 		panic(err)
 	}
@@ -191,7 +195,9 @@ func TestNewSlackReviewRequest(t *testing.T) {
 	// The line renders unconditionally, so an empty value would show a broken
 	// link. Until there is a page for one review, it points at the home page.
 	assert.NotEmpty(t, req.WebappURL, "an empty url renders as a dead More details link")
-	assert.Equal(t, appconfig.Get().ApiURL(), req.WebappURL)
+	assert.Equal(t, appconfig.Get().FullApiURL(), req.WebappURL)
+	assert.True(t, strings.HasSuffix(req.WebappURL, "/hoop"),
+		"ApiURL drops a configured path prefix and lands the approver outside the app")
 	assert.NotContains(t, req.WebappURL, "/sessions/",
 		"the control plane serves no /sessions route")
 

--- a/gateway/api/sidecar/reviews_test.go
+++ b/gateway/api/sidecar/reviews_test.go
@@ -161,3 +161,40 @@ func TestPostReviewRefusesAStatementOverTheCap(t *testing.T) {
 	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 	assert.Contains(t, rec.Body.String(), "larger than")
 }
+
+// What a reviewer ends up reading. The message renders Name, Email, Connection
+// and Type whether or not they mean anything for a sidecar review, so each one
+// carries something true rather than an empty label.
+func TestNewSlackReviewRequest(t *testing.T) {
+	sc := &models.Sidecar{ID: "sidecar-1", OrgID: "org-1", Name: "payments-sidecar"}
+	rev := newSidecarReview(sc, "appdb", "session-1", time.Now().UTC())
+	statement := "DELETE FROM users WHERE id = 42;"
+
+	req := newSlackReviewRequest(sc, rev, "appdb", statement)
+
+	// Without these two a click cannot find the review: the id becomes the
+	// message metadata and the prefix of every button id.
+	assert.Equal(t, rev.ID, req.ID)
+	assert.Equal(t, rev.SessionID, req.SessionID)
+
+	assert.Equal(t, "payments-sidecar", req.Name, "which environment asked")
+	assert.Equal(t, "appdb", req.Connection, "which listener it arrived on")
+	assert.Equal(t, reviewSlackType, req.ConnectionType)
+	assert.Equal(t, reviewOwnerEmail, req.Email)
+	assert.Equal(t, statement, req.Script, "the statement is what is being approved")
+
+	assert.ElementsMatch(t, []string{types.GroupAdmin, types.GroupApprover}, req.ApprovalGroups,
+		"one button pair per eligible role")
+	assert.ElementsMatch(t, req.ApprovalGroups, req.UserGroups,
+		"Groups renders unconditionally, so it says who may act rather than nothing")
+
+	// The line renders unconditionally, so an empty value would show a broken
+	// link. Until there is a page for one review, it points at the home page.
+	assert.NotEmpty(t, req.WebappURL, "an empty url renders as a dead More details link")
+	assert.Equal(t, appconfig.Get().ApiURL(), req.WebappURL)
+	assert.NotContains(t, req.WebappURL, "/sessions/",
+		"the control plane serves no /sessions route")
+
+	assert.Empty(t, req.SlackChannels, "a sidecar review has no connection, so the org default is the only destination")
+	assert.Nil(t, req.SessionTime, "a sidecar review grants no access window")
+}

--- a/gateway/slack/service.go
+++ b/gateway/slack/service.go
@@ -117,6 +117,11 @@ func New(slackBotToken, slackAppToken, slackChannel, instanceID, apiURL string) 
 func (s *SlackService) Close()           { s.cancelFn() }
 func (s *SlackService) BotToken() string { return s.slackBotToken }
 
+// DefaultChannel is where a message with no channels of its own is posted.
+// Empty means the org configured none, and a caller that has no other
+// destination is posting into nothing.
+func (s *SlackService) DefaultChannel() string { return s.slackChannel }
+
 type MessageReviewRequest struct {
 	ID             string
 	Name           string


### PR DESCRIPTION
## 📝 Description

A sidecar files a review and nobody is told. It sits `PENDING` until someone happens to open the reviews list.

This posts it to the org's Slack channel, which is the last piece of the flow: a sidecar files, the control plane registers, Slack notifies, a human approves. EVL-258 made the Slack service run in control-plane mode, so the buttons, the reject modal and the rewrite-on-verdict already work — nothing posted the first message.

## 📣 User-facing impact

When a sidecar holds a statement for approval, approvers get a Slack message with the statement and Approve/Reject buttons, instead of having to go looking for it.

## 🔗 Related Issue

EVL-272. Completes the flow started in EVL-258, EVL-273 (#1804) and EVL-261 (#1808).

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📋 Changes Made

- `gateway/api/sidecar/reviews.go`: `notifySlack` and `newSlackReviewRequest`.
- `gateway/slack/service.go`: a `DefaultChannel()` accessor, matching the existing `BotToken()` one-liner.

### What a reviewer sees

```
Name: payments-sidecar   Groups: admin, approver   Email: hoop@hoop.dev
Session time: -          Connection: appdb         Type: sidecar

_script_
DELETE FROM users WHERE id = 42;

Approver groups: admin      [Approve] [Reject]
Approver groups: approver   [Approve] [Reject]

More details →
```

The message renders `Name`, `Groups`, `Email`, `Connection` and `Type` unconditionally, so each carries what a sidecar review does know rather than a blank that reads as broken. `Groups` repeats the eligible roles: a sidecar has no groups of its own, and saying who may act beats an empty field.

### Three decisions worth naming

**The notification is detached from the request.** `SendMessageReview` sleeps a hardcoded 1200ms per channel and the Slack client carries no HTTP timeout, so on the request path this would hold the sidecar for at least that long — and potentially forever — while it blocks on a statement. A sidecar that gave up and retried would then file the review twice, since there is deliberately no idempotency key. Nothing in the response depends on the message: the review is persisted and visible to an approver either way.

**"More details" points at the control-plane home page**, not `/sessions/<sid>`. That route does not exist in control-plane mode, and the link renders unconditionally, so an empty value would show a dead link. The home page resolves; point it somewhere better when there is a layout for a single review.

**Slack stays optional.** No service for the org means no message and no error, the same as every other caller. A service with no default channel logs a warning — a sidecar review has no connection to take channels from, so the org default is its only destination, and silence there would otherwise look exactly like success.

## 🧪 Testing

### Test Configuration:
- **Browser(s)**: n/a
- **OS**: macOS 15.6, PostgreSQL 17

### Tests performed:
- [x] Unit tests pass
- [x] Manual testing completed

`make test-oss` green, 0 failures.

`newSlackReviewRequest` is split out so the message can be asserted without a Slack workspace. Every field that would make the notification arrive looking fine but do nothing is mutation-tested — dropping the review id, emptying `WebappURL`, sending no approval groups, or blanking `Groups` each fail a test.

Live against a real Postgres control plane, with Slack unconfigured: `POST /sidecars/reviews` still returns `201`, nothing is logged about Slack, and the review still approves through the API.

**Not verified, and worth a smoke test before customers see it:** I have no Slack workspace, so the rendered message and the approve-from-Slack round trip have not been exercised end to end. The round trip was traced through `processInteractive` → `processEventResponse` → `DoReview` and the required post-time values (`ID` for the message metadata and the `reviewID:group:index` button ids, non-empty `ApprovalGroups`) are asserted by test, but that is reading plus unit coverage, not a live click.

## 📄 Additional Notes

**Caught in review, worth knowing:** the first version blocked the `201` on the Slack call. See the first decision above — this is the one change here that protects the sidecar rather than the reviewer.

**`ParseGroups` is borrowed, not copied.** An earlier revision inlined it to avoid depending on the transport plugin package, with a comment claiming that package had nothing else to offer. That was wrong: `gateway/api/session/ai_review.go` already imports it from the API layer for exactly this. Using the shared helper also picked up the `SlackMaxButtons` ceiling both existing senders apply — harmless with two groups today, but the guard the rest of the codebase relies on.

**Still no product event for an approval.** EVL-261 added `hoop-create-sidecar-review` when a review is filed; nothing is emitted when one is approved or rejected, because `TrackSessionUsageData` resolves the session's connection and a sidecar session has none.

https://claude.ai/code/session_017sx9jEmnE7kqHjUSQxJ91L
